### PR TITLE
datamodel: disallow mixed case props

### DIFF
--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -17,7 +17,7 @@ import synapse.lib.types as s_types
 from synapse.common import *
 
 hexre = re.compile('^[0-9a-z]+$')
-propre = re.compile('^[0-9a-zA-Z:_]+$')
+propre = re.compile('^[0-9a-z:_]+$')
 
 def propdef(name, **info):
     return (name,info)


### PR DESCRIPTION
the cortex authors *suggest* all prop names should be lowercase; however, this policy should be enforced, and data modelsthat contain mixed case prop names should be rejected.

the current behavior is to accept mixed cased prop names, but implicitly lowercase them in the data model tufos; however, as subsequent tufos are formed, the props are not lowercased. this means the mixed case datamodel doesn't affect the formed tufos. personally, i find this quite unexpected. it would be better to raise an exception and highlight the issue as early as possible.