### PR TITLE
Don't raise NoSuchName when ingesting records with missing "vars"

### DIFF
--- a/synapse/lib/scope.py
+++ b/synapse/lib/scope.py
@@ -64,8 +64,8 @@ class Scope:
         Retrieve a value from the closest scope frame.
         '''
         for frame in reversed(self.frames):
-            valu = frame.get(name)
-            if valu != None:
+            valu = frame.get(name, defval)
+            if valu != defval:
                 return valu
 
         task = self.ctors.get(name)

--- a/synapse/lib/scope.py
+++ b/synapse/lib/scope.py
@@ -1,6 +1,7 @@
 import os
 import threading
 import contextlib
+from synapse.common import novalu
 
 class Scope:
     '''
@@ -64,8 +65,8 @@ class Scope:
         Retrieve a value from the closest scope frame.
         '''
         for frame in reversed(self.frames):
-            valu = frame.get(name, defval)
-            if valu != defval:
+            valu = frame.get(name, novalu)
+            if valu != novalu:
                 return valu
 
         task = self.ctors.get(name)

--- a/synapse/tests/test_lib_ingest.py
+++ b/synapse/tests/test_lib_ingest.py
@@ -498,6 +498,26 @@ class IngTest(SynTest):
 
             self.nn( core.getTufoByProp('inet:fqdn','vertex.link') )
 
+    def test_ingest_condform_with_missing_var(self):
+
+        data = {'foo':[ {'fqdn':'vertex.link','hehe':3} ] }
+
+        info = {'ingest':{
+            'iters':[
+                ["foo/*",{
+                    'vars':[ ['hehe',{'path':'heho'}] ],
+                    'forms':[ ('inet:fqdn',{'path':'fqdn','cond':'hehe != 3'}) ],
+                }],
+            ],
+        }}
+
+        with s_cortex.openurl('ram://') as core:
+
+            gest = s_ingest.Ingest(info)
+            gest.ingest(core,data=data)
+
+            self.nn( core.getTufoByProp('inet:fqdn','vertex.link') )
+
     def test_ingest_condtag(self):
 
         data = {'foo':[ {'fqdn':'vertex.link','hehe':3} ] }

--- a/synapse/tests/test_lib_scope.py
+++ b/synapse/tests/test_lib_scope.py
@@ -33,3 +33,18 @@ class GeneTest(SynTest):
 
         self.assertIsNone( s_scope.get('woot') )
         self.assertIsNone( s_scope.get('newp') )
+
+    def test_lib_scope_get_defval(self):
+        syms = {'foo': None, 'bar': 123}
+        scope = s_scope.Scope(**syms)
+        self.eq(scope.get('foo'), None)
+        self.eq(scope.get('foo', defval=None), None)
+        self.eq(scope.get('bar'), 123)
+        self.eq(scope.get('bar', defval=123), 123)
+        self.eq(scope.get('boo'), None)
+        self.eq(scope.get('boo', defval=None), None)
+
+        scope.enter({'bar': 321})
+        self.eq(scope.get('bar'), 321)
+        self.eq(scope.get('bar', defval=321), 321)
+        scope.leave()


### PR DESCRIPTION
Currently, during ingest if a record is missing a path that is used to define a var, a NoSuchName exception is raised. This change ensures that a NoSuchName error is raised only if the var is really undefined.