### PR TITLE
Add package data from synapse.data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include synapse/data/*.mpk

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(
 
     packages=find_packages(exclude=['*.tests','*.tests.*']),
 
+    include_package_data=True,
+
     install_requires=[
         'tornado>=3.2.2',
         'cryptography>=1.7.2',


### PR DESCRIPTION
Include .mpk files in the synapse/data directory when packaging/installing.  Previously these files would not be included, causing the import of synapse.lib.scrape (done by synapse.lib.ingest) to fail.

https://docs.python.org/2/distutils/sourcedist.html#manifest
http://python-packaging.readthedocs.io/en/latest/non-code-files.html