### PR TITLE
print help message instead of stacktrace when CLI args are missing

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -24,6 +24,10 @@ class AskCmd(s_cli.Cmd):
 
     def runCmdOpts(self, opts):
         ques = opts.get('query')
+        if ques == None:
+            self.printf(self.__doc__)
+            return
+
         core = self.getCmdItem()
         resp = core.ask(ques)
 
@@ -69,7 +73,7 @@ class AddNodeCmd(s_cli.Cmd):
     '''
     Form a node in the cortex.
 
-    Example:
+    Examples:
 
         addnode <prop> <valu>
 
@@ -86,10 +90,13 @@ class AddNodeCmd(s_cli.Cmd):
 
     def runCmdOpts(self, opts):
 
-        core = self.getCmdItem()
-
         prop = opts.get('prop')
         valu = opts.get('valu')
+        if prop == None or valu == None:
+            self.printf(self.__doc__)
+            return
+
+        core = self.getCmdItem()
 
         node = core.formTufoByFrob(prop,valu)
         self.printf('formed: %r' % (node,))
@@ -114,6 +121,10 @@ class AddTagCmd(s_cli.Cmd):
     def runCmdOpts(self, opts):
 
         tag = opts.get('tag')
+        if tag == None:
+            self.printf(self.__doc__)
+            return
+
         core = self.getCmdItem()
 
         nodes = core.eval( opts.get('query') )
@@ -156,6 +167,10 @@ class DelTagCmd(s_cli.Cmd):
     def runCmdOpts(self, opts):
 
         tag = opts.get('tag')
+        if tag == None:
+            self.printf(self.__doc__)
+            return
+
         core = self.getCmdItem()
 
         nodes = core.eval( opts.get('query') )

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -61,6 +61,13 @@ class SynCmdCoreTest(SynTest):
             cmdr.runCmdLine('addnode inet:email visi@vertex.link')
             self.nn( core.getTufoByProp('inet:email','visi@vertex.link') )
 
+    def test_cmds_addnode_noopts(self):
+        with self.getDmonCore() as core:
+            outp = s_output.OutPutStr()
+            cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+            cmdr.runCmdLine('addnode')
+            self.nn(re.search('Examples:', str(outp)))
+
     def test_cmds_addtag(self):
 
         with self.getDmonCore() as core:
@@ -82,6 +89,13 @@ class SynCmdCoreTest(SynTest):
 
             cmdr.runCmdLine('addtag woot inet:email="visi@vertex.link"')
             self.eq( str(outp).strip(), '0 nodes...')
+
+    def test_cmds_addtag_noopts(self):
+        with self.getDmonCore() as core:
+            outp = s_output.OutPutStr()
+            cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+            cmdr.runCmdLine('addtag')
+            self.nn(re.search('Examples:', str(outp)))
 
     def test_cmds_deltag(self):
 
@@ -105,6 +119,13 @@ class SynCmdCoreTest(SynTest):
 
             cmdr.runCmdLine('deltag woot inet:email="visi@vertex.link"')
             self.eq( str(outp).strip(), '0 nodes...')
+
+    def test_cmds_deltag_noopts(self):
+        with self.getDmonCore() as core:
+            outp = s_output.OutPutStr()
+            cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+            cmdr.runCmdLine('deltag')
+            self.nn(re.search('Examples:', str(outp)))
 
     def test_cmds_ask(self):
         with self.getDmonCore() as core:
@@ -157,3 +178,10 @@ class SynCmdCoreTest(SynTest):
 
             for term in terms:
                 self.nn(re.search(term, outp))
+
+    def test_cmds_ask_noopts(self):
+        with self.getDmonCore() as core:
+            outp = s_output.OutPutStr()
+            cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+            cmdr.runCmdLine('ask')
+            self.nn(re.search('Examples:', str(outp)))


### PR DESCRIPTION
As a user, seeing stack traces isn't very useful.  Adding some validation / sane error messages / help messages.