### PR TITLE
fixes for comp types in long form opers, new query planning pass, limit() oper

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -18,7 +18,7 @@ from binascii import hexlify
 import synapse.exc as s_exc
 
 from synapse.exc import *
-from synapse.compat import enbase64, debase64, canstor
+from synapse.compat import enbase64, debase64, canstor, isint
 
 class NoValu: pass
 
@@ -33,6 +33,21 @@ def guid(valu=None):
     # Generate a "stable" guid from the given item
     byts = msgenpack(valu)
     return hashlib.md5(byts).hexdigest()
+
+def intify(x):
+    '''
+    Ensure ( or frob ) a value into being an integer or None.
+
+    Args:
+        x (obj):    An object to intify
+
+    Returns:
+        (int):  The int value ( or None )
+    '''
+    try:
+        return int(x)
+    except (TypeError, ValueError) as e:
+        return None
 
 def addpref(pref, info):
     '''

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -18,7 +18,7 @@ from binascii import hexlify
 import synapse.exc as s_exc
 
 from synapse.exc import *
-from synapse.compat import enbase64, debase64, canstor, isint
+from synapse.compat import enbase64, debase64, canstor
 
 class NoValu: pass
 

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -36,7 +36,7 @@ def guid(valu=None):
 
 def intify(x):
     '''
-    Ensure ( or frob ) a value into being an integer or None.
+    Ensure ( or coerce ) a value into being an integer or None.
 
     Args:
         x (obj):    An object to intify

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -619,9 +619,12 @@ class Runtime(Configable):
         for oper in opers:
 
             # specify a limit backward from limit oper...
-            if oper[0] == 'limit' and len(retn):
-                limt = oper[1].get('args')[0]
-                setkw(retn[-1], 'limit', limt)
+            if oper[0] == 'limit' and retn:
+                args = oper[1].get('args',())
+                if args:
+                    limt = s_common.intify(args[0])
+                    if limt is not None:
+                        setkw(retn[-1], 'limit', limt)
 
             # TODO look for a form lift + tag filter and optimize
 
@@ -976,7 +979,10 @@ class Runtime(Configable):
         if len(args) != 1:
             raise s_common.BadSyntaxError(mesg='limit(<size>)')
 
-        size = int(args[0])
+        size = s_common.intify(args[0])
+        if size is None:
+            raise s_common.BadSyntaxError(mesg='limit(<int>)')
+
         if query.size() > size:
             [ query.add(node) for node in query.take()[:size] ]
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -368,7 +368,7 @@ def ge(x, y):
         return False
     return x >= y
 
-def setkw(oper,name,valu):
+def setkw(oper, name, valu):
     '''
     Set a keyword argument in a given operator.
 
@@ -384,8 +384,8 @@ def setkw(oper,name,valu):
     if kwlist is None:
         kwlist = []
 
-    kwlist = [ (k,v) for (k,v) in kwlist if k != name ]
-    kwlist.append((name,valu))
+    kwlist = [(k, v) for (k, v) in kwlist if k != name]
+    kwlist.append((name, valu))
     oper[1]['kwlist'] = kwlist
 
 class Runtime(Configable):
@@ -972,7 +972,7 @@ class Runtime(Configable):
         [query.add(tufo) for tufo in self.stormTufosBy(by, prop, valu, limit=limit)]
 
     def _stormOperLimit(self, query, oper):
-        args = oper[1].get('args',())
+        args = oper[1].get('args', ())
         if len(args) != 1:
             raise s_common.BadSyntaxError(mesg='limit(<size>)')
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -981,7 +981,7 @@ class Runtime(Configable):
 
         size = s_common.intify(args[0])
         if size is None:
-            raise s_common.BadSyntaxError(mesg='limit(<int>)')
+            raise s_common.BadSyntaxError(mesg='limit(<size>)')
 
         if query.size() > size:
             [ query.add(node) for node in query.take()[:size] ]

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -445,30 +445,6 @@ def parse_cmd_kwlist(text, off=0):
     _, off = nom(text, off, whites)
     return kwlist, off
 
-def parse_oarg(text, off=0):
-    '''
-    Parse something that might be a literal *or*
-    a kwarg name, *or* an unadorned literal string
-    ( which may not use any context sensitive chars )
-    '''
-    _, off = nom(text, off, whites)
-
-    valu, off = parse_valu(text, off)
-
-    if is_literal(text,off):
-        valu, off = parse_literal(text, off)
-        _, off = nom(text, off, whites)
-
-    else:
-        valu, off = meh(text, off, '=,)')
-        valu = valu.strip()
-        try:
-            valu = int(valu, 0)
-        except ValueError as e:
-            pass
-
-    return valu, off
-
 def parse_oper(text, off=0):
     '''
     Returns an inst,off tuple by parsing an operator expression.

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -453,8 +453,10 @@ def parse_oarg(text, off=0):
     '''
     _, off = nom(text, off, whites)
 
-    if nextchar(text, off, '"'):
-        valu, off = parse_string(text, off)
+    valu, off = parse_valu(text, off)
+
+    if is_literal(text,off):
+        valu, off = parse_literal(text, off)
         _, off = nom(text, off, whites)
 
     else:
@@ -482,7 +484,6 @@ def parse_oper(text, off=0):
 
     _, off = nom(text, off, whites)
 
-    #if text[off] != '(':
     if not nextchar(text, off, '('):
         raise s_common.BadSyntaxError(expected='( for operator ' + name, at=off)
 
@@ -496,14 +497,17 @@ def parse_oper(text, off=0):
             off += 1
             return inst, off
 
-        oarg, off = parse_oarg(text, off)
+        valu, off = parse_valu(text, off)
+        _, off = nom(text, off, whites)
 
         if nextchar(text, off, '='):
-            off += 1
-            valu, off = parse_oarg(text, off)
-            inst[1]['kwlist'].append((oarg, valu))
+
+            vval, off = parse_valu(text, off+1)
+            inst[1]['kwlist'].append((valu,vval))
+
         else:
-            inst[1]['args'].append(oarg)
+
+            inst[1]['args'].append(valu)
 
         if not nextin(text, off, [',', ')']):
             raise s_common.BadSyntaxError(mesg='Unexpected Token: ' + text[off], at=off)
@@ -686,7 +690,7 @@ def parse(text, off=0):
             continue
 
         # standard foo() oper syntax
-        if text[off] == '(':
+        if nextchar(text, off, '('):
             inst, off = parse_oper(text, origoff)
             ret.append(inst)
             continue

--- a/synapse/tests/test_common.py
+++ b/synapse/tests/test_common.py
@@ -11,6 +11,12 @@ class CommonTest(SynTest):
             fd = genfile(testdir, 'woot', 'foo.bin')
             fd.close()
 
+    def test_common_intify(self):
+        self.eq(intify(20), 20)
+        self.eq(intify("20"), 20)
+        self.none(intify(None))
+        self.none(intify("woot"))
+
     def test_common_guid(self):
         iden0 = guid()
         iden1 = guid('foo bar baz')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -125,6 +125,10 @@ class StormTest(SynTest):
             opts = dict(oper[1].get('kwlist'))
             self.eq(opts.get('limit'), 1 )
 
+            self.raises(BadSyntaxError, core.eval, 'inet:ipv4 limit()')
+            self.raises(BadSyntaxError, core.eval, 'inet:ipv4 limit(nodes=10)')
+            self.raises(BadSyntaxError, core.eval, 'inet:ipv4 limit(woot)')
+
     def test_storm_addtag(self):
         with s_cortex.openurl('ram:///') as core:
             iden = guid()

--- a/synapse/tests/test_syntax.py
+++ b/synapse/tests/test_syntax.py
@@ -111,3 +111,18 @@ class StormSyntaxTest(SynTest):
         inst0 = s_syntax.parse('[inet:ipv4=127.0.0.1 inet:ipv4=127.0.0.2]')
         inst1 = s_syntax.parse('   [   inet:ipv4   =    127.0.0.1  inet:ipv4   =   127.0.0.2   ]   ')
         self.eq(inst0, inst1)
+
+    def test_storm_syntax_oper_args(self):
+
+        oper = s_syntax.parse(' woot( (1,2), lol, "hehe haha", one=(3,4), two=5, three=whee) ')[0]
+        args = oper[1].get('args')
+        opts = dict(oper[1].get('kwlist'))
+
+        self.eq(args[0], [1,2])
+        self.eq(args[1], 'lol')
+        self.eq(args[2], 'hehe haha')
+
+        self.eq(opts.get('one'), [3,4])
+        self.eq(opts.get('two'), 5)
+        self.eq(opts.get('three'), 'whee')
+


### PR DESCRIPTION
the long form oper parser has been updated to properly use parse_valu to chop up internal arguments ( fixing issue with comp syntax as values in oper()

added a "plan()" method which allows us to modify the series of opers prior to execution.  this currently facilitates the limit(<size>) operator to reach backward and add a limit= kwarg to the previous oper