### PR TITLE
Change pivot() behavior to be pivot(dest), pivot(src, dest) 

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1000,7 +1000,8 @@ class Runtime(Configable):
         dstp = args[0]
 
         if len(args) > 1:
-            srcp = args[1]
+            srcp = args[0]
+            dstp = args[1]
 
         # do we have a relative source property?
         relsrc = srcp is not None and srcp.startswith(':')

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -660,7 +660,7 @@ def parse(text, off=0):
                 inst[1]['kwlist'].append(('from', pivn))
                 pivn, off = nom(text, off + 1, varset)
 
-            inst[1]['args'].insert(0, pivn)
+            inst[1]['args'].append(pivn)
 
             ret.append(inst)
             continue

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -25,7 +25,17 @@ class StormTest(SynTest):
             self.nn(node)
             self.eq(node[1].get('inet:dns:a'), 'woot.com/1.2.3.4')
 
+            node = core.eval('inet:ipv4="1.2.3.4" pivot(inet:ipv4,inet:dns:a:ipv4)')[0]
+
+            self.nn(node)
+            self.eq(node[1].get('inet:dns:a'), 'woot.com/1.2.3.4')
+
             node = core.eval('inet:dns:a="woot.com/1.2.3.4" :ipv4->inet:ipv4')[0]
+
+            self.nn(node)
+            self.eq(node[1].get('inet:ipv4'), 0x01020304)
+
+            node = core.eval('inet:dns:a="woot.com/1.2.3.4" pivot(:ipv4, inet:ipv4)')[0]
 
             self.nn(node)
             self.eq(node[1].get('inet:ipv4'), 0x01020304)
@@ -35,10 +45,18 @@ class StormTest(SynTest):
             self.nn(node)
             self.eq(node[1].get('inet:dns:a'), 'woot.com/1.2.3.4')
 
-            self.eq(len(core.eval('inet:dns:a:ipv4="5.6.7.8" :fqdn->inet:fqdn')), 2)
+            node = core.eval('inet:fqdn="woot.com" pivot(inet:dns:a:fqdn)')[0]
 
+            self.nn(node)
+            self.eq(node[1].get('inet:dns:a'), 'woot.com/1.2.3.4')
+
+            self.eq(len(core.eval('inet:dns:a:ipv4="5.6.7.8" :fqdn->inet:fqdn')), 2)
             self.eq(len(core.eval('inet:ipv4="5.6.7.8" -> inet:dns:a:ipv4')), 2)
             self.eq(len(core.eval('inet:ipv4="5.6.7.8" inet:ipv4->inet:dns:a:ipv4')), 2)
+
+            self.eq(len(core.eval('inet:dns:a:ipv4="5.6.7.8" pivot(:fqdn,inet:fqdn)')), 2)
+            self.eq(len(core.eval('inet:ipv4="5.6.7.8" pivot(inet:dns:a:ipv4)')), 2)
+            self.eq(len(core.eval('inet:ipv4="5.6.7.8" pivot(inet:ipv4, inet:dns:a:ipv4)')), 2)
 
     def test_storm_setprop(self):
         with s_cortex.openurl('ram:///') as core:

--- a/synapse/tests/test_syntax.py
+++ b/synapse/tests/test_syntax.py
@@ -91,7 +91,7 @@ class StormSyntaxTest(SynTest):
 
     def test_storm_syntax_pivot(self):
         insts = s_syntax.parse('foo:bar -> hehe.haha/baz:faz')
-        self.eq(insts[0], ('pivot', {'args': ['baz:faz', 'foo:bar'], 'kwlist': [('from', 'hehe.haha')]}))
+        self.eq(insts[0], ('pivot', {'args': ['foo:bar', 'baz:faz'], 'kwlist': [('from', 'hehe.haha')]}))
 
     def test_storm_syntax_whites(self):
         insts = s_syntax.parse('inet:fqdn     =      "1.2.3.4"')


### PR DESCRIPTION
This is in line with the macro syntax for pivot.