### PR TITLE
Read modules as binary files rather than ascii.

### DIFF
--- a/synapse/lib/moddef.py
+++ b/synapse/lib/moddef.py
@@ -133,7 +133,7 @@ def getModDefSrc(moddef):
     path = moddef[1].get('path')
 
     if fmt == 'src' and path != None and os.path.isfile(path):
-        with open(path,'r') as fd:
+        with open(path,'rb') as fd:
             return fd.read()
 
 def getModDefCode(moddef):


### PR DESCRIPTION
This fixes 6 or so tests on OS X that died with character decoding errors.