### PR TITLE
added from:unix:epoch cast conversion for types / ingest

### DIFF
--- a/synapse/lib/scrape.py
+++ b/synapse/lib/scrape.py
@@ -1,7 +1,6 @@
 import re
 
 import synapse.data as s_data
-import synapse.cortex as s_cortex
 import synapse.lib.datfile as s_datfile
 
 from synapse.common import *
@@ -43,6 +42,8 @@ def scrape(text, data=None):
 def getsync(text, tags=()):
 
     ret = []
+
+    import synapse.cortex as s_cortex
 
     core = s_cortex.openurl('ram://')
     with s_cortex.openurl('ram://'):

--- a/synapse/models/temporal.py
+++ b/synapse/models/temporal.py
@@ -157,3 +157,11 @@ class EpochType(DataType):
         dt = datetime.datetime(1970,1,1) + datetime.timedelta(seconds=int(valu))
         return '%d/%.2d/%.2d %.2d:%.2d:%.2d' % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
 
+def fromUnixEpoch(valu):
+    if s_compat.isstr(valu):
+        valu =int(valu,0)
+    return valu * 1000
+
+def addCoreOns(core):
+    core.addTypeCast('from:unix:epoch',fromUnixEpoch)
+

--- a/synapse/tests/test_model_temporal.py
+++ b/synapse/tests/test_model_temporal.py
@@ -25,3 +25,8 @@ class InetModelTest(SynTest):
             self.eq(tufo[1]['foo:latest'], 100)
             core.setTufoProp(tufo, 'latest', 1)
             self.eq(tufo[1]['foo:latest'], 100)
+
+    def test_model_time_from_unix(self):
+        with s_cortex.openurl('ram:///') as core:
+            self.eq( core.getTypeCast('from:unix:epoch', 100), 100000 )
+            self.eq( core.getTypeCast('from:unix:epoch', '0x20'), 32000 )


### PR DESCRIPTION
 a cast definition for the type library to convert unix epoch into our millisecond epoch