### PR TITLE
Removing defval for time:min/max types

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -153,8 +153,8 @@ def getDataModel():
                 ('email',{'ptype':'inet:email'}),
                 ('signup',{'ptype':'time','defval':0,'doc':'The time the netuser account was registered'}),
                 ('passwd',{'ptype':'inet:passwd','doc':'The current passwd for the netuser account'}),
-                ('seen:min',{'ptype':'time:min','defval':0}),
-                ('seen:max',{'ptype':'time:max','defval':0}),
+                ('seen:min',{'ptype':'time:min'}),
+                ('seen:max',{'ptype':'time:max'}),
             ]),
 
             ('inet:netmesg',{'ptype':'inet:netmesg'},[

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -27,7 +27,7 @@ def getDataModel():
             ]),
 
             ('ou:member',{'ptype':'sepr','sep':'/','fields':'org,ou:org|person,ou:person'},[
-                ('start',{'ptype':'time:min','defval':0}),
+                ('start',{'ptype':'time:min'}),
                 ('title',{'ptype':'str:lwr','defval':'??'}),
             ]),
 


### PR DESCRIPTION
Having default values, at least for time:min, can have undesirable side effects. For example, if a value is not available during tufo creation, and is provided later during an update, the min value of 0 will persist and not apply the valid min value being provided.