### PR TITLE
Fix Cortex() __init__ list comprehension to not smash 'conf' local on python 2.7

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -62,7 +62,7 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         self.axon = None
         self.seedctors = {}
 
-        self.modules = [(ctor, conf) for ctor, smod, conf in s_modules.ctorlist]
+        self.modules = [(ctor, modconf) for ctor, smod, modconf in s_modules.ctorlist]
         self.modsdone = False
 
         self.noauto = {'syn:form', 'syn:type', 'syn:prop'}


### PR DESCRIPTION
On 2.7 locals get smashed by comprehensions. This means that configable opts passed via __init__ are possibly overridden.  This fixes that.