### PR TITLE
Epiphyte tag base2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Contents:
     synapse/devops
     synapse/api/synapse
     synapse/datamodel
+    synapse/storm
     contributing
 
 Indices and tables

--- a/docs/synapse/storm.rst
+++ b/docs/synapse/storm.rst
@@ -1,0 +1,4 @@
+Storm: Synapse Query Language
+#############################
+
+Placeholder for future Storm documentation.

--- a/scripts/migrate_add_tag_base.py
+++ b/scripts/migrate_add_tag_base.py
@@ -1,0 +1,24 @@
+# Cortex migration script for migrating a cortex without tag:base values set.
+import sys
+import synapse.cortex as s_cortex
+url = sys.argv[1]
+print('Opening URL {}'.format(url))
+core = s_cortex.openurl(url)
+print('Getting tags')
+nodes = core.eval('syn:tag -syn:tag:base')
+print('Got {} tags'.format(len(nodes)))
+i = 0
+# Order the nodes.
+nodes.sort(key=lambda x: x[1].get('syn:tag'))
+with core.getCoreXact() as xact:
+    for node in nodes:
+        tag = node[1].get('syn:tag')
+        if 'syn:tag:base' in node[1]:
+            print('Skipping: [{}]'.format(tag))
+            continue
+        parts = tag.split('.')
+        base = parts[-1]
+        print('Setting syn:tag:base for [{}] to [{}]'.format(tag, base))
+        core.setTufoProps(node, base=base)
+        i += 1
+print('Migrated {} tag nodes.'.format(i))

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -985,6 +985,7 @@ class Cortex(EventBus,DataModel,Runtime,Configable,CortexMixin,s_ingest.IngestAp
             props['syn:tag:up'] = '.'.join(tags[:-1])
 
         props['syn:tag:depth'] = tlen - 1
+        props['syn:tag:base'] = tags[-1]
 
     def setSaveFd(self, fd, load=True, fini=False):
         '''

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -138,6 +138,7 @@ class DataModel(s_types.TypeLib):
         self.addTufoProp('syn:tag','doc',defval='',ptype='str')
         self.addTufoProp('syn:tag','depth',defval=0,ptype='int')
         self.addTufoProp('syn:tag','title',defval='',ptype='str')
+        self.addTufoProp('syn:tag', 'base', ptype='str', ro=1)
 
         self.addType('syn:tagform', subof='comp', fields='tag,syn:tag|form,syn:prop', ex="(foo.bar,baz:faz)")
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -969,7 +969,7 @@ class Runtime(Configable):
 
         leaf = opts.get('leaf', True)
         tags = {tag for node in nodes for tag in s_tufo.tags(node, leaf=leaf)}
-        [query.add(tufo) for tag in tags for tufo in core.getTufosByProp('syn:tag', tag)]
+        [query.add(tufo) for tufo in core.getTufosBy('in', 'syn:tag', list(tags))]
 
     def _stormOperFromTags(self, query, oper):
         args = oper[1].get('args')

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -951,12 +951,8 @@ class Runtime(Configable):
 
         if not forms:
             forms = core.getModelDict().get('forms')
-        # Predictable looping
-        tagforms = sorted(self._iterPropTags(forms, tags))
-        # This allows us to do 'join' source tufos together.
 
-
-        for form, tag in tagforms:
+        for form, tag in self._iterPropTags(forms, tags):
             lqs = query.size()
             tufos = core.getTufosByTag(form, tag, limit=limt.get())
             [query.add(tufo) for tufo in tufos]
@@ -990,10 +986,8 @@ class Runtime(Configable):
         # TODO This is O(m*n).
         if not forms:
             forms = core.getModelDict().get('forms')
-        # Predictable looping
-        tagforms = sorted(self._iterPropTags(forms, tags))
 
-        for form, tag in tagforms:
+        for form, tag in self._iterPropTags(forms, tags):
             lqs = query.size()
             tufos = core.getTufosByTag(form, tag, limit=limt.get())
             [query.add(tufo) for tufo in tufos]

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -937,25 +937,24 @@ class Runtime(Configable):
     def _stormOperJoinTags(self, query, oper):
         args = oper[1].get('args')
         opts = dict(oper[1].get('kwlist'))
+        core = self.getStormCore()
 
-        nodes = query.data()
-
+        forms = {arg for arg in args}
         keep_nodes = opts.get('keep_nodes', False)
         limt = LimitHelp(opts.get('limit'))
 
-        forms = {arg for arg in args}
+        nodes = query.data()
+        if not keep_nodes:
+            query.clear()
 
         tags = {tag for node in nodes for tag in s_tufo.tags(node, leaf=True)}
-
-        core = self.getStormCore()
 
         if not forms:
             forms = core.getModelDict().get('forms')
         # Predictable looping
         tagforms = sorted(self._iterPropTags(forms, tags))
         # This allows us to do 'join' source tufos together.
-        if not keep_nodes:
-            query.clear()
+
 
         for form, tag in tagforms:
             lqs = query.size()

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -974,19 +974,18 @@ class Runtime(Configable):
 
     def _stormOperToTags(self, query, oper):
         opts = dict(oper[1].get('kwlist'))
-        nodes = query.data()
+        nodes = query.take()
         core = self.getStormCore()
 
         leaf = opts.get('leaf', True)
         tags = {tag for node in nodes for tag in s_tufo.tags(node, leaf=leaf)}
-        query.clear()
         [query.add(tufo) for tag in tags for tufo in core.getTufosByProp('syn:tag', tag)]
 
     def _stormOperFromTags(self, query, oper):
         args = oper[1].get('args')
         opts = dict(oper[1].get('kwlist'))
 
-        nodes = query.data()
+        nodes = query.take()
 
         forms = {arg for arg in args}
         limt = LimitHelp(opts.get('limit'))
@@ -1000,7 +999,6 @@ class Runtime(Configable):
         # Predictable looping
         tagforms = sorted(itertools.product(tags, forms))
 
-        query.clear()
         for tag, form in tagforms:
             lqs = query.size()
             tufos = core.getTufosByTag(form, tag, limit=limt.get())

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -937,10 +937,9 @@ class Runtime(Configable):
 
         forms = {arg for arg in args}
 
-        bases = {tag.split('.')[-1] for node in nodes for tag in s_tufo.tags(node, leaf=True)}
+        tags = {tag for node in nodes for tag in s_tufo.tags(node, leaf=True)}
 
         core = self.getStormCore()
-        tags = {tufo[1].get('syn:tag') for base in bases for tufo in core.getTufosByProp('syn:tag:base', base)}
 
         if forms:
             tagforms = [(tag, tufo[1].get('syn:tagform:form')) for tag in tags
@@ -965,12 +964,14 @@ class Runtime(Configable):
                     break
 
     def _stormOperToTags(self, query, oper):
+        opts = dict(oper[1].get('kwlist'))
         nodes = query.data()
         core = self.getStormCore()
 
-        bases = {tag.split('.')[-1] for node in nodes for tag in s_tufo.tags(node, leaf=True)}
+        leaf = opts.get('leaf', True)
+        tags = {tag for node in nodes for tag in s_tufo.tags(node, leaf=leaf)}
         query.clear()
-        [query.add(tufo) for base in bases for tufo in core.getTufosByProp('syn:tag:base', base)]
+        [query.add(tufo) for tag in tags for tufo in core.getTufosByProp('syn:tag', tag)]
 
     def _stormOperFromTags(self, query, oper):
         args = oper[1].get('args')
@@ -981,10 +982,10 @@ class Runtime(Configable):
         forms = {arg for arg in args}
         limt = LimitHelp(opts.get('limit'))
 
-        bases = {node[1].get('syn:tag:base') for node in nodes if node[1].get('tufo:form') == 'syn:tag'}
+        tags = {node[1].get('syn:tag') for node in nodes if node[1].get('tufo:form') == 'syn:tag'}
 
         core = self.getStormCore()
-        tags = {tufo[1].get('syn:tag') for base in bases for tufo in core.getTufosByProp('syn:tag:base', base)}
+        # TODO This is O(m*n).
         if not forms:
             forms = {tufo[1].get('syn:type') for tufo in core.getTufosByProp('tufo:form', 'syn:type')}
         # Predictable looping

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -99,6 +99,15 @@ class Query:
             'data':list(data),
         }
 
+    def __len__(self):
+        return len(self.results['data'])
+
+    def size(self):
+        '''
+        Get the number of tufos currently in the query.
+        '''
+        return len(self)
+
     def log(self, **info):
         '''
         Log execution metadata for the current oper.
@@ -954,11 +963,11 @@ class Runtime(Configable):
             query.clear()
 
         for tag, form in tagforms:
-            lqs = len(query.results.get('data'))
+            lqs = query.size()
             tufos = core.getTufosByTag(form, tag, limit=limt.get())
             [query.add(tufo) for tufo in tufos]
             if tufos:
-                lq = len(query.results.get('data'))
+                lq = query.size()
                 nnewnodes = lq - lqs
                 if limt.dec(nnewnodes):
                     break
@@ -993,11 +1002,11 @@ class Runtime(Configable):
 
         query.clear()
         for tag, form in tagforms:
-            lqs = len(query.results.get('data'))
+            lqs = query.size()
             tufos = core.getTufosByTag(form, tag, limit=limt.get())
             [query.add(tufo) for tufo in tufos]
             if tufos:
-                lq = len(query.results.get('data'))
+                lq = query.size()
                 nnewnodes = lq - lqs
                 if limt.dec(nnewnodes):
                     break

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -645,6 +645,10 @@ class CortexTest(SynTest):
         core.addTufoTag(hehe,'lulz.rofl.zebr')
         wait.wait()
 
+        wait = self.getTestWait(core, 1, 'tufo:tag:add')
+        core.addTufoTag(hehe, 'duck.quack.rofl')
+        wait.wait()
+
         lulz = core.getTufoByProp('syn:tag','lulz')
 
         self.assertIsNone( lulz[1].get('syn:tag:up') )

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -651,6 +651,7 @@ class CortexTest(SynTest):
         self.assertEqual( lulz[1].get('syn:tag:doc'), '')
         self.assertEqual( lulz[1].get('syn:tag:title'), '')
         self.assertEqual( lulz[1].get('syn:tag:depth'), 0 )
+        self.eq(lulz[1].get('syn:tag:base'), 'lulz')
 
         rofl = core.getTufoByProp('syn:tag','lulz.rofl')
 
@@ -659,6 +660,10 @@ class CortexTest(SynTest):
         self.assertEqual( rofl[1].get('syn:tag:up'), 'lulz' )
 
         self.assertEqual( rofl[1].get('syn:tag:depth'), 1 )
+        self.eq(rofl[1].get('syn:tag:base'), 'rofl')
+
+        tags = core.getTufosByProp('syn:tag:base', 'rofl')
+        self.eq(len(tags), 2)
 
         wait = self.getTestWait(core, 2, 'tufo:tag:del')
         core.delTufoTag(hehe,'lulz.rofl')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -374,6 +374,9 @@ class StormTest(SynTest):
             nodes = core.eval('inet:dns:a fromtags()')
             self.eq(len(nodes), 0)
 
+            nodes = core.eval('syn:tag:base=bar fromtags()')
+            self.eq(len(nodes), 3)
+
 class LimitTest(SynTest):
 
     def test_limit_default(self):

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1,4 +1,5 @@
 import synapse.cortex as s_cortex
+import synapse.lib.storm as s_storm
 import synapse.cores.common as s_common
 
 from synapse.tests.common import *
@@ -237,3 +238,152 @@ class StormTest(SynTest):
 
             nodes = core.eval('inet:dns:a +#loc.milkyway.galactic**.tx')
             self.eq(len(nodes), 1)
+
+    def test_storm_tag_jointag(self):
+        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+            node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
+            node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
+            node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
+            node4 = core.formTufoByProp('inet:netuser', 'clowntown.link/pennywise')
+
+            core.addTufoTags(node1, ['aka.bar.baz',
+                                     'aka.duck.quack.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.ca.san_francisco'])
+            core.addTufoTags(node2, ['aka.duck.baz',
+                                     'aka.duck.quack.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.va.san_francisco'])
+            core.addTufoTags(node3, ['aka.bar.knight',
+                                     'aka.duck.sound.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.nv.perfection'])
+            core.addTufoTags(node4, ['aka.bar.knightdark',
+                                     'aka.duck.sound.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
+
+            nodes = core.eval('inet:dns:a jointags()')
+            self.eq(len(nodes), 4)
+
+            nodes = core.eval('inet:dns:a jointags(inet:url, limit=2)')
+            self.eq(len(nodes), 1)
+            self.eq(nodes[0][1].get('tufo:form'), 'inet:url')
+
+            nodes = core.eval('inet:dns:a jointags(ps:tokn, inet:url)')
+            self.eq(len(nodes), 1)
+            self.eq(nodes[0][1].get('tufo:form'), 'inet:url')
+
+            nodes = core.eval('inet:dns:a jointags(ps:tokn)')
+            self.eq(len(nodes), 0)
+
+            nodes = core.eval('inet:dns:a jointags(ps:tokn, keep_nodes=True)')
+            self.eq(len(nodes), 1)
+
+            nodes = core.eval('inet:dns:a jointags(limit=2)')
+            self.eq(len(nodes), 2)
+
+    def test_storm_tag_totag(self):
+        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+            node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
+            node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
+            node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
+            node4 = core.formTufoByProp('inet:netuser', 'clowntown.link/pennywise')
+
+            core.addTufoTags(node1, ['aka.bar.baz',
+                                     'aka.duck.quack.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.ca.san_francisco'])
+            core.addTufoTags(node2, ['aka.duck.baz',
+                                     'aka.duck.quack.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.va.san_francisco'])
+            core.addTufoTags(node3, ['aka.bar.knight',
+                                     'aka.duck.sound.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.nv.perfection'])
+            core.addTufoTags(node4, ['aka.bar.knightdark',
+                                     'aka.duck.sound.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
+
+            nodes = core.eval('inet:dns:a totags()')
+            self.eq(len(nodes), 6)
+
+            nodes = core.eval('inet:url totags()')
+            self.eq(len(nodes), 5)
+
+            nodes = core.eval('ps:tokn totags()')
+            self.eq(len(nodes), 0)
+
+    def test_storm_tag_fromtag(self):
+        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+            node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
+            node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
+            node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
+            node4 = core.formTufoByProp('inet:netuser', 'clowntown.link/pennywise')
+            core.addTufoTags(node1, ['aka.bar.baz',
+                                     'aka.duck.quack.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.ca.san_francisco'])
+            core.addTufoTags(node2, ['aka.duck.baz',
+                                     'aka.duck.quack.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.va.san_francisco'])
+            core.addTufoTags(node3, ['aka.bar.knight',
+                                     'aka.duck.sound.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.earth.us.nv.perfection'])
+            core.addTufoTags(node4, ['aka.bar.knightdark',
+                                     'aka.duck.sound.loud',
+                                     'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
+
+            nodes = core.eval('syn:tag=aka.bar.baz fromtags()')
+            self.eq(len(nodes), 2)
+
+            nodes = core.eval('syn:tag=aka.bar fromtags()')
+            self.eq(len(nodes), 3)
+
+            nodes = core.eval('syn:tag=aka.duck fromtags()')
+            self.eq(len(nodes), 4)
+
+            nodes = core.eval('syn:tag=aka.bar.baz fromtags(inet:dns:a)')
+            self.eq(len(nodes), 1)
+
+            nodes = core.eval('syn:tag=aka.bar.baz fromtags(inet:dns:a, ps:tokn)')
+            self.eq(len(nodes), 1)
+
+            nodes = core.eval('syn:tag=aka.bar.baz fromtags(ps:tokn)')
+            self.eq(len(nodes), 0)
+
+            nodes = core.eval('syn:tag=spam.and.eggs fromtags()')
+            self.eq(len(nodes), 0)
+
+            nodes = core.eval('syn:tag=aka.duck fromtags(limit=2)')
+            self.eq(len(nodes), 2)
+
+class LimitTest(SynTest):
+
+    def test_limit_default(self):
+        # LimitHelper would normally be used with the kwlist arg limit,
+        # which if not specified would default to None when the .get()
+        # is performed on the kwlist dictionary.
+        limt = s_storm.LimitHelp(None)
+        self.eq(limt.reached(), False)
+        self.eq(limt.get(), None)
+        self.eq(limt.dec(), False)
+        self.eq(limt.dec(100), False)
+
+    def test_limit_behavior(self):
+        n = 4
+        limt = s_storm.LimitHelp(n)
+        self.eq(limt.get(), 4)
+        self.eq(limt.reached(), False)
+
+        self.eq(limt.dec(), False)
+        self.eq(limt.get(), 3)
+        self.eq(limt.dec(4), True)
+
+    def test_limit_behavior_negatives(self):
+        n = 4
+        limt = s_storm.LimitHelp(n)
+        self.eq(limt.dec(0), False)
+        self.eq(limt.get(), 4)
+
+        self.eq(limt.dec(-1), False)
+        self.eq(limt.get(), 4)
+
+        self.eq(limt.dec(4), True)
+        self.eq(limt.get(), 0)
+        self.eq(limt.reached(), True)
+        self.eq(limt.dec(-1), True)
+        self.eq(limt.get(), 0)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -260,24 +260,27 @@ class StormTest(SynTest):
                                      'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
 
             nodes = core.eval('inet:dns:a jointags()')
-            self.eq(len(nodes), 4)
+            self.eq(len(nodes), 2)
 
-            nodes = core.eval('inet:dns:a jointags(inet:url, limit=2)')
+            nodes = core.eval('inet:dns:a jointags(inet:fqdn, limit=2)')
             self.eq(len(nodes), 1)
-            self.eq(nodes[0][1].get('tufo:form'), 'inet:url')
+            self.eq(nodes[0][1].get('tufo:form'), 'inet:fqdn')
 
-            nodes = core.eval('inet:dns:a jointags(ps:tokn, inet:url)')
+            nodes = core.eval('inet:dns:a jointags(ps:tokn, inet:fqdn)')
             self.eq(len(nodes), 1)
-            self.eq(nodes[0][1].get('tufo:form'), 'inet:url')
+            self.eq(nodes[0][1].get('tufo:form'), 'inet:fqdn')
 
             nodes = core.eval('inet:dns:a jointags(ps:tokn)')
             self.eq(len(nodes), 0)
 
-            nodes = core.eval('inet:dns:a jointags(ps:tokn, keep_nodes=True)')
+            nodes = core.eval('inet:dns:a jointags(ps:tokn, keep_nodes=1)')
             self.eq(len(nodes), 1)
 
-            nodes = core.eval('inet:dns:a jointags(limit=2)')
+            nodes = core.eval('inet:dns:a jointags(inet:fqdn, keep_nodes=1)')
             self.eq(len(nodes), 2)
+
+            nodes = core.eval('inet:dns:a jointags(limit=1)')
+            self.eq(len(nodes), 1)
 
     def test_storm_tag_totag(self):
         with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
@@ -285,6 +288,7 @@ class StormTest(SynTest):
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
             node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
             node4 = core.formTufoByProp('inet:netuser', 'clowntown.link/pennywise')
+            node5 = core.formTufoByProp('geo:loc', 'derry')
 
             core.addTufoTags(node1, ['aka.bar.baz',
                                      'aka.duck.quack.loud',
@@ -300,13 +304,28 @@ class StormTest(SynTest):
                                      'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
 
             nodes = core.eval('inet:dns:a totags()')
-            self.eq(len(nodes), 6)
+            self.eq(len(nodes), 3)
 
-            nodes = core.eval('inet:url totags()')
+            nodes = core.eval('inet:dns:a totags(leaf=0)')
+            self.eq(len(nodes), 14)
+
+            nodes = core.eval('#aka.duck.quack.loud totags()')
             self.eq(len(nodes), 5)
+
+            nodes = core.eval('#aka.duck totags()')
+            self.eq(len(nodes), 10)
 
             nodes = core.eval('ps:tokn totags()')
             self.eq(len(nodes), 0)
+
+            # Tag input
+            nodes = core.eval('syn:tag=aktoa.bar.baz totags()')
+            self.eq(len(nodes), 0)
+
+            # Tagless node input
+            nodes = core.eval('geo:loc=derry totags()')
+            self.eq(len(nodes), 0)
+
 
     def test_storm_tag_fromtag(self):
         with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
@@ -328,7 +347,7 @@ class StormTest(SynTest):
                                      'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
 
             nodes = core.eval('syn:tag=aka.bar.baz fromtags()')
-            self.eq(len(nodes), 2)
+            self.eq(len(nodes), 1)
 
             nodes = core.eval('syn:tag=aka.bar fromtags()')
             self.eq(len(nodes), 3)
@@ -350,6 +369,10 @@ class StormTest(SynTest):
 
             nodes = core.eval('syn:tag=aka.duck fromtags(limit=2)')
             self.eq(len(nodes), 2)
+
+            # Non-tag input
+            nodes = core.eval('inet:dns:a fromtags()')
+            self.eq(len(nodes), 0)
 
 class LimitTest(SynTest):
 


### PR DESCRIPTION
Add syn:tag:base property to the syn:tag model.
Add totags(), fromtags() and jointags() operators to the storm query language.
totags() pivots from nodes to any syn:tag nodes based on tags on the input nodes.  This may be a complete set of tags if leaf=0 is specified.
fromtags() pivots from syn:tag nodes to any tufos with those nodes.  This can be limited to specific forms (provided as args) or by a limited number of results.
jointags() pivots from nodes to any other nodes which share syn:tag properties from tagged nodes in the input.  The input set of nodes may be retained by setting the keep_nodes argument.  This pivot can be limited to specific forms (provided as args) or by limiting the number of results.