### PR TITLE
Adds method to form multiple tufos in one call/roundtrip

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1901,6 +1901,33 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
 
         return self.formTufoByProp(form, valu, **props)
 
+    def formTufosByItems(self, items):
+        '''
+        Forms tufos by prop, given a tuple of (form, valu, props) tuples.
+
+        Args:
+
+            items (tuple): A tuple of tuples of (form, valu, props)
+
+        Returns:
+            tuple: Tuple containing tufos, either with the node or error data
+
+        Example:
+
+            items = ( ('foo:thing', 'hehe', {'a': 1}), ('bar:thing', 'haha', {'b': 2}), )
+            results = core.formTufoByItems(items)
+        '''
+        retval = []
+
+        with self.getCoreXact() as xact:
+            for form, valu, props in items:
+                try:
+                    retval.append(self.formTufoByProp(form, valu, **props))
+                except Exception as e:
+                    retval.append(('error', s_common.excinfo(e)),)
+
+        return tuple(retval)
+
     def formTufoByProp(self, prop, valu, **props):
         '''
         Form an (iden,info) tuple by atomically deconflicting

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1901,7 +1901,7 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
 
         return self.formTufoByProp(form, valu, **props)
 
-    def formTufosByItems(self, items):
+    def formTufosByProps(self, items):
         '''
         Forms tufos by prop, given a tuple of (form, valu, props) tuples.
 
@@ -1910,12 +1910,13 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
             items (tuple): A tuple of tuples of (form, valu, props)
 
         Returns:
+
             tuple: Tuple containing tufos, either with the node or error data
 
         Example:
 
             items = ( ('foo:thing', 'hehe', {'a': 1}), ('bar:thing', 'haha', {'b': 2}), )
-            results = core.formTufoByItems(items)
+            results = core.formTufosByProps(items)
         '''
         retval = []
 
@@ -1924,7 +1925,9 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
                 try:
                     retval.append(self.formTufoByProp(form, valu, **props))
                 except Exception as e:
-                    retval.append(('error', s_common.excinfo(e)),)
+                    excinfo = s_common.excinfo(e)
+                    excval = excinfo.pop('err')
+                    retval.append(s_tufo.ephem('syn:err', excval, **excinfo))
 
         return tuple(retval)
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2509,7 +2509,7 @@ class CortexTest(SynTest):
             nodes = core.eval('inet:ipv4*inet:cidr=192.168.0.0/16')
             self.eq(len(nodes), 256 * 3)
 
-    def test_cortex_formtufosbyitems(self):
+    def test_cortex_formtufosbyprops(self):
 
         with s_cortex.openurl('ram:///') as core:
             core.setConfOpt('enforce', 1)
@@ -2522,7 +2522,7 @@ class CortexTest(SynTest):
                         ('inet:url', 'bad', {}),
                         ('bad', 'good', {'wat': 3}),
                     )
-                    actual = prox.formTufosByItems(items)
+                    actual = prox.formTufosByProps(items)
 
                     self.isinstance(actual, tuple)
                     self.eq(len(actual), 3)
@@ -2534,16 +2534,18 @@ class CortexTest(SynTest):
                     self.eq(actual[0][1]['inet:fqdn:zone'], 1)
 
                     self.isinstance(actual[1], tuple)
-                    self.eq(actual[1][0], 'error')
-                    self.eq(actual[1][1]['err'], 'BadTypeValu')
+                    self.eq(actual[1][0], None)
+                    self.eq(actual[1][1]['tufo:form'], 'syn:err')
+                    self.eq(actual[1][1]['syn:err'], 'BadTypeValu')
                     for s in ['BadTypeValu', 'name=', 'inet:url', 'valu=', 'bad']:
-                        self.isin(s, actual[1][1]['errmsg'])
+                        self.isin(s, actual[1][1]['syn:err:errmsg'])
 
                     self.isinstance(actual[2], tuple)
-                    self.eq(actual[2][0], 'error')
-                    self.eq(actual[2][1]['err'], 'NoSuchForm')
+                    self.eq(actual[2][0], None)
+                    self.eq(actual[2][1]['tufo:form'], 'syn:err')
+                    self.eq(actual[2][1]['syn:err'], 'NoSuchForm')
                     for s in ['NoSuchForm', 'name=', 'bad']:
-                        self.isin(s, actual[2][1]['errmsg'])
+                        self.isin(s, actual[2][1]['syn:err:errmsg'])
 
 class StorageTest(SynTest):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2509,6 +2509,42 @@ class CortexTest(SynTest):
             nodes = core.eval('inet:ipv4*inet:cidr=192.168.0.0/16')
             self.eq(len(nodes), 256 * 3)
 
+    def test_cortex_formtufosbyitems(self):
+
+        with s_cortex.openurl('ram:///') as core:
+            core.setConfOpt('enforce', 1)
+            with s_daemon.Daemon() as dmon:
+                dmon.share('core', core)
+                link = dmon.listen('tcp://127.0.0.1:0/core')
+                with s_cortex.openurl('tcp://127.0.0.1:%d/core' % link[1]['port']) as prox:
+                    items = (
+                        ('inet:fqdn', 'vertex.link', {'zone': 1}),
+                        ('inet:url', 'bad', {}),
+                        ('bad', 'good', {'wat': 3}),
+                    )
+                    actual = prox.formTufosByItems(items)
+
+                    self.isinstance(actual, tuple)
+                    self.eq(len(actual), 3)
+
+                    self.isinstance(actual[0], tuple)
+                    self.eq(len(actual[0]), 2)
+                    self.eq(actual[0][1]['tufo:form'], 'inet:fqdn')
+                    self.eq(actual[0][1]['inet:fqdn'], 'vertex.link')
+                    self.eq(actual[0][1]['inet:fqdn:zone'], 1)
+
+                    self.isinstance(actual[1], tuple)
+                    self.eq(actual[1][0], 'error')
+                    self.eq(actual[1][1]['err'], 'BadTypeValu')
+                    for s in ['BadTypeValu', 'name=', 'inet:url', 'valu=', 'bad']:
+                        self.isin(s, actual[1][1]['errmsg'])
+
+                    self.isinstance(actual[2], tuple)
+                    self.eq(actual[2][0], 'error')
+                    self.eq(actual[2][1]['err'], 'NoSuchForm')
+                    for s in ['NoSuchForm', 'name=', 'bad']:
+                        self.isin(s, actual[2][1]['errmsg'])
+
 class StorageTest(SynTest):
 
     def test_nonexist_ctor(self):


### PR DESCRIPTION
I need a way to form many tufos without round tripping for each call.

Performance comparison gist: https://gist.github.com/vertexmc/1ec1b08161e090cb4dfc971d38343f8f