### PR TITLE
Gracefully limit functionality if dependencies are missing

### DIFF
--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -3,16 +3,14 @@ The synapse distributed computing framework.
 '''
 import os
 import msgpack
-import tornado
 import logging
+from synapse.utils import importOptionalModule
+tornado = importOptionalModule('tornado')
 
 logger = logging.getLogger(__name__)
 
 if msgpack.version < (0,4,2):
     raise Exception('synapse requires msgpack >= 0.4.2')
-
-if tornado.version_info < (3,2):
-    raise Exception('synapse requires tornado >= 3.2')
 
 version = (0,0,10)
 verstring = '.'.join([ str(x) for x in version ])

--- a/synapse/link.py
+++ b/synapse/link.py
@@ -1,5 +1,7 @@
-import synapse.links.ssl as s_ssl
-import synapse.links.ssh as s_ssh
+from synapse.utils import importOptionalModule, FeatureNotEnabled
+s_ssl = importOptionalModule('synapse.links.ssl')
+s_ssh = importOptionalModule('synapse.links.ssh')
+
 import synapse.links.tcp as s_tcp
 import synapse.links.local as s_local
 import synapse.lib.urlhelp as s_urlhelp
@@ -14,8 +16,8 @@ Provides access to the synapse link protocols.
 
 protos = {
     'tcp':s_tcp.TcpRelay,
-    'ssl':s_ssl.SslRelay,
-    'ssh':s_ssh.SshRelay,
+    'ssl':s_ssl.SslRelay if type(s_ssl) is not FeatureNotEnabled else None,
+    'ssh':s_ssh.SshRelay if type(s_ssl) is not FeatureNotEnabled else None,
     'local':s_local.LocalRelay,
 }
 

--- a/synapse/links/common.py
+++ b/synapse/links/common.py
@@ -1,11 +1,13 @@
 import time
 import errno
 import threading
+from synapse.utils import importOptionalModule
 
-import synapse.crypto as s_crypto
+s_crypto = importOptionalModule('synapse.crypto')
+
 import synapse.lib.threads as s_threads
-
 from synapse.eventbus import EventBus
+
 
 from synapse.common import *
 

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -12,7 +12,10 @@ import collections
 
 import synapse.link as s_link
 import synapse.async as s_async
-import synapse.crypto as s_crypto
+
+from synapse.utils import importOptionalModule
+s_crypto = importOptionalModule('synapse.crypto')
+
 import synapse.dyndeps as s_dyndeps
 import synapse.eventbus as s_eventbus
 

--- a/synapse/utils.py
+++ b/synapse/utils.py
@@ -1,0 +1,22 @@
+import importlib
+
+class FeatureNotEnabledException(Exception):
+    pass
+
+class FeatureNotEnabled:
+    def __init__(self, module_name):
+        self.module_name = module_name
+
+    def __getattribute__(self, name):
+        if name == 'module_name':
+            return object.__getattribute__(self, name)
+        else:
+            raise FeatureNotEnabledException('{}.{} not enabled due to missing dependencies for {}'
+                                             .format(self.module_name, name, self.module_name))
+
+def importOptionalModule(module_name):
+    try:
+        module_or_stub = importlib.import_module(module_name)
+    except ImportError:
+        module_or_stub = FeatureNotEnabled(module_name)
+    return module_or_stub


### PR DESCRIPTION
Synapse relies on `pyOpenSSL`, `cryptography`, and `tornado`, but a pretty big subset of synapse doesn't actually rely on these. I put some wrappers around these imports so that the parts of synapse not dependent on them will work in their absence, and if those features are attempted to be used, explicit exceptions will be thrown.