### PR TITLE
Epiphyte remcycle updates

### DIFF
--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -73,7 +73,7 @@ class Cache(EventBus):
         finally:
             if not self.isfini and self.maxtime != None:
                 ival = self.maxtime / 10.0
-                self.sched.insec(ival, self._checkCacheTimes )
+                self.schevt = self.sched.insec(ival, self._checkCacheTimes )
 
     def clear(self):
         '''
@@ -174,7 +174,7 @@ class Cache(EventBus):
         return len(self.cache)
 
     def __iter__(self):
-        return list( self.cache.items() )
+        return iter(list(self.cache.items()))
 
     def __contains__(self, item):
         return item in self.cache

--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -176,6 +176,9 @@ class Cache(EventBus):
     def __iter__(self):
         return list( self.cache.items() )
 
+    def __contains__(self, item):
+        return item in self.cache
+
     def _onCacheFini(self):
         for key in self.keys():
             self.pop(key)
@@ -241,6 +244,9 @@ class FixedCache(EventBus):
 
     def __len__(self):
         return len(self.fifo)
+
+    def __contains__(self, item):
+        return item in self.cache
 
 class TufoCache(Cache):
 

--- a/synapse/lib/remcycle.py
+++ b/synapse/lib/remcycle.py
@@ -29,6 +29,7 @@ import synapse.axon as s_axon
 import synapse.async as s_async
 import synapse.compat as s_compat
 import synapse.cortex as s_cortex
+import synapse.lib.cache as s_cache
 import synapse.lib.ingest as s_ingest
 import synapse.lib.config as s_config
 import synapse.lib.threads as s_threads
@@ -40,13 +41,21 @@ logger = logging.getLogger(__name__)
 MIN_WORKER_THREADS = 'web_min_worker_threads'
 MAX_WORKER_THREADS = 'web_max_worker_threads'
 MAX_SPOOL_FILESIZE = 'web_max_spool_file_size'
+CACHE_ENABLED = 'web_result_cache_enable'
+CACHE_TIMEOUT = 'web_result_cache_timeout'
 HYPNOS_BASE_DEFS = (
     (MIN_WORKER_THREADS, {'type': 'int', 'doc': 'Minimum number of worker threads to spawn', 'defval': 8}),
     (MAX_WORKER_THREADS, {'type': 'int', 'doc': 'Maximum number of worker threads to spawn', 'defval': 64}),
     (MAX_SPOOL_FILESIZE, {'type': 'int',
                           'doc': 'Maximum spoolfile size, in bytes, to use for storing responses associated with '
                                  'APIs that have ingest definitions.',
-                          'defval': s_axon.megabyte * 2})
+                          'defval': s_axon.megabyte * 2}),
+    (CACHE_ENABLED, {'type': 'bool',
+                     'doc': 'Enable caching of job results for a period of time, retrievable by jobid.',
+                     'defval': False}),
+    (CACHE_TIMEOUT, {'type': 'int',
+                     'doc': 'Timeout value, in seconds, that the results will persist in the cache.',
+                     'defval': 300})
 )
 
 class Nyx(object):
@@ -283,6 +292,8 @@ class Hypnos(s_config.Config):
                 * ioloop: Tornado ioloop used by the IO thread. This would normally
                           be left unset, and an ioloop will be created for the io
                           thread. This is provided as a helper for testing.
+                * content_type_skip: A list of content-type values which will not have
+                                     any attempts to decode data done on them.
 
         Args:
             core (synapse.cores.common.Cortex): A cortex used to store ingest data. By default,
@@ -328,8 +339,18 @@ class Hypnos(s_config.Config):
         self._web_api_ingests = collections.defaultdict(list)
         self._web_api_gest_opens = {}
 
+        self.web_cache = s_cache.Cache()
+        self.web_cache_enabled = self.getConfOpt(CACHE_ENABLED)
+        if self.web_cache_enabled:
+            self.webCacheEnable()
         # Setup Fini handlers
         self.onfini(self._onHypoFini)
+
+        # List of content-type headers to skip processing on
+        self._web_content_type_skip = set([])
+        self.webContentTypeSkipAdd('application/octet-stream')
+        for ct in kwargs.get('content_type_skip', []):
+            self.webContentTypeSkipAdd(ct)
 
     def __repr__(self):
         d = {'name': self.__class__.__name__,
@@ -352,6 +373,8 @@ class Hypnos(s_config.Config):
         self.web_boss.fini()
         # Stop the consuming pool
         self.web_pool.fini()
+        # Stop the web cache
+        self.web_cache.fini()
 
     def getWebDescription(self):
         '''
@@ -361,8 +384,6 @@ class Hypnos(s_config.Config):
         Returns:
             dict: Dictionary describing the regsistered namespace API data.
         '''
-        # Make copies of object so the returned multable dictionary does not
-        # affect the
         d = {}
         for ns in self._web_namespaces:
             nsd = {'doc': self._web_docs[ns]}
@@ -666,8 +687,7 @@ class Hypnos(s_config.Config):
                           'effective_url': resp.effective_url, })
         return resp_dict
 
-    @staticmethod
-    def _webProcessResponseFlatten(resp_dict):
+    def _webProcessResponseFlatten(self, resp_dict):
         '''
         Process a flattened HTTP response to extract as much meaningful data
         out of it as possible.
@@ -691,9 +711,9 @@ class Hypnos(s_config.Config):
             return
         # Try to do a clean decoding of the provided data if possible.
         ct = resp_dict.get('headers', {}).get('Content-Type', 'text/plain')
-        if ct.lower() == 'application/octet-stream':
-            return
         ct_type, ct_params = cgi.parse_header(ct)
+        if ct_type.lower() in self._web_content_type_skip:
+            return
         charset = ct_params.get('charset', 'utf-8').lower()
         try:
             resp_dict['data'] = resp_dict.get('data').decode(charset)
@@ -944,3 +964,110 @@ class Hypnos(s_config.Config):
 
         '''
         return self.web_boss.wait(jid, timeout=timeout)
+
+    def webContentTypeSkipAdd(self, content_type):
+        '''
+        Add a content-type value to be skipped from any sort of decoding
+        attempts.
+
+        Args:
+            content_type (str): Content-type value to skip.
+             
+        Returns:
+            None: Returns None.
+        '''
+        self._web_content_type_skip.add(content_type)
+
+    def webContentTypeSkipDel(self, content_type):
+        '''
+        Removes a content-type value from the set of values to be skipped 
+        from any sort of decoding attempts.
+
+        Args:
+            content_type (str): Content-type value to remove.
+
+        Returns:
+            None: Returns None.
+        '''
+        if content_type in self._web_content_type_skip:
+            self._web_content_type_skip.remove(content_type)
+
+    def _cacheRequestResults(self, event):
+        '''
+        Cache the request response/errors.
+
+        Ideally, the cached results will be msgpack serializable.  If the
+        api_args provided were not msgpack serializable, attempts to get
+        cached results over Telepath may fail.
+
+        Args:
+            event ((str, dict)): job:fini event.
+
+        Returns:
+            None: Returns None.
+        '''
+        jid, job = event[1].get('job')
+        task_kwargs = job['task'][2]  # type: dict
+        # Cache items which are likely going to
+        resp = task_kwargs.get('resp', {}).copy()
+        if 'ingdata' in resp:
+            resp.pop('ingdata', None)
+            # Convert the spooled temporary file back into a bytes object
+            data = resp.pop('data')
+            data.seek(0)
+            data = data.read()
+            resp['data'] = data
+        d = {'web_api_name': task_kwargs.get('web_api_name'),
+             'resp': resp,
+             'api_args': task_kwargs.get('api_args', {})}
+        if 'err' in job:
+            d['err'] = job['err']
+            d['errmsg'] = job['errmsg']
+            d['errfile'] = job['errfile']
+            d['errline'] = job['errline']
+        self.web_cache.put(jid, d)
+
+    def getWebCachedReponse(self, jid):
+        '''
+        Retrieve the cached web response for a given job id.
+        
+        Args:
+            jid (str): Job ID to check. 
+
+        Returns:
+
+        '''
+        if not self.web_cache_enabled:
+            logger.warning('Cached response requested but cache not enabled.')
+        return self.web_cache.get(jid)
+
+    def delWebCachedResponse(self, jid):
+        '''
+        
+        Args:
+            jid: 
+
+        Returns:
+
+        '''
+        if not self.web_cache_enabled:
+            logger.warning('Cache deletion requested but cache not enabled.')
+        return self.web_cache.pop(jid)
+
+    def webCacheEnable(self):
+        '''
+        Enable caching of results from fireWebApi.
+        '''
+        self.web_cache_enabled = True
+        self.setConfOpt(CACHE_ENABLED, True)
+        self.web_cache.setMaxTime(self.getConfOpt(CACHE_TIMEOUT))
+        self.web_boss.on('job:fini', self._cacheRequestResults)
+
+    def webCacheDisable(self):
+        '''
+        Disable caching of results from fireWebApi and clear all data from the cache.
+        '''
+        self.web_boss.off('job:fini', self._cacheRequestResults)
+        self.web_cache.clear()
+        self.setConfOpt(CACHE_ENABLED, False)
+        self.web_cache_enabled = False

--- a/synapse/tests/test_cache.py
+++ b/synapse/tests/test_cache.py
@@ -47,7 +47,9 @@ class CacheTest(SynTest):
             return 10
 
         c.setOnMiss( onmiss )
+        self.false('woot' in c)
         self.assertEqual( c.get('woot'), 10 )
+        self.true('woot' in c)
 
     def test_cache_tufo(self):
         core = s_cortex.openurl('ram:///')
@@ -121,7 +123,9 @@ class CacheTest(SynTest):
             return x + 20
 
         cache = s_cache.FixedCache(maxsize=3, onmiss=getfoo)
+        self.false(30 in cache)
         self.eq( cache.get(30), 50 )
+        self.true(30 in cache)
         self.eq( cache.get(30), 50 )
         self.eq( cache.get(30), 50 )
         self.eq( cache.get(30), 50 )

--- a/synapse/tests/test_cache.py
+++ b/synapse/tests/test_cache.py
@@ -114,6 +114,10 @@ class CacheTest(SynTest):
         cache = s_cache.KeyCache(getfoo)
 
         self.assertEqual( cache[10], 'asdf' )
+        # Ensure put/pop methods work.
+        cache.put(20, 'wasd')
+        self.eq(cache[20], 'wasd')
+        self.eq(cache.pop(20), 'wasd')
 
     def test_cache_fixed(self):
 
@@ -125,6 +129,7 @@ class CacheTest(SynTest):
         cache = s_cache.FixedCache(maxsize=3, onmiss=getfoo)
         self.false(30 in cache)
         self.eq( cache.get(30), 50 )
+        self.eq(len(cache), 1)
         self.true(30 in cache)
         self.eq( cache.get(30), 50 )
         self.eq( cache.get(30), 50 )
@@ -147,3 +152,71 @@ class CacheTest(SynTest):
         self.eq( cache.get(30), 50 )
 
         self.eq( data[30], 3 )
+
+    def test_cache_magic(self):
+        c = s_cache.Cache()
+        c.put(1, 'a')
+        c.put(2, 'b')
+        keys = set([])
+        values = set([])
+
+        self.eq(len(c), 2)
+
+        cvs = c.values()
+        cvs.sort()
+        self.eq(cvs, ['a', 'b'])
+
+        cks = c.keys()
+        cks.sort()
+        self.eq(cks, [1, 2])
+
+        for k, v in c:
+            keys.add(k)
+            values.add(v)
+
+        self.eq(keys, {1, 2})
+        self.eq(values, {'a', 'b'})
+
+    def test_cache_clearing(self):
+        c = s_cache.Cache()
+
+        d = {}
+        def flush(event):
+            key = event[1].get('key')
+            d[key] = c.get(key)
+
+        c.on('cache:flush', flush)
+        c.put(1, 'a')
+        c.put(2, 'b')
+        self.eq(len(c), 2)
+
+        c.flush(1)
+        self.true(1 in d)
+        self.eq(d, {1: 'a'})
+        self.eq(len(c), 2)  # A straight flush doesn't remove the key.
+
+        c.clear()
+        self.eq(len(c), 0)
+
+    def test_cache_fini(self):
+        c = s_cache.Cache(maxtime=0.1)
+        c.put(1, 'a')
+        self.nn(c.schevt)
+        self.nn(c.schevt[1])
+        c.fini()
+        self.none(c.schevt[1])
+        self.eq(len(c), 0)
+
+    def test_cache_defval(self):
+        # Ensure default behaviors are covered.
+        c = s_cache.Cache()
+        r = c.get('foo')
+        self.none(r)
+
+        fc = s_cache.FixedCache(maxsize=10)
+        fr = fc.get('foo')
+        self.none(fr)
+
+        od = s_cache.OnDem()
+        with self.raises(KeyError) as cm:
+            od.get('foo')

--- a/synapse/tests/test_lib_remcycle.py
+++ b/synapse/tests/test_lib_remcycle.py
@@ -797,3 +797,116 @@ class HypnosTest(SynTest, AsyncTestCase):
         self.eq(len(tufos), 1)
         ip = s_inet.ipv4str(tufos[0][1].get('inet:ipv4'))
         self.true(len(ip) >= 7)
+
+    def test_hypnos_content_type_skips(self):
+        self.skipIfNoInternet()
+        gconf = get_ipify_global_config()
+        with s_remcycle.Hypnos(opts={s_remcycle.MIN_WORKER_THREADS: 1},
+                               ioloop=self.io_loop) as hypo_obj:
+            hypo_obj.addWebConfig(config=gconf)
+
+            self.true('ipify:jsonip' in hypo_obj._web_apis)
+
+            data = {}
+
+            def ondone(job_tufo):
+                _jid, jobd = job_tufo
+                resp_data = jobd.get('task')[2].get('resp').get('data')
+                data[_jid] = type(resp_data)
+
+            jid1 = hypo_obj.fireWebApi('ipify:jsonip',
+                                       ondone=ondone)
+            hypo_obj.web_boss.wait(jid1)
+
+            hypo_obj.webContentTypeSkipAdd('application/json')
+            jid2 = hypo_obj.fireWebApi('ipify:jsonip',
+                                       ondone=ondone)
+            hypo_obj.web_boss.wait(jid2)
+
+            hypo_obj.webContentTypeSkipDel('application/json')
+            jid3 = hypo_obj.fireWebApi('ipify:jsonip',
+                                       ondone=ondone)
+            hypo_obj.web_boss.wait(jid3)
+
+            self.true(jid1 in data)
+            self.eq(data[jid1], type({}))
+            self.true(jid2 in data)
+            self.eq(data[jid2], type(b''))
+            self.true(jid3 in data)
+            self.eq(data[jid3], type({}))
+
+    def test_hypnos_cache_job(self):
+        # Ensure that job results are available via cache when caching is enabled.
+        self.skipIfNoInternet()
+        gconf = get_ipify_global_config()
+        with s_remcycle.Hypnos(opts={s_remcycle.MIN_WORKER_THREADS: 2,
+                                     s_remcycle.CACHE_ENABLED: True},
+                               ioloop=self.io_loop) as hypo_obj:  # type: s_remcycle.Hypnos
+            hypo_obj.addWebConfig(config=gconf)
+
+            jid1 = hypo_obj.fireWebApi('ipify:jsonip')
+            self.false(jid1 in hypo_obj.web_cache)
+            hypo_obj.web_boss.wait(jid=jid1)
+            time.sleep(0.01)
+            self.true(jid1 in hypo_obj.web_cache)
+            cached_data = hypo_obj.getWebCachedReponse(jid=jid1)
+            self.true(isinstance(cached_data, dict))
+            resp = cached_data.get('resp')
+            self.true('data' in resp)
+            data = resp.get('data')
+            # This is expected data from the API endpoint.
+            self.true('ip' in data)
+            cached_data2 = hypo_obj.delWebCachedResponse(jid=jid1)
+            self.eq(cached_data, cached_data2)
+            self.false(jid1 in hypo_obj.web_cache)
+            # Disable the cache and ensure the responses are cleared and no longer cached.
+            hypo_obj.webCacheDisable()
+            self.false(jid1 in hypo_obj.web_cache)
+            jid2 = hypo_obj.fireWebApi('ipify:jsonip')
+            hypo_obj.web_boss.wait(jid=jid1)
+            time.sleep(0.01)
+            self.false(jid2 in hypo_obj.web_cache)
+            cached_data3 = hypo_obj.delWebCachedResponse(jid=jid2)
+            self.none(cached_data3)
+
+    def test_hypnos_cache_with_ingest(self):
+        # Ensure that the cached data from a result with a ingest definition is msgpack serializable.
+        self.skipIfNoInternet()
+        gconf = get_ipify_ingest_global_config()
+        with s_remcycle.Hypnos(opts={s_remcycle.MIN_WORKER_THREADS: 1,
+                                     s_remcycle.CACHE_ENABLED: True},
+                               ioloop=self.io_loop) as hypo_obj:  # type: s_remcycle.Hypnos
+            hypo_obj.addWebConfig(config=gconf)
+
+            jid = hypo_obj.fireWebApi(name='ipify:jsonip')
+            job = hypo_obj.web_boss.job(jid=jid)
+            hypo_obj.web_boss.wait(jid)
+            time.sleep(0.01)
+            cached_data = hypo_obj.getWebCachedReponse(jid=jid)
+            self.nn(cached_data)
+            # Ensure the cached data can be msgpacked as needed.
+            buf = msgenpack(cached_data)
+            self.true(isinstance(buf, bytes))
+            # Ensure that the existing job tufo is untouched when caching.
+            self.true('ingdata' in job[1].get('task')[2].get('resp'))
+
+    def test_hypnos_cached_failure(self):
+        # Test a simple failure case
+        self.skipIfNoInternet()
+        gconf = get_bad_vertex_global_config()
+        with s_remcycle.Hypnos(opts={s_remcycle.MIN_WORKER_THREADS: 1,
+                                     s_remcycle.CACHE_ENABLED: True},
+                               ioloop=self.io_loop) as hypo_obj:
+            hypo_obj.addWebConfig(config=gconf)
+
+            jid = hypo_obj.fireWebApi(name='vertexproject:fake_endpoint')
+            job = hypo_obj.web_boss.job(jid=jid)[1]  # type: dict
+            hypo_obj.web_boss.wait(jid)
+            # Ensure that we have error information cached for the job
+            time.sleep(0.01)
+            cached_data = hypo_obj.getWebCachedReponse(jid=jid)
+            self.true('err' in cached_data)
+            self.eq(cached_data.get('err'), 'HTTPError')
+            self.true('errfile' in cached_data)
+            self.true('errline' in cached_data)
+            self.true('errmsg' in cached_data)

--- a/synapse/tests/test_lib_remcycle.py
+++ b/synapse/tests/test_lib_remcycle.py
@@ -849,14 +849,14 @@ class HypnosTest(SynTest, AsyncTestCase):
             hypo_obj.web_boss.wait(jid=jid1)
             time.sleep(0.01)
             self.true(jid1 in hypo_obj.web_cache)
-            cached_data = hypo_obj.getWebCachedReponse(jid=jid1)
+            cached_data = hypo_obj.webCacheGet(jid=jid1)
             self.true(isinstance(cached_data, dict))
             resp = cached_data.get('resp')
             self.true('data' in resp)
             data = resp.get('data')
             # This is expected data from the API endpoint.
             self.true('ip' in data)
-            cached_data2 = hypo_obj.delWebCachedResponse(jid=jid1)
+            cached_data2 = hypo_obj.webCachePop(jid=jid1)
             self.eq(cached_data, cached_data2)
             self.false(jid1 in hypo_obj.web_cache)
             # Disable the cache and ensure the responses are cleared and no longer cached.
@@ -866,7 +866,7 @@ class HypnosTest(SynTest, AsyncTestCase):
             hypo_obj.web_boss.wait(jid=jid1)
             time.sleep(0.01)
             self.false(jid2 in hypo_obj.web_cache)
-            cached_data3 = hypo_obj.delWebCachedResponse(jid=jid2)
+            cached_data3 = hypo_obj.webCachePop(jid=jid2)
             self.none(cached_data3)
 
     def test_hypnos_cache_with_ingest(self):
@@ -882,7 +882,7 @@ class HypnosTest(SynTest, AsyncTestCase):
             job = hypo_obj.web_boss.job(jid=jid)
             hypo_obj.web_boss.wait(jid)
             time.sleep(0.01)
-            cached_data = hypo_obj.getWebCachedReponse(jid=jid)
+            cached_data = hypo_obj.webCacheGet(jid=jid)
             self.nn(cached_data)
             # Ensure the cached data can be msgpacked as needed.
             buf = msgenpack(cached_data)
@@ -896,7 +896,7 @@ class HypnosTest(SynTest, AsyncTestCase):
         gconf = get_bad_vertex_global_config()
         with s_remcycle.Hypnos(opts={s_remcycle.MIN_WORKER_THREADS: 1,
                                      s_remcycle.CACHE_ENABLED: True},
-                               ioloop=self.io_loop) as hypo_obj:
+                               ioloop=self.io_loop) as hypo_obj:  # type: s_remcycle.Hypnos
             hypo_obj.addWebConfig(config=gconf)
 
             jid = hypo_obj.fireWebApi(name='vertexproject:fake_endpoint')
@@ -904,7 +904,7 @@ class HypnosTest(SynTest, AsyncTestCase):
             hypo_obj.web_boss.wait(jid)
             # Ensure that we have error information cached for the job
             time.sleep(0.01)
-            cached_data = hypo_obj.getWebCachedReponse(jid=jid)
+            cached_data = hypo_obj.webCacheGet(jid=jid)
             self.true('err' in cached_data)
             self.eq(cached_data.get('err'), 'HTTPError')
             self.true('errfile' in cached_data)


### PR DESCRIPTION
Add simple __contains__ methods to Cache/KeyCache classes.
Add (optional) support for caching web requests made by using a Cache.
Add support for adding additional content-type fields from being processed in _webProcessResponseFlatten.
Tweak documentation to render __init__ method docs properly.