### PR TITLE
Wg update tufo docstring

### DIFF
--- a/synapse/lib/tufo.py
+++ b/synapse/lib/tufo.py
@@ -1,5 +1,5 @@
 '''
-Some common utility functions for deailing with tufos.
+Some common utility functions for dealing with tufos.
 '''
 
 def tufo(name,**props):
@@ -9,7 +9,7 @@ def tufo(name,**props):
     Example:
 
         tuf0 = s_tufo.tufo('bar',baz='faz',derp=20)
-        # tuf0 = ('bar',{'baz':'faz':'derp':20})
+        # tuf0 = ('bar',{'baz':'faz', 'derp':20})
 
     '''
     return (name,props)
@@ -22,8 +22,14 @@ def props(tufo,pref=None):
     Example:
 
         import synapse.tufo as s_tufo
-
-        info = s_tufo.props(tuf0)
+        tuf0 = s_tufo.tufo('bar', **{'baz':'faz', 'derp': 20, 'namespace:sound': 'quack'})
+        # tuf0 = ('bar', {'namespace:ducksound': 'quack', 'derp': 20, 'baz': 'faz'})
+        info = s_tufo.props(tuf0, pref='namespace')
+        # info = {'ducksound': 'quack'}
+        tuf1 = s_tufo.tufo('duck', **{'tufo:form': 'animal', 'animal:sound':'quack', 'animal:stype': 'duck'})
+        # tuf1 = ('duck', {'tufo:form': 'animal', 'animal:stype': 'duck', 'animal:sound': 'quack'})
+        info = s_tufo.props(tuf1)
+        # info = {'stype': 'duck', 'sound': 'quack'}
 
     '''
     if pref == None:

--- a/synapse/tests/test_tufo.py
+++ b/synapse/tests/test_tufo.py
@@ -1,0 +1,86 @@
+import unittest
+
+import synapse.lib.tufo as s_tufo
+
+# Unittests for synapse/lib/tufo.py
+
+
+class TufoEqualityTest(unittest.TestCase):
+    def setUp(self):
+        self.t1 = s_tufo.tufo('bar', baz='faz', derp=20)
+        self.t2 = s_tufo.tufo('bar', derp=20, baz='faz')
+        self.t3 = s_tufo.tufo('foo', derp=20, baz='faz')
+        self.t4 = s_tufo.tufo('bar', derp=20, baz='faz', prop='value')
+        self.t5 = s_tufo.tufo('bar', **{'baz': 'faz', 'derp': 20, 'namespace:sound': 'quack'})
+        self.t6 = s_tufo.tufo('bar', **{'baz': 'faz', 'derp': 20})
+
+    def test_equals(self):
+        '''
+        Ensure that tufo equality works where expected.
+        '''
+        r = s_tufo.equal(tuf0=self.t1, tuf1=self.t2)
+        self.assertTrue(r)
+        r = s_tufo.equal(tuf0=self.t1, tuf1=self.t6)
+        self.assertTrue(r)
+
+    def test_not_equals(self):
+        '''
+        Ensure that tufo equality works where expected.
+        '''
+        r = s_tufo.equal(tuf0=self.t1, tuf1=self.t3)
+        self.assertFalse(r)
+        r = s_tufo.equal(tuf0=self.t1, tuf1=self.t4)
+        self.assertFalse(r)
+        r = s_tufo.equal(tuf0=self.t1, tuf1=self.t5)
+        self.assertFalse(r)
+
+
+class TufoCreateTests(unittest.TestCase):
+    def setUp(self):
+        self.tuf0 = ('bar', {'baz': 'faz', 'derp': 20})
+
+    def test_simple_tufo_creation(self):
+        '''
+        Ensure that tufos can be created with explicit arguments.
+        '''
+        tuf0 = s_tufo.tufo('bar', baz='faz', derp=20)
+        r = s_tufo.equal(tuf0, self.tuf0)
+        self.assertTrue(r)
+
+    def test_kwargs_tufo_creation(self):
+        '''
+        Ensure that tufos' can be created via **kwargs.
+        '''
+        tuf0 = s_tufo.tufo('bar', **{'baz': 'faz', 'derp': 20,})
+        r = s_tufo.equal(tuf0, self.tuf0)
+        self.assertTrue(r)
+
+
+class TestTufoProps(unittest.TestCase):
+    def setUp(self):
+        self.t1 = s_tufo.tufo('bar', baz='faz', derp=20)
+        self.t2 = s_tufo.tufo('bar', **{'baz': 'faz', 'derp': 20, 'namespace:sound': 'quack'})
+        self.t3 = ('duck', {'tufo:form': 'animal', 'animal:stype': 'duck', 'animal:sound': 'quack'})
+
+    def test_default_props(self):
+        '''
+        Ensure that when no prefix is provided, the properties are taken from the form.
+        '''
+        r = s_tufo.props(self.t1)
+        self.assertEqual(r, {})
+        r = s_tufo.props(self.t2)
+        self.assertEqual(r, {})
+        r = s_tufo.props(self.t3)
+        self.assertEqual(r, {'sound': 'quack', 'stype': 'duck'})
+
+    def test_named_props(self):
+        '''
+        Ensure that provided prefixes are used.
+        '''
+        r = s_tufo.props(self.t2, pref='namespace')
+        self.assertEqual(r, {'sound': 'quack'})
+        r = s_tufo.props(self.t3, pref='animal')
+        self.assertEqual(r, {'sound': 'quack', 'stype': 'duck'})
+        r = s_tufo.props(self.t3, pref='geo')
+        self.assertEqual(r, {})
+


### PR DESCRIPTION
When looking over 5ce216784c39d5225490ad684eb01393348cccea and trying some of the utility code (synapse/lib/tufo.py), it wasn't entirely clear at first what the expected output of props() should look like.  Updated docstrings and added unit tests for the functions.