### PR TITLE
DISCUSSION: Initial inet:netlogon form + migration and tests.

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -109,7 +109,8 @@ class GuidType(DataType):
         # ( sigh... eventually everything will be a cortex... )
         node = self._getTufoByProp(self._guid_alias, valu[1:])
         if node is None:
-            self._raiseBadValu(valu, mesg='no result for guid resolver')
+            self._raiseBadValu(valu, mesg='no result for guid resolver',
+                               alias=self._guid_alias)
 
         iden = node[1].get(node[1].get('tufo:form'))
         return iden, {}

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -492,7 +492,7 @@ class InetMod(CoreModule):
 
                 ('inet:netuser', {'subof': 'sepr', 'sep': '/', 'fields': 'site,inet:fqdn|user,inet:user',
                                   'doc': 'A user account at a given web address', 'ex': 'twitter.com/invisig0th'}),
-                ('inet:netlogon', {'subof': 'guid',
+                ('inet:web:logon', {'subof': 'guid',
                                    'doc': 'An instance of a user account authenticating to a service.', }),
 
                 ('inet:netgroup', {'subof': 'sepr', 'sep': '/', 'fields': 'site,inet:fqdn|name,ou:name',
@@ -706,7 +706,7 @@ class InetMod(CoreModule):
                     ('seen:max', {'ptype': 'time:max'}),
                 ]),
 
-                ('inet:netlogon', {'ptype': 'inet:netlogon'}, [
+                ('inet:web:logon', {'ptype': 'inet:web:logon'}, [
                     ('netuser', {'ptype': 'inet:netuser', 'doc': 'The netuser associated with the logon event.', }),
                     ('netuser:site', {'ptype': 'inet:fqdn', }),
                     ('netuser:user', {'ptype': 'inet:user', }),

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -528,6 +528,7 @@ class InetMod(CoreModule):
 
                 ('inet:asn', {'ptype': 'inet:asn', 'doc': 'An Autonomous System'}, (
                     ('name', {'ptype': 'str:lwr', 'defval': '??'}),
+                    ('owner', {'ptype': 'ou:name', 'doc': 'Organization which controls an ASN'}),
                 )),
 
                 ('inet:asnet4',

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -407,8 +407,8 @@ class InetMod(CoreModule):
 
         types = [('inet:netlogon', {'subof': 'comp',
                                     'fields': 'user,inet:netuser|time,time|status,bool',
-                                    'doc': 'WORDS',
-                                    'ex': 'WORDS'})]
+                                    'doc': 'An instance of a user account authenticating to a service.',
+                                    'ex': '(vertex.link/pennywise,1503068162551,1)'})]
 
         forms = [
             ('inet:netlogon', {'syn:form': 'inet:netlogon',
@@ -516,8 +516,8 @@ class InetMod(CoreModule):
                                   'doc': 'A user account at a given web address', 'ex': 'twitter.com/invisig0th'}),
                 ('inet:netlogon', {'subof': 'comp',
                                    'fields': 'user,inet:netuser|time,time|status,bool',
-                                   'doc': 'WORDS',
-                                   'ex': 'WORDS'}),
+                                   'doc': 'An instance of a user account authenticating to a service.',
+                                   'ex': '(vertex.link/pennywise,1503068162551,1)'}),
 
                 ('inet:netgroup', {'subof': 'sepr', 'sep': '/', 'fields': 'site,inet:fqdn|name,ou:name',
                                    'doc': 'A group within an online community'}),

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -400,45 +400,6 @@ class InetMod(CoreModule):
     def _revModl201708231646(self):
         pass # for legacy/backward compat
 
-    @modelrev('inet', 201708172326)
-    def _revModl201708141516(self):
-
-        props = [
-            ('user',
-             {'ptype': 'inet:netuser', 'doc': 'The netuser associated with the logon event.', 'ro': 1,
-              'form': 'inet:netlogon'}),
-            ('time',
-             {'ptype': 'time', 'doc': 'The time the netuser logged into the service', 'ro': 1,
-              'form': 'inet:netlogon'}),
-            ('status', {'ptype': 'bool', 'ro': 1,
-                        'doc': 'The status of the logon action, denoting if it was successful or not.',
-                        'form': 'inet:netlogon'}),
-            ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The source IPv4 address of the logon.', 'form': 'inet:netlogon'}),
-            ('ipv6', {'ptype': 'inet:ipv6', 'doc': 'The source IPv6 address of the logon.', 'form': 'inet:netlogon'}),
-            ('logout', {'ptype': 'time', 'doc': 'The time the netuser logged out of the service.',
-                        'form': 'inet:netlogon'})
-        ]
-
-        ttufo = self.core.formTufoByProp('syn:type', 'inet:netlogon',
-                                         **{'subof': 'comp',
-                                            'fields': 'user,inet:netuser|time,time|status,bool',
-                                            'doc': 'An instance of a user account authenticating to a service.',
-                                            'ex': '(vertex.link/pennywise,1503068162551,1)'})
-
-        if not ttufo[1].get('.new'):
-            mesg = 'inet:netlogon rows already present. Skipping model update'
-            self.log(logging.WARNING, mesg=mesg)
-            logger.warning(mesg)
-            return
-
-        ftufo = self.core.formTufoByProp('syn:form', 'inet:netlogon', ptype='inet:netlogon')
-        ptufos = []
-        for prop, pnfo in props:
-            ptufo = self.core.formTufoByProp('syn:prop', ':'.join(['inet:netlogon', prop]), **pnfo)
-            ptufos.append(ptufo)
-
-        return
-
     @staticmethod
     def getBaseModels():
         modl = {

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -403,7 +403,7 @@ class InetMod(CoreModule):
     @modelrev('inet', 201709181501)
     def _revModl201709181501(self):
         '''
-        Replace inet:whois:rec:ns<int> rows with inet:whos:nsrec nodes.
+        Replace inet:whois:rec:ns<int> rows with inet:whos:recns nodes.
         '''
         adds = []
         srcprops = ('inet:whois:rec:ns1', 'inet:whois:rec:ns2', 'inet:whois:rec:ns3', 'inet:whois:rec:ns4')

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -407,8 +407,8 @@ class InetMod(CoreModule):
 
         types = [('inet:netlogon', {'subof': 'comp',
                                     'fields': 'user,inet:netuser|time,time|status,bool',
-                                    'doc': 'WORDS',
-                                    'ex': 'WORDS'})]
+                                    'doc': 'An instance of a user account authenticating to a service.',
+                                    'ex': '(vertex.link/pennywise,1503068162551,1)'})]
 
         forms = [
             ('inet:netlogon', {'syn:form': 'inet:netlogon',

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -492,10 +492,8 @@ class InetMod(CoreModule):
 
                 ('inet:netuser', {'subof': 'sepr', 'sep': '/', 'fields': 'site,inet:fqdn|user,inet:user',
                                   'doc': 'A user account at a given web address', 'ex': 'twitter.com/invisig0th'}),
-                ('inet:netlogon', {'subof': 'comp',
-                                   'fields': 'user,inet:netuser|time,time|status,bool',
-                                   'doc': 'An instance of a user account authenticating to a service.',
-                                   'ex': '(vertex.link/pennywise,1503068162551,1)'}),
+                ('inet:netlogon', {'subof': 'guid',
+                                   'doc': 'An instance of a user account authenticating to a service.', }),
 
                 ('inet:netgroup', {'subof': 'sepr', 'sep': '/', 'fields': 'site,inet:fqdn|name,ou:name',
                                    'doc': 'A group within an online community'}),
@@ -709,10 +707,10 @@ class InetMod(CoreModule):
                 ]),
 
                 ('inet:netlogon', {'ptype': 'inet:netlogon'}, [
-                    ('user', {'ptype': 'inet:netuser', 'doc': 'The netuser associated with the logon event.', 'ro': 1}),
-                    ('time', {'ptype': 'time', 'doc': 'The time the netuser logged into the service', 'ro': 1}),
-                    ('status', {'ptype': 'bool', 'ro': 1,
-                                'doc': 'The status of the logon action, denoting if it was successful or not.'}),
+                    ('netuser', {'ptype': 'inet:netuser', 'doc': 'The netuser associated with the logon event.', }),
+                    ('netuser:site', {'ptype': 'inet:fqdn', }),
+                    ('netuser:user', {'ptype': 'inet:user', }),
+                    ('time', {'ptype': 'time', 'doc': 'The time the netuser logged into the service', }),
                     ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The source IPv4 address of the logon.'}),
                     ('ipv6', {'ptype': 'inet:ipv6', 'doc': 'The source IPv6 address of the logon.'}),
                     ('logout', {'ptype': 'time', 'doc': 'The time the netuser logged out of the service.'})

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -400,6 +400,67 @@ class InetMod(CoreModule):
     def _revModl201708231646(self):
         pass # for legacy/backward compat
 
+    @modelrev('inet', 201708172326)
+    def _revModl201708141516(self):
+
+        tick = s_common.now()
+
+        types = [('inet:netlogon', {'subof': 'comp',
+                                    'fields': 'user,inet:netuser|time,time|status,bool',
+                                    'doc': 'WORDS',
+                                    'ex': 'WORDS'})]
+
+        forms = [
+            ('inet:netlogon', {'syn:form': 'inet:netlogon',
+                               'syn:form:ptype': 'inet:netlogon'})
+        ]
+
+        props = [
+            ('inet:netlogon', {'ptype': 'inet:netlogon'}, [
+                    ('user', {'ptype': 'inet:netuser', 'doc': 'The netuser associated with the logon event.', 'ro': 1, 'glob': 0, 'req': 0}),
+                    ('time', {'ptype': 'time', 'doc': 'The time the netuser logged into the service', 'ro': 1, 'glob': 0, 'req': 0}),
+                    ('status', {'ptype': 'bool', 'ro': 1,
+                                'doc': 'The status of the logon action, denoting if it was successful or not.', 'glob': 0, 'req': 0}),
+                    ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The source IPv4 address of the logon.', 'glob': 0, 'req': 0}),
+                    ('ipv6', {'ptype': 'inet:ipv6', 'doc': 'The source IPv6 address of the logon.', 'glob': 0, 'req': 0}),
+                    ('logout', {'ptype': 'time', 'doc': 'The time the netuser logged out of the service.', 'glob': 0, 'req': 0})
+                ])
+        ]
+
+        rows = self.core.getRowsByProp('syn:type', 'inet:netlogon')
+        if rows:
+            mesg = 'inet:netlogon rows already present. Skipping model update'
+            self.log(logging.WARNING, mesg=mesg)
+            logger.warning(mesg)
+            return
+
+        adds = []
+
+        for typ, tnfo in types:
+            iden = s_common.guid()
+            adds.append((iden, 'tufo:form', 'syn:type', tick))
+            adds.append((iden, 'syn:type', typ, tick))
+            for k, v in tnfo.items():
+                adds.append((iden, ':'.join(['syn:type', k]), v, tick))
+
+        for form, fnfo in forms:
+            iden = s_common.guid()
+            adds.append((iden, 'tufo:form', 'syn:form', tick))
+            for k, v in fnfo.items():
+                adds.append((iden, k, v, tick))
+
+        for form, fnfo, subs in props:
+            for prop, pnfo in subs:
+                iden = s_common.guid()
+                adds.append((iden, 'tufo:form', 'syn:prop', tick))
+                adds.append((iden, 'syn:prop', ':'.join([form, prop]), tick))
+                adds.append((iden, 'syn:prop:form', form, tick))
+                for k, v in pnfo.items():
+                    adds.append((iden, ':'.join(['syn:prop', k]), v, tick))
+
+        if adds:
+            self.core.addRows(adds)
+
     @staticmethod
     def getBaseModels():
         modl = {

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -425,11 +425,11 @@ class InetMod(CoreModule):
                 pprop = s_common.guid([ns, rec])
                 fqdn = rec.split('@', 1)[0]
                 rows = [
-                    (iden, 'tufo:form', 'inet:whois:nsrec', tick),
-                    (iden, 'inet:whois:nsrec', pprop, tick),
-                    (iden, 'inet:whois:nsrec:ns', ns, tick),
-                    (iden, 'inet:whois:nsrec:rec', rec, tick),
-                    (iden, 'inet:whois:nsrec:rec:fqdn', fqdn, tick),
+                    (iden, 'tufo:form', 'inet:whois:recns', tick),
+                    (iden, 'inet:whois:recns', pprop, tick),
+                    (iden, 'inet:whois:recns:ns', ns, tick),
+                    (iden, 'inet:whois:recns:rec', rec, tick),
+                    (iden, 'inet:whois:recns:rec:fqdn', fqdn, tick),
                 ]
                 adds.extend(rows)
 
@@ -518,7 +518,7 @@ class InetMod(CoreModule):
                 ('inet:whois:rec',
                  {'subof': 'sepr', 'sep': '@', 'fields': 'fqdn,inet:fqdn|asof,time', 'doc': 'A whois record',
                   'ex': ''}),
-                ('inet:whois:nsrec', {'subof': 'comp', 'fields': 'ns,inet:fqdn|rec,inet:whois:rec',
+                ('inet:whois:recns', {'subof': 'comp', 'fields': 'ns,inet:fqdn|rec,inet:whois:rec',
                                       'doc': 'A nameserver associated with a given WHOIS record.'}),
 
                 ('inet:whois:contact', {'subof': 'comp', 'fields': 'rec,inet:whois:rec|type,str:lwr',
@@ -567,7 +567,7 @@ class InetMod(CoreModule):
 
                 ('inet:asn', {'ptype': 'inet:asn', 'doc': 'An Autonomous System'}, (
                     ('name', {'ptype': 'str:lwr', 'defval': '??'}),
-                    ('owner', {'ptype': 'ou:name', 'doc': 'Organization which controls an ASN'}),
+                    ('owner', {'ptype': 'ou:org', 'doc': 'Organization which controls an ASN'}),
                 )),
 
                 ('inet:asnet4',
@@ -815,7 +815,7 @@ class InetMod(CoreModule):
                     ('registrant', {'ptype': 'inet:whois:reg', 'defval': '??'}),
                 ]),
 
-                ('inet:whois:nsrec', {}, [
+                ('inet:whois:recns', {}, [
                     ('ns', {'ptype': 'inet:fqdn', 'ro': 1, 'doct': 'Nameserver for a given FQDN'}),
                     ('rec', {'ptype': 'inet:whois:rec', 'ro': 1}),
                     ('rec:fqdn', {'ptype': 'inet:fqdn', 'ro': 1}),

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -423,13 +423,15 @@ class InetMod(CoreModule):
                 delprops.add(prop)
                 iden = s_common.guid()
                 pprop = s_common.guid([ns, rec])
-                fqdn = rec.split('@', 1)[0]
+                fqdn = node[1].get('inet:whois:rec:fqdn')
+                asof = node[1].get('inet:whois:rec:asof')
                 rows = [
                     (iden, 'tufo:form', 'inet:whois:recns', tick),
                     (iden, 'inet:whois:recns', pprop, tick),
                     (iden, 'inet:whois:recns:ns', ns, tick),
                     (iden, 'inet:whois:recns:rec', rec, tick),
                     (iden, 'inet:whois:recns:rec:fqdn', fqdn, tick),
+                    (iden, 'inet:whois:recns:rec:asof', asof, tick),
                 ]
                 adds.extend(rows)
 
@@ -819,6 +821,7 @@ class InetMod(CoreModule):
                     ('ns', {'ptype': 'inet:fqdn', 'ro': 1, 'doct': 'Nameserver for a given FQDN'}),
                     ('rec', {'ptype': 'inet:whois:rec', 'ro': 1}),
                     ('rec:fqdn', {'ptype': 'inet:fqdn', 'ro': 1}),
+                    ('rec:asof', {'ptype': 'time', 'ro': 1}),
                 ]),
 
                 ('inet:whois:contact', {}, [

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -432,46 +432,27 @@ class InetModelTest(SynTest):
         with s_cortex.openurl('ram:///') as core:
             core.setConfOpt('enforce', 1)
             tick = now()
-            # Form via list
-            t0 = core.formTufoByProp('inet:netlogon', ['vertex.link/pennywise',
-                                                       tick,
-                                                       False])
-            t1 = core.formTufoByProp('inet:netlogon', ['vertex.link/pennywise',
-                                                       tick,
-                                                       True])
-            # form via string
-            tick = tick + 1
-            t2 = core.formTufoByProp('inet:netlogon', '(vertex.link/pennywise,{},0)'.format(tick))
-            t3 = core.formTufoByProp('inet:netlogon', '(vertex.link/pennywise,{},1)'.format(tick))
+
+            t0 = core.formTufoByProp('inet:netlogon', '*',
+                                     netuser='vertex.link/pennywise',
+                                     time=tick)
 
             self.nn(t0)
-            self.nn(t1)
-            self.nn(t2)
-            self.nn(t3)
 
-            self.eq(t0[1].get('inet:netlogon:user'), 'vertex.link/pennywise')
-            self.eq(t0[1].get('inet:netlogon:time'), tick - 1)
-            self.eq(t0[1].get('inet:netlogon:status'), 0)
-
-            self.eq(t1[1].get('inet:netlogon:status'), 1)
+            self.eq(t0[1].get('inet:netlogon:time'), tick)
+            self.eq(t0[1].get('inet:netlogon:netuser'), 'vertex.link/pennywise')
+            self.eq(t0[1].get('inet:netlogon:netuser:user'), 'pennywise')
+            self.eq(t0[1].get('inet:netlogon:netuser:site'), 'vertex.link')
 
             # Pivot from a netuser to the netlogon forms via storm
             self.nn(core.getTufoByProp('inet:netuser', 'vertex.link/pennywise'))
-            nodes = core.eval('inet:netuser=vertex.link/pennywise inet:netuser -> inet:netlogon:user')
-            self.eq(len(nodes), 4)
-            self.eq(list({s_tufo.ndef(node)[0] for node in nodes}), ['inet:netlogon'])
+            nodes = core.eval('inet:netuser=vertex.link/pennywise inet:netuser -> inet:netlogon:netuser')
+            self.eq(len(nodes), 1)
 
-            # Cannot set ro props
-            _t0 = core.setTufoProps(t0, user='vertex.link/invisig0th', time=0, status=1)
-            self.eq(_t0[1].get('inet:netlogon:user'), 'vertex.link/pennywise')
-            self.eq(_t0[1].get('inet:netlogon:time'), tick - 1)
-            self.eq(_t0[1].get('inet:netlogon:status'), 0)
-
-            # Can set mutable props
             t0 = core.setTufoProps(t0, ipv4=0x01020304, logout=tick + 1, ipv6='0:0:0:0:0:0:0:1')
             self.eq(t0[1].get('inet:netlogon:ipv4'), 0x01020304)
             self.eq(t0[1].get('inet:netlogon:logout'), tick + 1)
-            self.eq(t0[1].get('inet:netlogon:logout') - t0[1].get('inet:netlogon:time'), 2)
+            self.eq(t0[1].get('inet:netlogon:logout') - t0[1].get('inet:netlogon:time'), 1)
             self.eq(t0[1].get('inet:netlogon:ipv6'), '::1')
 
     def test_model_inet_201706121318(self):

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -70,6 +70,15 @@ class InetModelTest(SynTest):
             self.nn(core.getTufoByProp('inet:ipv4', 0x01020304))
             self.nn(core.getTufoByProp('inet:ipv4', 0x05060708))
 
+            t1 = core.formTufoByProp('inet:asn', 12345)
+            self.none(t1[1].get('inet:asn:owner'))
+            t1 = core.setTufoProps(t1, owner='vertex')
+            self.eq(t1[1].get('inet:asn:owner'), 'vertex')
+            # TODO: Uncomment when we have a global alias resolver in place.
+            # self.nn(core.getTufoByProp('ou:alias', 'vertex'))
+            t2 = core.formTufoByProp('inet:asn', 12346, owner='vertex')
+            self.eq(t2[1].get('inet:asn:owner'), 'vertex')
+
     def test_model_inet_fqdn(self):
         with s_cortex.openurl('ram:///') as core:
             t0 = core.formTufoByProp('inet:fqdn', 'com', sfx=1)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -404,7 +404,7 @@ class InetModelTest(SynTest):
             self.eq(len(core.eval('inet:whois:rec="woot.com@20501217"')), 1)
             self.eq(len(core.eval('inet:whois:contact:rec="woot.com@20501217"')), 1)
 
-    def test_model_inet_whois_nsrec(self):
+    def test_model_inet_whois_recns(self):
         with s_cortex.openurl('ram:///') as core:
             core.setConfOpt('enforce', 1)
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -433,27 +433,27 @@ class InetModelTest(SynTest):
             core.setConfOpt('enforce', 1)
             tick = now()
 
-            t0 = core.formTufoByProp('inet:netlogon', '*',
+            t0 = core.formTufoByProp('inet:web:logon', '*',
                                      netuser='vertex.link/pennywise',
                                      time=tick)
 
             self.nn(t0)
 
-            self.eq(t0[1].get('inet:netlogon:time'), tick)
-            self.eq(t0[1].get('inet:netlogon:netuser'), 'vertex.link/pennywise')
-            self.eq(t0[1].get('inet:netlogon:netuser:user'), 'pennywise')
-            self.eq(t0[1].get('inet:netlogon:netuser:site'), 'vertex.link')
+            self.eq(t0[1].get('inet:web:logon:time'), tick)
+            self.eq(t0[1].get('inet:web:logon:netuser'), 'vertex.link/pennywise')
+            self.eq(t0[1].get('inet:web:logon:netuser:user'), 'pennywise')
+            self.eq(t0[1].get('inet:web:logon:netuser:site'), 'vertex.link')
 
             # Pivot from a netuser to the netlogon forms via storm
             self.nn(core.getTufoByProp('inet:netuser', 'vertex.link/pennywise'))
-            nodes = core.eval('inet:netuser=vertex.link/pennywise inet:netuser -> inet:netlogon:netuser')
+            nodes = core.eval('inet:netuser=vertex.link/pennywise inet:netuser -> inet:web:logon:netuser')
             self.eq(len(nodes), 1)
 
             t0 = core.setTufoProps(t0, ipv4=0x01020304, logout=tick + 1, ipv6='0:0:0:0:0:0:0:1')
-            self.eq(t0[1].get('inet:netlogon:ipv4'), 0x01020304)
-            self.eq(t0[1].get('inet:netlogon:logout'), tick + 1)
-            self.eq(t0[1].get('inet:netlogon:logout') - t0[1].get('inet:netlogon:time'), 1)
-            self.eq(t0[1].get('inet:netlogon:ipv6'), '::1')
+            self.eq(t0[1].get('inet:web:logon:ipv4'), 0x01020304)
+            self.eq(t0[1].get('inet:web:logon:logout'), tick + 1)
+            self.eq(t0[1].get('inet:web:logon:logout') - t0[1].get('inet:web:logon:time'), 1)
+            self.eq(t0[1].get('inet:web:logon:ipv6'), '::1')
 
     def test_model_inet_201706121318(self):
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -411,6 +411,10 @@ class InetModelTest(SynTest):
             node = core.formTufoByProp('inet:whois:rec', 'woot.com@20501217')
             form, pprop = s_tufo.ndef(node)
             node = core.formTufoByProp('inet:whois:recns', ['ns1.woot.com', pprop])
+            self.eq(node[1].get('inet:whois:recns:ns'), 'ns1.woot.com')
+            self.eq(node[1].get('inet:whois:recns:rec'), pprop)
+            self.eq(node[1].get('inet:whois:recns:rec:fqdn'), 'woot.com')
+            self.eq(node[1].get('inet:whois:recns:rec:asof'), 2554848000000)
             nodes = core.eval('inet:whois:recns:rec:fqdn=woot.com')
             self.eq(node[0], nodes[0][0])
             nodes = core.eval('inet:whois:rec:fqdn=woot.com inet:whois:rec->inet:whois:recns:rec')
@@ -532,6 +536,8 @@ class InetModelTest(SynTest):
         rows = [
             (iden0, 'tufo:form', 'inet:whois:rec', tick),
             (iden0, 'inet:whois:rec', 'vertex.link@2017/09/18 15:01:00.000', tick),  # 1505746860000,
+            (iden0, 'inet:whois:rec:fqdn', 'vertex.link', tick),
+            (iden0, 'inet:whois:rec:asof', 1505746860000, tick),
             (iden0, 'inet:whois:rec:ns1', 'ns1.vertex.link', tick),
             (iden0, 'inet:whois:rec:ns2', 'ns2.vertex.link', tick),
             (iden0, 'inet:whois:rec:ns3', 'ns3.vertex.link', tick),
@@ -567,3 +573,4 @@ class InetModelTest(SynTest):
                 node = nodes[0]
                 self.eq(node[1].get('inet:whois:recns:ns'), 'ns1.vertex.link')
                 self.eq(node[1].get('inet:whois:recns:rec:fqdn'), 'vertex.link')
+                self.eq(node[1].get('inet:whois:recns:rec:asof'), 1505746860000)


### PR DESCRIPTION
Closes #341 

Adds inet:web:logon to track logon actions by a netuser.
Adds inet:asn:owner property to track ASNs owned by an organization
Add inet:whois:recns to handle nameserver records associated with a whois record; and a migration function as well for migrating existing inet:whois:rec node data.