### PR TITLE
Add a guid() operator to the storm syntax.

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -406,6 +406,7 @@ class Runtime(Configable):
         self.setOperFunc('load', self._stormOperLoad)
         self.setOperFunc('clear', self._stormOperClear)
 
+        self.setOperFunc('guid', self._stormOperGuid)
         self.setOperFunc('join', self._stormOperJoin)
         self.setOperFunc('lift', self._stormOperLift)
         self.setOperFunc('refs', self._stormOperRefs)
@@ -1101,7 +1102,7 @@ class Runtime(Configable):
         core = self.getStormCore()
 
         props = {}
-        for k,v in kwlist:
+        for k, v in kwlist:
 
             if not k[0] == ':':
                 raise s_common.BadSyntaxError(mesg='addnode() expects relative props with : prefix')
@@ -1319,3 +1320,12 @@ class Runtime(Configable):
                 [query.add(n) for n in nodes]
 
         return
+
+    def _stormOperGuid(self, query, oper):
+        args = oper[1].get('args')
+        core = self.getStormCore()
+
+        for iden in args:
+            node = core.getTufoByIden(iden)
+            if node:
+                query.add(node)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1325,7 +1325,4 @@ class Runtime(Configable):
         args = oper[1].get('args')
         core = self.getStormCore()
 
-        for iden in args:
-            node = core.getTufoByIden(iden)
-            if node:
-                query.add(node)
+        [query.add(node) for node in core.getTufosByIdens(args)]

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -563,6 +563,29 @@ class StormTest(SynTest):
                 ['1.2.3.4', 'vv', '#foo.bar'],
             ])
 
+    def test_storm_guid(self):
+
+        with s_cortex.openurl('ram:///') as core:
+
+            node0 = core.formTufoByProp('inet:ipv4', '1.2.3.4')
+            node1 = core.formTufoByProp('inet:ipv4', '4.5.6.7')
+
+            nodes = core.eval('guid()')
+            self.eq(len(nodes), 0)
+
+            nodes = core.eval('guid(%s)' % node0[0])
+            self.eq(nodes[0][1].get('inet:ipv4'), 0x01020304)
+
+            nodes = core.eval('guid(%s,%s)' % (node0[0], node1[0]))
+            vals = list(sorted(v[1].get('inet:ipv4') for v in nodes))
+            self.eq(vals, [0x01020304, 0x04050607])
+
+            # We can lift dark rows using guid() but kind of an easter egg.
+            core.addTufoDark(node0, 'foo:bar', 'duck:knight')
+            nodes = core.eval('guid(%s)' % node0[0][::-1])
+            self.eq(len(nodes), 1)
+            self.eq(node0[0], nodes[0][0][::-1])
+
 class LimitTest(SynTest):
 
     def test_limit_default(self):


### PR DESCRIPTION
This allows lifting a node (or multiple nodes) using the nodes iden value.

Closes #348 