### PR TITLE
Fix redefined names

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -26,8 +26,10 @@ logger = logging.getLogger(__name__)
 
 megabyte = 1024000
 gigabyte = 1024000000
-
+terabyte = 1024000000000
 chunksize = megabyte * 10
+threedays = ((60 * 60) * 24) * 3
+axontag = 'class.synapse.axon.Axon'
 
 _fs_attrs = ('st_mode','st_nlink','st_size','st_atime','st_ctime','st_mtime')
 
@@ -90,13 +92,6 @@ class HashSet:
         '''
         return [ (name,item.hexdigest()) for (name,item) in self.hashes ]
 
-threedays = ((60 * 60) * 24) * 3
-
-megabyte = 1024000
-gigabyte = 1024000000
-terabyte = 1024000000000
-
-axontag = 'class.synapse.axon.Axon'
 
 class AxonHost(s_eventbus.EventBus):
     '''
@@ -215,7 +210,6 @@ class AxonHost(s_eventbus.EventBus):
         volinfo = s_thisplat.getVolInfo( self.datadir )
         return volinfo
 
-axontag = 'class.synapse.axon.Axon'
 
 class AxonMixin:
     '''

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2347,20 +2347,6 @@ class Cortex(EventBus,DataModel,Runtime,Configable):
         self.addTufoProp(form, prop, **info)
         return
 
-    def _tufosByIn(self, prop, valus, limit=None):
-        ret = []
-
-        for valu in valus:
-            res = self.getTufosByProp(prop, valu=valu, limit=limit)
-            ret.extend(res)
-
-            if limit != None:
-                limit -= len(res)
-                if limit <= 0:
-                    break
-
-        return ret
-
     def _stormOperStat(self, query, oper):
 
         name,prop = oper[1].get('args')

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -319,19 +319,6 @@ class CertDir:
 
         return capath
 
-    def getHostCaPath(self, name):
-        cert = self.getHostCert(name)
-        if cert == None:
-            return None
-
-        subj = cert.get_issuer()
-
-        capath = self.getPathJoin('cas','%s.crt' % subj.CN)
-        if not os.path.isfile(capath):
-            return None
-
-        return capath
-
     def isUserCert(self, name):
         crtpath = self.getPathJoin('users','%s.crt' % name)
         return os.path.isfile(crtpath)

--- a/synapse/lib/config.py
+++ b/synapse/lib/config.py
@@ -22,20 +22,6 @@ class Configable:
             self.setConfOpts(opts)
 
     def addConfDefs(self, defs):
-        for name,info in defs:
-            self.addConfDef(name,**info)
-
-    def addConfDef(self, name, **info):
-        self._conf_defs[name] = (name,dict(info))
-
-        defval = info.get('defval')
-        self._conf_opts.setdefault(name,defval)
-
-        asloc = info.get('asloc')
-        if asloc != None:
-            self.__dict__.setdefault(asloc,defval)
-
-    def addConfDefs(self, defs):
         '''
         Add configuration definitions for this object.
 
@@ -49,7 +35,17 @@ class Configable:
 
         '''
         for name,info in defs:
-            self._conf_defs[name] = (name,dict(info))
+            self.addConfDef(name,**info)
+
+    def addConfDef(self, name, **info):
+        self._conf_defs[name] = (name,dict(info))
+
+        defval = info.get('defval')
+        self._conf_opts.setdefault(name,defval)
+
+        asloc = info.get('asloc')
+        if asloc != None:
+            self.__dict__.setdefault(asloc,defval)
 
     def reqConfOk(self, opts):
         '''

--- a/synapse/tests/test_config.py
+++ b/synapse/tests/test_config.py
@@ -16,6 +16,9 @@ class ConfTest(SynTest):
 
         with s_config.Config(defs=defs) as conf:
 
+            self.eq(conf.getConfOpt('enabled'), 0)
+            self.eq(conf.getConfOpt('fooval'), 99)
+
             conf.onConfOptSet('enabled',callback)
 
             conf.setConfOpt('enabled','true')

--- a/synapse/tests/test_lib_cli.py
+++ b/synapse/tests/test_lib_cli.py
@@ -57,21 +57,6 @@ class CliTest(SynTest):
             self.eq( opts.get('bar'), True )
             self.eq( opts.get('haha'), 'hoho')
 
-    def test_cli_opts_flag(self):
-        with s_cli.Cli(None) as cli:
-
-            quit = cli.getCmdByName('quit')
-
-            quit._cmd_syntax = (
-                ('--bar',{}),
-                ('haha',{'type':'valu'}),
-            )
-
-            opts = quit.getCmdOpts('quit --bar hoho')
-
-            self.eq( opts.get('bar'), True )
-            self.eq( opts.get('haha'), 'hoho')
-
     def test_cli_opts_list(self):
 
         with s_cli.Cli(None) as cli:

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -29,14 +29,6 @@ class InetModelTest(SynTest):
             self.eq( t1[1].get('inet:mac'), 'ff:ee:dd:cc:bb:aa' )
             self.eq( t1[1].get('inet:mac:vendor'), 'woot' )
 
-    def test_model_inet_passwd(self):
-
-        with s_cortex.openurl('ram:///') as core:
-            t0 = core.formTufoByProp('inet:passwd','secret')
-            self.eq( t0[1].get('inet:passwd:md5'), '5ebe2294ecd0e0f08eab7690d2a6ee69' )
-            self.eq( t0[1].get('inet:passwd:sha1'), 'e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4' )
-            self.eq( t0[1].get('inet:passwd:sha256'), '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b' )
-
     def test_model_inet_ipv4(self):
 
         with s_cortex.openurl('ram:///') as core:

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -7,7 +7,7 @@ class PersonTest(SynTest):
 
         with s_cortex.openurl('ram:///') as core:
             dob = core.getTypeParse('time','19700101000000001')
-            node = core.formTufoByProp('ps:person', guid(), dob=dob, name='Kenshoto,Invisigoth')
+            node = core.formTufoByProp('ps:person', guid(), dob=dob[0], name='Kenshoto,Invisigoth')
             self.eq( node[1].get('ps:person:dob'), 1 )
             self.eq( node[1].get('ps:person:name'), 'kenshoto,invisigoth' )
             self.eq( node[1].get('ps:person:name:sur'), 'kenshoto' )

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -28,7 +28,7 @@ class PersonTest(SynTest):
             self.nn( core.getTufoByProp('ps:tokn','kenshoto') )
             self.nn( core.getTufoByProp('ps:tokn','invisigoth') )
 
-    def test_model_person(self):
+    def test_model_person_2(self):
 
         with s_cortex.openurl('ram:///') as core:
             node = core.formTufoByProp('ps:name','Kenshoto,Invisigoth')


### PR DESCRIPTION
There are a handful of redefined function names or values which are unnecessary.  This removes those and fixes the Config object functionality, allowing defval's to be retrieved via the getConfOpt method.