### PR TITLE
Epiphyte caching disable 236

### DIFF
--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -428,5 +428,15 @@ class RefDict:
         with self.lock:
             return [self._pop(k) for k in keys]
 
+    def clear(self):
+        with self.lock:
+            self.vals.clear()
+            self.refs.clear()
+
+    def __contains__(self, item):
+        with self.lock:
+            return item in self.vals
+
     def __len__(self):
-        return len(self.vals)
+        with self.lock:
+            return len(self.vals)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1279,6 +1279,26 @@ class CortexTest(SynTest):
             self.true(tufo0[1].get('.new'))
             self.false(tufo1[1].get('.new'))
 
+    def test_cortex_caching_disable(self):
+
+        with s_cortex.openurl('ram://') as core:
+
+            core.setConfOpt('caching', 1)
+
+            tufo = core.formTufoByProp('foo', 'bar')
+
+            self.nn(core.cache_byiden.get(tufo[0]))
+            self.nn(core.cache_bykey.get(('foo', 'bar', 1)))
+            self.nn(core.cache_byprop.get(('foo', 'bar')))
+            self.eq(len(core.cache_fifo), 1)
+
+            core.setConfOpt('caching', 0)
+
+            self.none(core.cache_byiden.get(tufo[0]))
+            self.none(core.cache_bykey.get(('foo', 'bar', 1)))
+            self.none(core.cache_byprop.get(('foo', 'bar')))
+            self.eq(len(core.cache_fifo), 0)
+
     def test_cortex_reqstor(self):
         with s_cortex.openurl('ram://') as core:
             self.raises(BadPropValu, core.formTufoByProp, 'foo:bar', True)


### PR DESCRIPTION
Closes #236 

Does need discussion about RefDict() behavior with respect to the _pop() implementation; if the _pop() should return the value store in self.val when self.refs[item] > 0 or not.  If so, that change is very quick to make.