### PR TITLE
Check user auth on splice.

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -388,23 +388,19 @@ class Cortex(EventBus,DataModel,ConfigMixin):
 
         tprops = info.get('props',{})
 
+        item = self.getTufoByProp(form,valu)
+        if item:
+            return None,item
+
         props['on:%s' % form] = valu
+        props['perm'] = 'tufo:add:%s' % (form,)
 
-        perm = 'tufo:add:%s' % (form,)
-
-        props['perm'] = perm
-
-        if not self._isSpliceAllow(props):
-            return None,None
-
-        splice = None
+        allow = self._isSpliceAllow(props)
+        splice = self.formTufoByProp('syn:splice',guid(),**props)
+        if not allow:
+            return splice,None
 
         item = self.formTufoByProp(form,valu,**tprops)
-
-        # if the tufo is newly formed, create a splice
-        if item[1].get('.new'):
-            splice = self.formTufoByProp('syn:splice',guid(),**props)
-
         return splice,item
 
     def _isSpliceAllow(self, props):
@@ -431,8 +427,10 @@ class Cortex(EventBus,DataModel,ConfigMixin):
 
         props['perm'] = 'tufo:set:%s' % fullprop
 
-        if not self._isSpliceAllow(props):
-            return None,None
+        allow = self._isSpliceAllow(props)
+        splice = self.formTufoByProp('syn:splice',guid(),**props)
+        if not allow:
+            return splice,None
 
         item = self.getTufoByProp(form,valu=valu)
         if item == None:
@@ -446,8 +444,6 @@ class Cortex(EventBus,DataModel,ConfigMixin):
             props['act:oval'] = oval
 
         item = self.setTufoProp(item,prop,pval)
-        splice = self.formTufoByProp('syn:splice',guid(),**props)
-
         return splice,item
 
     def _spliceTufoDel(self, act, info, props):
@@ -462,13 +458,12 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         props['on:%s' % form] = valu
         props['perm'] = 'tufo:del:%s' % form
 
-        if not self._isSpliceAllow(props):
-            return None,None
+        allow = self._isSpliceAllow(props)
+        splice = self.formTufoByProp('syn:splice',guid(),**props)
+        if not allow:
+            return splice,None
 
         self.delTufo(item)
-
-        splice = self.formTufoByProp('syn:splice',guid(),**props)
-
         return splice,item
 
     def _spliceTufoTagAdd(self, act, info, props):
@@ -484,16 +479,14 @@ class Cortex(EventBus,DataModel,ConfigMixin):
             return None,item
 
         props['on:%s' % form] = valu
+        props['perm'] = 'tufo:tag:add:%s|%s' % (form,tag)
 
-        perm = 'tufo:tag:add:%s|%s' % (form,tag)
-
-        props['perm'] = perm
-
-        if not self._isSpliceAllow(props):
-            return None,None
+        allow = self._isSpliceAllow(props)
+        splice = self.formTufoByProp('syn:splice',guid(),**props)
+        if not allow:
+            return splice,None
 
         item = self.addTufoTag(item,tag)
-        splice = self.formTufoByProp('syn:splice',guid(),**props)
         return splice,item
 
     def _spliceTufoTagDel(self, act, info, props):
@@ -509,16 +502,14 @@ class Cortex(EventBus,DataModel,ConfigMixin):
             return None,item
 
         props['on:%s' % form] = valu
+        props['perm'] = 'tufo:tag:del:%s|%s' % (form,tag)
 
-        perm = 'tufo:tag:del:%s|%s' % (form,tag)
-
-        props['perm'] = perm
-
-        if not self._isSpliceAllow(props):
-            return None,None
+        allow = self._isSpliceAllow(props)
+        splice = self.formTufoByProp('syn:splice',guid(),**props)
+        if not allow:
+            return splice,None
 
         item = self.delTufoTag(item,tag)
-        splice = self.formTufoByProp('syn:splice',guid(),**props)
         return splice,item
 
     def splice(self, user, act, actinfo, **props):

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -393,9 +393,9 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         perm = 'tufo:add:%s' % (form,)
 
         props['perm'] = perm
-        props['status'] = 'done'
 
-        # FIXME apply perm
+        if not self._isSpliceAllow(props):
+            return None,None
 
         splice = None
 
@@ -431,7 +431,8 @@ class Cortex(EventBus,DataModel,ConfigMixin):
 
         props['perm'] = 'tufo:set:%s' % fullprop
 
-        # FIXME apply perm
+        if not self._isSpliceAllow(props):
+            return None,None
 
         item = self.getTufoByProp(form,valu=valu)
         if item == None:
@@ -459,9 +460,10 @@ class Cortex(EventBus,DataModel,ConfigMixin):
             raise NoSuchTufo('%s=%r' % (form,valu))
 
         props['on:%s' % form] = valu
-        props['status'] = 'done'
-
         props['perm'] = 'tufo:del:%s' % form
+
+        if not self._isSpliceAllow(props):
+            return None,None
 
         self.delTufo(item)
 
@@ -483,10 +485,12 @@ class Cortex(EventBus,DataModel,ConfigMixin):
 
         props['on:%s' % form] = valu
 
-        perm = 'tufo:tag:add:%s*%s' % (form,tag)
+        perm = 'tufo:tag:add:%s|%s' % (form,tag)
 
         props['perm'] = perm
-        props['status'] = 'done'
+
+        if not self._isSpliceAllow(props):
+            return None,None
 
         item = self.addTufoTag(item,tag)
         splice = self.formTufoByProp('syn:splice',guid(),**props)
@@ -506,10 +510,12 @@ class Cortex(EventBus,DataModel,ConfigMixin):
 
         props['on:%s' % form] = valu
 
-        perm = 'tufo:tag:del:%s*%s' % (form,tag)
+        perm = 'tufo:tag:del:%s|%s' % (form,tag)
 
         props['perm'] = perm
-        props['status'] = 'done'
+
+        if not self._isSpliceAllow(props):
+            return None,None
 
         item = self.delTufoTag(item,tag)
         splice = self.formTufoByProp('syn:splice',guid(),**props)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -740,51 +740,61 @@ class CortexTest(SynTest):
 
                     auth.addUser('bobo')
                     splice, retval = core.splice('bobo', 'tufo:add', info1)
-                    self.assertFalse(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:add')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'pend')
                     self.assertFalse(retval)
 
                     auth.addUserRule('bobo', 'tufo:add:foo')
                     splice, retval = core.splice('bobo', 'tufo:add', info1)
-                    self.assertTrue(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:add')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'done')
                     self.assertEqual(retval[1]['tufo:form'], 'foo')
                     self.assertEqual(retval[1]['foo'], 'bar')
 
                     info2 = {'form': 'foo', 'valu': 'bar', 'prop': 'baz', 'pval': 'qux'}
                     splice, retval = core.splice('bobo', 'tufo:set', info2)
-                    self.assertFalse(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:set')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'pend')
                     self.assertFalse(retval)
 
                     auth.addUserRule('bobo', 'tufo:set:foo:baz')
                     splice, retval = core.splice('bobo', 'tufo:set', info2)
-                    self.assertTrue(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:set')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'done')
                     self.assertEqual(retval[1]['foo:baz'], 'qux')
 
                     info3 = {'form': 'foo', 'valu': 'bar', 'tag': 'test'}
                     splice, retval = core.splice('bobo', 'tufo:tag:add', info3)
-                    self.assertFalse(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:tag:add')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'pend')
                     self.assertFalse(retval)
 
                     auth.addUserRule('bobo', 'tufo:tag:add:foo|*')
                     splice, retval = core.splice('bobo', 'tufo:tag:add', info3)
-                    self.assertTrue(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:tag:add')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'done')
                     self.assertTrue('*|foo|test' in retval[1])
 
                     splice, retval = core.splice('bobo', 'tufo:tag:del', info3)
-                    self.assertFalse(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:tag:del')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'pend')
                     self.assertFalse(retval)
 
                     auth.addUserRule('bobo', 'tufo:tag:del:foo|*')
                     splice, retval = core.splice('bobo', 'tufo:tag:del', info3)
-                    self.assertTrue(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:tag:del')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'done')
                     self.assertFalse('*|foo|test' in retval[1])
 
                     splice, retval = core.splice('bobo', 'tufo:del', info1)
-                    self.assertFalse(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:del')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'pend')
                     self.assertFalse(retval)
 
                     auth.addUserRule('bobo', 'tufo:del:foo')
                     splice, retval = core.splice('bobo', 'tufo:del', info1)
-                    self.assertTrue(splice)
+                    self.assertEqual(splice[1]['syn:splice:action'], 'tufo:del')
+                    self.assertEqual(splice[1]['syn:splice:status'], 'done')
                     self.assertEqual(retval[1]['foo'], 'bar')
 
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -6,7 +6,8 @@ import synapse.link as s_link
 import synapse.compat as s_compat
 import synapse.common as s_common
 import synapse.cortex as s_cortex
-
+import synapse.exc as s_exc
+import synapse.lib.userauth as s_userauth
 import synapse.lib.tags as s_tags
 import synapse.lib.types as s_types
 
@@ -727,6 +728,65 @@ class CortexTest(SynTest):
         self.assertEqual( splice[1].get('syn:splice:act:valu'), 'bar' )
 
         core.fini()
+
+    def test_cortex_splice_userauth(self):
+        with s_cortex.openurl('ram:///') as auth_core:
+            with s_userauth.UserAuth(auth_core) as auth:
+                with s_cortex.openurl('ram:///') as core:
+                    core.auth = auth
+
+                    info1 = {'form': 'foo', 'valu': 'bar'}
+                    self.assertRaises(s_exc.NoSuchUser, core.splice, 'bobo', 'tufo:add', info1)
+
+                    auth.addUser('bobo')
+                    splice, retval = core.splice('bobo', 'tufo:add', info1)
+                    self.assertFalse(splice)
+                    self.assertFalse(retval)
+
+                    auth.addUserRule('bobo', 'tufo:add:foo')
+                    splice, retval = core.splice('bobo', 'tufo:add', info1)
+                    self.assertTrue(splice)
+                    self.assertEqual(retval[1]['tufo:form'], 'foo')
+                    self.assertEqual(retval[1]['foo'], 'bar')
+
+                    info2 = {'form': 'foo', 'valu': 'bar', 'prop': 'baz', 'pval': 'qux'}
+                    splice, retval = core.splice('bobo', 'tufo:set', info2)
+                    self.assertFalse(splice)
+                    self.assertFalse(retval)
+
+                    auth.addUserRule('bobo', 'tufo:set:foo:baz')
+                    splice, retval = core.splice('bobo', 'tufo:set', info2)
+                    self.assertTrue(splice)
+                    self.assertEqual(retval[1]['foo:baz'], 'qux')
+
+                    info3 = {'form': 'foo', 'valu': 'bar', 'tag': 'test'}
+                    splice, retval = core.splice('bobo', 'tufo:tag:add', info3)
+                    self.assertFalse(splice)
+                    self.assertFalse(retval)
+
+                    auth.addUserRule('bobo', 'tufo:tag:add:foo|*')
+                    splice, retval = core.splice('bobo', 'tufo:tag:add', info3)
+                    self.assertTrue(splice)
+                    self.assertTrue('*|foo|test' in retval[1])
+
+                    splice, retval = core.splice('bobo', 'tufo:tag:del', info3)
+                    self.assertFalse(splice)
+                    self.assertFalse(retval)
+
+                    auth.addUserRule('bobo', 'tufo:tag:del:foo|*')
+                    splice, retval = core.splice('bobo', 'tufo:tag:del', info3)
+                    self.assertTrue(splice)
+                    self.assertFalse('*|foo|test' in retval[1])
+
+                    splice, retval = core.splice('bobo', 'tufo:del', info1)
+                    self.assertFalse(splice)
+                    self.assertFalse(retval)
+
+                    auth.addUserRule('bobo', 'tufo:del:foo')
+                    splice, retval = core.splice('bobo', 'tufo:del', info1)
+                    self.assertTrue(splice)
+                    self.assertEqual(retval[1]['foo'], 'bar')
+
 
     def test_cortex_dict(self):
         core = s_cortex.openurl('ram://')


### PR DESCRIPTION
This change:
1. Completes the intended connections between a cortex and its UserAuth member
2. Changes the `tufo:tag:add:[form]*[tag]` permission pattern to `tufo:tag:add:[form]|[tag]`
3. Creates a splice in pend status if permission denied.
