### PR TITLE
WIP: Fix broken AxonFS Tests

### DIFF
--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -43,7 +43,7 @@ class FilePathType(DataType):
 
             fins.append(v)
 
-        subs = {'dir': '', 'depth': len(fins)}
+        subs = {'dir': lead, 'depth': len(fins)}
         valu = lead + ('/'.join(fins))
 
         if fins:
@@ -54,8 +54,7 @@ class FilePathType(DataType):
             if len(pext) > 1:
                 subs['ext'] = pext[1]
 
-            if len(fins) > 1:
-                subs['dir'] = lead + ('/'.join(fins[:-1]))
+            subs['dir'] += '/'.join(fins[:-1])
 
         return valu, subs
 

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -432,7 +432,6 @@ class AxonTest(SynTest):
                 self.eq(actual, b'')
 
     def test_axon_fs_readdir(self, *args, **kwargs):
-        raise unittest.SkipTest('FIXME file path norm breakage')
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
 
@@ -443,7 +442,6 @@ class AxonTest(SynTest):
                 self.raises(NotSupported, axon.fs_readdir, '/foofile')
 
     def test_axon_fs_rmdir(self, *args, **kwargs):
-        raise unittest.SkipTest('FIXME file path norm breakage')
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
 
@@ -459,7 +457,6 @@ class AxonTest(SynTest):
                 self.raises(NoSuchEntity, axon.fs_rmdir, '/foo')
 
     def test_axon_fs_rename(self, *args, **kwargs):
-        raise unittest.SkipTest('FIXME file path norm breakage')
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
 
@@ -544,7 +541,7 @@ class AxonTest(SynTest):
                 self.eq(tufo[1].get('axon:path:st_size'), 0)
                 self.eq(tufo[1].get('axon:path:blob'), None)
 
-                axon.fs_truncate('/notthere')  # FIXME - should this raise exception?
+                axon.fs_truncate('/notthere')
 
     def test_axon_fs_unlink(self, *args, **kwargs):
         with self.getTestDir() as dirname:

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -277,13 +277,13 @@ class DataModelTest(SynTest):
         prop = 'file:path'
 
         data = (
-            ('/', ('/', {'dir': '', 'depth': 0}), '/'),
-            ('//', ('/', {'dir': '', 'depth': 0}), '//'),
-            ('////////////', ('/', {'dir': '', 'depth': 0}), '////////////'),
+            ('/', ('/', {'dir': '/', 'depth': 0}), '/'),
+            ('//', ('/', {'dir': '/', 'depth': 0}), '//'),
+            ('////////////', ('/', {'dir': '/', 'depth': 0}), '////////////'),
             ('weirD', ('weird', {'base': 'weird', 'dir': '', 'depth': 1}), 'weirD'),
 
             ('foo1', ('foo1', {'base': 'foo1', 'dir': '', 'depth': 1}), 'foo1'),
-            ('/foo2', ('/foo2', {'base': 'foo2', 'dir': '', 'depth': 1}), '/foo2'),
+            ('/foo2', ('/foo2', {'base': 'foo2', 'dir': '/', 'depth': 1}), '/foo2'),
             ('/foo/bar3', ('/foo/bar3', {'base': 'bar3', 'dir': '/foo', 'depth': 2}), '/foo/bar3'),
             ('/foo/bar4    ', ('/foo/bar4    ', {'base': 'bar4    ', 'dir': '/foo', 'depth': 2}), '/foo/bar4    '),  # These are valid filepaths
             ('/foo/bar5/', ('/foo/bar5', {'base': 'bar5', 'dir': '/foo', 'depth': 2}), '/foo/bar5/'),

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -66,14 +66,46 @@ class FileModelTest(SynTest):
 
             core.formTufoByProp('file:path', '/foo/bar/baz/faz/')
 
-            self.nn(core.getTufoByProp('file:path', '/foo/bar/baz/faz'))
+            tufo = core.getTufoByProp('file:path', '/foo/bar/baz/faz/')
+            self.nn(tufo)
+            self.eq(tufo[1].get('file:path'), '/foo/bar/baz/faz')
+            self.eq(tufo[1].get('file:path:dir'), '/foo/bar/baz')
+            self.eq(tufo[1].get('file:path:base'), 'faz')
+            self.eq(tufo[1].get('file:path:depth'), 4)
             self.nn(core.getTufoByProp('file:base', 'faz'))
-            self.nn(core.getTufoByProp('file:path', '/foo/bar/baz'))
+
+            tufo = core.getTufoByProp('file:path', '/foo/bar/baz/')
+            self.nn(tufo)
+            self.eq(tufo[1].get('file:path'), '/foo/bar/baz')
+            self.eq(tufo[1].get('file:path:dir'), '/foo/bar')
+            self.eq(tufo[1].get('file:path:base'), 'baz')
+            self.eq(tufo[1].get('file:path:depth'), 3)
             self.nn(core.getTufoByProp('file:base', 'baz'))
-            self.nn(core.getTufoByProp('file:path', '/foo/bar'))
+
+            tufo = core.getTufoByProp('file:path', '/foo/bar/')
+            self.nn(tufo)
+            self.eq(tufo[1].get('file:path'), '/foo/bar')
+            self.eq(tufo[1].get('file:path:dir'), '/foo')
+            self.eq(tufo[1].get('file:path:base'), 'bar')
+            self.eq(tufo[1].get('file:path:depth'), 2)
             self.nn(core.getTufoByProp('file:base', 'bar'))
-            self.nn(core.getTufoByProp('file:path', '/foo'))
+
+            tufo = core.getTufoByProp('file:path', '/foo/')
+            self.nn(tufo)
+            self.eq(tufo[1].get('file:path'), '/foo')
+            self.eq(tufo[1].get('file:path:dir'), '/')
+            self.eq(tufo[1].get('file:path:base'), 'foo')
+            self.eq(tufo[1].get('file:path:depth'), 1)
             self.nn(core.getTufoByProp('file:base', 'foo'))
+
+            tufo = core.getTufoByProp('file:path', '/')
+            self.nn(tufo)
+            self.eq(tufo[1].get('file:path'), '/')
+            self.eq(tufo[1].get('file:path:dir'), '/')
+            self.eq(tufo[1].get('file:path:base'), None)
+            self.eq(tufo[1].get('file:path:depth'), 0)
+
+            self.raises(BadTypeValu, core.formTufoByProp, 'file:base', '/')
             self.none(core.getTufoByProp('file:base', ''))
 
     def test_filebase(self):

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -75,7 +75,7 @@ class InfoTechTest(SynTest):
             self.nn(node)
             self.none(node[1].get('file:path:ext'))
 
-            self.eq(node[1].get('file:path:dir'), '')
+            self.eq(node[1].get('file:path:dir'), '/')
             self.eq(node[1].get('file:path:base'), 'foo')
 
             node = core.formTufoByProp('file:path', r'c:\Windows\system32\Kernel32.dll')


### PR DESCRIPTION
These tests were broken sometime after v0.0.14 was cut and on/before when v0.0.15 was cut.  The norm behavior for `file:path` was changed and now the root of the filesystem is `''` instead of `'/'`.

##### Broken Tests:
https://github.com/vertexproject/synapse/blob/v0.0.19/synapse/tests/test_axon.py#L436-L532

##### Files model @ v0.0.14:
- https://github.com/vertexproject/synapse/blob/v0.0.14/synapse/models/files.py#L116-L147
- https://github.com/vertexproject/synapse/blob/v0.0.14/synapse/tests/test_model_files.py#L43-L59

##### Files model @ v0.0.15
- https://github.com/vertexproject/synapse/blob/v0.0.15/synapse/models/files.py#L128-L172
- https://github.com/vertexproject/synapse/blob/v0.0.15/synapse/tests/test_model_files.py#L48-L62