### PR TITLE
Epiphyte setprop 288

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2207,6 +2207,14 @@ class Cortex(EventBus, DataModel, Runtime, Configable, s_ingest.IngestApi):
 
             valu = inprops.get(name)
 
+            if name.startswith(form):
+                # Possibly a full prop - strip name off
+                name = name[len(form):]
+
+            if name.startswith(':'):
+                # Relative prop - strip and form
+                name = name[1:]
+
             prop = form + ':' + name
             if not self._okSetProp(prop):
                 inprops.pop(name, None)

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2208,7 +2208,6 @@ class Cortex(EventBus, DataModel, Runtime, Configable, s_ingest.IngestApi):
             valu = inprops.get(name)
 
             prop = form + ':' + name
-
             if not self.isSetPropOk(prop):
                 inprops.pop(name, None)
                 continue
@@ -2330,7 +2329,26 @@ class Cortex(EventBus, DataModel, Runtime, Configable, s_ingest.IngestApi):
         return node
 
     def isSetPropOk(self, prop):
-        # check for enforcement and validity of a full prop name
+        '''
+        Check for enforcement and validity of a full prop name.
+
+        This can be used to determine if a property name may be set on a node,
+        given the data models currently loaded in a Cortex.
+
+        Args:
+            prop (str): Full property name to check.
+
+        Examples:
+            Check if a value is valid before calling a function.::
+
+                prop = 'foo:bar:baz'
+                if core.isSetPropOk(prop):
+                    doSomething(...)
+
+        Returns:
+            bool: True if the property can be set on the node; False if it cannot be set.
+        '''
+        #
         if not self.enforce:
             return True
 

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2358,10 +2358,17 @@ class Cortex(EventBus, DataModel, Runtime, Configable, s_ingest.IngestApi):
         '''
         Set ( with de-duplication ) the given tufo props.
 
-        Example:
+        Args:
+            tufo ((str, dict)): The tufo to set properties on.
+            **props:  Properties to set on the tufo.
 
-            tufo = core.setTufoProps(tufo, woot='hehe', blah=10)
+        Examples:
+            ::
 
+                tufo = core.setTufoProps(tufo, woot='hehe', blah=10)
+
+        Returns:
+            ((str, dict)): The source tufo, with any updated properties.
         '''
         reqiden(tufo)
         # add tufo form prefix to props

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2207,15 +2207,9 @@ class Cortex(EventBus, DataModel, Runtime, Configable, s_ingest.IngestApi):
 
             valu = inprops.get(name)
 
-            if name.startswith(form):
-                prop = name
-            else:
-                if name.startswith(':'):
-                    # Relative prop - strip colon
-                    name = name[1:]
-                prop = form + ':' + name
+            prop = form + ':' + name
 
-            if not self._okSetProp(prop):
+            if not self.isSetPropOk(prop):
                 inprops.pop(name, None)
                 continue
 
@@ -2335,7 +2329,7 @@ class Cortex(EventBus, DataModel, Runtime, Configable, s_ingest.IngestApi):
 
         return node
 
-    def _okSetProp(self, prop):
+    def isSetPropOk(self, prop):
         # check for enforcement and validity of a full prop name
         if not self.enforce:
             return True
@@ -2405,7 +2399,7 @@ class Cortex(EventBus, DataModel, Runtime, Configable, s_ingest.IngestApi):
         form = tufo[1].get('tufo:form')
         prop = form + ':' + prop
 
-        if not self._okSetProp(prop):
+        if not self.isSetPropOk(prop):
             return tufo
 
         return self._incTufoProp(tufo, prop, incval=incval)

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2208,14 +2208,13 @@ class Cortex(EventBus, DataModel, Runtime, Configable, s_ingest.IngestApi):
             valu = inprops.get(name)
 
             if name.startswith(form):
-                # Possibly a full prop - strip name off
-                name = name[len(form):]
+                prop = name
+            else:
+                if name.startswith(':'):
+                    # Relative prop - strip colon
+                    name = name[1:]
+                prop = form + ':' + name
 
-            if name.startswith(':'):
-                # Relative prop - strip and form
-                name = name[1:]
-
-            prop = form + ':' + name
             if not self._okSetProp(prop):
                 inprops.pop(name, None)
                 continue

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1173,9 +1173,8 @@ class Runtime(Configable):
             raise s_common.BadSyntaxError(name=prop, mesg=mesg)
 
         for form, nodes in formnodes.items():
-            props = formprops.get(form)
-            for node in nodes:
-                core.setTufoProps(node, **props)
+            props = formprops.get(form, {})
+            [core.setTufoProps(node, **props) for node in nodes]
 
     def _iterPropTags(self, props, tags):
         for prop in props:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1126,6 +1126,14 @@ class Runtime(Configable):
 
         core = self.getStormCore()
 
+        forms = tuple(core.getModelDict().get('forms'))
+        for prop, valu in props.items():
+            if prop.startswith(':'):
+                continue
+            if prop.startswith(forms):
+                continue
+            raise s_common.BadSyntaxError(name=prop, mesg='Setprop requires props to start with relative or full prop names.')
+
         [core.setTufoProps(node, **props) for node in query.data()]
 
     def _iterPropTags(self, props, tags):

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -4,6 +4,7 @@ import re
 import time
 import fnmatch
 import logging
+import collections
 
 import synapse.common as s_common
 import synapse.compat as s_compat
@@ -1121,20 +1122,60 @@ class Runtime(Configable):
         # TODO: use edits here for requested delete
 
     def _stormOperSetProp(self, query, oper):
+        # Coverage of this function is affected by the following issue:
+        # https://bitbucket.org/ned/coveragepy/issues/198/continue-marked-as-not-covered
         args = oper[1].get('args')
         props = dict(oper[1].get('kwlist'))
 
         core = self.getStormCore()
 
-        forms = tuple(core.getModelDict().get('forms'))
-        for prop, valu in props.items():
-            if prop.startswith(':'):
-                continue
-            if prop.startswith(forms):
-                continue
-            raise s_common.BadSyntaxError(name=prop, mesg='Setprop requires props to start with relative or full prop names.')
+        formnodes = collections.defaultdict(list)
+        formprops = collections.defaultdict(dict)
 
-        [core.setTufoProps(node, **props) for node in query.data()]
+        nodes = query.data()
+
+        for node in nodes:
+            formnodes[node[1].get('tufo:form')].append(node)
+
+        forms = tuple(formnodes.keys())
+
+        for prop, valu in props.items():
+
+            if prop.startswith(':'):
+                valid = False
+                _prop = prop[1:]
+                # Check against every lifted form, since we may have a relative prop
+                # Which is valid against
+                for form in forms:
+                    _fprop = form + prop
+                    if core.isSetPropOk(_fprop):
+                        formprops[form][_prop] = valu
+                        valid = True
+                if not valid:
+                    mesg = 'Relative prop is not valid on any lifted forms.'
+                    raise s_common.BadSyntaxError(name=prop, mesg=mesg)
+                continue  # pragma: no cover
+
+            if prop.startswith(forms):
+                valid = False
+                for form in forms:
+                    if prop.startswith(form) and core.isSetPropOk(prop):
+                        _prop = prop[len(form) + 1:]
+                        formprops[form][_prop] = valu
+                        valid = True
+                        break
+                if not valid:
+                    mesg = 'Full prop is not valid on any lifted forms.'
+                    raise s_common.BadSyntaxError(name=prop, mesg=mesg)
+                continue  # pragma: no cover
+
+            mesg = 'setprop operator requires props to start with relative or full prop names.'
+            raise s_common.BadSyntaxError(name=prop, mesg=mesg)
+
+        for form, nodes in formnodes.items():
+            props = formprops.get(form)
+            for node in nodes:
+                core.setTufoProps(node, **props)
 
     def _iterPropTags(self, props, tags):
         for prop in props:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1159,7 +1159,7 @@ class Runtime(Configable):
             if prop.startswith(forms):
                 valid = False
                 for form in forms:
-                    if prop.startswith(form) and core.isSetPropOk(prop):
+                    if prop.startswith(form + ':') and core.isSetPropOk(prop):
                         _prop = prop[len(form) + 1:]
                         formprops[form][_prop] = valu
                         valid = True

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1132,9 +1132,7 @@ class Runtime(Configable):
         formnodes = collections.defaultdict(list)
         formprops = collections.defaultdict(dict)
 
-        nodes = query.data()
-
-        for node in nodes:
+        for node in query.data():
             formnodes[node[1].get('tufo:form')].append(node)
 
         forms = tuple(formnodes.keys())
@@ -1173,8 +1171,9 @@ class Runtime(Configable):
             raise s_common.BadSyntaxError(name=prop, mesg=mesg)
 
         for form, nodes in formnodes.items():
-            props = formprops.get(form, {})
-            [core.setTufoProps(node, **props) for node in nodes]
+            props = formprops.get(form)
+            if props:
+                [core.setTufoProps(node, **props) for node in nodes]
 
     def _iterPropTags(self, props, tags):
         for prop in props:

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -573,8 +573,6 @@ def parse(text, off=0):
         # [ -#foo.bar ] == deltag(foo.bar)
         if nextchar(text, off, '['):
 
-            added_props = set()
-
             off += 1
 
             while True:
@@ -612,20 +610,12 @@ def parse(text, off=0):
                     raise s_common.BadSyntaxError(mesg='edit macro expected prop=valu syntax')
 
                 valu, off = parse_macro_valu(text, off + 1)
-                # Relative property syntax parsing
                 if prop[0] == ':':
                     kwargs = {prop: valu}
                     ret.append(oper('setprop', **kwargs))
                     continue
 
-                # Full property syntax parsing
-                if added_props and prop.startswith(tuple(added_props)):
-                    kwargs = {prop: valu}
-                    ret.append(oper('setprop', **kwargs))
-                    continue
-
                 ret.append(oper('addnode', prop, valu))
-                added_props.add(prop)
 
             continue
 

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -573,6 +573,8 @@ def parse(text, off=0):
         # [ -#foo.bar ] == deltag(foo.bar)
         if nextchar(text, off, '['):
 
+            added_props = set()
+
             off += 1
 
             while True:
@@ -610,12 +612,20 @@ def parse(text, off=0):
                     raise s_common.BadSyntaxError(mesg='edit macro expected prop=valu syntax')
 
                 valu, off = parse_macro_valu(text, off + 1)
+                # Relative property syntax parsing
                 if prop[0] == ':':
                     kwargs = {prop: valu}
                     ret.append(oper('setprop', **kwargs))
                     continue
 
+                # Full property syntax parsing
+                if added_props and prop.startswith(tuple(added_props)):
+                    kwargs = {prop: valu}
+                    ret.append(oper('setprop', **kwargs))
+                    continue
+
                 ret.append(oper('addnode', prop, valu))
+                added_props.add(prop)
 
             continue
 

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -611,7 +611,7 @@ def parse(text, off=0):
 
                 valu, off = parse_macro_valu(text, off + 1)
                 if prop[0] == ':':
-                    kwargs = {prop[1:]: valu}
+                    kwargs = {prop: valu}
                     ret.append(oper('setprop', **kwargs))
                     continue
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -44,13 +44,25 @@ class StormTest(SynTest):
         with s_cortex.openurl('ram:///') as core:
             core.setConfOpt('enforce', 1)
 
+            # kwlist key/val syntax
             node = core.formTufoByProp('inet:fqdn', 'vertex.link')
-
             node = core.eval('inet:fqdn=vertex.link setprop(created="2016-05-05",updated="2017/05/05")')[0]
 
             self.eq(node[1].get('inet:fqdn'), 'vertex.link')
             self.eq(node[1].get('inet:fqdn:created'), 1462406400000)
             self.eq(node[1].get('inet:fqdn:updated'), 1493942400000)
+
+            # Another relative key/val syntax, explicitly relative vals
+            node = core.formTufoByProp('inet:netuser', 'vertex.link/pennywise')
+            node = core.eval('inet:netuser=vertex.link/pennywise setprop(:realname="Robert Gray")')[0]
+
+            self.eq(node[1].get('inet:netuser'), 'vertex.link/pennywise')
+            self.eq(node[1].get('inet:netuser:realname'), 'robert gray')
+
+            # Full prop val syntax
+            node = core.eval('inet:netuser=vertex.link/pennywise setprop(inet:netuser:signup="1970-01-01")')[0]
+            self.eq(node[1].get('inet:netuser'), 'vertex.link/pennywise')
+            self.eq(node[1].get('inet:netuser:signup'), 0)
 
     def test_storm_filt_regex(self):
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -487,10 +487,6 @@ class StormTest(SynTest):
             node = core.eval('inet:ipv4=5.6.7.8')[0]
             self.eq(node[1].get('inet:ipv4:cc'), 'us')
 
-            core.eval(' [ inet:ipv4=5.6.7.8 inet:ipv4:asn=666 ]')
-            node = core.eval('inet:ipv4=5.6.7.8')[0]
-            self.eq(node[1].get('inet:ipv4:asn'), 666)
-
     def test_storm_tag_ival(self):
 
         with s_cortex.openurl('ram:///') as core:

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -487,6 +487,10 @@ class StormTest(SynTest):
             node = core.eval('inet:ipv4=5.6.7.8')[0]
             self.eq(node[1].get('inet:ipv4:cc'), 'us')
 
+            core.eval(' [ inet:ipv4=5.6.7.8 inet:ipv4:asn=666 ]')
+            node = core.eval('inet:ipv4=5.6.7.8')[0]
+            self.eq(node[1].get('inet:ipv4:asn'), 666)
+
     def test_storm_tag_ival(self):
 
         with s_cortex.openurl('ram:///') as core:

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -78,6 +78,29 @@ class StormTest(SynTest):
             bad_cmd = 'inet:fqdn=vertex.link setprop(:typocreated="2016-05-05")'
             self.raises(BadSyntaxError, core.eval, bad_cmd)
 
+            # test  possible form confusion
+            modl = {
+                'types': (
+                    ('foo:bar', {'subof': 'str'}),
+                    ('foo:barbaz', {'subof': 'str'})
+                ),
+                'forms': (
+                    ('foo:bar', {'ptype': 'str'}, [
+                        ('blah', {'ptype': 'str'})
+                    ]),
+                    ('foo:barbaz', {'ptype': 'str'}, [
+                        ('blah', {'ptype': 'str'})
+                    ]),
+                )
+            }
+            core.addDataModel('form_confusion', modl)
+            node = core.formTufoByProp('foo:bar', 'hehe')
+            core.addTufoTag(node, 'confusion')
+            node = core.formTufoByProp('foo:barbaz', 'haha')
+            core.addTufoTag(node, 'confusion')
+            node = core.eval('''#confusion setprop(foo:barbaz:blah=duck) +foo:barbaz''')[0]
+            self.eq(node[1].get('foo:barbaz:blah'), 'duck')
+
     def test_storm_filt_regex(self):
 
         with s_cortex.openurl('ram:///') as core:

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -44,15 +44,12 @@ class StormTest(SynTest):
         with s_cortex.openurl('ram:///') as core:
             core.setConfOpt('enforce', 1)
 
-            # kwlist key/val syntax
+            # kwlist key/val syntax is no longer valid in setprop()
             node = core.formTufoByProp('inet:fqdn', 'vertex.link')
-            node = core.eval('inet:fqdn=vertex.link setprop(created="2016-05-05",updated="2017/05/05")')[0]
+            bad_cmd = 'inet:fqdn=vertex.link setprop(created="2016-05-05",updated="2017/05/05")'
+            self.raises(BadSyntaxError, core.eval, bad_cmd)
 
-            self.eq(node[1].get('inet:fqdn'), 'vertex.link')
-            self.eq(node[1].get('inet:fqdn:created'), 1462406400000)
-            self.eq(node[1].get('inet:fqdn:updated'), 1493942400000)
-
-            # Another relative key/val syntax, explicitly relative vals
+            # relative key/val syntax, explicitly relative vals
             node = core.formTufoByProp('inet:netuser', 'vertex.link/pennywise')
             node = core.eval('inet:netuser=vertex.link/pennywise setprop(:realname="Robert Gray")')[0]
 


### PR DESCRIPTION
Closes #288.
Updated from original opening:

Allows the storm operator setprop() to accept relative and full prop names.  It no longer accept plain keyword/arg property names (see tests where they are invalid now).

cc: @therealsilence for possible doc updates.