### PR TITLE
Rearrange CortexTest into two classes

### DIFF
--- a/docs/synapse/devopsguides/cortex_storage_details.rst
+++ b/docs/synapse/devopsguides/cortex_storage_details.rst
@@ -282,7 +282,7 @@ Basic Cortex Test Suite
 
 Adding a new storage layer implementation to the test suite is fairly
 straightforward.  In the synapse/tests/test_cortex.py file, add the following
-test to the CortexTest class (this assumes you registered the handler as
+test to the CortexBaseTest class (this assumes you registered the handler as
 "mystore")::
 
     def test_cortex_mystore(self):
@@ -292,7 +292,7 @@ test to the CortexTest class (this assumes you registered the handler as
 Then you can run the Cortex tests using the following command to ensure your
 Cortex works properly::
 
-    python -m unittest synapse.tests.test_cortex.CortexTest.test_cortex_mystore
+    python -m unittest synapse.tests.test_cortex.CortexBaseTest.test_cortex_mystore
 
 
 

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -418,6 +418,7 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
         self.inprog = {}
         self.axondir = s_common.gendir(axondir)
+        self.clonedir = s_common.gendir(axondir, 'clones')
 
         self.clones = {}
         self.cloneinfo = {}
@@ -485,6 +486,9 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         self.core.on('splice', self._fireAxonSync)
         self.heap.on('heap:sync', self._fireAxonSync)
 
+        dirname = s_common.gendir(axondir, 'sync')
+        syncopts = self.opts.get('syncopts', {})
+
         self.syncdir = None
 
         self.onfini(self._onAxonFini)
@@ -495,8 +499,6 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
         # if we're not a clone, create a sync dir
         if not self.opts.get('clone'):
-            dirname = s_common.gendir(axondir, 'sync')
-            syncopts = self.opts.get('syncopts', {})
             self.syncdir = s_persist.Dir(dirname, **syncopts)
             self.onfini(self.syncdir.fini)
 

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -418,7 +418,6 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
         self.inprog = {}
         self.axondir = s_common.gendir(axondir)
-        self.clonedir = s_common.gendir(axondir, 'clones')
 
         self.clones = {}
         self.cloneinfo = {}
@@ -486,9 +485,6 @@ class Axon(s_eventbus.EventBus, AxonMixin):
         self.core.on('splice', self._fireAxonSync)
         self.heap.on('heap:sync', self._fireAxonSync)
 
-        dirname = s_common.gendir(axondir, 'sync')
-        syncopts = self.opts.get('syncopts', {})
-
         self.syncdir = None
 
         self.onfini(self._onAxonFini)
@@ -499,6 +495,8 @@ class Axon(s_eventbus.EventBus, AxonMixin):
 
         # if we're not a clone, create a sync dir
         if not self.opts.get('clone'):
+            dirname = s_common.gendir(axondir, 'sync')
+            syncopts = self.opts.get('syncopts', {})
             self.syncdir = s_persist.Dir(dirname, **syncopts)
             self.onfini(self.syncdir.fini)
 


### PR DESCRIPTION
This splits the tests run by basic_core_expectations into their own class(CortexBaseTest), leaving all other Cortex API testes in the CortexTest class.  This facilitates quick checking and isolation of API issues related to storage layer implementations without requiring the whole test suite to be run at once.