### PR TITLE
initial support for optional fields in comp types

### DIFF
--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -17,7 +17,7 @@ tagfilt = varset.union({'#', '*', '@'})
 alphaset = set('abcdefghijklmnopqrstuvwxyz')
 
 # this may be used to meh() potentially unquoted values
-valmeh = whites.union({'(',')','=',','})
+valmeh = whites.union({'(',')','=',',','[',']'})
 
 def nom(txt, off, cset, trim=True):
     '''

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -16,6 +16,9 @@ starset = varset.union({'*'})
 tagfilt = varset.union({'#', '*', '@'})
 alphaset = set('abcdefghijklmnopqrstuvwxyz')
 
+# this may be used to meh() potentially unquoted values
+valmeh = whites.union({'(',')','=',','})
+
 def nom(txt, off, cset, trim=True):
     '''
     Consume chars in set from the string and return (subtxt,offset).
@@ -53,15 +56,6 @@ def meh(txt, off, cset):
 def is_literal(text, off):
     return text[off] in '("0123456789'
 
-def parse_literal(text, off, trim=True):
-    if text[off] == '(':
-        return parse_cmd_list(text, off, trim=trim)
-
-    if text[off] == '"':
-        return parse_string(text, off, trim=trim)
-
-    return parse_int(text, off, trim=trim)
-
 def parse_int(text, off, trim=True):
     numstr, off = nom(text, off, intset, trim=trim)
     try:
@@ -69,33 +63,13 @@ def parse_int(text, off, trim=True):
     except Exception as e:
         raise s_common.BadSyntaxError(expected='Literal', at=off, got=text[off:off + 10])
 
-def parse_list(text, off, trim=True):
-    if text[off] != '(':
-        raise s_common.BadSyntaxError(expected='List', at=off)
-
-    off += 1
-    valus = []
-    while True:
-
-        valu, off = parse_literal(text, off, trim=trim)
-
-        valus.append(valu)
-
-        if text[off] == ')':
-            return valus, off + 1
-
-        if text[off] != ',':
-            raise s_common.BadSyntaxError(invalid='List Syntax', at=off)
-
-        off += 1
-
 def nom_whitespace(text, off):
     return nom(text, off, whites)
 
 def isquote(text, off):
     return nextin(text, off, (",", '"'))
 
-def parse_cmd_list(text, off=0, trim=True):
+def parse_list(text, off=0, trim=True):
     '''
     Parse a list (likely for comp type) coming from a command line input.
 
@@ -110,13 +84,23 @@ def parse_cmd_list(text, off=0, trim=True):
     valus = []
     while off < len(text):
 
-        _, off = nom_whitespace(text, off)
+        _, off = nom(text, off, whites)
 
-        if isquote(text, off):
-            valu, off = parse_string(text, off, trim=trim)
-        else:
-            valu, off = meh(text, off, ',)')
-            valu = valu.strip()
+        valu,off = parse_valu(text, off)
+
+        _, off = nom(text, off, whites)
+
+
+        # check for foo=bar kw tuple syntax
+        if nextchar(text, off, '='):
+
+            _, off = nom(text, off+1, whites)
+
+            vval, off = parse_valu(text, off)
+
+            _, off = nom(text, off, whites)
+
+            valu = (valu, vval)
 
         valus.append(valu)
 
@@ -126,7 +110,7 @@ def parse_cmd_list(text, off=0, trim=True):
             return valus, off + 1
 
         if not nextchar(text, off, ','):
-            raise s_common.BadSyntaxError(at=off, mesg='expected comma in list')
+            raise s_common.BadSyntaxError(at=off, text=text, mesg='expected comma in list')
 
         off += 1
 
@@ -143,7 +127,7 @@ def parse_cmd_string(text, off, trim=True):
         return parse_string(text, off, trim=trim)
 
     if nextchar(text, off, '('):
-        return parse_cmd_list(text, off)
+        return parse_list(text, off)
 
     return meh(text, off, whites)
 
@@ -254,7 +238,7 @@ def parse_opts(text, off=0):
     name, off = nom(text, off, varset, trim=True)
 
     if nextchar(text, off, '='):
-        valu, off = parse_literal(text, off + 1, trim=True)
+        valu, off = parse_valu(text, off + 1, trim=True)
 
     inst[1]['kwlist'].append((name, valu))
     return inst, off
@@ -271,35 +255,6 @@ def nextin(text, off, vals):
     if len(text) <= off:
         return False
     return text[off] in vals
-
-#def parse_pivot(text,off=0):
-    #'''
-    #^foo:bar
-    #^foo:bar=baz:faz
-    #^hehe.haha/foo:bar=baz:faz
-    #'''
-    #inst = ('pivot',{'args':[],'kwlist':[]})
-
-    #prop,off = nom(text,off,varset,trim=True)
-
-    #if len(text) == off:
-        #inst[1]['args'].append(prop)
-        #return inst,off
-
-    #if text[off] == '/':
-        #inst[1]['kwlist'].append( ('from',prop) )
-        #prop,off = nom(text,off+1,varset,trim=True)
-
-    #inst[1]['args'].append( prop )
-
-    #if len(text) == off:
-        #return inst,off
-
-    #if nextchar(text,off,'='):
-        #prop,off = nom(text,off+1,varset,trim=True)
-        #inst[1]['args'].append( prop )
-
-    #return inst,off
 
 def parse_macro_join(text, off=0):
     '''
@@ -394,14 +349,14 @@ def parse_ques(text, off=0, trim=True):
 
             _, off = nom(text, off + 1, whites)
 
-            ques['valu'], off = parse_macro_valu(text, off)
+            ques['valu'], off = parse_valu(text, off)
             return ques, off
 
         if nextchar(text, off, '='):
             _, off = nom(text, off + 1, whites)
 
             ques['cmp'] = 'eq'
-            ques['valu'], off = parse_macro_valu(text, off)
+            ques['valu'], off = parse_valu(text, off)
             break
 
         textpart = text[off:]
@@ -416,19 +371,19 @@ def parse_ques(text, off=0, trim=True):
 
     return ques, off
 
-def parse_macro_valu(text, off=0):
+def parse_valu(text, off=0):
     '''
     Special syntax for the right side of equals in a macro
     '''
     if nextchar(text, off, '('):
-        return parse_cmd_list(text, off)
+        return parse_list(text, off)
 
     if isquote(text, off):
         return parse_string(text, off)
 
-    # since it's not quoted, we can assume we are white
-    # space bound ( only during macro syntax )
-    valu, off = meh(text, off, whites)
+    # since it's not quoted, we can assume we are bound by both
+    # white space and storm syntax chars ( ) , =
+    valu, off = meh(text, off, valmeh)
 
     # for now, give it a shot as an int...  maybe eventually
     # we'll be able to disable this completely, but for now
@@ -586,17 +541,17 @@ def parse(text, off=0):
                     raise s_common.BadSyntaxError(mesg='unexpected end of text in edit mode')
 
                 if nextstr(text, off, '+#'):
-                    valu, off = parse_macro_valu(text, off + 2)
+                    valu, off = parse_valu(text, off + 2)
                     ret.append(oper('addtag', valu))
                     continue
 
                 if nextstr(text, off, '-#'):
-                    valu, off = parse_macro_valu(text, off + 2)
+                    valu, off = parse_valu(text, off + 2)
                     ret.append(oper('deltag', valu))
                     continue
 
                 if nextchar(text, off, '#'):
-                    valu, off = parse_macro_valu(text, off + 1)
+                    valu, off = parse_valu(text, off + 1)
                     ret.append(oper('addtag', valu))
                     continue
 
@@ -609,7 +564,7 @@ def parse(text, off=0):
                 if not nextchar(text, off, '='):
                     raise s_common.BadSyntaxError(mesg='edit macro expected prop=valu syntax')
 
-                valu, off = parse_macro_valu(text, off + 1)
+                valu, off = parse_valu(text, off + 1)
                 if prop[0] == ':':
                     kwargs = {prop[1:]: valu}
                     ret.append(oper('setprop', **kwargs))

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -56,6 +56,15 @@ def meh(txt, off, cset):
 def is_literal(text, off):
     return text[off] in '("0123456789'
 
+def parse_literal(text, off, trim=True):
+    if text[off] == '(':
+        return parse_list(text, off, trim=trim)
+
+    if text[off] == '"':
+        return parse_string(text, off, trim=trim)
+
+    return parse_int(text, off, trim=trim)
+
 def parse_int(text, off, trim=True):
     numstr, off = nom(text, off, intset, trim=trim)
     try:
@@ -238,7 +247,7 @@ def parse_opts(text, off=0):
     name, off = nom(text, off, varset, trim=True)
 
     if nextchar(text, off, '='):
-        valu, off = parse_valu(text, off + 1, trim=True)
+        valu, off = parse_valu(text, off + 1)
 
     inst[1]['kwlist'].append((name, valu))
     return inst, off
@@ -375,6 +384,8 @@ def parse_valu(text, off=0):
     '''
     Special syntax for the right side of equals in a macro
     '''
+    _, off = nom(text,off,whites)
+
     if nextchar(text, off, '('):
         return parse_list(text, off)
 

--- a/synapse/lib/time.py
+++ b/synapse/lib/time.py
@@ -44,7 +44,7 @@ def parse(text, base=None):
     epoch = datetime.datetime(1970, 1, 1)
     return int((dt - epoch).total_seconds() * 1000)
 
-def repr(tick):
+def repr(tick, pack=False):
     '''
     Return a date string for an epoch-millis timestamp.
 
@@ -56,4 +56,6 @@ def repr(tick):
     '''
     dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=tick)
     millis = dt.microsecond / 1000
+    if pack:
+        return '%d%.2d%.2d%.2d%.2d%.2d%.3d' % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, millis)
     return '%d/%.2d/%.2d %.2d:%.2d:%.2d.%.3d' % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, millis)

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -332,7 +332,7 @@ class InetMod(CoreModule):
                     'inet:cidr4',
                     {'ctor': 'synapse.models.inet.CidrType', 'doc': 'An IPv4 CIDR type', 'ex': '1.2.3.0/24'}),
 
-                ('inet:urlfile', {'subof': 'comp', 'types': 'inet:url,file:bytes', 'names': 'url,file',
+                ('inet:urlfile', {'subof': 'comp', 'fields':'url=inet:url,file=file:bytes',
                                   'doc': 'A File at a Universal Resource Locator (URL)'}),
                 ('inet:net4',
                  {'subof': 'sepr', 'sep': '-', 'fields': 'min,inet:ipv4|max,inet:ipv4', 'doc': 'An IPv4 address range',

--- a/synapse/tests/test_syntax.py
+++ b/synapse/tests/test_syntax.py
@@ -93,3 +93,8 @@ class StormSyntaxTest(SynTest):
 
         valu,off = s_syntax.parse_valu('(   foo   ,    bar   ,   baz    =     faz    )')
         self.eq( valu, ['foo','bar',('baz','faz')] )
+
+    def test_storm_syntax_edit(self):
+        inst0 = s_syntax.parse('[inet:ipv4=127.0.0.1 inet:ipv4=127.0.0.2]')
+        inst1 = s_syntax.parse('   [   inet:ipv4   =    127.0.0.1  inet:ipv4   =   127.0.0.2   ]   ')
+        self.eq(inst0,inst1)

--- a/synapse/tests/test_syntax.py
+++ b/synapse/tests/test_syntax.py
@@ -83,3 +83,13 @@ class StormSyntaxTest(SynTest):
     def test_storm_syntax_whites(self):
         insts = s_syntax.parse('inet:fqdn     =      "1.2.3.4"')
         self.eq(insts[0], s_syntax.oper('lift', 'inet:fqdn', '1.2.3.4', by='eq'))
+
+    def test_storm_syntax_comp_opts(self):
+        valu,off = s_syntax.parse_valu('(foo,bar,baz=faz)')
+        self.eq( valu, ['foo','bar',('baz','faz')] )
+
+        valu,off = s_syntax.parse_valu('(foo, bar, baz=faz)')
+        self.eq( valu, ['foo','bar',('baz','faz')] )
+
+        valu,off = s_syntax.parse_valu('(   foo   ,    bar   ,   baz    =     faz    )')
+        self.eq( valu, ['foo','bar',('baz','faz')] )

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -539,3 +539,25 @@ class DataTypesTest(SynTest):
         self.eq(subs, tuple(sorted(s1.items())))
         self.eq(subs, tuple(sorted(s2.items())))
         self.eq(subs, tuple(sorted(s3.items())))
+
+    def test_types_comp_opt_only(self):
+
+        tlib = s_types.TypeLib()
+
+        tlib.addType('foo:bar', subof='comp', optfields='baz=str,faz=int')
+
+        subs = (('baz','asdf'),('faz',30))
+
+        v0,s0 = tlib.getTypeNorm('foo:bar', (('baz','asdf'),('faz',30)))
+        v1,s1 = tlib.getTypeNorm('foo:bar', (('faz',30),('baz','asdf')))
+        v2,s2 = tlib.getTypeNorm('foo:bar', '(baz=asdf,faz=30)')
+        v3,s3 = tlib.getTypeNorm('foo:bar', '(faz=30,baz=asdf)')
+
+        self.eq(v0,v1)
+        self.eq(v1,v2)
+        self.eq(v2,v3)
+
+        self.eq(subs, tuple(sorted(s0.items())))
+        self.eq(subs, tuple(sorted(s1.items())))
+        self.eq(subs, tuple(sorted(s2.items())))
+        self.eq(subs, tuple(sorted(s3.items())))

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -236,16 +236,12 @@ class DataTypesTest(SynTest):
 
     def test_type_comp(self):
         tlib = s_types.TypeLib()
-        tlib.addType('foo:bar', subof='comp', types='inet:fqdn,inet:ipv4', names='hehe,haha')
+        tlib.addType('foo:bar', subof='comp', fields='hehe=inet:fqdn,haha=inet:ipv4')
 
         valu, subs = tlib.getTypeNorm('foo:bar', ('WOOT.COM', 0x01020304))
         self.eq(valu, '47e2e1c0f894266153f836a75440f803')
         self.eq(subs.get('hehe'), 'woot.com')
         self.eq(subs.get('haha'), 0x01020304)
-
-    #def test_type_comp_err(self):
-        #tlib = s_types.TypeLib()
-        #self.raises( BadInfoValu, tlib.addType, 'fake:newp', subof='comp',fields='asdfqwer')
 
     def test_datatype_int_minmax(self):
         tlib = s_types.TypeLib()
@@ -504,3 +500,42 @@ class DataTypesTest(SynTest):
             self.eq(valu, 'foo.bar')
             self.eq(subs['seen:min'], 1481932800000)
             self.eq(subs['seen:max'], 1513468800000)
+
+    def test_types_comp_optfields(self):
+
+        tlib = s_types.TypeLib()
+
+        tlib.addType('foo:bar', subof='comp', fields='foo=str,bar=int', optfields='baz=str,faz=int')
+
+        subs = (('bar',20),('baz','asdf'),('faz',30),('foo','qwer'))
+
+        v0,s0 = tlib.getTypeNorm('foo:bar', ('qwer',20,('baz','asdf'),('faz',30)))
+        v1,s1 = tlib.getTypeNorm('foo:bar', ('qwer',20,('faz',30),('baz','asdf')))
+        v2,s2 = tlib.getTypeNorm('foo:bar', '(qwer,20,baz=asdf,faz=30)')
+        v3,s3 = tlib.getTypeNorm('foo:bar', '(qwer,20,faz=30,baz=asdf)')
+
+        self.eq(v0,v1)
+        self.eq(v1,v2)
+        self.eq(v2,v3)
+
+        self.eq(subs, tuple(sorted(s0.items())))
+        self.eq(subs, tuple(sorted(s1.items())))
+        self.eq(subs, tuple(sorted(s2.items())))
+        self.eq(subs, tuple(sorted(s3.items())))
+
+
+        subs = (('bar',20),('baz','asdf'),('foo','qwer'))
+
+        v0,s0 = tlib.getTypeNorm('foo:bar', ('qwer',20,('baz','asdf')))
+        v1,s1 = tlib.getTypeNorm('foo:bar', ('qwer',20,('baz','asdf')))
+        v2,s2 = tlib.getTypeNorm('foo:bar', '(qwer,20,baz=asdf)')
+        v3,s3 = tlib.getTypeNorm('foo:bar', '(qwer,20,baz=asdf)')
+
+        self.eq(v0,v1)
+        self.eq(v1,v2)
+        self.eq(v2,v3)
+
+        self.eq(subs, tuple(sorted(s0.items())))
+        self.eq(subs, tuple(sorted(s1.items())))
+        self.eq(subs, tuple(sorted(s2.items())))
+        self.eq(subs, tuple(sorted(s3.items())))


### PR DESCRIPTION
Allows comp types to have "optional fields" which are included in deconfliction if present.  Syntax for a comp value is updated from a simple "tuple like" syntax 
```
(<val0>, <val1>, ... ) 
```
 to including "kwword" syntax for optional fields
```
(<val0>, <val1>, <opt0>=<oval0>, <opt1>=<oval1> )
```