### PR TITLE
Clean up a bunch of stuff inside of Axon

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,6 +17,7 @@ matrix:
       PG_DB: root@database:5432/syn_test
       COVERAGE_ARGS: --cov synapse --no-cov-on-fail
       SLEEP: 6
+      SYN_RUN_LONG_TESTS: 1
     - TEST_NAME: "Python 37 without coverage."
       IMAGE_VERSION: py37
       PG_DB: root@database:5432/syn_test
@@ -40,7 +41,7 @@ pipeline:
     commands:
       - if [ -n "${SLEEP}" ]; then sleep ${SLEEP}; fi;
       - python setup.py install
-      - pytest -v -s --durations 6 ${COVERAGE_ARGS}
+      - pytest -v -s -rs --durations 6 ${COVERAGE_ARGS}
       - if [ -n "${COVERAGE_ARGS}" ]; then codecov --name ${IMAGE_VERSION} --required; fi;
 
 services:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,14 @@
+buildcommands: &runbuild
+  image: vertexproject/synapse-docker-testimages:${IMAGE_VERSION}
+  pull: true
+  secrets:
+    [ CODECOV_TOKEN ]
+  commands:
+    - if [ -n "${SLEEP}" ]; then sleep ${SLEEP}; fi;
+    - python setup.py install
+    - pytest -v -s -rs --durations 6 ${COVERAGE_ARGS}
+    - if [ -n "${COVERAGE_ARGS}" ]; then codecov --name ${IMAGE_VERSION} --required; fi;
+
 clone:
   git:
     image: plugins/git
@@ -17,7 +28,6 @@ matrix:
       PG_DB: root@database:5432/syn_test
       COVERAGE_ARGS: --cov synapse --no-cov-on-fail
       SLEEP: 6
-      SYN_RUN_LONG_TESTS: 1
     - TEST_NAME: "Python 37 without coverage."
       IMAGE_VERSION: py37
       PG_DB: root@database:5432/syn_test
@@ -26,23 +36,25 @@ matrix:
 pipeline:
   pycodestyle:
     group: style_checks
-    image: vepiphyte/synapse_test_images:py36
+    image: vertexproject/synapse-docker-testimages:py36
     commands:
       - pycodestyle --max-line-length=120 --select E111,E101,E201,E202,E203,E221,E222,E223,E224,E225,E226,E227,E228,E231,E241,E242,E251,E303,E304,E502,E711,E712,E713,E714,E721,E741,E742,E743,W191,W291,W293,W292,W391,W602,W603 synapse
       - pycodestyle --max-line-length=120 --select E111,E101,E201,E202,E203,E221,E222,E223,E224,E225,E226,E227,E228,E231,E241,E242,E251,E303,E304,E502,E711,E712,E713,E714,E721,E741,E742,E743,W191,W291,W293,W292,W391,W602,W603 scripts
 
-  build:
-    image: vertexproject/synapse-docker-testimages:${IMAGE_VERSION}
-    pull: true
-    secrets:
-      [ CODECOV_TOKEN ]
+  buildpush:
+    when:
+      event: [push]
     environment:
       - SYN_TEST_PG_DB=${PG_DB}
-    commands:
-      - if [ -n "${SLEEP}" ]; then sleep ${SLEEP}; fi;
-      - python setup.py install
-      - pytest -v -s -rs --durations 6 ${COVERAGE_ARGS}
-      - if [ -n "${COVERAGE_ARGS}" ]; then codecov --name ${IMAGE_VERSION} --required; fi;
+      - SYN_TEST_SKIP_LONG=1
+    <<: *runbuild
+
+  build:
+    when:
+      event: [pull_request, tag, deployment]
+    environment:
+      - SYN_TEST_PG_DB=${PG_DB}
+    <<: *runbuild
 
 services:
   database:

--- a/scripts/testrunner.sh
+++ b/scripts/testrunner.sh
@@ -17,7 +17,7 @@ if [ -e $HTML_DIR ]; then
     rm -rf $HTML_DIR
 fi
 
-pytest -v -s --durations 6 --cov $MODULE --no-cov-on-fail --cov-report=html:$HTML_DIR $1
+pytest -v -s --durations 6 -rs --cov $MODULE --no-cov-on-fail --cov-report=html:$HTML_DIR $1
 
 if [ $? -eq 0 ]; then
     if [ -e $INDEX ]; then

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -851,10 +851,7 @@ class Axon(s_config.Config, AxonMixin):
         Returns:
             bytes:  A chunk of bytes
         '''
-        if htype == 'guid':
-            blob = self.core.getTufoByProp('axon:blob', valu=hvalu)
-        else:
-            blob = self.core.getTufoByProp('axon:blob:%s' % htype, valu=hvalu)
+        blob = self.has(htype, hvalu)
         if blob:
             for byts in self.iterblob(blob):
                 yield byts
@@ -1025,13 +1022,14 @@ class Axon(s_config.Config, AxonMixin):
                     stuff()
 
         Returns:
-            bool: True if the axon has the hash present.
+            ((str, dict)): axon:blob tufo if the axon has the hash or guid. None otherwise.
         '''
         if htype == 'guid':
             tufo = self.core.getTufoByProp('axon:blob', hvalu)
         else:
             tufo = self.core.getTufoByProp('axon:blob:%s' % htype, hvalu)
-        return tufo is not None
+        if tufo:
+            return tufo
 
     def byiden(self, iden):
         '''

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -70,11 +70,11 @@ class AxonHost(s_config.Config):
             self._fireAxonIden(iden)
 
         # fire auto-run axons
-        auto = self.getConfOpt('axonhost:autorun')
+        auto = self.getConfOpt('autorun')
         while (len(self.axons) - len(self.cloneaxons)) < auto:
             self.add()
 
-        url = self.getConfOpt('axonhost:axonbus')
+        url = self.getConfOpt('axon:axonbus')
         if url:
             self.axonbus = s_service.openurl(url)
             self.axonbus.runSynSvc(s_common.guid(), self)
@@ -85,18 +85,18 @@ class AxonHost(s_config.Config):
         confdefs = (
             ('axonhost:autorun', {'type': 'int', 'defval': 0,
                                   'doc': 'Number of Axons to autostart.'}),
-            ('axonhost:axonbus', {'type': 'str', 'defval': '',
+            ('axon:axonbus', {'type': 'str', 'defval': '',
                                   'doc': 'URL to an axonbus'}),
-            ('axonhost:bytemax', {'type': 'int', 'defval': terabyte,
+            ('axon:bytemax', {'type': 'int', 'defval': terabyte,
                                   'doc': 'Max size of each axon created by the host.'}),
-            ('axonhost:clones', {'type': 'int', 'defval': 2,
+            ('axon:clones', {'type': 'int', 'defval': 2,
                                  'doc': 'The default number of clones for a axon.'}),
             ('axonhost:maxsize', {'type': 'int', 'defval': 0,
                                   'doc': 'Max total allocations for Axons created by the host. '
                                          'Only applies if set to a positive integer.'}),
-            ('axonhost:syncmax', {'type': 'int', 'defval': gigabyte * 10,
+            ('axon:syncmax', {'type': 'int', 'defval': gigabyte * 10,
                                   'doc': ''}),  # XXX Words
-            ('axonhost:hostname', {'type': 'str', 'defval': s_thishost.get('hostname'),
+            ('axon:hostname', {'type': 'str', 'defval': s_thishost.get('hostname'),
                                    'doc': 'AxonHost hostname'}),
         )
         return confdefs
@@ -114,7 +114,7 @@ class AxonHost(s_config.Config):
         # itself properly.
         axonbus = opts.get('axon:axonbus')
         if axonbus is not None:
-            myaxonbus = self.getConfOpt('axonhost:axonbus')
+            myaxonbus = self.getConfOpt('axon:axonbus')
             if axonbus != myaxonbus:
                 opts['axon:axonbus'] = myaxonbus
                 s_common.jssave(opts, axondir, 'axon.opts')
@@ -142,11 +142,10 @@ class AxonHost(s_config.Config):
             dict: Configable dict of valid options which can be passed to a Axon()
         '''
         ret = {}
-        for name, _ in self.getConfDefs().items():
-            axonname = name.replace('axonhost:', 'axon:')
-            if axonname not in self._axonconfs:
+        for name, valu in self.getConfOpts().items():
+            if name not in self._axonconfs:
                 continue
-            ret[axonname] = self.getConfOpt(name)
+            ret[name] = valu
         return ret
 
     def info(self):
@@ -158,7 +157,7 @@ class AxonHost(s_config.Config):
             'count': len(self.axons),
             'free': usage.get('free', 0),
             'used': usage.get('used', 0),
-            'hostname': self.getConfOpt('axonhost:hostname'),
+            'hostname': self.getConfOpt('axon:hostname'),
         }
 
     def add(self, **opts):

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -556,7 +556,7 @@ class Axon(s_config.Config, AxonMixin):
         self.axthrs = set()
 
         self.setAxonInfo('link', self.link)
-        self.setAxonInfo('opts', {key: self.getConfOpt(key) for key, _ in self.getConfDefs().items()})
+        self.setAxonInfo('opts', self.getConfOpts())
         self.on('syn:conf:set', self._onSetConfigableValu)
 
         self.dmon.share('axon', self)

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -112,7 +112,7 @@ class AxonHost(s_config.Config):
         # Special case where the axonbus may update - we want to ensure
         # we're passing the latest axonbus to the Axon so it can register
         # itself properly.
-        axonbus = opts.get('axonbus')
+        axonbus = opts.get('axon:axonbus')
         if axonbus is not None:
             myaxonbus = self.getConfOpt('axonhost:axonbus')
             if axonbus != myaxonbus:

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -112,8 +112,8 @@ class AxonHost(s_config.Config):
         # Special case where the axonbus may update - we want to ensure
         # we're passing the latest axonbus to the Axon so it can register
         # itself properly.
-        if 'axon:axonbus' in opts:
-            axonbus = opts.get('axon:axonbus')
+        axonbus = opts.get('axonbus')
+        if axonbus is not None:
             myaxonbus = self.getConfOpt('axonhost:axonbus')
             if axonbus != myaxonbus:
                 opts['axon:axonbus'] = myaxonbus

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -56,8 +56,7 @@ class AxonHost(s_config.Config):
 
         self._axonconfs = [_name for _name, _ in Axon._axon_confdefs()]
 
-        # track the total number of bytes which may be used by axons
-        # associated with this axonhost (disregarding heap overhead)
+        # track the total number of bytes which may be used by axons for startup operations
         self.usedspace = 0
 
         for name in os.listdir(self.datadir):

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1,6 +1,7 @@
 import os
 import stat
 import time
+import random
 import logging
 import threading
 
@@ -13,6 +14,7 @@ import synapse.eventbus as s_eventbus
 import synapse.telepath as s_telepath
 
 import synapse.lib.heap as s_heap
+import synapse.lib.config as s_config
 import synapse.lib.persist as s_persist
 import synapse.lib.service as s_service
 import synapse.lib.thishost as s_thishost
@@ -32,36 +34,31 @@ axontag = 'class.synapse.axon.Axon'
 
 _fs_attrs = ('st_mode', 'st_nlink', 'st_size', 'st_atime', 'st_ctime', 'st_mtime')
 
-class AxonHost(s_eventbus.EventBus):
+class AxonHost(s_config.Config):
     '''
     Manage multiple axons on a given host.
     '''
     def __init__(self, datadir, **opts):
-        s_eventbus.EventBus.__init__(self)
+        s_config.Config.__init__(self)
 
         self.datadir = s_common.gendir(datadir)
 
-        self.opts = opts
         self.lock = threading.Lock()
 
-        self.axons = {}
+        self.axons = {}  # iden -> Axon mapping.
         self.axonbus = None
         self.axonforks = {}
+        self.cloneaxons = []  # List of idens which are clones.
 
         self.onfini(self._onAxonHostFini)
 
-        self.opts.setdefault('autorun', 0)               # how many axons to auto-start
-        self.opts.setdefault('axonbus', '')              # url to axonbus
+        self.setConfOpts(opts)
 
-        self.opts.setdefault('bytemax', terabyte)        # by default make each Axon 1 Terabyte
-        self.opts.setdefault('syncmax', gigabyte * 10)   #
+        self._axonconfs = [_name for _name, _ in Axon._axon_confdefs()]
 
-        self.opts.setdefault('hostname', s_thishost.get('hostname')) # allow override for testing
-
-        url = self.opts.get('axonbus')
-        if url:
-            self.axonbus = s_service.openurl(url)
-            self.axonbus.runSynSvc(s_common.guid(), self)
+        # track the total number of bytes which may be used by axons
+        # associated with this axonhost (disregarding heap overhead)
+        self.usedspace = 0
 
         for name in os.listdir(self.datadir):
 
@@ -73,23 +70,84 @@ class AxonHost(s_eventbus.EventBus):
             self._fireAxonIden(iden)
 
         # fire auto-run axons
-        auto = self.opts.get('autorun')
-        while len(self.axons) < auto:
+        auto = self.getConfOpt('axonhost:autorun')
+        while (len(self.axons) - len(self.cloneaxons)) < auto:
             self.add()
+
+        url = self.getConfOpt('axonhost:axonbus')
+        if url:
+            self.axonbus = s_service.openurl(url)
+            self.axonbus.runSynSvc(s_common.guid(), self)
+
+    @staticmethod
+    @s_config.confdef(name='axonhost')
+    def _axonhost_confdefs():
+        confdefs = (
+            ('axonhost:autorun', {'type': 'int', 'defval': 0,
+                                  'doc': 'Number of Axons to autostart.'}),
+            ('axonhost:axonbus', {'type': 'str', 'defval': '',
+                                  'doc': 'URL to an axonbus'}),
+            ('axonhost:bytemax', {'type': 'int', 'defval': terabyte,
+                                  'doc': 'Max size of each axon created by the host.'}),
+            ('axonhost:clones', {'type': 'int', 'defval': 2,
+                                 'doc': 'The default number of clones for a axon.'}),
+            ('axonhost:maxsize', {'type': 'int', 'defval': 0,
+                                  'doc': 'Max total allocations for Axons created by the host. '
+                                         'Only applies if set to a positive integer.'}),
+            ('axonhost:syncmax', {'type': 'int', 'defval': gigabyte * 10,
+                                  'doc': ''}),  # XXX Words
+            ('axonhost:hostname', {'type': 'str', 'defval': s_thishost.get('hostname'),
+                                   'doc': 'AxonHost hostname'}),
+        )
+        return confdefs
 
     def _fireAxonIden(self, iden):
         axondir = s_common.gendir(self.datadir, '%s.axon' % iden)
 
-        opts = dict(self.opts)
+        opts = self.makeAxonOpts()
         jsopts = s_common.jsload(axondir, 'axon.opts')
         if jsopts is not None:
             opts.update(jsopts)
 
+        # Special case where the axonbus may update - we want to ensure
+        # we're passing the latest axonbus to the Axon so it can register
+        # itself properly.
+        if 'axon:axonbus' in opts:
+            axonbus = opts.get('axon:axonbus')
+            myaxonbus = self.getConfOpt('axonhost:axonbus')
+            if axonbus != myaxonbus:
+                opts['axon:axonbus'] = myaxonbus
+                s_common.jssave(opts, axondir, 'axon.opts')
+
         self.axons[iden] = Axon(axondir, **opts)
+
+        bytemax = opts.get('axon:bytemax')
+        clone = opts.get('axon:clone')
+
+        if clone:
+            self.cloneaxons.append(iden)
+        else:
+            bytemax += opts.get('axon:syncmax')
+        self.usedspace = self.usedspace + bytemax
 
     def _onAxonHostFini(self):
         for axon in list(self.axons.values()):
             axon.fini()
+
+    def makeAxonOpts(self):
+        '''
+        Make a configable dictionary from the current AxonHost options.
+
+        Returns:
+            dict: Configable dict of valid options which can be passed to a Axon()
+        '''
+        ret = {}
+        for name, _ in self.getConfDefs().items():
+            axonname = name.replace('axonhost:', 'axon:')
+            if axonname not in self._axonconfs:
+                continue
+            ret[axonname] = self.getConfOpt(name)
+        return ret
 
     def info(self):
         '''
@@ -100,45 +158,68 @@ class AxonHost(s_eventbus.EventBus):
             'count': len(self.axons),
             'free': usage.get('free', 0),
             'used': usage.get('used', 0),
-            'hostname': self.opts.get('hostname'),
+            'hostname': self.getConfOpt('axonhost:hostname'),
         }
 
     def add(self, **opts):
         '''
         Add a new axon to the AxonHost.
 
-        Example:
+        Args:
+            **opts: kwarg values which supersede the defaults of the AxonHost when making the Axon.
 
-            # add another axon to the host with defaults
-            axfo = axho.add()
+        Examples:
+            Add another Axon to the host with defaults::
 
+                axfo = host.add()
+
+        Returns:
+            ((str, dict)): A Axon information tuple containing configuration and link data.
         '''
         iden = s_common.guid()
-        opts['iden'] = iden     # store iden as a specified option
 
-        fullopts = dict(self.opts)
+        fullopts = self.makeAxonOpts()
+        fullopts['axon:iden'] = iden  # store iden as a specified option
         fullopts.update(opts)
 
-        bytemax = fullopts.get('bytemax')
-        if not fullopts.get('clone'):
-            bytemax += fullopts.get('syncmax')
+        bytemax = fullopts.get('axon:bytemax')
+        clone = fullopts.get('axon:clone')
+        if not clone:
+            bytemax += fullopts.get('axon:syncmax')
 
         volinfo = s_thisplat.getVolInfo(self.datadir)
 
         free = volinfo.get('free')
         total = volinfo.get('total')
+        maxsize = self.getConfOpt('axonhost:maxsize')
+
+        if maxsize and (self.usedspace + bytemax) > maxsize:
+            raise s_common.NotEnoughFree(mesg='Not enough free space on the AxonHost (due to axonhost:maxsize) to '
+                                              'create the new Axon.',
+                                         bytemax=bytemax, maxsize=maxsize, usedspace=self.usedspace)
+
+        if (self.usedspace + bytemax) > free:
+            raise s_common.NotEnoughFree(mesg='Not enough free space on the volume when considering the allocations'
+                                              ' of existing Axons.',
+                                         bytemax=bytemax, free=free, usedspace=self.usedspace)
 
         if bytemax > free:
-            raise s_common.NotEnoughFree(bytemax)
+            raise s_common.NotEnoughFree(mesg='Not enough free space on the volume to create the new Axon.',
+                                         bytemax=bytemax, free=free)
 
         axondir = s_common.gendir(self.datadir, '%s.axon' % iden)
 
-        s_common.jssave(opts, axondir, 'axon.opts')
+        s_common.jssave(fullopts, axondir, 'axon.opts')
 
         # FIXME fork
         axon = Axon(axondir, **fullopts)
 
+        self.usedspace = self.usedspace + bytemax
+
         self.axons[iden] = axon
+
+        if clone:
+            self.cloneaxons.append(iden)
 
         return axon.axfo
 
@@ -149,12 +230,10 @@ class AxonHost(s_eventbus.EventBus):
         volinfo = s_thisplat.getVolInfo(self.datadir)
         return volinfo
 
-
 class AxonMixin:
-
     '''
     The parts of the Axon which must be executed locally in proxy cases.
-    ( used as mixin for both Axon and AxonProxy )
+    ( used as mixin for both Axon and AxonCluster )
     '''
     @s_telepath.clientside
     def eatfd(self, fd):
@@ -236,6 +315,23 @@ class AxonCluster(AxonMixin):
                 return True
 
         return False
+
+    def byiden(self, iden, bytag=axontag):
+        '''
+        Get a axon:blob node by iden (superhash) value.
+
+        Args:
+            iden (str): Iden to look up.
+
+        Returns:
+            ((str, dict)): Blob tufo returned by the Axon's cortex.
+        '''
+        dyntask = s_common.gentask('byiden', iden)
+        for svcfo, retval in self.svcprox.callByTag(bytag, dyntask):
+            if retval:
+                return retval
+
+        return None
 
     def _getSvcAxon(self, iden):
 
@@ -346,9 +442,9 @@ class AxonCluster(AxonMixin):
         '''
         axons = self._getWrAxons(bytag=bytag)
         if not len(axons):
-            raise s_common.NoWritableAxons(bytag)
+            raise s_common.NoWritableAxons(mesg='No Writeable axons found in AxonCluster', bytag=bytag)
 
-        # FIXME shuffle/randomize
+        random.shuffle(axons)
 
         for axon in axons:
             iden = axon.alloc(size)
@@ -375,7 +471,7 @@ class AxonCluster(AxonMixin):
         dyntask = s_common.gentask('getAxonInfo')
         for svcfo, axfo in self.svcprox.callByTag(bytag, dyntask):
 
-            if axfo[1]['opts'].get('ro'):
+            if axfo[1]['opts'].get('axon:ro'):
                 continue
 
             axon = self._getSvcAxon(svcfo[0])
@@ -399,7 +495,7 @@ class AxonCluster(AxonMixin):
 
             time.sleep(0.1)
 
-class Axon(s_eventbus.EventBus, AxonMixin):
+class Axon(s_config.Config, AxonMixin):
     '''
     An Axon acts as a binary blob store with hash based indexing/retrieval.
 
@@ -412,11 +508,10 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
     '''
     def __init__(self, axondir, **opts):
-        s_eventbus.EventBus.__init__(self)
+        s_config.Config.__init__(self)
 
         self.inprog = {}
         self.axondir = s_common.gendir(axondir)
-        self.clonedir = s_common.gendir(axondir, 'clones')
 
         self.clones = {}
         self.cloneinfo = {}
@@ -426,32 +521,22 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         self.readyclones = set()                # iden of each clone added as it comes up
         self.clonesready = threading.Event()    # set once all clones are up and running
 
-        self.opts = opts
         self.axonbus = None
 
-        self.iden = self.opts.get('iden')
-        self.tags = self.opts.get('tags', ())
+        self.setConfOpts(opts)
 
-        self.opts.setdefault('ro', False)
-        self.opts.setdefault('clone', '')   # are we a clone?
-        self.opts.setdefault('clones', 2)   # how many clones do we want?
-        self.opts.setdefault('axonbus', '')  # do we have an axon svcbus?
-
-        self.opts.setdefault('hostname', s_thishost.get('hostname'))
-
-        self.opts.setdefault('listen', 'tcp://0.0.0.0:0/axon') # our default "ephemeral" listener
+        self.iden = self.getConfOpt('axon:iden')
+        self.tags = self.getConfOpt('axon:tags')
 
         # if we're a clone, we're read-only and have no clones
-        if self.opts.get('clone'):
-            self.opts['ro'] = True
-            self.opts['clones'] = 0
-
-        self.opts.setdefault('synckeep', threedays)
-        self.opts.setdefault('syncsize', gigabyte * 10)
+        if self.getConfOpt('axon:clone'):
+            self.setConfOpt('axon:ro', 1)
+            self.setConfOpt('axon:clones', 0)
 
         corepath = os.path.join(self.axondir, 'axon.db')
         self.core = s_cortex.openurl('sqlite:///%s' % corepath)
         self.core.setConfOpt('modules', (('synapse.models.axon.AxonMod', {}),))
+        self.core.setConfOpt('caching', 1)
 
         self._fs_mkdir_root()  # create the fs root
         self.flock = threading.Lock()
@@ -462,7 +547,7 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         self.heap = s_heap.Heap(fd)
         self.dmon = s_daemon.Daemon()
 
-        lisn = self.opts.get('listen')
+        lisn = self.getConfOpt('axon:listen')
         if lisn:
             self.link = self.dmon.listen(lisn)
 
@@ -471,7 +556,8 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         self.axthrs = set()
 
         self.setAxonInfo('link', self.link)
-        self.setAxonInfo('opts', self.opts)
+        self.setAxonInfo('opts', {key: self.getConfOpt(key) for key, _ in self.getConfDefs().items()})
+        self.on('syn:conf:set', self._onSetConfigableValu)
 
         self.dmon.share('axon', self)
 
@@ -484,9 +570,6 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         self.core.on('splice', self._fireAxonSync)
         self.heap.on('heap:sync', self._fireAxonSync)
 
-        dirname = s_common.gendir(axondir, 'sync')
-        syncopts = self.opts.get('syncopts', {})
-
         self.syncdir = None
 
         self.onfini(self._onAxonFini)
@@ -496,7 +579,9 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         self.onfini(self.dmon.fini)
 
         # if we're not a clone, create a sync dir
-        if not self.opts.get('clone'):
+        if not self.getConfOpt('axon:clone'):
+            dirname = s_common.gendir(axondir, 'sync')
+            syncopts = self.getConfOpt('axon:syncopts')
             self.syncdir = s_persist.Dir(dirname, **syncopts)
             self.onfini(self.syncdir.fini)
 
@@ -505,17 +590,66 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         self.axcthr = None
 
         # share last to avoid startup races
-        busurl = self.opts.get('axonbus')
+        busurl = self.getConfOpt('axon:axonbus')
         if busurl:
             self.axonbus = s_service.openurl(busurl)
 
             props = {'link': self.link, 'tags': self.tags}
             self.axonbus.runSynSvc(self.iden, self, **props)
-
             self.axcthr = self._fireAxonClones()
+
+    @staticmethod
+    @s_config.confdef(name='axon')
+    def _axon_confdefs():
+        confdefs = (
+            ('axon:ro', {'type': 'bool', 'defval': 0,
+                         'doc': 'Axon Read-only mode. Prevents allocating new space for writing data to the heap file.',
+                         }),
+            ('axon:clone', {'type': 'bool', 'defval': 0,
+                            'doc': 'Flag to indicate the axon is to be a clone axon or not. Not usually directly set'
+                                   'by the user.',
+                            }),
+            ('axon:clone:iden', {'type': 'str', 'defval': '',
+                                 'doc': 'Iden of the axon that this is a clone of (only applies to clones). Not usually'
+                                        ' directly set by the user.'}),
+            ('axon:clones', {'type': 'int', 'defval': 2,
+                       'doc': 'Number of clones to make of this axon on the axonbus.', }),
+            ('axon:axonbus', {'type': 'str', 'defval': '',
+                       'doc': 'Axon servicebus used for making clones of a Axon.', }),
+            ('axon:hostname', {'type': 'str', 'defval': s_thishost.get('hostname'),
+                       'doc': 'Hostname associated with an Axon.', }),
+            ('axon:listen', {'type': 'str', 'defval': 'tcp://0.0.0.0:0/axon',
+                       'doc': 'Default listener URL for the axon', }),
+            ('axon:synckeep', {'type': 'int', 'defval': threedays,
+                       'doc': 'how long to keep an axon sync block', }),
+            ('axon:syncsize', {'type': 'int', 'defval': gigabyte * 10,
+                       'doc': 'approx max size for each sync file', }),
+            ('axon:tags', {'defval': (),
+                           'doc': 'Tuple of tag values for the axon over a Axon servicebus.'}),
+            ('axon:iden', {'type': 'str', 'defval': None,
+                           'doc': 'Unique identifier for the axon.  Not usally directly set by the user.'}),
+            ('axon:syncopts', {'defval': {},
+                               'doc': 'kwarg Options used when making a persistent sync directory.'}),
+            ('axon:bytemax', {'type': 'int', 'defval': terabyte,
+                              'doc': 'Max size of data this axon is allowed to store.'}),
+            ('axon:syncmax', {'type': 'int', 'defval': terabyte,
+                              'doc': ''}), # XXX Words this does nothing
+        )
+        return confdefs
+
+    def _onSetConfigableValu(self, mesg):
+        axfo = self.getAxonInfo()
+        name = mesg[1].get('name')
+        valu = mesg[1].get('valu')
+        opts = axfo[1].get('opts')
+        opts[name] = valu
 
     @s_common.firethread
     def _fireAxonClones(self):
+
+        # If this axon is a clone, then don't try to make or find other clones
+        if self.getConfOpt('axon:clone'):
+            return
 
         clones = self.core.getTufosByProp('axon:clone')
         for axfo in clones:
@@ -545,7 +679,7 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         if iden in self.readyclones:
             return
 
-        count = self.opts.get('clones')
+        count = self.getConfOpt('axon:clones')
         with self.clonelock:
             self.readyclones.add(iden)
             if len(self.readyclones) == count:
@@ -555,7 +689,7 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         '''
         Sleep/Loop attempting to find AxonHost instances to clone for us.
         '''
-        while len(self.clones) < self.opts.get('clones'):
+        while len(self.clones) < self.getConfOpt('axon:clones'):
 
             if self.isfini:
                 break
@@ -569,12 +703,16 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
                 self._initAxonClone(axfo[0])
 
-            except Exception as e:
-                logger.exception('findAxonClones')
+                waiter = self.waiter(1, 'syn:axon:clone:ready')
+                waiter.wait(60)
+
+            except Exception as e:  # pragma: no cover
+                logger.exception('Unhandled exception during _findAxonClones')
 
     def _findAxonClone(self):
-        myhost = self.opts.get('hostname')
-        bytemax = self.opts.get('bytemax')
+
+        myhost = self.getConfOpt('axon:hostname')
+        bytemax = self.getConfOpt('axon:bytemax')
 
         dyntask = s_common.gentask('info')
         hostinfo = list(self.axonbus.callByTag('class.synapse.axon.AxonHost', dyntask))
@@ -593,12 +731,19 @@ class Axon(s_eventbus.EventBus, AxonMixin):
                 if host in self.clonehosts:
                     continue
 
-                props = {'clone': self.iden, 'bytemax': bytemax, 'host': host}
+                props = {'axon:clone': 1,
+                         'axon:clones': 0,
+                         'axon:clone:iden': self.iden,
+                         'axon:bytemax': bytemax,
+                         'axon:hostname': host,
+                         }
+
                 axfo = self.axonbus.callByIden(svcfo[0], 'add', **props)
 
                 tufo = self.core.formTufoByProp('axon:clone', axfo[0], host=host)
                 self.clonehosts.add(host)
-
+                if not axfo:  # pragma: no cover
+                    logger.error('{} Did not get a clone for {} from {}'.format(myhost, self.iden, host))
                 return axfo
 
             except Exception as e:
@@ -626,9 +771,13 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
                     svcfo = self.axonbus.getSynSvcByName(iden)
 
+                    if not svcfo:
+                        time.sleep(0.3)
+                        continue
+
                     link = svcfo[1].get('link')
-                    if link is None:
-                        raise Exception('NoLinkFor: %s' % (iden,))
+                    if link is None:  # pragma: no cover
+                        raise s_common.LinkErr('No Axon clone Link For: %s' % (iden,))
 
                     with s_telepath.openlink(link) as axon:
 
@@ -639,6 +788,8 @@ class Axon(s_eventbus.EventBus, AxonMixin):
                         #if oldp == None:
                             #self.cloned.release()
 
+                        self.fire('syn:axon:clone:ready', iden=iden)
+
                         off = poff.get()
 
                         for noff, item in self.syncdir.items(off):
@@ -647,9 +798,9 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
                             clonefo['off'] = noff
 
-                except Exception as e:
+                except Exception as e:  # pragma: no cover
 
-                    logger.exception('_fireAxonClone')
+                    logger.exception('exception during _fireAxonClone')
 
                     if self.isfini:
                         break
@@ -669,10 +820,17 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         '''
         Returns a list of blob tufos for hashes in the axon.
 
-        Example:
+        Args:
+            htype (str): Hash type.
+            hvalu (str): Hash value.
 
-            blobs = axon.find('sha256',x)
+        Examples:
+            Find all blobs for a given md5sum::
 
+                blobs = axon.find('md5', md5hash)
+
+        Returns:
+            list: List of tufos for a given hash value.
         '''
         return self.core.getTufosByProp('axon:blob:%s' % htype, valu=hvalu)
 
@@ -680,27 +838,46 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         '''
         Yield chunks of bytes for the given hash value.
 
-        Example:
+        Args:
+            htype (str): Hash type.
+            hvalu (str): Hash value.
 
-            for byts in axon.bytes('md5',md5sum):
-                fd.write(byts)
+        Examples:
+            Write bytes for a md5 to disk::
 
+                for byts in axon.bytes('md5',md5sum):
+                    fd.write(byts)
+
+        Returns:
+            bytes:  A chunk of bytes
         '''
         if htype == 'guid':
             blob = self.core.getTufoByProp('axon:blob', valu=hvalu)
         else:
             blob = self.core.getTufoByProp('axon:blob:%s' % htype, valu=hvalu)
-        return self.iterblob(blob)
+        if blob:
+            for byts in self.iterblob(blob):
+                yield byts
 
     def iterblob(self, blob):
         '''
-        Yield byts blocks from the give blob until complete.
+        Yield bytes blocks from the give blob until complete.
 
-        Example:
+        Args:
+            blob ((str, dict)):  axon:blob tufo to yield bytes from.
 
-            for byts in axon.iterAxonBlob(blob):
-                dostuff(byts)
+        Examples:
+            Get the bytes from a blob::
 
+                for byts in axon.iterAxonBlob(blob):
+                    dostuff(byts)
+
+            Form a contiguous bytes object for a given blob::
+
+                byts = b''.join((_byts for _bytes in eaxon.iterAxonBlob(blob)))
+
+        Yields:
+            bytes:  A chunk of bytes
         '''
         off = blob[1].get('axon:blob:off')
         size = blob[1].get('axon:blob:size')
@@ -710,15 +887,23 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
     def wants(self, htype, hvalu, size):
         '''
-        Single round trip call to has and possibly alloc.
+        Single round trip call to Axon.has() and possibly Axon.alloc().
 
-        Example:
+        Args:
+            htype (str): Hash type.
+            hvalu (str): Hash value.
+            size (int): Number of bytes to allocate.
 
-            iden = axon.wants('sha256',valu,size)
-            if iden != None:
-                for byts in chunks(filebytes,onemeg):
-                    axon.chunk(iden,byts)
+        Examples:
+            Check if a sha256 value is present in the Axon, and if not, create the node for a set of bytes::
 
+                iden = axon.wants('sha256',valu,size)
+                if iden != None:
+                    for byts in chunks(filebytes,onemeg):
+                        axon.chunk(iden,byts)
+
+        Returns:
+            None if the hvalu is present; otherwise the iden is returned for writing.
         '''
         if self.has(htype, hvalu):
             return None
@@ -732,17 +917,10 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         '''
         Consume an axon:sync event (only if we are a clone).
         '''
-        if not self.opts.get('clone'):
-            raise Exception('Not A Clone')
+        if not self.getConfOpt('axon:clone'):
+            raise s_common.NotSupported(mesg='Axon is not a Clone and cannot react to sync events')
 
         self.syncact.react(mesg[1].get('mesg'))
-
-    def syncs(self, msgs):
-        '''
-        Consume a list of axon:sync events.
-        '''
-        with self.core.getCoreXact():
-            [self.sync(m) for m in msgs]
 
     def _onAxonFini(self):
         # join clone threads
@@ -754,16 +932,34 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         '''
         Initialize a new blob upload context within this axon.
 
-        Example:
+        Args:
+            size (int): Size of the blob to allocate space for.
 
-            iden = axon.alloc(len(byts))
+        Examples:
+            Allocate a blob for a set of bytes and write it too the axon::
 
-            for b in chunks(byts,10240):
-                axon.chunk(iden,b)
+                iden = axon.alloc(len(byts))
+                for b in chunks(byts,10240):
+                    axon.chunk(iden,b)
+
+        Returns:
+            str: Identifier for a given upload.
+
+        Raises:
 
         '''
-        if self.opts.get('clone'):
-            raise Exception('Axon Is Clone') # FIXME
+        if self.getConfOpt('axon:clone'):
+            raise s_common.NotSupported(mesg='Axon Is Clone - cannot allocate new blobs.')
+
+        if self.getConfOpt('axon:ro'):
+            raise s_common.NotSupported(mesg='Axon Is Read-Only - cannot allocate new blobs.')
+
+        # This is slightly crude since it ignores the possible overhead of the Heapfile structures.
+        hsize = self.heap.used
+        bytmax = self.getConfOpt('axon:bytemax')
+        if (hsize + size) > bytmax:
+            raise s_common.NotEnoughFree(mesg='Not enough free space on the heap to allocate bytes.',
+                                         size=size, heapsize=hsize, bytemax=bytmax)
 
         iden = s_common.guid()
         off = self.heap.alloc(size)
@@ -775,6 +971,16 @@ class Axon(s_eventbus.EventBus, AxonMixin):
     def chunk(self, iden, byts):
         '''
         Save a chunk of a blob allocated with alloc().
+
+        Args:
+            iden (str): Iden to save bytes too
+            byts (bytes): Bytes to write to the blob.
+
+        Returns:
+            ((str, dict)): axon:blob node if the upload is complete; otherwise None.
+
+        Raises:
+            NoSuchIden: If the iden is not in progress.
         '''
         info = self.inprog.get(iden)
 
@@ -801,13 +1007,25 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
     def has(self, htype, hvalu):
         '''
-        Return True if the Axon contains the given hash type/valu combo.
+        Check if the Axon has a given hash type/valu combination stored in it.
 
-        Example:
+        Args:
+            htype (str): Hash type.
+            hvalu (str): Hash value.
 
-            if not axon.has('sha256', shaval):
-                stuff()
+        Examples:
+            Check if a sha256 value is present::
 
+                if not axon.has('sha256', shaval):
+                    stuff()
+
+            Check if a known superhash iden is present::
+
+                if axon.has('guid', guidval):
+                    stuff()
+
+        Returns:
+            bool: True if the axon has the hash present.
         '''
         if htype == 'guid':
             tufo = self.core.getTufoByProp('axon:blob', hvalu)
@@ -816,18 +1034,36 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         return tufo is not None
 
     def byiden(self, iden):
+        '''
+        Get a axon:blob node by iden (superhash) value.
+
+        Args:
+            iden (str): Iden to look up.
+
+        Returns:
+            ((str, dict)): Blob tufo returned by the Axon's cortex.
+        '''
         return self.core.getTufoByProp('axon:blob', iden)
 
     def fs_create(self, path, mode):
         '''
         Forms an axon:path node and sets its properties based on a given file mode.
-        Returns 0.
 
-        Example:
+        Args:
+            path (str):  Path to form.
+            mode (int): Path mode.
 
-            axon.fs_create('/mydir',        0x1FD)
-            axon.fs_create('/mydir/myfile', 0x81B4)
+        Examples:
+            Creating a directory::
 
+                axon.fs_create('/mydir', 0o775)
+
+            Creating a file ::
+
+                axon.fs_create('/mydir/myfile', 0x81B4)
+
+        Returns:
+            None
         '''
         normed, props = self.core.getPropNorm('axon:path', path)
 
@@ -850,23 +1086,40 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         '''
         Return the file attributes for a given file path.
 
-        Example:
+        Args:
+            path (str): Path to look up.
 
-            axon.fs_getattr('/foo/bar/baz.faz')
+        Examples:
+            Get the attributes for a given file::
 
+                axon.fs_getattr('/foo/bar/baz.faz')
+
+        Returns:
+            dict: Attribute dictionary.
         '''
         path = self._fs_normpath(path)
         tufo = self.core.getTufoByProp('axon:path', path)
+        # Inconsistent exception raising between this and fs_getxattr
         return Axon._fs_tufo2attr(tufo)
 
     def fs_getxattr(self, path, name):
         '''
         Return a file attribute value for a given file path and attr name.
 
-        Example:
+        Args:
+            path (str): Path to look up.
+            name (str): Attribute name to retrieve.
 
-            axon.fs_getxattr('/foo/bar/baz.faz', 'st_size')
+        Examples:
+            Get the size of a file::
 
+                axon.fs_getxattr('/foo/bar/baz.faz', 'st_size')
+
+        Returns:
+            Requested attribute value, or None if the attribute does not exist.
+
+        Raises:
+            NoSuchData if the requested path does not exist.
         '''
         if name not in _fs_attrs:
             raise s_common.NoSuchData()
@@ -881,12 +1134,20 @@ class Axon(s_eventbus.EventBus, AxonMixin):
     def fs_mkdir(self, path, mode):
         '''
         Creates a new directory at the given path.
-        Returns 0.
+
+        Args:
+            path (str): Path to create.
+            mode (int): Mode for any created path nodes.
 
         Example:
 
-            axon.fs_mkdir('/mydir')
+            axon.fs_mkdir('/mydir', 0o775)
 
+        Returns:
+            None
+
+        Raises:
+            FileExists: If the path already exists.
         '''
         normed, props = self.core.getPropNorm('axon:path', path)
 
@@ -906,6 +1167,18 @@ class Axon(s_eventbus.EventBus, AxonMixin):
             self.core.incTufoProp(dirn, 'st_nlink', 1)
 
     def _getDirNode(self, path):
+        '''
+        Get the axon:path node for a directory.
+
+        Args:
+            path (str): Path to retrieve
+
+        Returns:
+            ((str, dict)): axon:path node.
+
+        Raises:
+            NoSuchDir: If the path does not exist or if the path is a file.
+        '''
 
         node = self.core.getTufoByProp('axon:path', path)
         if node is None:
@@ -918,13 +1191,23 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
     def fs_read(self, path, size, offset):
         '''
-        Reads a directory.
-        Returns list of files.
+        Reads a file.
 
-        Example:
+        Args:
+            path (str): Path to read
+            size (int): Number of bytes to read.
+            offset (int): File offset to retrieve.
 
-            axon.fs_read('/mydir', 100, 0)
+        Examples:
+            Get the bytes of a file::
 
+                byts = axon.fs_read('/dir/file1', 100, 0)
+
+        Returns:
+            bytes: Bytes read from the path.
+
+        Raises:
+            NoSuchEntity: If the path does not exist.
         '''
         tufo = self.core.getTufoByProp('axon:path', path)
         if not tufo:
@@ -946,13 +1229,18 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
     def fs_readdir(self, path):
         '''
-        Reads a directory.
-        Returns list of files.
+        Reads a directory and gets a list of files in the directory.
 
-        Example:
+        Args:
+            path (str): Path to get a list of files for.
 
-            axon.fs_readdir('/mydir')
+        Examples:d
+            Read the files in the root directory::
 
+                files = axon.fs_readdir('/')
+
+        Returns:
+            list: List of files / folders under the path
         '''
         files = ['.', '..']
 
@@ -971,12 +1259,22 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
     def fs_rmdir(self, path):
         '''
-        Removes a directory.
+        Removes a directory
 
-        Example:
+        Args:
+            path (str): Path to remove.
 
-            axon.fs_rmdir('/mydir')
+        Examples:
+            Remove a directory::
 
+                axon.fs_rmdir('/mydir')
+
+        Returns:
+            None
+
+        Raises:
+            NoSuchEntity: If the path does not exist.
+            NotEmpty: If the path is not empty.
         '''
         tufo = self.core.getTufoByProp('axon:path', path)
         if not tufo:
@@ -994,12 +1292,24 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
     def fs_rename(self, src, dst):
         '''
-        Renames a file.
+        Rename a file:
 
-        Example:
+        Args:
+            src (str): Full path to the source file.
+            dst (str): Full path to teh destination.
 
-            axon.fs_rename('/myfile', '/mycoolerfile')
+        Examples:
+            Rename a file::
 
+                axon.fs_rename('/myfile', '/mycoolerfile')
+
+        Returns:
+            None
+
+        Raises:
+            NoSuchEntity: If the source does not exist.
+            NoSuchDir: If the source or destination parent path does not exist.
+            NotEmpty: If the destination already exists.
         '''
 
         _, srcprops = self.core.getPropNorm('axon:path', src)
@@ -1045,7 +1355,7 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
             # if overwriting a regular file with a dir, remove its st_size
             if src_isdir:
-                self.core.delRowsByIdProp(dstfo[0], 'axon:path:st_size')
+                self.core.delTufoProp(dstfo, 'st_size')
                 self._fs_reroot_kids(src, dst)
 
             # Remove src and decrement its parent's link count
@@ -1054,28 +1364,47 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
     def fs_truncate(self, path):
         '''
-        Tuncates a file.
-        Returns 0.
+        Truncates a file by setting its st_size to zero.
 
-        Example:
+        Args:
+            path (str): Path to truncate.
 
-            axon.fs_truncate('/myfile')
+        Examples:
+            Truncate a file::
 
+                axon.fs_truncate('/myfile')
+
+        Returns:
+            None
+
+        Raises:
+            NoSuchEntity: If the path does not exist.
         '''
         tufo = self.core.getTufoByProp('axon:path', path)
         if tufo:
-            self.core.delRowsByIdProp(tufo[0], 'axon:path:blob')
+            self.core.delTufoProp(tufo, 'blob')
             self.core.setTufoProps(tufo, st_size=0)
+            return
+
+        raise s_common.NoSuchEntity(mesg='File does not exist to truncate.', path=path)
 
     def fs_unlink(self, path):
         '''
-        Deletes a file.
-        Returns 0.
+        Unlink (delete) a file.
 
-        Example:
+        Args:
+            path (str): Path to unlink.
 
-            axon.fs_unlink('/myfile')
+        Examples:
+            Delete a file::
 
+                axon.fs_unlink('/myfile')
+
+        Returns:
+            None
+
+        Raises:
+            NoSuchFile: If the path does not exist.
         '''
         tufo = self.core.getTufoByProp('axon:path', path)
         if not tufo:
@@ -1088,17 +1417,21 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         if parentfo:
             self.core.incTufoProp(parentfo, 'st_nlink', -1)
 
-        return 0
-
     def fs_utimens(self, path, times=None):
         '''
-        Changes file timstamp.
-        Returns None.
+        Change file timestamps (st_atime, st_mtime).
 
-        Example:
+        Args:
+            path (str): Path to file to change.
+            times (tuple): Tuple containing two integers - st_atime and st_mtime.
 
-            axon.fs_utimens('/myfile', (0, 0))
+        Examples:
+            Set the timestamps to epoch 0::
 
+                axon.fs_utimens('/myfile', (0, 0))
+
+        Returns:
+            None
         '''
         if not(type(times) is tuple and len(times) == 2):
             return
@@ -1109,6 +1442,9 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         tufo = self.core.getTufoByProp('axon:path', path)
         if tufo:
             self.core.setTufoProps(tufo, st_atime=st_atime, st_mtime=st_mtime)
+            return
+
+        raise s_common.NoSuchEntity(mesg='Path does not exist.', path=path)
 
     def _fs_reroot_kids(self, oldroot, newroot):
 
@@ -1119,8 +1455,10 @@ class Axon(s_eventbus.EventBus, AxonMixin):
             cmode = child[1].get('axon:path:st_mode')
 
             newdst = '%s%s%s' % (newroot, '/', cfname)
-            self.core.setTufoProp(child, 'dir', newroot)
-            self.core.setRowsByIdProp(child[0], 'axon:path', newdst)
+            self.core.delTufo(child)
+            child[1]['axon:path:dir'] = newroot
+            child[1]['axon:path'] = newdst
+            self.core.formTufoByTufo(child)
 
             # move the kids
             if Axon._fs_isdir(cmode):
@@ -1137,7 +1475,9 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         return normed
 
     def _fs_mkdir_root(self):
-
+        '''
+        Makes the root ('/') axon:path node.
+        '''
         attr = Axon._fs_new_dir_attrs(None, 0x1FD)
         del attr['dir']
         attr['base'] = ''
@@ -1198,6 +1538,15 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 def _ctor_axon(opts):
     '''
     A function to allow terse/clean construction of an axon from a dmon ctor.
+
+    Args:
+        opts (dict): Options dictionary used to make the Axon object. Requires a "datadir" value.
+
+    Returns:
+        Axon: Axon created with the opts.
+
+    Raises:
+        BadInfoBalu: If the "datadir" value is missing from opts.
     '''
     datadir = opts.pop('datadir', None)
     if datadir is None:

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2365,9 +2365,26 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
     def formTufoByTufo(self, tufo):
         '''
         Form an (iden,info) tufo by extracting information from an existing one.
+
+        Args:
+            tufo ((str, dict)): An existing tufo to form a new tufo from.
+
+        Examples:
+            Create an IPv4 node from an existing node::
+
+                t0 = (None, {'inet:ipv4':0x01020304, 'inet:ipv4:asn': 1024})
+                new_tufo = core.formTufoByTufo(t0)
+
+        Notes:
+            This API uses the formTufoByProp API to form the new tufo; after extracting
+            the form, primary property and sub properties from the input tufo.
+            In addition, this API does not utilize the iden value present in the first
+            element of the tuple when making a new node.
+
+        Returns:
+            ((str, dict)): The new tufo, or an existing tufo if the tufo already existed.
         '''
-        form = tufo[1].get('tufo:form')
-        valu = tufo[1].get(form)
+        form, valu = s_tufo.ndef(tufo)
         prefix = '%s:' % (form,)
         prelen = len(prefix)
         props = {k[prelen:]: v for (k, v) in tufo[1].items() if k.startswith(prefix)}

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -331,7 +331,7 @@ class OnHelp:
 
     def dist(self, mesg):
 
-        for sock, filts in self.ons.items():
+        for sock, filts in list(self.ons.items()):
 
             for filt in filts.values():
 
@@ -490,6 +490,7 @@ class Daemon(EventBus, DmonConf):
         reflect = mesg[1].get('reflect')
 
         user = sock.get('syn:user')
+
         if not self._isUserAllowed(user, 'tele:push:' + name):
             return sock.tx(s_common.tufo('job:done', err='NoSuchRule', jid=jid))
 

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -136,8 +136,17 @@ class HitCoreLimit(SynErr):
     ''' You've reached some limit of the storage layer.'''
     pass
 
-class NotEnoughFree(Exception): pass
-class NoWritableAxons(Exception): pass
+class NotEnoughFree(SynErr):
+    '''
+    There is not enough disk space free for the required operation.
+    '''
+    pass
+
+class NoWritableAxons(SynErr):
+    '''
+    There are no writable axons available for the required operation.
+    '''
+    pass
 
 class MustNotWait(Exception): pass   # blocking function called by no-wait thread
 
@@ -147,6 +156,11 @@ class FileExists(SynErr): pass
 class NotEmpty(SynErr): pass
 class NotSupported(SynErr): pass
 
+class BadAtomFile(SynErr):
+    '''
+    Raised when there is a internal issue with an atomfile.
+    '''
+    pass
 
 class IsFini(Exception): pass
 

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -113,7 +113,7 @@ class IsRuntProp(SynErr): pass
 class NoSuch(Exception): pass
 class NoSuchJob(Exception): pass
 class NoSuchObj(SynErr): pass
-class NoSuchFile(Exception): pass
+class NoSuchFile(SynErr): pass
 class NoSuchIden(Exception): pass
 class NoSuchMeth(SynErr): pass
 class NoSuchFunc(SynErr): pass

--- a/synapse/lib/config.py
+++ b/synapse/lib/config.py
@@ -201,6 +201,15 @@ class Configable:
         '''
         return {name: dict(info[1]) for (name, info) in self._conf_defs.items()}
 
+    def getConfOpts(self):
+        '''
+        Get the current configuration for this object.
+
+        Returns:
+            dict: Dictionary of option and configured value for the object.
+        '''
+        return {key: self.getConfOpt(key) for key, _ in self.getConfDefs().items()}
+
     def getConfNorm(self, name, valu):
         '''
         Return a normalized version of valu based on type knowledge for name.

--- a/synapse/lib/hashset.py
+++ b/synapse/lib/hashset.py
@@ -7,12 +7,12 @@ class HashSet:
         self.size = 0
 
         # BEWARE ORDER MATTERS FOR guid()
-        self.hashes = [
+        self.hashes = (
             ('md5', hashlib.md5()),
             ('sha1', hashlib.sha1()),
             ('sha256', hashlib.sha256()),
             ('sha512', hashlib.sha512())
-        ]
+        )
 
     def guid(self):
         '''

--- a/synapse/lib/heap.py
+++ b/synapse/lib/heap.py
@@ -96,6 +96,7 @@ class Heap(s_eventbus.EventBus):
 
     def _actSyncHeapResize(self, mesg):
         size = mesg[1].get('size')
+        self.atom.resize(size)
 
     def _writeoff(self, off, byts):
         self.atom.writeoff(off, byts)

--- a/synapse/lib/persist.py
+++ b/synapse/lib/persist.py
@@ -73,7 +73,7 @@ class Offset(s_eventbus.EventBus):
 
 class Dir(s_eventbus.EventBus):
     '''
-    A persistance dir may be used similar to a Write-Ahead-Log to sync
+    A persistence dir may be used similar to a Write-Ahead-Log to sync
     objects based on events ( and allow desync-catch-up )
     '''
 
@@ -300,7 +300,7 @@ class Dir(s_eventbus.EventBus):
 
 class File(s_eventbus.EventBus):
     '''
-    A single fd based persistance stream.
+    A single fd based persistence stream.
 
     This is mostly a helper for Dir().  All consume/resume
     behavior should be facilitated by the Dir() object.

--- a/synapse/lib/service.py
+++ b/synapse/lib/service.py
@@ -124,6 +124,14 @@ class SvcProxy(s_eventbus.EventBus):
     def __init__(self, sbus, timeout=None):
         s_eventbus.EventBus.__init__(self)
 
+        self.byiden = {}
+        self.byname = {}
+        self.bytag = s_tags.ByTag()
+
+        self.idenprox = {}
+        self.nameprox = {}
+        self.tagprox = {}
+
         self.sbus = sbus
         self.timeout = timeout
 
@@ -132,14 +140,6 @@ class SvcProxy(s_eventbus.EventBus):
         # FIXME set a reconnect handler for sbus
         self.sbus.on('syn:svc:init', self._onSynSvcInit)
         self.sbus.on('syn:svc:fini', self._onSynSvcFini)
-
-        self.byiden = {}
-        self.byname = {}
-        self.bytag = s_tags.ByTag()
-
-        self.idenprox = {}
-        self.nameprox = {}
-        self.tagprox = {}
 
         [self._addSvcTufo(svcfo) for svcfo in sbus.getSynSvcs()]
 
@@ -202,7 +202,7 @@ class SvcProxy(s_eventbus.EventBus):
                 dostuff(svcfo)
 
         '''
-        return self.byiden.values()
+        return list(self.byiden.values())
 
     def getSynSvcsByTag(self, tag):
         '''

--- a/synapse/models/axon.py
+++ b/synapse/models/axon.py
@@ -53,7 +53,9 @@ class AxonMod(CoreModule):
                     ('sha512', {'ptype': 'hash:sha512', 'req': True}),
                 )),
 
-                ('axon:clone', {'ptype': 'guid'}, ()),
+                ('axon:clone', {'ptype': 'guid'}, (
+                    ('host', {'ptype': 'str', 'req': 1}),
+                )),
 
                 ('axon:path', {'ptype': 'axon:path'}, (
                     ('dir', {'ptype': 'axon:path', 'req': False, 'doc': 'The parent directory for this path.'}),

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -609,14 +609,36 @@ def clientside(f):
     A function decorator which causes the given function to be run on
     the telepath client side.
 
+    Args:
+        f: The function being decorated.
+
+    Notes:
+        A decorated function **must** use APIs within the function to access
+        object locals, variables, etc. In other words, the method must be able
+        to have **self** be a Telepath Proxy object.
+
     Example:
+        A class with a decorated clientside function::
 
-        @s_telepath.clientside
-        def foo(self, bar):
-            dostuff()
+            class Foob:
+                def __init__(self, data):
+                    self.locals = data
 
-    NOTE: you *must* use APIs within the function to access locals etc.
-          ( ie, the method must be able to have self be a telepath proxy )
+                def getLocals():
+                    return self.locals
+
+                @s_telepath.clientside
+                def foo(self, bar):
+
+                    # We use an API to get data from self.locals instead
+                    # accessing it directly, since that would cause failures.
+                    object_locals = self.getLocals()
+
+                    # Now do stuff on the client side.
+                    dostuff(object_locals)
+
+    Returns:
+        The decorated function.
     '''
     f._tele_clientside = True
     return f

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -84,9 +84,10 @@ class SynTest(unittest.TestCase):
         if bool(int(os.getenv('SYN_TEST_SKIP_INTERNET', 0))):
             raise unittest.SkipTest('SYN_TEST_SKIP_INTERNET envar set')
 
-    def skipLongTests(self):
-        if not os.getenv('SYN_RUN_LONG_TESTS'):
-            raise unittest.SkipTest('no SYN_RUN_LONG_TESTS envar')
+    def skipLongTest(self):
+        valu = os.getenv('SYN_TEST_SKIP_LONG', 0)
+        if bool(int(valu)):
+            raise unittest.SkipTest('SYN_TEST_SKIP_LONG envar set')
 
     def getPgConn(self):
         '''

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -11,7 +11,10 @@ import contextlib
 
 import unittest.mock as mock
 
-logging.basicConfig(level=logging.WARNING)
+
+loglevel = int(os.getenv('SYN_TEST_LOG_LEVEL', logging.WARNING))
+logging.basicConfig(level=loglevel,
+                    format='%(asctime)s [%(levelname)s] %(message)s [%(filename)s:%(funcName)s]')
 
 import synapse.link as s_link
 import synapse.cortex as s_cortex
@@ -80,6 +83,10 @@ class SynTest(unittest.TestCase):
     def skipIfNoInternet(self):
         if bool(int(os.getenv('SYN_TEST_SKIP_INTERNET', 0))):
             raise unittest.SkipTest('SYN_TEST_SKIP_INTERNET envar set')
+
+    def skipLongTests(self):
+        if not os.getenv('SYN_RUN_LONG_TESTS'):
+            raise unittest.SkipTest('no SYN_RUN_LONG_TESTS envar')
 
     def getPgConn(self):
         '''

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -85,8 +85,7 @@ class SynTest(unittest.TestCase):
             raise unittest.SkipTest('SYN_TEST_SKIP_INTERNET envar set')
 
     def skipLongTest(self):
-        valu = os.getenv('SYN_TEST_SKIP_LONG', 0)
-        if bool(int(valu)):
+        if bool(int(os.getenv('SYN_TEST_SKIP_LONG', 0))):
             raise unittest.SkipTest('SYN_TEST_SKIP_LONG envar set')
 
     def getPgConn(self):

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -208,8 +208,8 @@ class AxonHostTest(SynTest):
             syncmax = s_axon.megabyte * 5
 
             props = {
-                'axonhost:bytemax': bytemax,
-                'axonhost:syncmax': syncmax,
+                'axon:bytemax': bytemax,
+                'axon:syncmax': syncmax,
                 'axonhost:maxsize': maxsize
             }
 
@@ -243,8 +243,8 @@ class AxonHostTest(SynTest):
                 bytemax = int(_t * 0.66)
                 syncmax = int(_t * 0.33)
 
-                host.setConfOpt('axonhost:bytemax', bytemax)
-                host.setConfOpt('axonhost:syncmax', syncmax)
+                host.setConfOpt('axon:bytemax', bytemax)
+                host.setConfOpt('axon:syncmax', syncmax)
 
                 axons = {}
                 for i in range(max_axons):
@@ -271,18 +271,18 @@ class AxonHostTest(SynTest):
             dir1 = gendir(datadir, 'host1')
             dir2 = gendir(datadir, 'host2')
 
-            host0 = s_axon.AxonHost(dir0, **{'axonhost:hostname': 'host0',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
-            host1 = s_axon.AxonHost(dir1, **{'axonhost:hostname': 'host1',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
-            host2 = s_axon.AxonHost(dir2, **{'axonhost:hostname': 'host2',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host0 = s_axon.AxonHost(dir0, **{'axon:hostname': 'host0',
+                                             'axon:axonbus': busurl,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
+            host1 = s_axon.AxonHost(dir1, **{'axon:hostname': 'host1',
+                                             'axon:axonbus': busurl,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
+            host2 = s_axon.AxonHost(dir2, **{'axon:hostname': 'host2',
+                                             'axon:axonbus': busurl,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
 
             props = {
                 'axon:syncmax': s_axon.megabyte * 10,
@@ -392,30 +392,30 @@ class AxonHostTest(SynTest):
             dir2 = gendir(datadir, 'host2')
             dir3 = gendir(datadir, 'host3')
 
-            host0 = s_axon.AxonHost(dir0, **{'axonhost:hostname': 'host0',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:clones': 1,
+            host0 = s_axon.AxonHost(dir0, **{'axon:hostname': 'host0',
+                                             'axon:axonbus': busurl,
+                                             'axon:clones': 1,
                                              'axonhost:autorun': 2,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
-            host1 = s_axon.AxonHost(dir1, **{'axonhost:hostname': 'host1',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:clones': 1,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
+            host1 = s_axon.AxonHost(dir1, **{'axon:hostname': 'host1',
+                                             'axon:axonbus': busurl,
+                                             'axon:clones': 1,
                                              'axonhost:autorun': 2,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
-            host2 = s_axon.AxonHost(dir2, **{'axonhost:hostname': 'host2',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:clones': 1,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
+            host2 = s_axon.AxonHost(dir2, **{'axon:hostname': 'host2',
+                                             'axon:axonbus': busurl,
+                                             'axon:clones': 1,
                                              'axonhost:autorun': 2,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
-            host3 = s_axon.AxonHost(dir3, **{'axonhost:hostname': 'host3',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:clones': 1,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
+            host3 = s_axon.AxonHost(dir3, **{'axon:hostname': 'host3',
+                                             'axon:axonbus': busurl,
+                                             'axon:clones': 1,
                                              'axonhost:autorun': 2,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
 
             time.sleep(3)
             ta = [len(host.axons) for host in [host0, host1, host2, host3]]
@@ -432,8 +432,8 @@ class AxonHostTest(SynTest):
         with self.getTestDir() as dirname:
             opts = {
                 'axonhost:autorun': 2,
-                'axonhost:syncmax': s_axon.megabyte,
-                'axonhost:bytemax': s_axon.megabyte,
+                'axon:syncmax': s_axon.megabyte,
+                'axon:bytemax': s_axon.megabyte,
             }
             host = s_axon.AxonHost(dirname, **opts)
             self.eq(len(host.axons), 2)
@@ -446,20 +446,20 @@ class AxonHostTest(SynTest):
         hstcfg = {
             "vars": {
                 "hcfg0": {
-                    "axonhost:hostname": "host0",
-                    "axonhost:bytemax": 1024000000,
-                    "axonhost:syncmax": 512000000,
+                    "axon:hostname": "host0",
+                    "axon:bytemax": 1024000000,
+                    "axon:syncmax": 512000000,
                     "axonhost:maxsize": 10240000000,
                     "axonhost:autorun": 1,
-                    "axonhost:clones": 1,
+                    "axon:clones": 1,
                 },
                 "hcfg1": {
-                    "axonhost:hostname": "host1",
-                    "axonhost:bytemax": 1024000000,
-                    "axonhost:syncmax": 512000000,
+                    "axon:hostname": "host1",
+                    "axon:bytemax": 1024000000,
+                    "axon:syncmax": 512000000,
                     "axonhost:maxsize": 10240000000,
                     "axonhost:autorun": 1,
-                    "axonhost:clones": 1,
+                    "axon:clones": 1,
                 }
             },
             "ctors": [
@@ -512,8 +512,8 @@ class AxonHostTest(SynTest):
                 link = svcdmon.listen('tcp://127.0.0.1:0/')
                 port = link[1].get('port')
                 busurl = 'tcp://127.0.0.1:{}/axonbus'.format(port)
-                hstcfg['vars']['hcfg0']['axonhost:axonbus'] = busurl
-                hstcfg['vars']['hcfg1']['axonhost:axonbus'] = busurl
+                hstcfg['vars']['hcfg0']['axon:axonbus'] = busurl
+                hstcfg['vars']['hcfg1']['axon:axonbus'] = busurl
 
                 with s_daemon.Daemon() as axondmon:
                     axondmon.loadDmonConf(hstcfg)
@@ -537,8 +537,8 @@ class AxonHostTest(SynTest):
                 link = svcdmon.listen('tcp://127.0.0.1:0/')
                 port = link[1].get('port')
                 busurl = 'tcp://127.0.0.1:{}/axonbus'.format(port)
-                hstcfg['vars']['hcfg0']['axonhost:axonbus'] = busurl
-                hstcfg['vars']['hcfg1']['axonhost:axonbus'] = busurl
+                hstcfg['vars']['hcfg0']['axon:axonbus'] = busurl
+                hstcfg['vars']['hcfg1']['axon:axonbus'] = busurl
 
                 with s_daemon.Daemon() as axondmon:
                     axondmon.loadDmonConf(hstcfg)
@@ -572,18 +572,18 @@ class AxonClusterTest(SynTest):
             dir1 = gendir(datadir, 'host1')
             dir2 = gendir(datadir, 'host2')
 
-            host0 = s_axon.AxonHost(dir0, **{'axonhost:hostname': 'host0',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
-            host1 = s_axon.AxonHost(dir1, **{'axonhost:hostname': 'host1',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
-            host2 = s_axon.AxonHost(dir2, **{'axonhost:hostname': 'host2',
-                                             'axonhost:axonbus': busurl,
-                                             'axonhost:bytemax': s_axon.megabyte * 100,
-                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host0 = s_axon.AxonHost(dir0, **{'axon:hostname': 'host0',
+                                             'axon:axonbus': busurl,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
+            host1 = s_axon.AxonHost(dir1, **{'axon:hostname': 'host1',
+                                             'axon:axonbus': busurl,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
+            host2 = s_axon.AxonHost(dir2, **{'axon:hostname': 'host2',
+                                             'axon:axonbus': busurl,
+                                             'axon:bytemax': s_axon.megabyte * 100,
+                                             'axon:syncmax': s_axon.megabyte * 10})
 
             props = {
                 'axon:clones': 1,

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -1,59 +1,102 @@
+import io
+import logging
+
 import synapse.axon as s_axon
 import synapse.daemon as s_daemon
 import synapse.telepath as s_telepath
 
+import synapse.lib.tufo as s_tufo
 import synapse.lib.service as s_service
 
 from synapse.tests.common import *
 
 craphash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 asdfhash = '6a204bd89f3c8348afd5c77c717a097a'
+asdfhash_iden = '1c753abfe85b4cbe46584fa5b1834fa4'
+
+logger = logging.getLogger(__name__)
 
 class AxonTest(SynTest):
-
     def test_axon_basics(self):
         with self.getTestDir() as axondir:
+            with s_axon.Axon(axondir) as axon:
+                self.false(axon.has('md5', craphash))
+                self.false(axon.has('md5', asdfhash))
 
-            axon = s_axon.Axon(axondir)
+                iden0 = axon.alloc(8)
 
-            self.false(axon.has('md5', craphash))
-            self.false(axon.has('md5', asdfhash))
+                self.nn(axon.chunk(iden0, b'asdfasdf'))
 
-            iden0 = axon.alloc(8)
+                self.raises(NoSuchIden, axon.chunk, guid(), b'asdfasdf')
 
-            self.nn(axon.chunk(iden0, b'asdfasdf'))
+                self.true(axon.has('md5', asdfhash))
+                self.false(axon.has('md5', craphash))
 
-            self.true(axon.has('md5', asdfhash))
-            self.false(axon.has('md5', craphash))
+                byts = b''.join(axon.bytes('md5', asdfhash))
 
-            byts = b''.join(axon.bytes('md5', asdfhash))
+                self.eq(byts, b'asdfasdf')
 
-            self.eq(byts, b'asdfasdf')
+                byts = b''.join(axon.bytes('guid', asdfhash_iden))
 
-            axon.fini()
+                self.eq(byts, b'asdfasdf')
 
-            axon = s_axon.Axon(axondir)
+                axon.fini()
 
-            self.true(axon.has('md5', asdfhash))
-            self.false(axon.has('md5', craphash))
+                axon = s_axon.Axon(axondir)
 
-            byts = b''.join(axon.bytes('md5', asdfhash))
+                self.true(axon.has('md5', asdfhash))
+                self.true(axon.has('guid', asdfhash_iden))
+                self.false(axon.has('md5', craphash))
 
-            self.eq(byts, b'asdfasdf')
+                byts = b''.join(axon.bytes('md5', asdfhash))
 
-            self.none(axon.wants('md5', asdfhash, 8))
-            self.nn(axon.wants('md5', craphash, 8))
+                self.eq(byts, b'asdfasdf')
 
-            axon.fini()
+                self.none(axon.wants('md5', asdfhash, 8))
+                self.nn(axon.wants('md5', craphash, 8))
+
+    def test_axon_restrictions(self):
+        with self.getTestDir() as axondir:
+            with s_axon.Axon(axondir) as axon:
+                iden0 = axon.alloc(8)
+                self.nn(axon.chunk(iden0, b'asdfasdf'))
+
+                # set the axon as read-only and ensure we cannot write new blobs to it
+                axon.setConfOpt('axon:ro', 1)
+                axfo = axon.getAxonInfo()
+                self.eq(axfo[1].get('opts').get('axon:ro'), 1)
+                self.raises(NotSupported, axon.alloc, 8)
+
+                # But we can still read from axon:ro=1 axons
+                byts = b''.join(axon.bytes('guid', asdfhash_iden))
+                self.eq(byts, b'asdfasdf')
+
+                # non-clones cannot sync events
+                self.raises(NotSupported, axon.sync, ())
+
+                # clones cannot alloc new blobs directly
+                axon.setConfOpt('axon:clone', 1)
+                self.raises(NotSupported, axon.alloc, 8)
+
+    def test_axon_bytesize(self):
+        opts = {'axon:bytemax': s_axon.megabyte}
+        with self.getTestDir() as axondir:
+            with s_axon.Axon(axondir, **opts) as axon:
+                iden = axon.alloc(1024)
+                self.nn(iden)
+                # Exceed bytemax by 1 byte - we should fail to allocate that space.
+                self.raises(NotEnoughFree, axon.alloc, s_axon.megabyte - 1023)
+                # But we still have some space left to alloc more blobs
+                iden2 = axon.alloc(1024)
+                self.nn(iden2)
 
     def test_axon_sync(self):
-
         with self.getTestDir() as axondir:
-
             byts = os.urandom(128)
             bytsmd5 = hashlib.md5(byts).hexdigest()
-
-            axon = s_axon.Axon(axondir, syncsize=64)
+            # XXX It is not clear what this test is actually testing since syncsize is not used by anything inside of
+            # axon.py
+            axon = s_axon.Axon(axondir, **{'axon:syncsize': 64})
 
             iden = axon.alloc(128)
             for chnk in chunks(byts, 10):
@@ -65,12 +108,49 @@ class AxonTest(SynTest):
 
             axon.fini()
 
+    def test_axon_telepath(self):
+        with self.getTestDir() as dirname:
+            with s_daemon.Daemon() as dmon:
+                link = dmon.listen('tcp://127.0.0.1:0/')
+                port = link[1].get('port')
+
+                with s_axon.Axon(dirname) as axon:
+                    dmon.share('axon', axon)
+
+                    prox = s_telepath.openurl('tcp://127.0.0.1/axon', port=port)
+
+                    with io.BytesIO(b'vertex') as fd:
+                        blob = prox.eatfd(fd)
+                        self.eq(blob[1]['axon:blob:sha256'],
+                                'e1b683e26a3aad218df6aa63afe9cf57fdb5dfaf5eb20cddac14305d67f48a02')
+
+    def test_axon_eatbytes(self):
+        self.thisHostMustNot(platform='windows')
+
+        with self.getTestDir() as dirname:
+            with s_axon.Axon(dirname) as axon:
+                blob0 = axon.eatbytes(b'visi')
+                with io.BytesIO(b'vertex') as fd:
+                    blob1 = axon.eatfd(fd)
+
+                port = axon.getAxonInfo()[1].get('link')[1].get('port')
+
+                with s_telepath.openurl('tcp://127.0.0.1/axon', port=port) as prox:
+                    blob2 = prox.eatbytes(b'hurr')
+                    with io.BytesIO(b'durr') as fd:
+                        blob3 = prox.eatfd(fd)
+
+        self.eq(blob0[1].get('axon:blob'), '442f602ecf8230b2a59a44b4f845be27')
+        self.eq(blob1[1].get('axon:blob'), 'd4552906c1f6966b96d27e6fc79441b5')
+        self.eq(blob2[1].get('axon:blob'), '0d60960570ef6da0a15f68c24b420334')
+        self.eq(blob3[1].get('axon:blob'), '97c11d1057f75c9c0b79090131709f62')
+
+class AxonHostTest(SynTest):
     def test_axon_host(self):
 
         self.thisHostMustNot(platform='windows')
 
         with self.getTestDir() as datadir:
-
             with open(os.path.join(datadir, 'foo'), 'w') as fd:
                 fd.write('useless file to skip')
 
@@ -78,13 +158,17 @@ class AxonTest(SynTest):
             usage = host.usage()
 
             props = {
-                'syncmax': s_axon.megabyte * 10,
-                'bytemax': s_axon.megabyte * 10,
+                'axon:syncmax': s_axon.megabyte * 10,
+                'axon:bytemax': s_axon.megabyte * 10,
             }
+
+            self.eq(host.usedspace, 0)
 
             axfo = host.add(**props)
 
             self.nn(usage.get('total'))
+
+            self.eq(host.usedspace, s_axon.megabyte * 20)
 
             axon = host.axons.get(axfo[0])
 
@@ -100,6 +184,8 @@ class AxonTest(SynTest):
             host.fini()
 
             host = s_axon.AxonHost(datadir)
+            self.eq(host.usedspace, s_axon.megabyte * 20)
+
             axon = host.axons.get(axfo[0])
 
             self.true(axon.has('md5', blob[1].get('hash:md5')))
@@ -107,14 +193,70 @@ class AxonTest(SynTest):
             self.true(axon.has('sha256', blob[1].get('hash:sha256')))
 
             props = {
-                'syncmax': s_axon.megabyte * 10,
+                'axon:syncmax': s_axon.megabyte * 10,
             }
             self.raises(NotEnoughFree, host.add, **props)
 
             host.fini()
 
+    def test_axon_host_maxsize_limit(self):
+        self.thisHostMustNot(platform='windows')
+
+        with self.getTestDir() as datadir:
+            bytemax = s_axon.megabyte * 50
+            maxsize = s_axon.megabyte * 100
+            syncmax = s_axon.megabyte * 5
+
+            props = {
+                'axonhost:bytemax': bytemax,
+                'axonhost:syncmax': syncmax,
+                'axonhost:maxsize': maxsize
+            }
+
+            with s_axon.AxonHost(datadir, **props) as host:  # type: s_axon.AxonHost
+
+                # Make a 55mb axon
+                axfo0 = host.add()
+                self.nn(axfo0)
+
+                # We'd exceed maxsize by 5mb so fail there
+                self.raises(NotEnoughFree, host.add)
+
+                # We can still make a 15mb Axon
+                axfo1 = host.add(**{'axon:bytemax': s_axon.megabyte * 10})
+                self.nn(axfo1)
+
+    def test_axon_host_free_limit(self):
+        self.skipLongTests()
+        self.thisHostMustNot(platform='windows')
+
+        with self.getTestDir() as datadir:
+
+            with s_axon.AxonHost(datadir) as host:  # type: s_axon.AxonHost
+
+                usage = host.usage()
+                free = usage.get('free')
+                max_axons = 8
+
+                _t = int(free / max_axons)
+
+                bytemax = int(_t * 0.66)
+                syncmax = int(_t * 0.33)
+
+                host.setConfOpt('axonhost:bytemax', bytemax)
+                host.setConfOpt('axonhost:syncmax', syncmax)
+
+                axons = {}
+                for i in range(max_axons):
+                    axfo = host.add()
+                    axons[i] = axfo
+                self.assertEqual(len(axons), max_axons)
+
+                # Create one more axon which will exceed the free space available on the host
+                self.raises(NotEnoughFree, host.add)
+
     def test_axon_host_clone(self):
-
+        self.skipLongTests()
         self.thisHostMustNot(platform='windows')
 
         busurl = 'local://%s/axons' % guid()
@@ -125,48 +267,116 @@ class AxonTest(SynTest):
         dmon.share('axons', s_service.SvcBus(), fini=True)
 
         with self.getTestDir() as datadir:
-
             dir0 = gendir(datadir, 'host0')
             dir1 = gendir(datadir, 'host1')
             dir2 = gendir(datadir, 'host2')
 
-            opts = {
-                'axonbus': busurl,
-            }
-
-            host0 = s_axon.AxonHost(dir0, hostname='host0', **opts)
-            host1 = s_axon.AxonHost(dir1, hostname='host1', **opts)
-            host2 = s_axon.AxonHost(dir2, hostname='host2', **opts)
+            host0 = s_axon.AxonHost(dir0, **{'axonhost:hostname': 'host0',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host1 = s_axon.AxonHost(dir1, **{'axonhost:hostname': 'host1',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host2 = s_axon.AxonHost(dir2, **{'axonhost:hostname': 'host2',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
 
             props = {
-                'syncmax': s_axon.megabyte,
-                'bytemax': s_axon.megabyte,
+                'axon:syncmax': s_axon.megabyte * 10,
+                'axon:bytemax': s_axon.megabyte * 50,
             }
 
             axfo0 = host0.add(**props)
-
-            axon0 = s_telepath.openlink(axfo0[1].get('link'))
+            axon0 = s_telepath.openlink(axfo0[1].get('link'))  # type: s_axon.Axon
             self.true(axon0._waitClonesReady(timeout=8))
+            self.notin(axfo0[0], host0.cloneaxons)
 
+            # get refs to axon0's clones
+            ciden1 = host1.cloneaxons[0]
+            axonc1 = host1.axons.get(ciden1)  # type: s_axon.Axon
+            self.eq(axonc1.getConfOpt('axon:clone:iden'), axfo0[0])
+            ciden2 = host2.cloneaxons[0]
+            axonc2 = host2.axons.get(ciden2)  # type: s_axon.Axon
+            self.eq(axonc2.getConfOpt('axon:clone:iden'), axfo0[0])
+
+            # Ensure axon:clone events have fired on the cores
             iden = axon0.alloc(100)
-            blob = axon0.chunk(iden, b'V' * 100)
+            cv = b'V' * 100
+            blob = axon0.chunk(iden, cv)
+
+            # We need to check the clones of axon0 to ensure that the clones have the data too
+            time.sleep(1)
 
             self.nn(blob)
-
             self.true(axon0.has('md5', blob[1].get('hash:md5')))
             self.true(axon0.has('sha1', blob[1].get('hash:sha1')))
             self.true(axon0.has('sha256', blob[1].get('hash:sha256')))
+            axonbyts = b''.join(_byts for _byts in axon0.iterblob(blob))
+            self.eq(axonbyts, cv)
 
+            self.true(axonc1.has('md5', blob[1].get('hash:md5')))
+            self.true(axonc1.has('sha1', blob[1].get('hash:sha1')))
+            self.true(axonc1.has('sha256', blob[1].get('hash:sha256')))
+            axonbyts = b''.join(_byts for _byts in axonc1.iterblob(blob))
+            self.eq(axonbyts, cv)
+
+            self.true(axonc2.has('md5', blob[1].get('hash:md5')))
+            self.true(axonc2.has('sha1', blob[1].get('hash:sha1')))
+            self.true(axonc2.has('sha256', blob[1].get('hash:sha256')))
+            axonbyts = b''.join(_byts for _byts in axonc2.iterblob(blob))
+            self.eq(axonbyts, cv)
+
+            # Now write a large amount of data to axon0 and ensure that data is replicated
+            blobs = []
+            n = 5
+            tststr = 'deadb33f' * 100000
+            for i in range(n):
+                byts = tststr + 'lol' * i
+                byts = byts.encode()
+                blob = axon0.eatbytes(byts)
+                blobs.append(blob)
+            self.eq(len(blobs), n)
+            time.sleep(2)
+            for i, blob in enumerate(blobs):
+                form, pprop = s_tufo.ndef(blob)
+                ret = axonc1.byiden(pprop)
+                self.nn(ret)
+                ret = axonc2.byiden(pprop)
+                self.nn(ret)
+
+            # Add axons to the other two hosts and see that they clone over to the other hosts
+            axfo1 = host1.add(**props)
+            axon1 = s_telepath.openlink(axfo1[1].get('link'))  # type: s_axon.Axon
+            self.true(axon1._waitClonesReady(timeout=8))
+
+            axfo2 = host2.add(**props)
+            axon2 = s_telepath.openlink(axfo2[1].get('link'))  # type: s_axon.Axon
+            self.true(axon2._waitClonesReady(timeout=8))
+
+            self.eq(len(host0.axons), 3)
+            self.eq(len(host1.axons), 3)
+            self.eq(len(host2.axons), 3)
+
+            self.eq(len(host0.cloneaxons), 2)
+            self.eq(len(host1.cloneaxons), 2)
+            self.eq(len(host2.cloneaxons), 2)
+
+            # Fini the proxy objects
             axon0.fini()
+            axon1.fini()
+            axon2.fini()
 
+            # Fini the hosts
             host0.fini()
             host1.fini()
             host2.fini()
-
         dmon.fini()
 
-    def test_axon_clustered(self):
-
+    def test_axon_clone_large(self):
+        self.skipLongTests()
         self.thisHostMustNot(platform='windows')
 
         busurl = 'local://%s/axons' % guid()
@@ -177,54 +387,173 @@ class AxonTest(SynTest):
         dmon.share('axons', s_service.SvcBus(), fini=True)
 
         with self.getTestDir() as datadir:
-
             dir0 = gendir(datadir, 'host0')
             dir1 = gendir(datadir, 'host1')
             dir2 = gendir(datadir, 'host2')
+            dir3 = gendir(datadir, 'host3')
 
+            host0 = s_axon.AxonHost(dir0, **{'axonhost:hostname': 'host0',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:clones': 1,
+                                             'axonhost:autorun': 2,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host1 = s_axon.AxonHost(dir1, **{'axonhost:hostname': 'host1',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:clones': 1,
+                                             'axonhost:autorun': 2,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host2 = s_axon.AxonHost(dir2, **{'axonhost:hostname': 'host2',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:clones': 1,
+                                             'axonhost:autorun': 2,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host3 = s_axon.AxonHost(dir3, **{'axonhost:hostname': 'host3',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:clones': 1,
+                                             'axonhost:autorun': 2,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
+
+            time.sleep(3)
+            ta = [len(host.axons) for host in [host0, host1, host2, host3]]
+            tc = [len(host.cloneaxons) for host in [host0, host1, host2, host3]]
+            total_axons = sum(ta)
+            total_clones = sum(tc)
+            self.eq(total_axons, 16)
+            self.eq(total_clones, 8)
+
+    def test_axon_autorun(self):
+
+        self.thisHostMustNot(platform='windows')
+
+        with self.getTestDir() as dirname:
             opts = {
-                'axonbus': busurl,
+                'axonhost:autorun': 2,
+                'axonhost:syncmax': s_axon.megabyte,
+                'axonhost:bytemax': s_axon.megabyte,
             }
+            host = s_axon.AxonHost(dirname, **opts)
+            self.eq(len(host.axons), 2)
+            host.fini()
 
-            host0 = s_axon.AxonHost(dir0, hostname='host0', **opts)
-            host1 = s_axon.AxonHost(dir1, hostname='host1', **opts)
-            host2 = s_axon.AxonHost(dir2, hostname='host2', **opts)
+    def test_axon_host_spinbackup(self):
+        self.skipLongTests()
+        self.thisHostMustNot(platform='windows')
 
-            props = {
-                'clones': 2,
-                'syncmax': s_axon.megabyte,
-                'bytemax': s_axon.megabyte,
-            }
+        hstcfg = {
+            "vars": {
+                "hcfg0": {
+                    "axonhost:hostname": "host0",
+                    "axonhost:bytemax": 1024000000,
+                    "axonhost:syncmax": 512000000,
+                    "axonhost:maxsize": 10240000000,
+                    "axonhost:autorun": 1,
+                    "axonhost:clones": 1,
+                },
+                "hcfg1": {
+                    "axonhost:hostname": "host1",
+                    "axonhost:bytemax": 1024000000,
+                    "axonhost:syncmax": 512000000,
+                    "axonhost:maxsize": 10240000000,
+                    "axonhost:autorun": 1,
+                    "axonhost:clones": 1,
+                }
+            },
+            "ctors": [
+                [
+                    "host0",
+                    "ctor://synapse.axon.AxonHost(dir0, **hcfg0)"
+                ],
+                [
+                    "host1",
+                    "ctor://synapse.axon.AxonHost(dir1, **hcfg1)"
+                ]
+            ],
+            "share": [
+                [
+                    "host0",
+                    {
+                        "onfini": True
+                    }
+                ]
+            ]
+        }
 
-            axfo0 = host0.add(**props)
+        svccfg = {
+            "comment": "dmon file for axon stresstest",
+            "ctors": [
+                [
+                    "axonbus",
+                    "ctor://synapse.lib.service.SvcBus()",
+                    {}
+                ]
+            ],
+            "share": [
+                [
+                    "axonbus",
+                    {
+                        "onfini": True
+                    }
+                ]
+            ]
+        }
 
-            axon0 = s_telepath.openlink(axfo0[1].get('link'))
+        with self.getTestDir() as dirname:
+            hostdir0 = gendir(dirname, 'host0')
+            hostdir1 = gendir(dirname, 'host1')
+            hstcfg['vars']['dir0'] = hostdir0
+            hstcfg['vars']['dir1'] = hostdir1
 
-            # wait for clones to come online
-            self.true(axon0._waitClonesReady(timeout=8))
+            with s_daemon.Daemon() as svcdmon:
+                svcdmon.loadDmonConf(svccfg)
+                link = svcdmon.listen('tcp://127.0.0.1:0/')
+                port = link[1].get('port')
+                busurl = 'tcp://127.0.0.1:{}/axonbus'.format(port)
+                hstcfg['vars']['hcfg0']['axonhost:axonbus'] = busurl
+                hstcfg['vars']['hcfg1']['axonhost:axonbus'] = busurl
 
-            #self.nn( usage.get('total') )
-            #axon = host.axons.get(iden)
+                with s_daemon.Daemon() as axondmon:
+                    axondmon.loadDmonConf(hstcfg)
+                    svcbus = s_service.openurl('tcp://127.0.0.1:0/axonbus', port=port)  # type: s_service.SvcProxy
+                    time.sleep(2)
+                    first_axons = svcbus.getSynSvcsByTag(s_axon.axontag)
+                    self.eq(len(first_axons), 4)
+                    # Close the proxy
+                    svcbus.fini()
 
-            iden = axon0.alloc(100)
-            blob = axon0.chunk(iden, b'V' * 100)
+            # Spin the AxonHost back up
+            # This does exercise a behavior in the AxonHost to always give
+            # preference for its :axonbus configuration option over that of
+            # its Axon's. While this scenario is present in the unit test,
+            # in a real migration which could involve changing the :axonbus,
+            # this ensures that the children Axons of the AxonHost are updated
+            # to point to the new bus.
 
-            self.nn(blob)
+            with s_daemon.Daemon() as svcdmon:
+                svcdmon.loadDmonConf(svccfg)
+                link = svcdmon.listen('tcp://127.0.0.1:0/')
+                port = link[1].get('port')
+                busurl = 'tcp://127.0.0.1:{}/axonbus'.format(port)
+                hstcfg['vars']['hcfg0']['axonhost:axonbus'] = busurl
+                hstcfg['vars']['hcfg1']['axonhost:axonbus'] = busurl
 
-            self.true(axon0.has('md5', blob[1].get('hash:md5')))
-            self.true(axon0.has('sha1', blob[1].get('hash:sha1')))
-            self.true(axon0.has('sha256', blob[1].get('hash:sha256')))
+                with s_daemon.Daemon() as axondmon:
+                    axondmon.loadDmonConf(hstcfg)
+                    svcbus = s_service.openurl('tcp://127.0.0.1:0/axonbus', port=port)  # type: s_service.SvcProxy
+                    time.sleep(2)
+                    axons = svcbus.getSynSvcsByTag(s_axon.axontag)
+                    self.eq(len(axons), 4)
+                    # Ensure these are the same axons we had first created
+                    self.eq({axn[1].get('name') for axn in axons}, {axn[1].get('name') for axn in first_axons})
+                    # Close the proxy
+                    svcbus.fini()
 
-            axon0.fini()
-
-            host0.fini()
-            host1.fini()
-            host2.fini()
-
-        dmon.fini()
-
+class AxonClusterTest(SynTest):
     def test_axon_cluster(self):
-
+        self.skipLongTests()
         self.thisHostMustNot(platform='windows')
 
         busurl = 'local://%s/axons' % guid()
@@ -243,23 +572,39 @@ class AxonTest(SynTest):
             dir1 = gendir(datadir, 'host1')
             dir2 = gendir(datadir, 'host2')
 
-            opts = {
-                'axonbus': busurl,
-            }
-
-            host0 = s_axon.AxonHost(dir0, hostname='host0', **opts)
-            host1 = s_axon.AxonHost(dir1, hostname='host1', **opts)
-            host2 = s_axon.AxonHost(dir2, hostname='host2', **opts)
+            host0 = s_axon.AxonHost(dir0, **{'axonhost:hostname': 'host0',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host1 = s_axon.AxonHost(dir1, **{'axonhost:hostname': 'host1',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
+            host2 = s_axon.AxonHost(dir2, **{'axonhost:hostname': 'host2',
+                                             'axonhost:axonbus': busurl,
+                                             'axonhost:bytemax': s_axon.megabyte * 100,
+                                             'axonhost:syncmax': s_axon.megabyte * 10})
 
             props = {
-                'clones': 1,
-                'syncmax': s_axon.megabyte,
-                'bytemax': s_axon.megabyte,
+                'axon:clones': 1,
+                'axon:syncmax': s_axon.megabyte,
+                'axon:bytemax': s_axon.megabyte,
             }
 
             axfo0 = host0.add(**props)
 
             axcluster._waitWrAxons(1, 4)
+
+            # Ensure our axfo0 was cloned to someone in the cluster
+            axon0 = s_telepath.openlink(axfo0[1].get('link'))  # type: s_axon.Axon
+            axon0._waitClonesReady(timeout=8)
+            foundclone = False
+            if host1.cloneaxons:
+                foundclone = True
+            if host2.cloneaxons:
+                foundclone = True
+            self.true(foundclone)
+            axon0.fini()  # fini the proxy object
 
             self.false(axcluster.has('md5', craphash))
             self.false(axcluster.has('md5', asdfhash))
@@ -270,12 +615,14 @@ class AxonTest(SynTest):
 
             self.false(axcluster.has('md5', craphash))
             self.true(axcluster.has('md5', asdfhash))
+            self.true(axcluster.has('guid', asdfhash_iden))
 
             blobs = axcluster.find('md5', craphash)
             self.eq(len(blobs), 0)
 
             blobs = axcluster.find('md5', asdfhash)
-            self.eq(len(blobs), 1)
+            # We have two blobs for the same hash since the clone of axfo0 is up on host1/host2
+            self.eq(len(blobs), 2)
 
             blob = blobs[0]
             byts = b''.join(axcluster.iterblob(blob))
@@ -288,56 +635,33 @@ class AxonTest(SynTest):
             self.nn(axcluster.wants('md5', craphash, len(buf)))
             self.none(axcluster.wants('md5', asdfhash, len(buf)))
 
+            # Eat bytes via AxonMixin APIs
+            byts = 'pennywise'.encode()
+
+            blob = axcluster.eatbytes(byts)
+            self.nn(blob)
+            self.isin('.new', blob[1])
+            blob = axcluster.eatbytes(byts)
+            self.notin('.new', blob[1])
+
+            buf = io.BytesIO('dancing clown'.encode())
+            blob = axcluster.eatfd(buf)
+            self.nn(blob)
+            self.isin('.new', blob[1])
+            blob = axcluster.eatfd(buf)
+            self.notin('.new', blob[1])
+
             host0.fini()
             host1.fini()
             host2.fini()
 
         dmon.fini()
 
-    def test_axon_autorun(self):
-
-        self.thisHostMustNot(platform='windows')
-
-        with self.getTestDir() as dirname:
-
-            opts = {
-                'autorun': 2,
-                'syncmax': s_axon.megabyte,
-                'bytemax': s_axon.megabyte,
-            }
-            host = s_axon.AxonHost(dirname, **opts)
-            self.eq(len(host.axons), 2)
-            host.fini()
-
-    def test_axon_eatbytes(self):
-        self.thisHostMustNot(platform='windows')
-
-        with self.getTestDir() as dirname:
-            with s_axon.Axon(dirname) as axon:
-
-                blob0 = axon.eatbytes(b'visi')
-                with io.BytesIO(b'vertex') as fd:
-                    blob1 = axon.eatfd(fd)
-
-                port = axon.getAxonInfo()[1].get('link')[1].get('port')
-
-                with s_telepath.openurl('tcp://127.0.0.1/axon', port=port) as prox:
-                    blob2 = prox.eatbytes(b'hurr')
-                    with io.BytesIO(b'durr') as fd:
-                        blob3 = prox.eatfd(fd)
-
-        self.eq(blob0[1].get('axon:blob'), '442f602ecf8230b2a59a44b4f845be27')
-        self.eq(blob1[1].get('axon:blob'), 'd4552906c1f6966b96d27e6fc79441b5')
-        self.eq(blob2[1].get('axon:blob'), '0d60960570ef6da0a15f68c24b420334')
-        self.eq(blob3[1].get('axon:blob'), '97c11d1057f75c9c0b79090131709f62')
-
-    #def test_axon_proxy(self):
-
+class AxonFSTest(SynTest):
     # Axon File System Tests
     def test_axon_fs_create(self):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 axon.fs_create('/foofile', 33204)
                 actual = axon.fs_getattr('/foofile')
 
@@ -348,12 +672,11 @@ class AxonTest(SynTest):
                 self.gt(actual['st_mtime'], 1000000000)
 
                 self.raises(NoSuchDir, axon.fs_create, '/foodir/foo2', 33204)
-                #self.raises(NoSuchDir, axon.fs_create, 'foo2nope', 33204)  # No parent
+                # self.raises(NoSuchDir, axon.fs_create, 'foo2nope', 33204)  # No parent
 
     def test_axon_fs_getattr(self):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 actual = axon.fs_getattr('/')
 
                 self.eq(actual['st_nlink'], 2)
@@ -365,7 +688,6 @@ class AxonTest(SynTest):
     def test_axon_fs_getxattr(self):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 actual = axon.fs_getattr('/')
                 self.eq(actual['st_nlink'], 2)
                 self.eq(actual['st_mode'], 16893)
@@ -381,7 +703,6 @@ class AxonTest(SynTest):
     def test_axon_fs_mkdir(self):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 actual = axon.fs_mkdir('/foo', 0x1FD)
                 self.eq(actual, None)
 
@@ -393,14 +714,13 @@ class AxonTest(SynTest):
                 self.gt(actual['st_mtime'], 1000000000)
 
                 self.raises(NoSuchDir, axon.fs_mkdir, '/foodir/foo2', 16893)
-                #self.raises(NoSuchDir, axon.fs_mkdir, 'noparent', 16893)
+                # self.raises(NoSuchDir, axon.fs_mkdir, 'noparent', 16893)
 
                 self.raises(FileExists, axon.fs_mkdir, '/foo', 0x1FD)
 
     def test_axon_fs_read(self, *args, **kwargs):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 data = b'haha\n'
 
                 fd = tempfile.SpooledTemporaryFile()
@@ -428,7 +748,6 @@ class AxonTest(SynTest):
     def test_axon_fs_readdir(self, *args, **kwargs):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 axon.fs_create('/foofile', 33204)
                 self.eq(sorted(axon.fs_readdir('/')), sorted(['.', '..', 'foofile']))
 
@@ -438,7 +757,6 @@ class AxonTest(SynTest):
     def test_axon_fs_rmdir(self, *args, **kwargs):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 axon.fs_mkdir('/foo', 0x1FD)
                 axon.fs_create('/foo/haha', 33204)
 
@@ -453,7 +771,6 @@ class AxonTest(SynTest):
     def test_axon_fs_rename(self, *args, **kwargs):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 axon.fs_mkdir('/dir', 0x1FD)
                 axon.fs_create('/dir/a', 33204)
                 axon.fs_rename('/dir/a', '/dir/b')
@@ -523,7 +840,6 @@ class AxonTest(SynTest):
     def test_axon_fs_truncate(self, *args, **kwargs):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 axon.fs_create('/foofile', 33204)
                 tufo = axon.core.getTufoByProp('axon:path', '/foofile')
                 axon.core.setTufoProps(tufo, st_size=100, blob=32 * 'a')
@@ -535,12 +851,11 @@ class AxonTest(SynTest):
                 self.eq(tufo[1].get('axon:path:st_size'), 0)
                 self.eq(tufo[1].get('axon:path:blob'), None)
 
-                axon.fs_truncate('/notthere')
+                self.raises(NoSuchEntity, axon.fs_truncate, '/notthere')
 
     def test_axon_fs_unlink(self, *args, **kwargs):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 axon.fs_create('/foofile', 33204)
 
                 actual = axon.fs_getattr('/foofile')
@@ -557,7 +872,6 @@ class AxonTest(SynTest):
     def test_axon_fs_utimens(self, *args, **kwargs):
         with self.getTestDir() as dirname:
             with s_axon.Axon(dirname) as axon:
-
                 axon.fs_create('/foofile', 33204)
                 actual = axon.fs_getattr('/foofile')
                 ctime = actual['st_ctime']
@@ -578,6 +892,8 @@ class AxonTest(SynTest):
                 self.eq(actual['st_ctime'], ctime)
                 self.eq(actual['st_atime'], 0)
 
+                self.raises(NoSuchEntity, axon.fs_utimens, '/derry/sewers', (0, 0))
+
     # test_axon_fs_write  - do not implement this function
 
     def test_axon__fs_isdir(self, *args, **kwargs):
@@ -594,9 +910,9 @@ class AxonTest(SynTest):
 
     def test_axon_get_renameprops(self, *args, **kwargs):
         tufo = ('99ac9490ad2e1d4669de1c005a4ec666',
-            {'tufo:form': 'axon:path', 'axon:path:st_ctime': 1491191818, 'axon:path:st_mode': 16893,
-            'axon:path:st_atime': 1491191818, 'axon:path': '/dir', 'axon:path:base': 'dir', 'axon:path:dir': '/',
-            'axon:path:st_nlink': 3, 'axon:path:st_mtime': 1491191818, 'axon:path:blob': 32 * 'a'})
+                {'tufo:form': 'axon:path', 'axon:path:st_ctime': 1491191818, 'axon:path:st_mode': 16893,
+                 'axon:path:st_atime': 1491191818, 'axon:path': '/dir', 'axon:path:base': 'dir', 'axon:path:dir': '/',
+                 'axon:path:st_nlink': 3, 'axon:path:st_mtime': 1491191818, 'axon:path:blob': 32 * 'a'})
         actual = s_axon.Axon._get_renameprops(tufo)
 
         self.eq(actual['st_nlink'], 3)
@@ -605,20 +921,3 @@ class AxonTest(SynTest):
         self.gt(actual['st_atime'], 1000000000)
         self.gt(actual['st_ctime'], 1000000000)
         self.gt(actual['st_mtime'], 1000000000)
-
-    def test_axon_telepath(self):
-        with self.getTestDir() as dirname:
-
-            with s_daemon.Daemon() as dmon:
-
-                link = dmon.listen('tcp://127.0.0.1:0/')
-                port = link[1].get('port')
-
-                with s_axon.Axon(dirname) as axon:
-                    dmon.share('axon', axon)
-
-                    prox = s_telepath.openurl('tcp://127.0.0.1/axon', port=port)
-
-                    with io.BytesIO(b'vertex') as fd:
-                        blob = prox.eatfd(fd)
-                        self.eq(blob[1]['axon:blob:sha256'], 'e1b683e26a3aad218df6aa63afe9cf57fdb5dfaf5eb20cddac14305d67f48a02')

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -227,7 +227,7 @@ class AxonHostTest(SynTest):
                 self.nn(axfo1)
 
     def test_axon_host_free_limit(self):
-        self.skipLongTests()
+        self.skipLongTest()
         self.thisHostMustNot(platform='windows')
 
         with self.getTestDir() as datadir:
@@ -256,7 +256,7 @@ class AxonHostTest(SynTest):
                 self.raises(NotEnoughFree, host.add)
 
     def test_axon_host_clone(self):
-        self.skipLongTests()
+        self.skipLongTest()
         self.thisHostMustNot(platform='windows')
 
         busurl = 'local://%s/axons' % guid()
@@ -376,7 +376,7 @@ class AxonHostTest(SynTest):
         dmon.fini()
 
     def test_axon_clone_large(self):
-        self.skipLongTests()
+        self.skipLongTest()
         self.thisHostMustNot(platform='windows')
 
         busurl = 'local://%s/axons' % guid()
@@ -440,7 +440,7 @@ class AxonHostTest(SynTest):
             host.fini()
 
     def test_axon_host_spinbackup(self):
-        self.skipLongTests()
+        self.skipLongTest()
         self.thisHostMustNot(platform='windows')
 
         hstcfg = {
@@ -553,7 +553,7 @@ class AxonHostTest(SynTest):
 
 class AxonClusterTest(SynTest):
     def test_axon_cluster(self):
-        self.skipLongTests()
+        self.skipLongTest()
         self.thisHostMustNot(platform='windows')
 
         busurl = 'local://%s/axons' % guid()

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -55,6 +55,9 @@ class AxonTest(SynTest):
                 self.none(axon.wants('md5', asdfhash, 8))
                 self.nn(axon.wants('md5', craphash, 8))
 
+                with self.assertRaises(NoSuchFile):
+                    _ = [byts for byts in axon.bytes('md5', craphash)]
+
     def test_axon_restrictions(self):
         with self.getTestDir() as axondir:
             with s_axon.Axon(axondir) as axon:

--- a/synapse/tests/test_lib_atomfile.py
+++ b/synapse/tests/test_lib_atomfile.py
@@ -18,6 +18,14 @@ class AtomTest(SynTest):
 
         self.eq(atom.readoff(100, 8), b'asdfqwer')
 
+        # calling resize with the current size does nothing
+        self.eq(atom.size, 8192)
+        atom.resize(8192)
+        self.eq(atom.size, 8192)
+
+        self.raises(BadAtomFile, atom.resize, 10)
+        self.raises(BadAtomFile, atom.writeoff, 0xFFFFFFFF, b'deadb33f')
+
     def test_atomfile_base(self):
         fd = self._getTempFile()
         with s_atomfile.AtomFile(fd) as atom:

--- a/synapse/tests/test_lib_config.py
+++ b/synapse/tests/test_lib_config.py
@@ -54,6 +54,9 @@ class ConfTest(SynTest):
             self.eq(edict.get('defval'), 0)
             self.eq(edict.get('doc'), 'is thing enabled?')
 
+            opts = conf.getConfOpts()
+            self.eq(opts, {'enabled': 1, 'fooval': 0x30})
+
     def test_conf_defval(self):
         defs = (
             ('mutable:dict', {'doc': 'some dictionary', 'defval': {}}),

--- a/synapse/tests/test_model_axon.py
+++ b/synapse/tests/test_model_axon.py
@@ -6,6 +6,26 @@ from synapse.tests.common import *
 
 class AxonModelTest(SynTest):
 
+    def test_axonblob(self):
+        with self.getTestDir() as axondir:
+            axon = s_axon.Axon(axondir)
+            core = axon.core
+
+            hset = s_axon.HashSet()
+            hset.update(b'visi')
+
+            valu, props = hset.guid()
+            props.update({'off': 0})
+
+            t0 = core.formTufoByProp('axon:blob', valu, **props)
+            self.eq(t0[1].get('axon:blob:off'), 0)
+            self.eq(t0[1].get('axon:blob:size'), 4)
+            self.eq(t0[1].get('axon:blob'), '442f602ecf8230b2a59a44b4f845be27')
+            self.eq(t0[1].get('axon:blob:md5'), '1b2e93225959e3722efed95e1731b764')
+            self.eq(t0[1].get('axon:blob:sha1'), '93de0c7d579384feb3561aa504acd8f23f388040')
+            self.eq(t0[1].get('axon:blob:sha256'), 'e45bbb7e03acacf4d1cca4c16af1ec0c51d777d10e53ed3155bd3d8deb398f3f')
+            self.eq(t0[1].get('axon:blob:sha512'), '8238be12bcc3c10da7e07dbea528e9970dc809c07c5aef545a14e5e8d2038563b29c2e818d167b06e6a33412e6beb8347fcc44520691347aea9ee21fcf804e39')
+
     def test_axonpath(self):
 
         with self.getTestDir() as axondir:

--- a/synapse/tests/test_tools_dumprows_loadrows.py
+++ b/synapse/tests/test_tools_dumprows_loadrows.py
@@ -174,6 +174,7 @@ class DumpRowsTest(SynTest):
             self.eq(ret, 0)
 
     def test_dump_largecore(self):
+        self.skipLongTests()
         # This ensure we're executing the "dump rows
         # when we have N number of bytes cached codepath.
         # Unfortunately this is a bit slow (2-4 seconds).

--- a/synapse/tests/test_tools_dumprows_loadrows.py
+++ b/synapse/tests/test_tools_dumprows_loadrows.py
@@ -174,7 +174,7 @@ class DumpRowsTest(SynTest):
             self.eq(ret, 0)
 
     def test_dump_largecore(self):
-        self.skipLongTests()
+        self.skipLongTest()
         # This ensure we're executing the "dump rows
         # when we have N number of bytes cached codepath.
         # Unfortunately this is a bit slow (2-4 seconds).

--- a/synapse/tests/test_tools_pushfile.py
+++ b/synapse/tests/test_tools_pushfile.py
@@ -9,7 +9,7 @@ import synapse.tools.pushfile as s_pushfile
 class TestPushFile(SynTest):
 
     def test_tools_pushfile(self):
-
+        self.skipLongTests()
         with self.getTestDir() as path:
 
             visipath = os.path.join(path, 'visi.txt')

--- a/synapse/tests/test_tools_pushfile.py
+++ b/synapse/tests/test_tools_pushfile.py
@@ -9,7 +9,7 @@ import synapse.tools.pushfile as s_pushfile
 class TestPushFile(SynTest):
 
     def test_tools_pushfile(self):
-        self.skipLongTests()
+        self.skipLongTest()
         with self.getTestDir() as path:
 
             visipath = os.path.join(path, 'visi.txt')


### PR DESCRIPTION
- Add various docstrings
- Make Axon configable
- Make AxonHost configable
- Add tracking to the axonhost the space used in a host
- Update unit tests for Axons to account for configable options.
- UnitTests for Axons were broken into four classes (for sanity) - AxonTest for testing the base Axon, AxonFSTest for testing the FS features, AxonHostTest for testing the AxonHost class, and AxonClusterTest for testing the AxonCluster class.
- Fixed a bug in the daemon.py Onhelp() class which could cause a runtimewarning due to dictionary size changing.
 - Update SvcProxy.getSynSvcs to return a list instead of a dict_values
 - Randomize the axon's allocated too by calls to AxonCluster.alloc()
 - Add a test spinning up a svcbus and axonhost, tearing them down and spinning them back up.
 -  Ensure the clone axon does not have any clones of its own.
 - If an axon is a clone, it doesn't need to find clones or fire other clones
 - Make Heap's reactor resize actually resize the underlying atom file.
 - Initialize the svcproxy local attributes prior to strapping in the event handlers.  This prevents events firing during __init__ before class attributes are set.
 - Have the axonhost advertise itself on the bus AFTER it has made or instantiated any local axons it needs to do.  This allows axons to then find hosts on the bus after the axonhosts have finished doing their startup and then they can start doing clone operations.
- Address a issue in the Axon datamodel where clone :host was not present
- hashset's hashes are now immutable (tuple)
- logging in tests is now run by envars and has useful messages format
- make sure we check the guid in the axoncluster test.
- Enable caching on the Axon cortices.  This required updating some of the Axon FS APIs to not perform row-level operations.
- Rewrite Cortex formTufoByTufo docstring, add formTufoByTufo test.
- Add a Cortex test for delTufoProp with caching.
- Misc test coverage improvements
- Remove Axon.syncs() api.  It is not compatible with delivering one sync event at a time from the persistence file, which requires updating the persistence file for each event sent.
- Add a skipLongTests helper to the SynTest class to enable skipping tests which may run long.  Run those only when SYN_RUN_LONG_TESTS envar is set.
- Add -rs switch to print skip messages in pytest.