### PR TITLE
Use the local logger.info instead of logging.info. 

### DIFF
--- a/synapse/lib/modules.py
+++ b/synapse/lib/modules.py
@@ -53,7 +53,7 @@ def load(name):
     '''
     smod = synmods.get(name)
     if smod == None:
-        logger.info('loading syn mod: %s' % (name,))
+        logger.info('loading syn mod: %s', name)
         smod = s_dyndeps.tryDynMod(name)
         synmods[name] = smod
         modlist.append( (name,smod) )

--- a/synapse/lib/modules.py
+++ b/synapse/lib/modules.py
@@ -53,7 +53,7 @@ def load(name):
     '''
     smod = synmods.get(name)
     if smod == None:
-        logging.info('loading syn mod: %s' % (name,))
+        logger.info('loading syn mod: %s' % (name,))
         smod = s_dyndeps.tryDynMod(name)
         synmods[name] = smod
         modlist.append( (name,smod) )


### PR DESCRIPTION
 This can cause issues down the line with other loggers down the line. Generally 3rd party libraries shouldn't cause issues with configuring other loggers.

```
$ python
Python 3.5.3 (default, Apr 10 2017, 19:09:11) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import logging
>>> from synapse import gene as s_gene  # causes model loading, executing the logging.info call.
>>> logging.basicConfig(level=logging.DEBUG,
...                         format='%(asctime)s [%(levelname)s] %(message)s [%(filename)s:%(funcName)s]')
>>> log = logging.getLogger(__name__)
>>> log.info('sup')  # No message!
>>> log.error('sup') # No formatting applied!
ERROR:__main__:sup
>>> exit()
```

vs expected behavior

```
$ python
Python 3.5.3 (default, Apr 10 2017, 19:09:11) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG,
...                         format='%(asctime)s [%(levelname)s] %(message)s [%(filename)s:%(funcName)s]')
>>> log = logging.getLogger(__name__)
>>> log.info('hi')
2017-04-20 12:13:42,052 [INFO] hi [<stdin>:<module>]
```