### PR TITLE
WIP: Fix for inet:srv4 form props

### DIFF
--- a/docs/synapse/devopsguides/model_format.rst
+++ b/docs/synapse/devopsguides/model_format.rst
@@ -35,6 +35,11 @@ An example of a simple model definition file is the following ::
                 'types': (
                     ('foo:bar', {'subof': 'str', 'doc': 'A foo bar!'}),
                 ),
+                'forms': (
+                    ('foo:bar',
+                     {'ptype': 'foo:bar'},
+                     [])
+                )
             }
             name = 'foobar'
             return ((name, modl), )
@@ -52,7 +57,7 @@ a iterable of name, model tuples. This serves two purposes:
      On existing Cortexes which do not have nodes storing the model revision, the revision 0 of the model will be
      created and the base model automatically loaded.
 
-When model updates need to be done, these updates are be delivered as functions in the CoreModule sublcass.  These
+When model updates need to be done, these updates are to be delivered as functions in the CoreModule sublcass. These
 functions must be decorated with the @s_module.modelrev function.  This decorator takes two arguments:
 
   #. The name of the model to be updated.
@@ -89,7 +94,7 @@ will be updated to 201707210101 in the Cortex.::
                 ),
                 'forms': (
                     ('foo:bar',
-                     {'ptype': 'str'},
+                     {'ptype': 'foo:bar'},
                      [('duck', {'defval': 'mallard', 'ptype': 'str', 'doc': 'Duck type.'})]
                      ),
                 ),
@@ -159,11 +164,11 @@ An example of extending the previous example is shown below (minus migration fun
                 ),
                 'forms': (
                     ('foo:bar',
-                     {'ptype': 'str'},
+                     {'ptype': 'foo:bar'},
                      [('duck', {'defval': 'mallard', 'ptype': 'str', 'doc': 'Duck type.'})]
                      ),
                     ('foo:knight',
-                     {'ptype': 'str'},
+                     {'ptype': 'foo:knight'},
                      [('court', {'ptype': 'str', 'doc': 'Knight court'})]
                      ),
                 ),

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -147,7 +147,7 @@ class Srv4Type(DataType):
 
         addr = ipv4int(astr)
         port = int(pstr, 0)
-        return (addr << 16) | port, {}
+        return (addr << 16) | port, {'port': port, 'ipv4': addr}
 
 srv6re = re.compile('^\[([a-f0-9:]+)\]:(\d+)$')
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -109,6 +109,9 @@ def ipv6norm(text):
     return s_socket.inet_ntop(socket.AF_INET6, s_socket.inet_pton(socket.AF_INET6, text))
 
 class IPv6Type(DataType):
+    def repr(self, valu):
+        return self.norm(valu)[0]
+
     def norm(self, valu, oldval=None):
         try:
             return ipv6norm(valu), {}
@@ -159,6 +162,9 @@ class Srv6Type(DataType):
         ('port', {'ptype': 'inet:port'}),
         ('ipv6', {'ptype': 'inet:ipv6'}),
     )
+
+    def repr(self, valu):
+        return self.norm(valu)[0]
 
     def norm(self, valu, oldval=None):
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -344,8 +344,8 @@ class InetMod(CoreModule):
         for tufo in self.core.getTufosByProp('inet:fqdn:domain', fqdn):
             self.core.setTufoProp(tufo, 'zone', sfx)
 
-    @modelrev('inet', 201704201837)
-    def _retModl201704201837(self):
+    @modelrev('inet', 201706201837)
+    def _revModl201706201837(self):
         '''
         Add :port and :ipv4 to inet:tcp4 and inet:udp4 nodes.
         '''
@@ -371,6 +371,27 @@ class InetMod(CoreModule):
 
             if adds:
                 self.core.addRows(adds)
+
+    @modelrev('inet', 201706121318)
+    def _revModl201706121318(self):
+
+        # account for the updated sub-property extraction for inet:url nodes
+        adds = []
+        rows = self.core.getRowsByProp('inet:url')
+
+        for i, p, v, t in rows:
+            norm, subs = s_datamodel.tlib.getTypeNorm('inet:url', v)
+
+            fqdn = subs.get('fqdn')
+            if fqdn is not None:
+                adds.append((i, 'inet:url:fqdn', fqdn, t))
+
+            ipv4 = subs.get('ipv4')
+            if ipv4 is not None:
+                adds.append((i, 'inet:url:ipv4', ipv4, t))
+
+        if adds:
+            self.core.addRows(adds)
 
     @staticmethod
     def getBaseModels():
@@ -717,24 +738,3 @@ class InetMod(CoreModule):
         }
         name = 'inet'
         return ((name, modl), )
-
-    @modelrev('inet', 201706121318)
-    def _revModl201706121318(self):
-
-        # account for the updated sub-property extraction for inet:url nodes
-        adds = []
-        rows = self.core.getRowsByProp('inet:url')
-
-        for i, p, v, t in rows:
-            norm, subs = s_datamodel.tlib.getTypeNorm('inet:url', v)
-
-            fqdn = subs.get('fqdn')
-            if fqdn is not None:
-                adds.append((i, 'inet:url:fqdn', fqdn, t))
-
-            ipv4 = subs.get('ipv4')
-            if ipv4 is not None:
-                adds.append((i, 'inet:url:ipv4', ipv4, t))
-
-        if adds:
-            self.core.addRows(adds)

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -344,7 +344,7 @@ class InetMod(CoreModule):
         for tufo in self.core.getTufosByProp('inet:fqdn:domain', fqdn):
             self.core.setTufoProp(tufo, 'zone', sfx)
 
-    @modelrev('inet', '201704201837')
+    @modelrev('inet', 201704201837)
     def _retModl201704201837(self):
         '''
         Add :port and :ipv4 to inet:tcp4 and inet:udp4 nodes.

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -3,6 +3,7 @@ import socket
 import struct
 import hashlib
 
+import synapse.common as s_common
 import synapse.compat as s_compat
 import synapse.datamodel as s_datamodel
 import synapse.lib.socket as s_socket
@@ -342,6 +343,34 @@ class InetMod(CoreModule):
         fqdn = mesg[1].get('valu')
         for tufo in self.core.getTufosByProp('inet:fqdn:domain', fqdn):
             self.core.setTufoProp(tufo, 'zone', sfx)
+
+    @modelrev('inet', '201704201837')
+    def _retModl201704201837(self):
+        '''
+        Add :port and :ipv4 to inet:tcp4 and inet:udp4 nodes.
+        '''
+        tick = s_common.now()
+
+        forms = ('inet:tcp4', 'inet:udp4')
+        for form in forms:
+            adds = []
+            portprop = '{}:port'.format(form)
+            ipv4prop = '{}:ipv4'.format(form)
+
+            rows = self.core.getRowsByProp(form)
+            for i, p, v, _ in rows:
+                norm, subs = self.core.getTypeNorm(form, v)
+
+                port = subs.get('port')
+                if port:
+                    adds.append((i, portprop, port, tick))
+
+                ipv4 = subs.get('ipv4')
+                if ipv4:
+                    adds.append((i, ipv4prop, ipv4, tick))
+
+            if adds:
+                self.core.addRows(adds)
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -359,7 +359,7 @@ class InetMod(CoreModule):
 
             rows = self.core.getRowsByProp(form)
             for i, p, v, _ in rows:
-                norm, subs = self.core.getTypeNorm(form, v)
+                norm, subs = s_datamodel.tlib.getTypeNorm(form, v)
 
                 port = subs.get('port')
                 if port:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -63,7 +63,12 @@ class CoreTestDataModelModuleV0(s_module.CoreModule):
             'types': (
                 ('foo:bar', {'subof': 'str', 'doc': 'A foo bar!'}),
             ),
-            'forms': (),
+            'forms': (
+                ('foo:bar',
+                 {'ptype': 'foo:bar'},
+                 []
+                 ),
+            ),
         }
         name = 'test'
         return ((name, modl),)
@@ -78,7 +83,7 @@ class CoreTestDataModelModuleV1(s_module.CoreModule):
             ),
             'forms': (
                 ('foo:bar',
-                 {'ptype': 'str'},
+                 {'ptype': 'foo:bar'},
                  [('duck', {'defval': 'mallard', 'ptype': 'str', 'doc': 'Duck value!'})]
                  ),
             ),

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -440,7 +440,7 @@ class InetModelTest(SynTest):
                 t1 = core.getTufoByIden(iden1)
                 self.eq(t1[1].get('inet:url:ipv4'), 0x01020304)
 
-    def test_modelrev_201704201837(self):
+    def test_model_inet_201706201837(self):
 
         byts = self.getRev0DbByts()
 
@@ -471,7 +471,7 @@ class InetModelTest(SynTest):
             # Validate our nodes now have the correct data
             with s_cortex.openurl(url) as core:
                 modlrev = core.getModlVers('inet')
-                self.ge(modlrev, 201704201837)
+                self.ge(modlrev, 201706201837)
 
                 t1 = core.getTufoByIden(iden1)
                 self.eq(t1[1].get('inet:tcp4:port'), 80)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -43,6 +43,9 @@ class InetModelTest(SynTest):
             self.eq(t0[1].get('inet:ipv6'), '::1')
             self.eq(t0[1].get('inet:ipv6:asn'), -1)
 
+            self.eq(core.getTypeRepr('inet:ipv6', '0:0:0:0:0:0:0:1'), '::1')
+            self.eq(core.getTypeRepr('inet:ipv6', '::1'), '::1')
+
     def test_model_inet_cidr4(self):
 
         with s_cortex.openurl('ram:///') as core:

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-import synapse.cortex as s_cortex
+import synapse.lib.tufo as s_tufo
 
 from synapse.tests.common import *
 
@@ -81,6 +81,31 @@ class InetModelTest(SynTest):
             self.eq(t1[1].get('inet:fqdn:domain'), 'com')
             self.eq(t1[1].get('inet:fqdn:sfx'), 0)
             self.eq(t1[1].get('inet:fqdn:zone'), 1)
+
+    def test_model_inet_srv4_types(self):
+        with s_cortex.openurl('ram:///') as core:
+            core.setConfOpt('enforce', 1)
+            t0 = core.formTufoByProp('inet:tcp4', '8.8.8.8:80')
+            form, pprop = s_tufo.ndef(t0)
+            self.eq(pprop, 8830587502672)
+            self.eq(t0[1].get('inet:tcp4:port'), 80)
+            self.eq(t0[1].get('inet:tcp4:ipv4'), core.getTypeNorm('inet:ipv4', '8.8.8.8')[0])
+
+            # 1.2.3.4:8443
+            t1 = core.formTufoByProp('inet:tcp4', 1108152164603)
+            self.eq(t1[1].get('inet:tcp4:port'), 8443)
+            self.eq(t1[1].get('inet:tcp4:ipv4'), core.getTypeNorm('inet:ipv4', '1.2.3.4')[0])
+
+            t2 = core.formTufoByProp('inet:udp4', '8.8.8.8:80')
+            form, pprop = s_tufo.ndef(t2)
+            self.eq(pprop, 8830587502672)
+            self.eq(t2[1].get('inet:udp4:port'), 80)
+            self.eq(t2[1].get('inet:udp4:ipv4'), core.getTypeNorm('inet:ipv4', '8.8.8.8')[0])
+
+            # 1.2.3.4:8443
+            t3 = core.formTufoByProp('inet:udp4', 1108152164603)
+            self.eq(t3[1].get('inet:udp4:port'), 8443)
+            self.eq(t3[1].get('inet:udp4:ipv4'), core.getTypeNorm('inet:ipv4', '1.2.3.4')[0])
 
     def test_model_inet_fqdn_unicode(self):
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -107,6 +107,31 @@ class InetModelTest(SynTest):
             self.eq(t3[1].get('inet:udp4:port'), 8443)
             self.eq(t3[1].get('inet:udp4:ipv4'), core.getTypeNorm('inet:ipv4', '1.2.3.4')[0])
 
+    def test_model_inet_srv6_types(self):
+        with s_cortex.openurl('ram:///') as core:
+            core.setConfOpt('enforce', 1)
+            t0 = core.formTufoByProp('inet:tcp6', '[0:0:0:0:0:0:0:1]:80')
+            form, pprop = s_tufo.ndef(t0)
+            self.eq(pprop, '[::1]:80')
+            self.eq(t0[1].get('inet:tcp6:port'), 80)
+            self.eq(t0[1].get('inet:tcp6:ipv6'), '::1')
+
+            t1 = core.formTufoByProp('inet:tcp6', '[0:0:0:0:0:3:2:1]:443')
+            form, pprop = s_tufo.ndef(t1)
+            self.eq(pprop, '[::3:2:1]:443')
+            self.eq(t1[1].get('inet:tcp6:port'), 443)
+            self.eq(t1[1].get('inet:tcp6:ipv6'), '::3:2:1')
+
+            t2 = core.formTufoByProp('inet:udp6', '[0:0:0:0:0:3:2:1]:5000')
+            form, pprop = s_tufo.ndef(t2)
+            self.eq(pprop, '[::3:2:1]:5000')
+            self.eq(t2[1].get('inet:udp6:port'), 5000)
+            self.eq(t2[1].get('inet:udp6:ipv6'), '::3:2:1')
+
+            self.eq(core.getTypeRepr('inet:tcp6', '[0:0:0:0:0:0:0:1]:80'), '[::1]:80')
+            self.eq(core.getTypeRepr('inet:tcp6', '[::1]:80'), '[::1]:80')
+            self.eq(core.getTypeRepr('inet:tcp6', '[0:0:0:0:0:3:2:1]:5000'), '[::3:2:1]:5000')
+
     def test_model_inet_fqdn_unicode(self):
 
         with s_cortex.openurl('ram:///') as core:


### PR DESCRIPTION
Closes #354

Also adds consistent repr() functions for ipv6 values.

Blocked by #320 for easy testing support of migration.