### PR TITLE
dns.py docstrings, RO props

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1760,6 +1760,7 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
 
                 adds = []
                 rows = []
+                allfulls = []
 
                 for props in chunk:
 
@@ -1773,7 +1774,7 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
                     fulls['tufo:form'] = form
 
                     if self.autoadd:
-                        self._runToAdd(fulls)
+                        allfulls.append(fulls)
 
                     # fire these immediately since we need them to potentially fill
                     # in values before we generate rows for the new tufo
@@ -1798,6 +1799,10 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
                 for form, valu, props, node in adds:
                     xact.fire('node:add', form=form, valu=valu, node=node)
                     xact.spliced('node:add', form=form, valu=valu, props=props)
+
+                if self.autoadd:
+                    for fulls in allfulls:
+                        self._runToAdd(fulls)
 
         return ret
 

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -6,68 +6,103 @@ class DnsMod(CoreModule):
     def getBaseModels():
         modl = {
             'types': (
-                ('inet:dns:look', {'subof': 'guid'}),
-                ('inet:dns:a', {'subof': 'sepr', 'sep': '/', 'fields': 'fqdn,inet:fqdn|ipv4,inet:ipv4',
-                                'ex': 'vertex.link/1.2.3.4', 'doc': 'The result of a DNS A record lookup'}),
-                ('inet:dns:ns', {'subof': 'sepr', 'sep': '/', 'fields': 'zone,inet:fqdn|ns,inet:fqdn',
-                                 'ex': 'vertex.link/ns.dnshost.com', 'doc': 'The result of a DNS NS record lookup'}),
-                ('inet:dns:rev', {'subof': 'sepr', 'sep': '/', 'fields': 'ipv4,inet:ipv4|fqdn,inet:fqdn',
-                                  'ex': '1.2.3.4/vertex.link',
-                                  'doc': 'The transformed result of a DNS PTR record lookup'}),
-                ('inet:dns:aaaa', {'subof': 'sepr', 'sep': '/', 'fields': 'fqdn,inet:fqdn|ipv6,inet:ipv6',
-                                   'ex': 'vertex.link/2607:f8b0:4004:809::200e',
-                                   'doc': 'The result of a DNS AAAA record lookup'}),
+                ('inet:dns:look', {
+                    'subof': 'guid',
+                    'doc': 'The instance (point-in-time) result of a DNS record lookup'}),
+
+                ('inet:dns:a', {
+                    'subof': 'sepr',
+                    'sep': '/',
+                    'fields': 'fqdn,inet:fqdn|ipv4,inet:ipv4',
+                    'doc': 'The result of a DNS A record lookup',
+                    'ex': 'vertex.link/1.2.3.4'}),
+
+                ('inet:dns:ns', {
+                    'subof': 'sepr',
+                    'sep': '/',
+                    'fields': 'zone,inet:fqdn|ns,inet:fqdn',
+                    'doc': 'The result of a DNS NS record lookup',
+                    'ex': 'vertex.link/ns.dnshost.com'}),
+
+                ('inet:dns:rev', {
+                    'subof': 'sepr',
+                    'sep': '/',
+                    'fields': 'ipv4,inet:ipv4|fqdn,inet:fqdn',
+                    'doc': 'The transformed result of a DNS PTR record lookup',
+                    'ex': '1.2.3.4/vertex.link'}),
+
+                ('inet:dns:aaaa', {
+                    'subof': 'sepr',
+                    'sep': '/',
+                    'fields': 'fqdn,inet:fqdn|ipv6,inet:ipv6',
+                    'doc': 'The result of a DNS AAAA record lookup',
+                    'ex': 'vertex.link/2607:f8b0:4004:809::200e'}),
             ),
 
             'forms': (
-                ('inet:dns:a', {'ptype': 'inet:dns:a', 'doc': 'One-time-knowledge represenation of a DNS A record'}, [
-                    ('fqdn', {'ptype': 'inet:fqdn'}),
-                    ('ipv4', {'ptype': 'inet:ipv4'}),
-                    ('seen:min', {'ptype': 'time:min'}),
-                    ('seen:max', {'ptype': 'time:max'}),
+                ('inet:dns:a', {'ptype': 'inet:dns:a', 'doc': 'Fused knowledge of a DNS A record'}, [
+                    ('fqdn', {'ptype': 'inet:fqdn', 'doc': 'The domain queried for its DNS A record', 'ro': 1}),
+                    ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The IPv4 address returned in the DNS A record', 'ro': 1}),
+                    ('seen:min', {'ptype': 'time:min',
+                                  'doc': 'The earliest observed time for the data in the A record'}),
+                    ('seen:max', {'ptype': 'time:max',
+                                  'doc': 'The most recent observed time for the data in the A record'}),
                 ]),
-                (
-                    'inet:dns:ns',
-                    {'ptype': 'inet:dns:ns', 'doc': 'One-time-knowledge represenation of a DNS NS record'}, [
-                        ('ns', {'ptype': 'inet:fqdn'}),
-                        ('zone', {'ptype': 'inet:fqdn'}),
-                        ('seen:min', {'ptype': 'time:min'}),
-                        ('seen:max', {'ptype': 'time:max'}),
-                    ]),
-                ('inet:dns:rev',
-                 {'ptype': 'inet:dns:rev', 'doc': 'One-time-knowledge represenation of a DNS PTR reverse'}, [
-                     ('ipv4', {'ptype': 'inet:ipv4'}),
-                     ('fqdn', {'ptype': 'inet:fqdn'}),
-                     ('seen:min', {'ptype': 'time:min'}),
-                     ('seen:max', {'ptype': 'time:max'}),
-                 ]),
-                ('inet:dns:aaaa',
-                 {'ptype': 'inet:dns:aaaa', 'doc': 'One-time-knowledge represenation of a DNS AAAA record'}, [
-                     ('fqdn', {'ptype': 'inet:fqdn'}),
-                     ('ipv6', {'ptype': 'inet:ipv6'}),
-                     ('seen:min', {'ptype': 'time:min'}),
-                     ('seen:max', {'ptype': 'time:max'}),
+
+                ('inet:dns:ns', {'ptype': 'inet:dns:ns', 'doc': 'Fused knowledge of a DNS NS record'}, [
+                    ('zone', {'ptype': 'inet:fqdn', 'doc': 'The domain queried for its DNS NS record', 'ro': 1}),
+                    ('ns', {'ptype': 'inet:fqdn', 'doc': 'The domain returned in the DNS NS record', 'ro': 1}),
+                    ('seen:min', {'ptype': 'time:min',
+                                  'doc': 'The earliest observed time for the data in the NS record'}),
+                    ('seen:max', {'ptype': 'time:max',
+                                  'doc': 'The most recent observed time for the data in the NS record'}),
+                ]),
+
+                ('inet:dns:rev', {'ptype': 'inet:dns:rev', 'doc': 'Fused knowledge of a DNS PTR record'}, [
+                     ('ipv4', {'ptype': 'inet:ipv4',
+                               'doc': 'The IPv4 address queried for its DNS PTR record', 'ro': 1}),
+                     ('fqdn', {'ptype': 'inet:fqdn', 'doc': 'The domain returned in the DNS PTR record', 'ro': 1}),
+                     ('seen:min', {'ptype': 'time:min',
+                                   'doc': 'The earliest observed time for the data in the PTR record'}),
+                     ('seen:max', {'ptype': 'time:max',
+                                   'doc': 'The most recent observed time for the data in the PTR record'}),
                  ]),
 
-                ('inet:dns:look', {'doc': 'Occurance knowledge of a DNS record lookup'}, [
+                ('inet:dns:aaaa', {'ptype': 'inet:dns:aaaa', 'doc': 'Fused knowledge of a DNS AAAA record'}, [
+                     ('fqdn', {'ptype': 'inet:fqdn', 'doc': 'The domain queried for its DNS AAAA record', 'ro': 1}),
+                     ('ipv6', {'ptype': 'inet:ipv6',
+                               'doc': 'The IPv6 address returned in the DNS AAAA record', 'ro': 1}),
+                     ('seen:min', {'ptype': 'time:min',
+                                   'doc': 'The earliest observed time for the data in the DNS AAAA record'}),
+                     ('seen:max', {'ptype': 'time:max',
+                                   'doc': 'The most recent observed time for the data in the DNS AAAA record'}),
+                 ]),
 
-                    ('time', {'ptype': 'time'}),
+                ('inet:dns:look', {'ptype': 'inet:dns:look', 'doc': 'Instance knowledge of a DNS record lookup'}, [
+                    ('time', {'ptype': 'time', 'req': 1, 'ro': 1}),
+                    # one of the following should be set...
+                    # FIXME define a way to add subfields to prop decl so we dont have to declare them all
+                    ('a', {'ptype': 'inet:dns:a', 'doc': 'The DNS A record returned by the lookup', 'ro': 1}),
+                    ('a:fqdn', {'ptype': 'inet:fqdn', 'doc': 'The domain queried for its DNS A record', 'ro': 1}),
+                    ('a:ipv4', {'ptype': 'inet:ipv4', 'doc': ' The IPv4 address returned in the DNS A record',
+                                'ro': 1}),
 
-                    ('a', {'ptype': 'inet:dns:a'}),
-                    ('a:fqdn', {'ptype': 'inet:fqdn', 'ro': 1}),
-                    ('a:ipv4', {'ptype': 'inet:ipv4', 'ro': 1}),
+                    ('ns', {'ptype': 'inet:dns:ns', 'doc': 'The DNS NS record returned by the lookup', 'ro': 1}),
+                    ('ns:zone', {'ptype': 'inet:fqdn', 'doc': 'The domain queried for its DNS NS record', 'ro': 1}),
+                    ('ns:ns', {'ptype': 'inet:fqdn', 'doc': 'The domain returned in the DNS NS record', 'ro': 1}),
 
-                    ('ns', {'ptype': 'inet:dns:ns'}),
-                    ('ns:ns', {'ptype': 'inet:fqdn', 'ro': 1}),
-                    ('ns:zone', {'ptype': 'inet:fqdn', 'ro': 1}),
+                    ('rev', {'ptype': 'inet:dns:rev', 'doc': 'The DNS PTR record returned by the lookup', 'ro': 1}),
+                    ('rev:ipv4', {'ptype': 'inet:ipv4', 'doc': 'The IPv4 address queried for its DNS PTR record',
+                                  'ro': 1}),
+                    ('rev:fqdn', {'ptype': 'inet:fqdn', 'doc': 'The domain returned in the DNS PTR record',
+                                  'ro': 1}),
 
-                    ('rev', {'ptype': 'inet:dns:rev'}),
-                    ('rev:ipv4', {'ptype': 'inet:ipv4', 'ro': 1}),
-                    ('rev:fqdn', {'ptype': 'inet:fqdn', 'ro': 1}),
-
-                    ('aaaa', {'ptype': 'inet:dns:aaaa'}),
-                    ('aaaa:fqdn', {'ptype': 'inet:fqdn', 'ro': 1}),
-                    ('aaaa:ipv6', {'ptype': 'inet:ipv6', 'ro': 1}),
+                    ('aaaa', {'ptype': 'inet:dns:aaaa', 'doc': 'The DNS AAAA record returned by the lookup',
+                              'ro': 1}),
+                    ('aaaa:fqdn', {'ptype': 'inet:fqdn', 'doc': 'The domain queried for its DNS AAAA record',
+                                   'ro': 1}),
+                    ('aaaa:ipv6', {'ptype': 'inet:ipv6', 'doc': 'The IPv6 address returned in the DNS AAAA record',
+                                   'ro': 1}),
 
                 ]),
             ),


### PR DESCRIPTION
- Format tweaks for readability
- Revise / add docstrings to forms and props
- Add read only ( 'ro' ) to properties that should not be modified once created