### PR TITLE
cortex: remove getRowsByIds

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -990,17 +990,6 @@ class Cortex(EventBus,DataModel,Runtime,Configable):
         '''
         return self._getRowsByIdProp(iden, prop)
 
-    def getRowsByIds(self, idens):
-        '''
-        Return all the rows for a given list of idens.
-
-        Example:
-
-            rows = core.getRowsByIds( (id1, id2, id3) )
-
-        '''
-        return self._getRowsByIds(idens)
-
     def delRowsById(self, iden):
         '''
         Delete all the rows for a given iden.


### PR DESCRIPTION
remove `getRowsByIds` API since none of the backends support this method