### PR TITLE
Fix eventbus fini for py27

### DIFF
--- a/synapse/eventbus.py
+++ b/synapse/eventbus.py
@@ -184,7 +184,7 @@ class EventBus(object):
 
         # explicitly release the handlers
         self._syn_funcs.clear()
-        self._fini_funcs.clear()
+        del self._fini_funcs[:]
 
         self.finievt.set()
 


### PR DESCRIPTION
Python 2.7 does not support .clear() on list objects. Use del instead.