### PR TITLE
Null values in JSON break 'vars' during ingest.

### DIFF
--- a/synapse/gene.py
+++ b/synapse/gene.py
@@ -162,10 +162,9 @@ class ValuNode(GeneNode):
 class VarNode(GeneNode):
     def _eval(self, syms):
         name = self.tokn[1].get('name')
-        valu = syms.get(name)
-        if valu == None:
+        if name not in syms:
             raise s_exc.NoSuchName(name=name)
-        return valu
+        return syms.get(name)
 
 class CallNode(GeneNode):
     def _eval(self, syms):

--- a/synapse/gene.py
+++ b/synapse/gene.py
@@ -3,6 +3,10 @@ import operator
 import synapse.exc as s_exc
 import synapse.lib.syntax as s_syntax
 
+
+class UndefinedValue: pass
+undefined = UndefinedValue()
+
 class GeneLab:
 
     def __init__(self, globs=None):
@@ -162,9 +166,10 @@ class ValuNode(GeneNode):
 class VarNode(GeneNode):
     def _eval(self, syms):
         name = self.tokn[1].get('name')
-        if name not in syms:
+        valu = syms.get(name, undefined)
+        if valu is undefined:
             raise s_exc.NoSuchName(name=name)
-        return syms.get(name)
+        return valu
 
 class CallNode(GeneNode):
     def _eval(self, syms):

--- a/synapse/lib/scope.py
+++ b/synapse/lib/scope.py
@@ -77,15 +77,6 @@ class Scope:
 
         return defval
 
-    def __contains__(self, name):
-        '''
-        Test for the existence of given name in the scope.
-        '''
-        for frame in self.frames:
-            if name in frame:
-                return True
-        return False
-
     def add(self, name, *vals):
         '''
         Add values as iter() compatible items in the current scope frame.

--- a/synapse/lib/scope.py
+++ b/synapse/lib/scope.py
@@ -77,6 +77,15 @@ class Scope:
 
         return defval
 
+    def __contains__(self, name):
+        '''
+        Test for the existence of given name in the scope.
+        '''
+        for frame in self.frames:
+            if name in frame:
+                return True
+        return False
+
     def add(self, name, *vals):
         '''
         Add values as iter() compatible items in the current scope frame.

--- a/synapse/tests/test_gene.py
+++ b/synapse/tests/test_gene.py
@@ -75,6 +75,9 @@ class GeneTest(SynTest):
         self.eq( id(expr0), id(expr1) )
         self.eq( expr0({'foo':10}), 1 )
 
+    def test_gene_empty_value(self):
+        self.eq(s_gene.eval('empty', syms={'empty': None}), None)
+
     def test_gene_noname(self):
         self.assertRaises( NoSuchName, s_gene.eval, 'x + 20' )
 


### PR DESCRIPTION
Basically what happens is that synapse in unable to distinguish a variable set in a scope as the None literal from a variable that was never set to begin with. As an example, with the following ingest definition (source boilerplate removed) we can break the ingest process.

```json
{
  "open": {"format": "jsonl"},
  "ingest": {
    "vars": [
      ["foo", {"path": "foo"}]
    ],
    "conds": [
      ["foo == 5", {
        "forms": [
          ["name", {"path": "bar"}]
        ]
      }]
    ]
  }
}
```

This row will ingest "yo" just fine

```json
{"foo": 5, "bar": "yo"}
```

But this perfectly valid JSON row will cause the ingest to crash, claiming that I never defined the foo var.

```json
{"foo": null, "bar": "dawg"}
```

I could be missing a feature to deal with this case, but it seems like a new edge case. Thoughts?