### PR TITLE
fix cmdr for 2.7 users

### DIFF
--- a/synapse/compat.py
+++ b/synapse/compat.py
@@ -118,6 +118,18 @@ if version < (3, 0, 0):
         '''Convert bytes to buffer'''
         return buffer(x)
 
+    def user_input(text):
+        '''
+        Get input from a user via stdin.
+
+        Args:
+            text (str): Text displayed prior to the input prompt.
+
+        Returns:
+            str: String of text from the user.
+        '''
+        return raw_input(text)
+
 else:
 
     import sys
@@ -181,3 +193,16 @@ else:
     def bytesToMem(x):
         '''Convert bytes to memoryview'''
         return memoryview(x)
+
+    def user_input(text):
+        '''
+        Get input from a user via stdin.
+
+        Args:
+            text (str): Text displayed prior to the input prompt.
+
+        Returns:
+            str: String of text from the user.
+        '''
+
+        return input(text)

--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -1,6 +1,7 @@
 import traceback
 import collections
 
+import synapse.compat as s_compat
 import synapse.lib.output as s_output
 import synapse.lib.syntax as s_syntax
 
@@ -12,7 +13,7 @@ def get_input(text):  # pragma: no cover
     Wrapper for input() function for testing runCmdLoop.
     :param text: Banner to display.
     '''
-    return input(text)
+    return s_compat.user_input(text)
 
 
 class CliFini(Exception): pass

--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -10,8 +10,13 @@ from synapse.eventbus import EventBus
 
 def get_input(text):  # pragma: no cover
     '''
-    Wrapper for input() function for testing runCmdLoop.
-    :param text: Banner to display.
+    Wrapper for s_compat.user_input() function for testing runCmdLoop.
+
+    Args:
+        text (str): Banner to display
+
+    Returns:
+        str: User provided string.
     '''
     return s_compat.user_input(text)
 


### PR DESCRIPTION
Add a user_input function to compat and use that for getting user input in cmdr.  This allows python27 to run cmdr.

(vmc edit):
Closes #335