### PR TITLE
Add PropValuDatatype. 

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1171,7 +1171,7 @@ class Runtime(Configable):
 
                     # ensure that the prop's type is also a form
                     name = core.getPropTypeName(prop)
-                    if not core.isTufoForm(name):
+                    if not core.isTufoForm(name) and name != 'propvalu':
                         continue
 
                     pkey = (prop, valu)
@@ -1179,6 +1179,9 @@ class Runtime(Configable):
                         continue
 
                     done.add(pkey)
+
+                    if name == 'propvalu':
+                        name, valu = valu.split('=', 1)
 
                     news = core.getTufosByProp(name, valu=valu, limit=limt.get())
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -662,7 +662,7 @@ class PropValuType(DataType):
             self._raiseBadValu(text, mesg='No text left after strip().')
 
         if '=' not in text:
-            self._raiseBadValu(text, mesg='Provalu is missing a =')
+            self._raiseBadValu(text, mesg='PropValu is missing a =')
 
         valu = text.split('=', 1)
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -454,6 +454,11 @@ class XrefType(DataType):
 
     def _norm_str(self, text, oldval=None):
 
+        text = text.strip()
+
+        if not text:
+            self._raiseBadValu(text, mesg='No text left after strip().')
+
         if len(text) == 32 and text.find('=') == -1:
             return self.tlib.getTypeNorm('guid', text)
 

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -141,7 +141,7 @@ class FileMod(CoreModule):
                 ('file:imgof', {}, [
                     ('file', {'ptype': 'file:bytes', 'ro': 1}),
                     ('xref', {'ptype': 'propvalu', 'ro': 1}),
-                    ('xtype', {'ptype': 'str', 'ro': 1}),
+                    ('xref:prop', {'ptype': 'str', 'ro': 1}),
                     ('xref:intval', {'ptype': 'int', 'ro': 1}),
                     ('xref:strval', {'ptype': 'str', 'ro': 1}),
                 ]),

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -149,7 +149,7 @@ class FileMod(CoreModule):
                 ('file:txtref', {}, [
                     ('file', {'ptype': 'file:bytes', 'ro': 1}),
                     ('xref', {'ptype': 'propvalu', 'ro': 1}),
-                    ('xtype', {'ptype': 'str', 'ro': 1}),
+                    ('xref:prop', {'ptype': 'str', 'ro': 1}),
                     ('xref:intval', {'ptype': 'int', 'ro': 1}),
                     ('xref:strval', {'ptype': 'str', 'ro': 1}),
                 ]),

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -1,3 +1,4 @@
+import synapse.common as s_common
 import synapse.compat as s_compat
 
 from synapse.lib.types import DataType
@@ -138,13 +139,19 @@ class FileMod(CoreModule):
             'forms': (
 
                 ('file:imgof', {}, [
-                    ('file', {'ptype': 'file:bytes'}),
-                    ('xref:*', {'glob': 1}),
+                    ('file', {'ptype': 'file:bytes', 'ro': 1}),
+                    ('xref', {'ptype': 'propvalu', 'ro': 1}),
+                    ('xtype', {'ptype': 'str', 'ro': 1}),
+                    ('xref:intval', {'ptype': 'int', 'ro': 1}),
+                    ('xref:strval', {'ptype': 'str', 'ro': 1}),
                 ]),
 
                 ('file:txtref', {}, [
-                    ('file', {'ptype': 'file:bytes'}),
-                    ('xref:*', {'glob': 1}),
+                    ('file', {'ptype': 'file:bytes', 'ro': 1}),
+                    ('xref', {'ptype': 'propvalu', 'ro': 1}),
+                    ('xtype', {'ptype': 'str', 'ro': 1}),
+                    ('xref:intval', {'ptype': 'int', 'ro': 1}),
+                    ('xref:strval', {'ptype': 'str', 'ro': 1}),
                 ]),
 
                 ('file:path', {}, (

--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -154,6 +154,7 @@ class SynMod(CoreModule):
                             form = prop.split('xref:', 1)[1]
                             if self.core.isTufoForm(form):
                                 srcvtype = form
+                                break
                     if not srcvtype:
                         raise s_common.NoSuchProp(iden=node[0], type=ntyp,
                                                   mesg='Unable to find a xref prop which is a form for migrating a '

--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -143,15 +143,18 @@ class SynMod(CoreModule):
             for node in nodes:
                 iden = node[0]
                 srcvtype = node[1].get(xtyp)
+                xrefprop = '{}:xref:prop'.format(ntyp)
                 srcprp = '{}:xref:{}'.format(ntyp, srcvtype)
                 srcv = node[1].get(srcprp)
                 valu, subs = self.core.getPropNorm(xrefp, [srcvtype, srcv])
                 adds.append((iden, xrefp, valu, tick))
+                adds.append((iden, xrefprop, srcvtype, tick))
                 if 'intval' in subs:
                     adds.append((iden, xrefpint, subs.get('intval'), tick))
                 else:
                     adds.append((iden, xrefpstr, subs.get('strval'), tick))
                 dels.add(srcprp)
+                dels.add(xtyp)
         with self.core.getCoreXact():
             self.core.addRows(adds)
             for prop in dels:

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -319,6 +319,8 @@ class SynTest(unittest.TestCase):
     def le(self, x, y):
         self.assertLessEqual(x, y)
 
+    def len(self, x, obj):
+        self.eq(x, len(obj))
 
 testdir = os.path.dirname(__file__)
 def getTestPath(*paths):

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -215,7 +215,8 @@ class SynTest(unittest.TestCase):
                 ('strform', {'subof': 'str'},),
                 ('intform', {'subof': 'int'},),
                 ('default_foo', {'subof': 'str'},),
-                ('guidform', {'subof': 'guid'},)
+                ('guidform', {'subof': 'guid'},),
+                ('pvsub', {'subof': 'str'}),
             ),
             'forms': (
                 (
@@ -244,6 +245,23 @@ class SynTest(unittest.TestCase):
                     (
                         ('foo', {'ptype': 'str'}),
                         ('baz', {'ptype': 'int'}),
+                    )
+                ),
+                (
+                    'pvsub', {'ptype': 'pvsub'},
+                    (
+                        ('xref', {'ptype': 'propvalu', 'ro': 1, }),
+                        ('xref:intval', {'ptype': 'int', 'ro': 1, }),
+                        ('xref:strval', {'ptype': 'str', 'ro': 1}),
+                        ('xref:prop', {'ptype': 'str', 'ro': 1}),
+                    )
+                ),
+                (
+                    'pvform', {'ptype': 'propvalu'},
+                    (
+                        ('intval', {'ptype': 'int', 'ro': 1, }),
+                        ('strval', {'ptype': 'str', 'ro': 1}),
+                        ('prop', {'ptype': 'str', 'ro': 1}),
                     )
                 ),
             )

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -61,7 +61,7 @@ class SynCmdCoreTest(SynTest):
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             core.formTufoByProp('inet:email', 'visi@vertex.link')
             resp = cmdr.runCmdLine('ask inet:email="visi@vertex.link"')
-            self.eq(len(resp['data']), 1)
+            self.len(1, resp['data'])
             self.ne(str(outp).strip().find('visi@vertex.link'), -1)
 
     def test_cmds_ask_debug(self):
@@ -70,7 +70,7 @@ class SynCmdCoreTest(SynTest):
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             core.formTufoByProp('inet:email', 'visi@vertex.link')
             resp = cmdr.runCmdLine('ask --debug inet:email="visi@vertex.link"')
-            self.eq(len(resp['data']), 1)
+            self.len(1, resp['data'])
 
             outp = str(outp)
             terms = ('oplog', 'took', 'options', 'limits')
@@ -84,7 +84,7 @@ class SynCmdCoreTest(SynTest):
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             core.formTufoByProp('inet:email', 'visi@vertex.link')
             resp = cmdr.runCmdLine('ask --props inet:email="visi@vertex.link"')
-            self.eq(len(resp['data']), 1)
+            self.len(1, resp['data'])
 
             outp = str(outp)
             terms = ('fqdn = vertex.link', 'user = visi')
@@ -100,7 +100,7 @@ class SynCmdCoreTest(SynTest):
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
 
             resp = cmdr.runCmdLine('ask [ inet:ipv4=1.2.3.4 #foo.bar@2011-2016 #baz.faz ]')
-            self.eq(len(resp['data']), 1)
+            self.len(1, resp['data'])
 
             lines = [s.strip() for s in str(outp).split('\n')]
 
@@ -149,7 +149,7 @@ class SynCmdCoreTest(SynTest):
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             core.formTufoByProp('inet:email', 'visi@vertex.link')
             resp = cmdr.runCmdLine('ask --raw inet:email="visi@vertex.link"')
-            self.eq(len(resp['data']), 1)
+            self.len(1, resp['data'])
 
             outp = str(outp)
             terms = ('"tufo:form": "inet:email"', '"inet:email:user": "visi"')
@@ -163,7 +163,7 @@ class SynCmdCoreTest(SynTest):
             core.formTufoByProp('strform', 'hehe')
             core.formTufoByProp('inet:ipv4', 0)
             resp = cmdr.runCmdLine('ask strform inet:ipv4')
-            self.eq(len(resp['data']), 2)
+            self.len(2, resp['data'])
 
             outp = str(outp)
             terms = ('0.0.0.0', 'hehe')

--- a/synapse/tests/test_config.py
+++ b/synapse/tests/test_config.py
@@ -113,7 +113,7 @@ class ConfTest(SynTest):
                 self.proxy = proxy
                 s_config.Configable.__init__(self)
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             with s_daemon.Daemon() as dmon:
                 dmon.share('core', core)
                 link = dmon.listen('tcp://127.0.0.1:0/core')

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1391,9 +1391,9 @@ class CortexTest(SynTest):
 
     def test_cortex_enforce(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             # Disable enforce for first set of tests
-            core.setConfOpt('enforce', False)
+            core.setConfOpt('enforce', 0)
 
             core.addTufoForm('foo:bar', ptype='inet:email')
 
@@ -1411,7 +1411,7 @@ class CortexTest(SynTest):
             self.true(core.isSetPropOk('foo:baz:duck'))
 
             # Now re-enable enforce
-            core.setConfOpt('enforce', True)
+            core.setConfOpt('enforce', 1)
 
             self.true(core.enforce)
 
@@ -1454,7 +1454,7 @@ class CortexTest(SynTest):
 
     def test_cortex_minmax(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
 
             core.addTufoForm('foo', ptype='str')
             core.addTufoProp('foo', 'min', ptype='int:min')
@@ -1477,7 +1477,7 @@ class CortexTest(SynTest):
 
     def test_cortex_minmax_epoch(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
 
             core.addTufoForm('foo', ptype='str')
             core.addTufoProp('foo', 'min', ptype='time:epoch:min')
@@ -1500,7 +1500,7 @@ class CortexTest(SynTest):
 
     def test_cortex_by_type(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
 
             core.addTufoForm('foo', ptype='str')
             core.addTufoProp('foo', 'min', ptype='time:epoch:min')
@@ -1699,9 +1699,7 @@ class CortexTest(SynTest):
             self.none(core.cache_bykey.get(('strform:baz', None, 2)))
             self.none(core.cache_bykey.get(('strform:baz', 10, 2)))
 
-        with s_cortex.openurl('ram://') as core:
-
-            self.addTstForms(core)
+        with self.getRamCore() as core:
 
             tufo0 = core.formTufoByProp('strform', 'bar', baz=10)
             tufo1 = core.formTufoByProp('strform', 'baz', baz=10)
@@ -1801,9 +1799,7 @@ class CortexTest(SynTest):
 
     def test_cortex_caching_disable(self):
 
-        with s_cortex.openurl('ram://') as core:
-
-            self.addTstForms(core)
+        with self.getRamCore() as core:
 
             core.setConfOpt('caching', 1)
 
@@ -1825,7 +1821,7 @@ class CortexTest(SynTest):
         # Ensure that the cortex won't let us store data that is invalid
         # This requires us to disable enforcement, since otherwise all
         # data is normed and that fails with BadTypeValu instead
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             core.setConfOpt('enforce', 0)
             self.raises(BadPropValu, core.formTufoByProp, 'foo:bar', True)
 
@@ -1848,7 +1844,7 @@ class CortexTest(SynTest):
     def test_cortex_splicefd(self):
         with self.getTestDir() as path:
             with genfile(path, 'savefile.mpk') as fd:
-                with s_cortex.openurl('ram://') as core:
+                with self.getRamCore() as core:
                     core.addSpliceFd(fd)
 
                     tuf0 = core.formTufoByProp('inet:fqdn', 'woot.com')
@@ -1862,7 +1858,7 @@ class CortexTest(SynTest):
 
                 fd.seek(0)
 
-                with s_cortex.openurl('ram://') as core:
+                with self.getRamCore() as core:
 
                     core.eatSpliceFd(fd)
 
@@ -1874,7 +1870,7 @@ class CortexTest(SynTest):
 
     def test_cortex_addmodel(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
 
             core.addDataModel('a.foo.module',
                 {
@@ -1908,7 +1904,7 @@ class CortexTest(SynTest):
             self.nn(core.getTufoByProp('syn:form', 'foo:baz'))
             self.nn(core.getTufoByProp('syn:prop', 'foo:baz:faz'))
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             core.addDataModels([('a.foo.module',
                 {
                     'prefix': 'foo',
@@ -1973,7 +1969,7 @@ class CortexTest(SynTest):
 
     def test_cortex_seed(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             def seedFooBar(prop, valu, **props):
                 return core.formTufoByProp('inet:fqdn', valu, **props)
@@ -1983,12 +1979,12 @@ class CortexTest(SynTest):
             self.eq(tufo[1].get('inet:fqdn'), 'woot.com')
 
     def test_cortex_bytype(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             self.eq(len(core.eval('inet:ipv4*type="1.2.3.4"')), 2)
 
     def test_cortex_seq(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             core.formTufoByProp('syn:seq', 'foo')
             node = core.formTufoByProp('syn:seq', 'bar', nextvalu=10, width=4)
@@ -2005,7 +2001,7 @@ class CortexTest(SynTest):
 
         data = {'results': {'fqdn': 'woot.com', 'ipv4': '1.2.3.4'}}
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             idef = {
                 'ingest': {
@@ -2036,9 +2032,7 @@ class CortexTest(SynTest):
 
     def test_cortex_tagform(self):
 
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('inet:fqdn', 'vertex.link')
 
@@ -2057,24 +2051,24 @@ class CortexTest(SynTest):
     def test_cortex_splices_errs(self):
 
         splices = [('newp:fake', {})]
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.on('splice', splices.append)
             core.formTufoByProp('inet:fqdn', 'vertex.link')
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             errs = core.splices(splices)
             self.eq(len(errs), 1)
             self.eq(errs[0][0][0], 'newp:fake')
             self.nn(core.getTufoByProp('inet:fqdn', 'vertex.link'))
 
     def test_cortex_norm_fail(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.formTufoByProp('inet:netuser', 'vertex.link/visi')
             self.raises(BadTypeValu, core.eval, 'inet:netuser="totally invalid input"')
 
     def test_cortex_local(self):
         splices = []
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             core.on('splice', splices.append)
             node = core.formTufoByProp('syn:splice', None)
@@ -2086,7 +2080,7 @@ class CortexTest(SynTest):
 
     def test_cortex_module(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('inet:ipv4', '1.2.3.4')
             self.eq(node[1].get('inet:ipv4:asn'), -1)
@@ -2114,7 +2108,7 @@ class CortexTest(SynTest):
 
     def test_cortex_modlvers(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             self.eq(core.getModlVers('hehe'), -1)
 
@@ -2126,7 +2120,7 @@ class CortexTest(SynTest):
 
     def test_cortex_modlrevs(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             def v0():
                 core.formTufoByProp('inet:fqdn', 'foo.com')
@@ -2167,13 +2161,13 @@ class CortexTest(SynTest):
 
     def test_cortex_notguidform(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             self.raises(NotGuidForm, core.addTufoEvents, 'inet:fqdn', [{}])
 
     def test_cortex_getbytag(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             node0 = core.formTufoByProp('inet:user', 'visi')
             node1 = core.formTufoByProp('inet:ipv4', 0x01020304)
@@ -2188,7 +2182,7 @@ class CortexTest(SynTest):
     def test_cortex_tag_ival(self):
 
         splices = []
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             core.on('splice', splices.append)
 
@@ -2207,21 +2201,21 @@ class CortexTest(SynTest):
             node = core.eval('[ inet:ipv4=1.2.3.4 +#foo.bar@2012-2013 ]')[0]
             self.eq(s_tufo.ival(node, '#foo.bar'), (1293840000000, 1514764800000))
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.splices(splices)
             core.on('splice', splices.append)
             node = core.eval('inet:ipv4=1.2.3.4')[0]
             self.eq(s_tufo.ival(node, '#foo.bar'), (1293840000000, 1514764800000))
             core.eval('inet:ipv4=1.2.3.4 [ -#foo.bar ]')
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.splices(splices)
             node = core.eval('inet:ipv4=1.2.3.4')[0]
             self.eq(s_tufo.ival(node, '#foo.bar'), None)
 
     def test_cortex_module_datamodel_migration(self):
         self.skipTest('Needs global model registry available')
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             # Enforce data model consistency.
             core.setConfOpt('enforce', 1)
@@ -2358,7 +2352,7 @@ class CortexTest(SynTest):
 
     def test_cortex_lift_by_cidr(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             # Add a bunch of nodes
             for n in range(0, 256):
                 r = core.formTufoByProp('inet:ipv4', '192.168.1.{}'.format(n))
@@ -2495,7 +2489,7 @@ class CortexTest(SynTest):
 
     def test_cortex_runts(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             core.addDataModel('hehe', {'forms': (
                 ('hehe:haha', {'ptype': 'str'}, (
@@ -2527,7 +2521,7 @@ class CortexTest(SynTest):
 
     def test_cortex_trigger(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('syn:trigger', '*', on='node:add form=inet:fqdn', run='[ #foo ]', en=1)
             self.eq(node[1].get('syn:trigger:on'), 'node:add form=inet:fqdn')
@@ -2542,7 +2536,7 @@ class CortexTest(SynTest):
 
     def test_cortex_auth(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             core.formTufoByProp('syn:auth:user', 'visi@vertex.link')
             core.formTufoByProp('syn:auth:user', 'fred@woot.com')

--- a/synapse/tests/test_lib_ingest.py
+++ b/synapse/tests/test_lib_ingest.py
@@ -1089,7 +1089,9 @@ class IngTest(SynTest):
             self.eq(len(nodes3), 1)
             xrefnode = nodes3[0]
             self.eq(xrefnode[1].get('file:txtref:file'), nodes1[0][1].get('file:bytes'))
-            self.eq(xrefnode[1].get('file:txtref:xref:inet:ipv4'), nodes2[0][1].get('inet:ipv4'))
+            self.eq(xrefnode[1].get('file:txtref:xtype'), 'inet:ipv4')
+            self.eq(xrefnode[1].get('file:txtref:xref'), 'inet:ipv4=8.8.8.8')
+            self.eq(xrefnode[1].get('file:txtref:xref:intval'), nodes2[0][1].get('inet:ipv4'))
 
     def test_ingest_reqprops(self):
 

--- a/synapse/tests/test_lib_ingest.py
+++ b/synapse/tests/test_lib_ingest.py
@@ -1070,7 +1070,7 @@ class IngTest(SynTest):
                     [
                         "file:txtref",
                         {
-                            "template": "{{file_guid}}|inet:ipv4|{{ip_guid}}"
+                            "template": "({{file_guid}},inet:ipv4={{ip_guid}})"
                         }
                     ]
                 ]
@@ -1089,8 +1089,8 @@ class IngTest(SynTest):
             self.eq(len(nodes3), 1)
             xrefnode = nodes3[0]
             self.eq(xrefnode[1].get('file:txtref:file'), nodes1[0][1].get('file:bytes'))
-            self.eq(xrefnode[1].get('file:txtref:xtype'), 'inet:ipv4')
             self.eq(xrefnode[1].get('file:txtref:xref'), 'inet:ipv4=8.8.8.8')
+            self.eq(xrefnode[1].get('file:txtref:xref:prop'), 'inet:ipv4')
             self.eq(xrefnode[1].get('file:txtref:xref:intval'), nodes2[0][1].get('inet:ipv4'))
 
     def test_ingest_reqprops(self):

--- a/synapse/tests/test_lib_ingest.py
+++ b/synapse/tests/test_lib_ingest.py
@@ -123,8 +123,8 @@ class IngTest(SynTest):
             self.nn(core.getTufoByProp('inet:ipv4', '1.2.3.4'))
             self.nn(core.getTufoByProp('inet:ipv4', '5.6.7.8'))
 
-            self.eq(len(core.eval('inet:ipv4*tag=hehe.haha')), 2)
-            self.eq(len(core.eval('inet:fqdn*tag=hehe.haha')), 2)
+            self.len(2, core.eval('inet:ipv4*tag=hehe.haha'))
+            self.len(2, core.eval('inet:fqdn*tag=hehe.haha'))
 
     def test_ingest_files(self):
 
@@ -345,8 +345,8 @@ class IngTest(SynTest):
                 self.nn(core.getTufoByProp('inet:url', 'http://evil.com/'))
                 self.nn(core.getTufoByProp('inet:url', 'http://badguy.com/'))
 
-                self.eq(len(core.eval('inet:dns:a*tag=lolxml')), 2)
-                self.eq(len(core.eval('inet:url*tag=lolxml')), 2)
+                self.len(2, core.eval('inet:dns:a*tag=lolxml'))
+                self.len(2, core.eval('inet:url*tag=lolxml'))
 
     def test_ingest_xml_search(self):
 
@@ -406,7 +406,7 @@ class IngTest(SynTest):
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
-            self.eq(len(core.eval('inet:fqdn*tag="foo.bar.lulz"')), 1)
+            self.len(1, core.eval('inet:fqdn*tag="foo.bar.lulz"'))
 
     def test_ingest_cast(self):
 
@@ -697,8 +697,8 @@ class IngTest(SynTest):
             self.nn(core.getTufoByProp('inet:fqdn', 'laughitup.edu'))
             self.nn(core.getTufoByProp('inet:email', 'pennywise@weallfloat.com'))
 
-            self.eq(2, len(core.eval('inet:fqdn*tag=hehe.haha.hoho')))
-            self.eq(1, len(core.eval('inet:email*tag=hehe.haha.hoho')))
+            self.len(2, core.eval('inet:fqdn*tag=hehe.haha.hoho'))
+            self.len(1, core.eval('inet:email*tag=hehe.haha.hoho'))
 
     def test_ingest_embed_props(self):
         with self.getRamCore() as core:
@@ -724,7 +724,7 @@ class IngTest(SynTest):
             self.nn(core.getTufoByProp('inet:fqdn', 'net'))
             self.nn(core.getTufoByProp('inet:fqdn', 'org'))
 
-            self.eq(3, len(core.eval('inet:fqdn:sfx=1')))
+            self.len(3, core.eval('inet:fqdn:sfx=1'))
 
     def test_ingest_embed_pernode_tagsprops(self):
         with self.getRamCore() as core:
@@ -756,8 +756,8 @@ class IngTest(SynTest):
             self.nn(core.getTufoByProp('inet:netuser', 'rootkit.com/metr0'))
             self.nn(core.getTufoByProp('inet:netuser', 'twitter.com/invisig0th'))
 
-            self.eq(1, len(core.eval('inet:netuser:email="visi@vertex.link"')))
-            self.eq(1, len(core.eval('inet:netuser:email="metr0@kenshoto.com"')))
+            self.len(1, core.eval('inet:netuser:email="visi@vertex.link"'))
+            self.len(1, core.eval('inet:netuser:email="metr0@kenshoto.com"'))
 
             node = core.eval('inet:email*tag=foo.bar')[0]
             self.eq(node[1].get('inet:email'), 'visi@vertex.link')
@@ -879,7 +879,7 @@ class IngTest(SynTest):
                                        'ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c'))
             self.nn(core.getTufoByProp('it:av:filehit:sig', 'memesec/meme32.lazydog.puntuation'))
             self.nn(core.getTufoByProp('it:av:sig:sig', 'meme32.lazydog.puntuation'))
-            self.eq(len(core.getTufosByProp('it:av:sig:org', 'memesec')), 2)
+            self.len(2, core.getTufosByProp('it:av:sig:org', 'memesec'))
 
     def test_ingest_cortex_registration(self):
 
@@ -1082,11 +1082,11 @@ class IngTest(SynTest):
             ingest.ingest(core=core, data=data)
 
             nodes1 = core.eval('file:bytes')
-            self.eq(len(nodes1), 1)
+            self.len(1, nodes1)
             nodes2 = core.eval('inet:ipv4')
-            self.eq(len(nodes2), 1)
+            self.len(1, nodes2)
             nodes3 = core.eval('file:txtref')
-            self.eq(len(nodes3), 1)
+            self.len(1, nodes3)
             xrefnode = nodes3[0]
             self.eq(xrefnode[1].get('file:txtref:file'), nodes1[0][1].get('file:bytes'))
             self.eq(xrefnode[1].get('file:txtref:xref'), 'inet:ipv4=8.8.8.8')
@@ -1145,7 +1145,7 @@ class IngTest(SynTest):
             ingest.ingest(core=core, data=data)
 
             nodes = core.eval('inet:dns:look')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
             node = nodes[0]
             self.eq(node[1].get('inet:dns:look:time'), tick)
             self.eq(node[1].get('inet:dns:look:a'), 'vertex.link/1.2.3.4')

--- a/synapse/tests/test_lib_ingest.py
+++ b/synapse/tests/test_lib_ingest.py
@@ -29,7 +29,7 @@ class IngTest(SynTest):
 
         # test an iters directive within an iters directive for
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             info = {'ingest': {
                 'iters': [
                     ('*/*', {
@@ -47,7 +47,7 @@ class IngTest(SynTest):
 
     def test_ingest_basic(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             info = {
                 'ingest': {
                     'iters': (
@@ -91,7 +91,7 @@ class IngTest(SynTest):
 
     def test_ingest_csv(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             with self.getTestDir() as path:
                 csvp = os.path.join(path, 'woot.csv')
 
@@ -138,7 +138,7 @@ class IngTest(SynTest):
             }]]
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -160,7 +160,7 @@ class IngTest(SynTest):
             ]
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -189,7 +189,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             core.addTufoForm('hehe:haha', ptype='file:bytes')
 
             gest = s_ingest.Ingest(info)
@@ -213,7 +213,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -263,7 +263,7 @@ class IngTest(SynTest):
         testjsonl = b'''{"fqdn": "spooky.com", "ipv4": "192.168.1.1"}
 {"fqdn":"spookier.com", "ipv4":"192.168.1.2"}'''
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             with self.getTestDir() as path:
                 xpth = os.path.join(path, 'woot.jsonl')
 
@@ -292,7 +292,7 @@ class IngTest(SynTest):
                 self.nn(core.getTufoByProp('inet:ipv4', '192.168.1.2'))
 
     def test_ingest_xml(self):
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             with self.getTestDir() as path:
                 xpth = os.path.join(path, 'woot.xml')
 
@@ -350,7 +350,7 @@ class IngTest(SynTest):
 
     def test_ingest_xml_search(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             with self.getTestDir() as path:
                 xpth = os.path.join(path, 'woot.xml')
 
@@ -386,7 +386,7 @@ class IngTest(SynTest):
 
     def test_ingest_taginfo(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             info = {
                 'ingest': {
                     'iters': [
@@ -429,7 +429,7 @@ class IngTest(SynTest):
             self.nn(core.getTufoByProp('strform', 'lulz'))
 
     def test_ingest_lines(self):
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             with self.getTestDir() as path:
                 path = os.path.join(path, 'woot.txt')
 
@@ -467,7 +467,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -492,7 +492,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -512,7 +512,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -539,7 +539,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -563,7 +563,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -591,7 +591,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -613,7 +613,7 @@ class IngTest(SynTest):
         self.nn(s_ingest.fmtyielders.get('woot'))
         s_ingest.addFormat('woot', _fmt_woot, opts)  # last write wins
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             with self.getTestDir() as path:
                 wootpath = os.path.join(path, 'woot.woot')
                 with genfile(wootpath) as fd:
@@ -637,7 +637,7 @@ class IngTest(SynTest):
 
     def test_ingest_embed_nodes(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             info = {
                 "embed": [
                     {
@@ -667,7 +667,7 @@ class IngTest(SynTest):
 
     def test_ingest_embed_tags(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             info = {
                 "embed": [
                     {
@@ -701,7 +701,7 @@ class IngTest(SynTest):
             self.eq(1, len(core.eval('inet:email*tag=hehe.haha.hoho')))
 
     def test_ingest_embed_props(self):
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             info = {
                 "embed": [
                     {
@@ -727,7 +727,7 @@ class IngTest(SynTest):
             self.eq(3, len(core.eval('inet:fqdn:sfx=1')))
 
     def test_ingest_embed_pernode_tagsprops(self):
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             info = {
                 "embed": [
                     {
@@ -785,7 +785,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -822,7 +822,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -867,7 +867,7 @@ class IngTest(SynTest):
             ],
         }}
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             gest = s_ingest.Ingest(info)
             gest.ingest(core, data=data)
 
@@ -915,7 +915,7 @@ class IngTest(SynTest):
         gest = s_ingest.Ingest(ingest_def)
         gest2 = s_ingest.Ingest(ingest_def2)
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             ret1 = s_ingest.register_ingest(core=core, gest=gest, evtname='ingest:test')
             ret2 = s_ingest.register_ingest(core=core, gest=gest2, evtname='ingest:test2', ret_func=True)
             self.none(ret1)
@@ -943,7 +943,7 @@ class IngTest(SynTest):
 
     def test_ingest_basic_bufio(self):
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             info = {
                 'ingest': {
                     'iters': (
@@ -1077,7 +1077,7 @@ class IngTest(SynTest):
             }
         }
 
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             ingest = s_ingest.Ingest(info=ingdef)
             ingest.ingest(core=core, data=data)
 
@@ -1140,8 +1140,7 @@ class IngTest(SynTest):
 
         data = {"time": tick, "ipv4": "1.2.3.4", "fqdn": "vertex.link"}
 
-        with s_cortex.openurl('ram://') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             ingest = s_ingest.Ingest(info=ingdef)
             ingest.ingest(core=core, data=data)
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -243,6 +243,16 @@ class StormTest(SynTest):
             forms = {s_tufo.ndef(node)[0] for node in nodes}
             self.eq(forms, {'inet:ipv4', 'file:bytes', 'file:txtref'})
 
+            # Make sure we're also pivoting on something with a "=" in the valu
+            # since we have to do a split operation inside of the refs() operator
+            self.nn(core.formTufoByProp('inet:passwd', 'oh=my=graph!'))
+            node = core.formTufoByProp('file:txtref', '{}|inet:passwd|oh=my=graph!'.format(pprop))
+            form, pprop = s_tufo.ndef(node)
+            nodes = core.eval('file:txtref={} refs()'.format(pprop))
+            self.eq(len(nodes), 3)
+            forms = {s_tufo.ndef(node)[0] for node in nodes}
+            self.eq(forms, {'file:bytes', 'file:txtref', 'inet:passwd'})
+
             # Try refs() with a non-XREF type which has propvalu properties.
             f1 = core.formTufoByProp('foob', 'hai', xref='inet:ipv4=1.2.3.4')
             self.nn(f1)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -237,7 +237,7 @@ class StormTest(SynTest):
             # Try refs() with a file:txtref node.  This uses propvalu to do the pivoting
             fnode = core.formTufoByProp('file:bytes:md5', 'd41d8cd98f00b204e9800998ecf8427e')
             form, pprop = s_tufo.ndef(fnode)
-            node = core.formTufoByProp('file:txtref', '{}|inet:ipv4|1.2.3.4'.format(pprop))
+            node = core.formTufoByProp('file:txtref', '({},inet:ipv4=1.2.3.4)'.format(pprop))
             nodes = core.eval('file:txtref refs()')
             self.eq(len(nodes), 3)
             forms = {s_tufo.ndef(node)[0] for node in nodes}
@@ -246,7 +246,7 @@ class StormTest(SynTest):
             # Make sure we're also pivoting on something with a "=" in the valu
             # since we have to do a split operation inside of the refs() operator
             self.nn(core.formTufoByProp('inet:passwd', 'oh=my=graph!'))
-            node = core.formTufoByProp('file:txtref', '{}|inet:passwd|oh=my=graph!'.format(pprop))
+            node = core.formTufoByProp('file:txtref', '({},"inet:passwd=oh=my=graph!")'.format(pprop))
             form, pprop = s_tufo.ndef(node)
             nodes = core.eval('file:txtref={} refs()'.format(pprop))
             self.eq(len(nodes), 3)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -453,10 +453,10 @@ class StormTest(SynTest):
             core.formTufoByProp('inet:ipv4', '1.2.3.4')
             core.formTufoByProp('inet:ipv4', '5.6.7.8')
 
-            self.eq(2, len(core.eval('lift(inet:ipv4)')))
-            self.eq(1, len(core.eval('lift(inet:ipv4, limit=1)')))
-            self.eq(1, len(core.eval('lift(inet:ipv4, 1.2.3.4)')))
-            self.eq(1, len(core.eval('lift(inet:ipv4, 2.0.0.0, by=lt)')))
+            self.len(2, core.eval('lift(inet:ipv4)'))
+            self.len(1, core.eval('lift(inet:ipv4, limit=1)'))
+            self.len(1, core.eval('lift(inet:ipv4, 1.2.3.4)'))
+            self.len(1, core.eval('lift(inet:ipv4, 2.0.0.0, by=lt)'))
 
     def test_storm_lifts_by(self):
         # Test various lifts by handlers
@@ -477,19 +477,19 @@ class StormTest(SynTest):
 
             # Lift by tags
             nodes = core.eval('inet:dns:a*tag=src.clowntown')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             # Lift by type
             nodes = core.eval('inet:user*type=pennywise')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             # Lift by inet:cidr
             nodes = core.eval('inet:dns:a:ipv4*inet:cidr=1.2.0.0/16')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             # Lift by dark
             nodes = core.eval('hehe*dark=haha')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
     def test_storm_addnode(self):
         with self.getRamCore() as core:
@@ -528,19 +528,19 @@ class StormTest(SynTest):
             node = core.formTufoByProp('inet:ipv4', 0x01020304)
 
             core.eval('inet:ipv4=1.2.3.4 [ #foo.bar ]')
-            self.eq(len(core.eval('#foo.bar')), 1)
+            self.len(1, core.eval('#foo.bar'))
 
             core.eval('inet:ipv4=1.2.3.4 [ +#foo.bar.baz ]')
-            self.eq(len(core.eval('#foo.bar.baz')), 1)
+            self.len(1, core.eval('#foo.bar.baz'))
 
             core.eval('inet:ipv4=1.2.3.4 [ -#foo.bar ]')
-            self.eq(len(core.eval('#foo')), 1)
-            self.eq(len(core.eval('#foo.bar')), 0)
-            self.eq(len(core.eval('#foo.bar.baz')), 0)
+            self.len(1, core.eval('#foo'))
+            self.len(0, core.eval('#foo.bar'))
+            self.len(0, core.eval('#foo.bar.baz'))
 
             core.eval(' [ inet:ipv4=5.6.7.8 :cc=US #hehe.haha ]')
 
-            self.eq(len(core.eval('#hehe.haha')), 1)
+            self.len(1, core.eval('#hehe.haha'))
 
             node = core.eval('inet:ipv4=5.6.7.8')[0]
             self.eq(node[1].get('inet:ipv4:cc'), 'us')
@@ -558,24 +558,24 @@ class StormTest(SynTest):
             self.eq(s_tufo.ival(node, '#foo.bar'), (1388534400000, 1388534400000))
 
             nodes = core.eval('inet:ipv4 +#foo.bar@201606')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
             self.eq(nodes[0][1].get('inet:ipv4'), 0x01020304)
 
             nodes = core.eval('inet:ipv4 +#foo.bar@201602-2019')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
             self.eq(nodes[0][1].get('inet:ipv4'), 0x01020304)
 
             nodes = core.eval('inet:ipv4 -#foo.bar@201606')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
             self.eq(nodes[0][1].get('inet:ipv4'), 0x05060708)
 
             nodes = core.eval('inet:ipv4 -#foo.bar@2015-201606')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
             self.eq(nodes[0][1].get('inet:ipv4'), 0x05060708)
 
     def test_storm_edit_end(self):
         with self.getRamCore() as core:
-            self.eq(len(core.eval(' [ inet:dns:a="woot.com/1.2.3.4" ] +:seen:min >= "2014" ')), 0)
+            self.len(0, core.eval(' [ inet:dns:a="woot.com/1.2.3.4" ] +:seen:min >= "2014" '))
 
     def test_storm_show_help(self):
         show0 = {
@@ -621,7 +621,7 @@ class StormTest(SynTest):
             node1 = core.formTufoByProp('inet:ipv4', '4.5.6.7')
 
             nodes = core.eval('guid()')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('guid(%s)' % node0[0])
             self.eq(nodes[0][1].get('inet:ipv4'), 0x01020304)
@@ -633,7 +633,7 @@ class StormTest(SynTest):
             # We can lift dark rows using guid() but kind of an easter egg.
             core.addTufoDark(node0, 'foo:bar', 'duck:knight')
             nodes = core.eval('guid(%s)' % node0[0][::-1])
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
             self.eq(node0[0], nodes[0][0][::-1])
 
     def test_storm_task(self):
@@ -660,13 +660,13 @@ class StormTest(SynTest):
             nodes = core.eval('inet:ipv4 task(foo, bar, baz, sekrit:priority1, key=valu)')
 
             # We don't consume nodes when tasking
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             # Events were fired
-            self.eq(len(foo), 2)
-            self.eq(len(bar), 2)
-            self.eq(len(baz), 2)
-            self.eq(len(sekrit), 2)
+            self.len(2, foo)
+            self.len(2, bar)
+            self.len(2, baz)
+            self.len(2, sekrit)
 
             # Events contained data we expected
             evt = foo[0]
@@ -699,13 +699,13 @@ class StormTest(SynTest):
                               'knights.ni'])
 
             nodes = core.eval('syn:tag=foo tree(syn:tag, syn:tag:up)')
-            self.eq(len(nodes), 6)
+            self.len(6, nodes)
 
             nodes = core.eval('syn:tag=foo tree(syn:tag, syn:tag:up, recurlim=1)')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('syn:tag=foo.bar tree(syn:tag, syn:tag:up)')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('syn:tag=foo.baz tree(syn:tag, syn:tag:up)')
             self.eq(len(nodes), 2)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -6,14 +6,14 @@ from synapse.tests.common import *
 
 class StormTest(SynTest):
     def test_storm_cmpr_norm(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             self.eq(len(core.eval('inet:dns:a:ipv4="1.2.3.4"')), 1)
             self.eq(len(core.eval('inet:dns:a:ipv4="1.2.3.4" -:ipv4="1.2.3.4"')), 0)
             self.eq(len(core.eval('inet:dns:a:ipv4="1.2.3.4" +:ipv4="1.2.3.4"')), 1)
 
     def test_storm_pivot(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             core.formTufoByProp('inet:dns:a', 'vertex.vis/5.6.7.8')
             core.formTufoByProp('inet:dns:a', 'vertex.link/5.6.7.8')
@@ -57,8 +57,7 @@ class StormTest(SynTest):
             self.eq(len(core.eval('inet:ipv4="5.6.7.8" pivot(inet:ipv4, inet:dns:a:ipv4)')), 2)
 
     def test_storm_setprop(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             # relative key/val syntax, explicitly relative vals
             node = core.formTufoByProp('inet:netuser', 'vertex.link/pennywise')
@@ -87,8 +86,7 @@ class StormTest(SynTest):
             self.raises(BadSyntaxError, core.eval, bad_cmd)
 
     def test_storm_filt_regex(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             iden0 = guid()
             iden1 = guid()
@@ -102,9 +100,7 @@ class StormTest(SynTest):
             self.eq(len(nodes), 2)
 
     def test_storm_alltag(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
-
+        with self.getRamCore() as core:
             iden = guid()
             node = core.formTufoByProp('inet:fqdn', 'vertex.link')
 
@@ -124,9 +120,7 @@ class StormTest(SynTest):
             self.eq(len(core.eval('#lol limit(1)')), 1)
 
     def test_storm_limit(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
-
+        with self.getRamCore() as core:
             # test that the limit operator correctly handles being first (no opers[-1])
             # and will subsequently filter down to the correct number of nodes
             nodes = core.eval('[ inet:ipv4=1.2.3.4 inet:ipv4=3.4.5.6 ]')
@@ -143,7 +137,7 @@ class StormTest(SynTest):
             self.raises(BadSyntaxError, core.eval, 'inet:ipv4 limit(woot)')
 
     def test_storm_addtag(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             iden = guid()
             node = core.formTufoByProp('inet:fqdn', 'vertex.link')
 
@@ -157,7 +151,7 @@ class StormTest(SynTest):
             self.nn(node[1].get('#baz.faz'))
 
     def test_storm_deltag(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             iden = guid()
             node = core.formTufoByProp('inet:fqdn', 'vertex.link')
 
@@ -174,8 +168,7 @@ class StormTest(SynTest):
             self.none(node[1].get('#baz.faz'))
 
     def test_storm_refs(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             tstmodl = {
                 'types': [
@@ -261,7 +254,7 @@ class StormTest(SynTest):
 
     def test_storm_tag_query(self):
         # Ensure that non-glob tag filters operate as expected.
-        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+        with self.getRamCore() as core:  # type: s_common.Cortex
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:dns:a', 'vertex.vis/5.6.7.8')
             node3 = core.formTufoByProp('inet:dns:a', 'vertex.link/5.6.7.8')
@@ -290,7 +283,7 @@ class StormTest(SynTest):
 
     def test_storm_tag_glob(self):
         # Ensure that glob operators with tag filters operate properly.
-        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+        with self.getRamCore() as core:  # type: s_common.Cortex
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:dns:a', 'vertex.vis/5.6.7.8')
             node3 = core.formTufoByProp('inet:dns:a', 'vertex.link/5.6.7.8')
@@ -368,7 +361,7 @@ class StormTest(SynTest):
             self.eq(len(nodes), 1)
 
     def test_storm_tag_jointag(self):
-        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+        with self.getRamCore() as core:  # type: s_common.Cortex
 
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
@@ -412,7 +405,7 @@ class StormTest(SynTest):
             self.eq(len(nodes), 1)
 
     def test_storm_tag_totag(self):
-        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+        with self.getRamCore() as core:  # type: s_common.Cortex
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
             node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
@@ -455,7 +448,7 @@ class StormTest(SynTest):
             self.eq(len(nodes), 0)
 
     def test_storm_tag_fromtag(self):
-        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+        with self.getRamCore() as core:  # type: s_common.Cortex
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
             node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
@@ -505,7 +498,7 @@ class StormTest(SynTest):
             self.eq(len(nodes), 3)
 
     def test_storm_lift(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.formTufoByProp('inet:ipv4', '1.2.3.4')
             core.formTufoByProp('inet:ipv4', '5.6.7.8')
 
@@ -516,7 +509,7 @@ class StormTest(SynTest):
 
     def test_storm_lifts_by(self):
         # Test various lifts by handlers
-        with s_cortex.openurl('ram:///') as core:  # type: s_common.Cortex
+        with self.getRamCore() as core:  # type: s_common.Cortex
 
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
@@ -548,7 +541,7 @@ class StormTest(SynTest):
             self.eq(len(nodes), 3)
 
     def test_storm_addnode(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             # add a node with addnode(<form>,<valu>) syntax
             node = core.eval('addnode(inet:ipv4,1.2.3.4)')[0]
 
@@ -563,7 +556,7 @@ class StormTest(SynTest):
             self.raises(BadSyntaxError, core.eval, 'addnode(inet:ipv4, 1.2.3.4, asn=20)')
 
     def test_storm_delnode(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.formTufoByProp('inet:ipv4', 0x01020304)
             core.eval('inet:ipv4=1.2.3.4 delnode()')
             self.nn(core.getTufoByProp('inet:ipv4', 0x01020304))
@@ -571,7 +564,7 @@ class StormTest(SynTest):
             self.none(core.getTufoByProp('inet:ipv4', 0x01020304))
 
     def test_storm_delnode_caching(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.setConfOpt('caching', True)
             node = core.formTufoByProp('inet:ipv4', 0x01020304)
             core.eval('inet:ipv4=1.2.3.4 delnode()')
@@ -580,7 +573,7 @@ class StormTest(SynTest):
             self.none(core.getTufoByProp('inet:ipv4', 0x01020304))
 
     def test_storm_editmode(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.formTufoByProp('inet:ipv4', 0x01020304)
 
             core.eval('inet:ipv4=1.2.3.4 [ #foo.bar ]')
@@ -602,7 +595,7 @@ class StormTest(SynTest):
             self.eq(node[1].get('inet:ipv4:cc'), 'us')
 
     def test_storm_tag_ival(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.eval('[ inet:ipv4=1.2.3.4  +#foo.bar@2016-2017 ] ')[0]
 
             minv = node[1].get('>#foo.bar')
@@ -630,7 +623,7 @@ class StormTest(SynTest):
             self.eq(nodes[0][1].get('inet:ipv4'), 0x05060708)
 
     def test_storm_edit_end(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.eq(len(core.eval(' [ inet:dns:a="woot.com/1.2.3.4" ] +:seen:min >= "2014" ')), 0)
 
     def test_storm_show_help(self):
@@ -638,7 +631,7 @@ class StormTest(SynTest):
             'columns': ['inet:ipv4', ':cc', '#foo.*'],
         }
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node0 = core.eval('[inet:ipv4=108.111.118.101 :cc=kd #foo.bar #hehe.haha ]')[0]
             node1 = core.eval('[inet:ipv4=1.2.3.4 :cc=vv #foo.bar #hehe.haha ]')[0]
 
@@ -672,7 +665,7 @@ class StormTest(SynTest):
             ])
 
     def test_storm_guid(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node0 = core.formTufoByProp('inet:ipv4', '1.2.3.4')
             node1 = core.formTufoByProp('inet:ipv4', '4.5.6.7')
 
@@ -693,7 +686,7 @@ class StormTest(SynTest):
             self.eq(node0[0], nodes[0][0][::-1])
 
     def test_storm_task(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             foo = []
             bar = []
             baz = []
@@ -741,7 +734,7 @@ class StormTest(SynTest):
             self.raises(BadSyntaxError, core.eval, 'inet:ipv4 task()')
 
     def test_storm_tree(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node0 = core.formTufoByProp('inet:ipv4', '1.2.3.4')
             node1 = core.formTufoByProp('inet:ipv4', '4.5.6.7')
             core.addTufoTags(node0,
@@ -841,7 +834,7 @@ class StormTest(SynTest):
             self.eq(len(nodes), 5)
 
     def test_storm_delprop(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:fqdn', 'vertex.link', created="20170101")
             self.isin('inet:fqdn:created', t0[1])
             # Operator syntax requires force=1

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -169,55 +169,6 @@ class StormTest(SynTest):
 
     def test_storm_refs(self):
         with self.getRamCore() as core:
-
-            tstmodl = {
-                'types': [
-                    [
-                        'foob',
-                        {
-                            'subof': 'str'
-                        }
-                    ],
-                ],
-                'forms': [
-                    [
-                        'foob',
-                        {},
-                        [
-                            [
-                                'xref',
-                                {
-                                    'ptype': 'propvalu',
-                                    'ro': 1,
-                                },
-                            ],
-                            [
-                                'xref:intval',
-                                {
-                                    'ptype': 'int',
-                                    'ro': 1,
-                                }
-                            ],
-                            [
-                                'xref:strval',
-                                {
-                                    'ptype': 'str',
-                                    'ro': 1
-                                }
-                            ],
-                            [
-                                'xref:prop',
-                                {
-                                    'ptype': 'str',
-                                    'ro': 1
-                                }
-                            ]
-                        ]
-                    ],
-                ]
-            }
-            core.addDataModel('pvtest', tstmodl)
-
             core.formTufoByProp('inet:dns:a', 'foo.com/1.2.3.4')
             core.formTufoByProp('inet:dns:a', 'bar.com/1.2.3.4')
 
@@ -247,9 +198,9 @@ class StormTest(SynTest):
             self.eq(forms, {'file:bytes', 'file:txtref', 'inet:passwd'})
 
             # Try refs() with a non-XREF type which has propvalu properties.
-            f1 = core.formTufoByProp('foob', 'hai', xref='inet:ipv4=1.2.3.4')
+            f1 = core.formTufoByProp('pvsub', 'hai', xref='inet:ipv4=1.2.3.4')
             self.nn(f1)
-            nodes = core.eval('foob refs()')
+            nodes = core.eval('pvsub refs()')
             self.eq(len(nodes), 2)
 
     def test_storm_tag_query(self):

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -708,16 +708,16 @@ class StormTest(SynTest):
             self.len(3, nodes)
 
             nodes = core.eval('syn:tag=foo.baz tree(syn:tag, syn:tag:up)')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('syn:tag=blah tree(syn:tag, syn:tag:up)')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('syn:tag=blah tree(syn:tag, syn:tag:up, recurlim=1)')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('syn:tag=foo tree(syn:tag:up)')
-            self.eq(len(nodes), 6)
+            self.len(6, nodes)
 
             o0 = core.formTufoByProp('ou:org:alias', 'master')
             o1 = core.formTufoByProp('ou:org:alias', 's1')
@@ -735,16 +735,16 @@ class StormTest(SynTest):
             s46 = core.formTufoByProp('ou:suborg', [o4[1].get('ou:org'), o6[1].get('ou:org')])
 
             nodes = core.eval('ou:org:alias=master -> ou:suborg:org tree(ou:suborg:sub, ou:suborg:org) :sub-> ou:org')
-            self.eq(len(nodes), 6)
+            self.len(6, nodes)
 
             nodes = core.eval('ou:org:alias=master -> ou:suborg:org tree(:sub, ou:suborg:org) :sub-> ou:org')
-            self.eq(len(nodes), 6)
+            self.len(6, nodes)
 
             nodes = core.eval('ou:org:alias=s2 -> ou:suborg:org tree(ou:suborg:sub, ou:suborg:org) :sub-> ou:org')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('ou:org:alias=s1 -> ou:suborg:org tree(ou:suborg:sub, ou:suborg:org) :sub-> ou:org')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('ou:org:alias=s4 -> ou:suborg:org tree(ou:suborg:sub, ou:suborg:org) :sub-> ou:org')
             self.eq(len(nodes), 2)

--- a/synapse/tests/test_lib_webapp.py
+++ b/synapse/tests/test_lib_webapp.py
@@ -178,7 +178,7 @@ class WebAppTest(AsyncTestCase, SynTest):
         s_dyndeps.addDynAlias('FooServer', FooServer)
 
         with s_daemon.Daemon() as core_dmon:
-            with s_cortex.openurl('ram:///') as core:
+            with self.getRamCore() as core:
                 core_dmon.share('core', core)
                 link = core_dmon.listen('tcp://127.0.0.1:0/')
                 linkurl = 'tcp://127.0.0.1:%d/core' % link[1]['port']

--- a/synapse/tests/test_model_crypto.py
+++ b/synapse/tests/test_model_crypto.py
@@ -29,7 +29,7 @@ class CryptoModelTest(SynTest):
         }
         valu = (MODULUS, PUBLIC_EXPONENT)
         tufo = ('', {})
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             tufo = core.formTufoByProp(prop, valu, **props)
         self.eq(tufo[1].get('tufo:form'), 'rsa:key')
         self.eq(tufo[1].get('rsa:key'), HEXSTR_RSA_KEY)

--- a/synapse/tests/test_model_dns.py
+++ b/synapse/tests/test_model_dns.py
@@ -5,7 +5,7 @@ from synapse.tests.common import *
 class DnsModelTest(SynTest):
 
     def test_model_dns_a(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             t0 = core.formTufoByProp('inet:dns:a', 'WOOT.com/1.2.3.4')
             self.eq(t0[1].get('inet:dns:a'), 'woot.com/1.2.3.4')
@@ -18,29 +18,28 @@ class DnsModelTest(SynTest):
             self.eq(t1[1].get('inet:dns:a:ipv4'), 0x05060708)
 
     def test_model_dns_aaaa(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:dns:aaaa', 'WOOT.com/FF::56')
             self.eq(t0[1].get('inet:dns:aaaa'), 'woot.com/ff::56')
             self.eq(t0[1].get('inet:dns:aaaa:fqdn'), 'woot.com')
             self.eq(t0[1].get('inet:dns:aaaa:ipv6'), 'ff::56')
 
     def test_model_dns_ns(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:dns:ns', 'WOOT.com/ns.yermom.com')
             self.eq(t0[1].get('inet:dns:ns'), 'woot.com/ns.yermom.com')
             self.eq(t0[1].get('inet:dns:ns:zone'), 'woot.com')
             self.eq(t0[1].get('inet:dns:ns:ns'), 'ns.yermom.com')
 
     def test_model_dns_rev(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:dns:rev', '1.002.3.4/WOOT.com')
             self.eq(t0[1].get('inet:dns:rev'), '1.2.3.4/woot.com')
             self.eq(t0[1].get('inet:dns:rev:ipv4'), 0x01020304)
             self.eq(t0[1].get('inet:dns:rev:fqdn'), 'woot.com')
 
     def test_model_dns_look(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             tick = now()
 

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -11,8 +11,7 @@ from synapse.tests.common import *
 class FileModelTest(SynTest):
 
     def test_model_file_bytes(self):
-
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             hset = s_axon.HashSet()
             hset.update(b'visi')
@@ -29,8 +28,7 @@ class FileModelTest(SynTest):
             self.eq(t0[1].get('file:bytes:sha512'), '8238be12bcc3c10da7e07dbea528e9970dc809c07c5aef545a14e5e8d2038563b29c2e818d167b06e6a33412e6beb8347fcc44520691347aea9ee21fcf804e39')
 
     def test_model_file_seeds(self):
-
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             hset = s_axon.HashSet()
             hset.update(b'visi')
@@ -49,7 +47,7 @@ class FileModelTest(SynTest):
         fhash_lower = fhash.lower()
         stable_guid = 'ed73917b1dc4011627f7a101ace491c8'
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             n1 = core.formTufoByProp('file:bytes:sha256', fhash)
             n2 = core.formTufoByProp('file:bytes:sha256', fhash_lower)
@@ -61,8 +59,7 @@ class FileModelTest(SynTest):
             self.eq(n1[0], n2[0])
 
     def test_filepath(self):
-
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             core.formTufoByProp('file:path', '/foo/bar/baz/faz/')
 
@@ -77,8 +74,7 @@ class FileModelTest(SynTest):
             self.none(core.getTufoByProp('file:base', ''))
 
     def test_filebase(self):
-
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             core.formTufoByProp('file:base', 'baz.quux')
             self.nn(core.getTufoByProp('file:base', 'baz.quux'))
@@ -86,10 +82,7 @@ class FileModelTest(SynTest):
             self.raises(BadTypeValu, core.formTufoByProp, 'file:base', '/haha')
 
     def test_model_files_imgof(self):
-
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             pnod = core.formTufoByProp('ps:person', None)
             fnod = core.formTufoByProp('file:bytes', None)
@@ -108,9 +101,7 @@ class FileModelTest(SynTest):
             self.eq(img0[1].get('file:imgof:xref:intval'), None)
 
     def test_model_files_txtref(self):
-
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             iden = guid()
 

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -97,13 +97,13 @@ class FileModelTest(SynTest):
             piden = pnod[1].get('ps:person')
             fiden = fnod[1].get('file:bytes')
 
-            img0 = core.formTufoByProp('file:imgof', (fiden, 'ps:person', piden))
-            img1 = core.formTufoByProp('file:imgof', '%s|ps:person|%s' % (fiden, piden))
+            img0 = core.formTufoByProp('file:imgof', (fiden, ('ps:person', piden)))
+            img1 = core.formTufoByProp('file:imgof', '(%s,ps:person=%s)' % (fiden, piden))
 
             self.eq(img0[0], img1[0])
             self.eq(img0[1].get('file:imgof:file'), fiden)
-            self.eq(img0[1].get('file:imgof:xtype'), 'ps:person')
             self.eq(img0[1].get('file:imgof:xref'), 'ps:person=' + piden)
+            self.eq(img0[1].get('file:imgof:xref:prop'), 'ps:person')
             self.eq(img0[1].get('file:imgof:xref:strval'), piden)
             self.eq(img0[1].get('file:imgof:xref:intval'), None)
 
@@ -114,13 +114,13 @@ class FileModelTest(SynTest):
 
             iden = guid()
 
-            img0 = core.formTufoByProp('file:txtref', (iden, 'inet:email', 'visi@vertex.link'))
-            img1 = core.formTufoByProp('file:txtref', '%s|inet:email|visi@VERTEX.LINK' % iden)
+            img0 = core.formTufoByProp('file:txtref', (iden, ('inet:email', 'visi@vertex.link')))
+            img1 = core.formTufoByProp('file:txtref', '(%s,inet:email=visi@VERTEX.LINK)' % iden)
 
             self.eq(img0[0], img1[0])
             self.eq(img0[1].get('file:txtref:file'), iden)
             self.eq(img0[1].get('file:txtref:xref'), 'inet:email=visi@vertex.link')
-            self.eq(img0[1].get('file:txtref:xtype'), 'inet:email')
+            self.eq(img0[1].get('file:txtref:xref:prop'), 'inet:email')
             self.eq(img0[1].get('file:txtref:xref:strval'), 'visi@vertex.link')
             self.eq(img0[1].get('file:txtref:xref:intval'), None)
 

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -102,7 +102,10 @@ class FileModelTest(SynTest):
 
             self.eq(img0[0], img1[0])
             self.eq(img0[1].get('file:imgof:file'), fiden)
-            self.eq(img0[1].get('file:imgof:xref:ps:person'), piden)
+            self.eq(img0[1].get('file:imgof:xtype'), 'ps:person')
+            self.eq(img0[1].get('file:imgof:xref'), 'ps:person=' + piden)
+            self.eq(img0[1].get('file:imgof:xref:strval'), piden)
+            self.eq(img0[1].get('file:imgof:xref:intval'), None)
 
     def test_model_files_txtref(self):
 
@@ -116,7 +119,10 @@ class FileModelTest(SynTest):
 
             self.eq(img0[0], img1[0])
             self.eq(img0[1].get('file:txtref:file'), iden)
-            self.eq(img0[1].get('file:txtref:xref:inet:email'), 'visi@vertex.link')
+            self.eq(img0[1].get('file:txtref:xref'), 'inet:email=visi@vertex.link')
+            self.eq(img0[1].get('file:txtref:xtype'), 'inet:email')
+            self.eq(img0[1].get('file:txtref:xref:strval'), 'visi@vertex.link')
+            self.eq(img0[1].get('file:txtref:xref:intval'), None)
 
     def test_model_file_bytes_axon(self):
 

--- a/synapse/tests/test_model_geopol.py
+++ b/synapse/tests/test_model_geopol.py
@@ -5,28 +5,28 @@ from synapse.tests.common import *
 class GeopolModelTest(SynTest):
 
     def test_model_geopol_iso2(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.eq(core.getTypeNorm('pol:iso2', 'FO'), ('fo', {}))
             self.eq(core.getTypeParse('pol:iso2', 'FO'), ('fo', {}))
             self.raises(BadTypeValu, core.getTypeNorm, 'pol:iso2', 'asdf')
             self.raises(BadTypeValu, core.getTypeParse, 'pol:iso2', 'asdf')
 
     def test_model_geopol_iso3(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.eq(core.getTypeNorm('pol:iso3', 'FOO'), ('foo', {}))
             self.eq(core.getTypeParse('pol:iso3', 'FOO'), ('foo', {}))
             self.raises(BadTypeValu, core.getTypeNorm, 'pol:iso3', 'asdf')
             self.raises(BadTypeValu, core.getTypeParse, 'pol:iso3', 'asdf')
 
     def test_model_geopol_isonum(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.eq(core.getTypeNorm('pol:isonum', 10), (10, {}))
             self.eq(core.getTypeParse('pol:isonum', '10')[0], 10)
             self.raises(BadTypeValu, core.getTypeNorm, 'pol:isonum', 'asdf')
             self.raises(BadTypeValu, core.getTypeParse, 'pol:isonum', 'asdf')
 
     def test_model_geopol_country(self):
-        with s_cortex.openurl('ram:///?enforce=1') as core:
+        with self.getRamCore() as core:
             props = {'iso2': 'VI', 'iso3': 'VIS', 'isonum': 31337}
             t0 = core.formTufoByProp('pol:country', guid(), name='Republic of Visi', **props)
             self.eq(t0[1].get('pol:country:name'), 'republic of visi')

--- a/synapse/tests/test_model_gov_cn.py
+++ b/synapse/tests/test_model_gov_cn.py
@@ -3,8 +3,7 @@ from synapse.tests.common import *
 class CnGovTest(SynTest):
 
     def test_models_cngov_mucd(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             node = core.formTufoByProp('gov:cn:mucd', 61786)
 
             self.nn(node)

--- a/synapse/tests/test_model_gov_us.py
+++ b/synapse/tests/test_model_gov_us.py
@@ -3,8 +3,7 @@ from synapse.tests.common import *
 class UsGovTest(SynTest):
 
     def test_models_usgov_cage(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             node = core.formTufoByProp('gov:us:cage', '7QE71', phone0=17035551212)
             self.eq(node[1].get('gov:us:cage'), '7qe71')
             self.eq(node[1].get('gov:us:cage:phone0'), 17035551212)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -8,20 +8,20 @@ from synapse.tests.common import *
 class InetModelTest(SynTest):
 
     def test_model_inet_email(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:email', 'visi@vertex.link')
             self.eq(t0[1].get('inet:email:user'), 'visi')
             self.eq(t0[1].get('inet:email:fqdn'), 'vertex.link')
 
     def test_model_inet_passwd(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:passwd', 'secret')
             self.eq(t0[1].get('inet:passwd:md5'), '5ebe2294ecd0e0f08eab7690d2a6ee69')
             self.eq(t0[1].get('inet:passwd:sha1'), 'e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4')
             self.eq(t0[1].get('inet:passwd:sha256'), '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b')
 
     def test_model_inet_mac(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:mac', '00:01:02:03:04:05')
             self.eq(t0[1].get('inet:mac:vendor'), '??')
 
@@ -31,14 +31,14 @@ class InetModelTest(SynTest):
 
     def test_model_inet_ipv4(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:ipv4', '16909060')
             self.eq(t0[1].get('inet:ipv4'), 0x01020304)
             self.eq(t0[1].get('inet:ipv4:asn'), -1)
 
     def test_model_inet_ipv6(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:ipv6', '0:0:0:0:0:0:0:1')
             self.eq(t0[1].get('inet:ipv6'), '::1')
             self.eq(t0[1].get('inet:ipv6:asn'), -1)
@@ -48,7 +48,7 @@ class InetModelTest(SynTest):
 
     def test_model_inet_cidr4(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:cidr4', '1.2.3.4/24')
 
             self.eq(t0[1].get('inet:cidr4'), '1.2.3.0/24')
@@ -57,7 +57,7 @@ class InetModelTest(SynTest):
 
     def test_model_inet_asnet4(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             t0 = core.formTufoByProp('inet:asnet4', '54959/1.2.3.4-5.6.7.8')
 
@@ -85,7 +85,7 @@ class InetModelTest(SynTest):
             self.eq(len(nodes), 2)
 
     def test_model_inet_fqdn(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:fqdn', 'com', sfx=1)
             t1 = core.formTufoByProp('inet:fqdn', 'woot.com')
 
@@ -100,8 +100,7 @@ class InetModelTest(SynTest):
             self.eq(t1[1].get('inet:fqdn:zone'), 1)
 
     def test_model_inet_srv4_types(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:tcp4', '8.8.8.8:80')
             form, pprop = s_tufo.ndef(t0)
             self.eq(pprop, 8830587502672)
@@ -125,8 +124,7 @@ class InetModelTest(SynTest):
             self.eq(t3[1].get('inet:udp4:ipv4'), core.getTypeNorm('inet:ipv4', '1.2.3.4')[0])
 
     def test_model_inet_srv6_types(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:tcp6', '[0:0:0:0:0:0:0:1]:80')
             form, pprop = s_tufo.ndef(t0)
             self.eq(pprop, '[::1]:80')
@@ -151,7 +149,7 @@ class InetModelTest(SynTest):
 
     def test_model_inet_fqdn_unicode(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             prop = 'inet:fqdn'
             idna_valu = 'xn--tst-6la.xn--xampl-3raf.link'
             unicode_valu = 'tèst.èxamplè.link'
@@ -174,7 +172,7 @@ class InetModelTest(SynTest):
             unicode_tufo = core.formTufoByProp(prop, unicode_valu)
             self.eq(unicode_tufo, idna_tufo)
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             prop = 'inet:netuser'
             valu = '%s/%s' % ('xn--tst-6la.xn--xampl-3raf.link', 'user')
             tufo = core.formTufoByProp(prop, valu)
@@ -182,21 +180,21 @@ class InetModelTest(SynTest):
             self.eq(tufo[1].get('inet:netuser'), 'tèst.èxamplè.link/user')
             idna_valu = 'xn--tst-6la.xn--xampl-3raf.link'
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             prop = 'inet:email'
             valu = '%s@%s' % ('user', 'tèst.èxamplè.link')
             tufo = core.formTufoByProp(prop, valu)
             self.eq(tufo[1].get('inet:email:fqdn'), 'xn--tst-6la.xn--xampl-3raf.link')
             self.eq(tufo[1].get('inet:email'), 'user@xn--tst-6la.xn--xampl-3raf.link')
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             prop = 'inet:url'
             valu = '%s://%s/%s' % ('https', 'xn--tst-6la.xn--xampl-3raf.link', 'things')
             tufo = core.formTufoByProp(prop, valu)
             self.eq(tufo[1].get('inet:url'), 'https://xn--tst-6la.xn--xampl-3raf.link/things') # hostpart is not normed in inet:url
 
     def test_model_inet_fqdn_set_sfx(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             tufo = core.formTufoByProp('inet:fqdn', 'abc.dyndns.com') # abc.dyndns.com - zone=0 sfx=0, dyndns.com - zone=1 sfx=0, com - zone=0 sfx=1
             self.eq(tufo[1].get('inet:fqdn:host'), 'abc')
             self.eq(tufo[1].get('inet:fqdn:domain'), 'dyndns.com')
@@ -279,11 +277,11 @@ class InetModelTest(SynTest):
             self.eq(tufo[1].get('inet:fqdn:zone'), 0) # should remain zone=0 sfx=0 because its parent is not a sfx
 
     def test_model_inet_cast_defang(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.eq(core.getTypeCast('inet:defang', '1[.]2[.]3[.]4'), '1.2.3.4')
 
     def test_model_inet_whoisemail(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.formTufoByProp('inet:whois:regmail', ('WOOT.COM', 'visi@vertex.LINK'))
             self.nn(core.getTufoByProp('inet:fqdn', 'woot.com'))
             self.nn(core.getTufoByProp('inet:email', 'visi@vertex.link'))
@@ -291,7 +289,7 @@ class InetModelTest(SynTest):
             self.eq(node[1].get('inet:whois:regmail:fqdn'), 'woot.com')
 
     def test_model_inet_url_fields(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.formTufoByProp('inet:url', 'HTTP://visi:hehe@www.vertex.link:9999/')
             self.eq(node[1].get('inet:url:port'), 9999)
             self.eq(node[1].get('inet:url:user'), 'visi')
@@ -306,10 +304,7 @@ class InetModelTest(SynTest):
 
     def test_model_inet_netpost(self):
 
-        with s_cortex.openurl('sqlite:///:memory:') as core:
-
-            core.setConfOpt('enforce', 1)
-
+        with self.getRamCore() as core:
             node0 = core.formTufoByProp('inet:netpost', ('vertex.link/visi', 'knock knock'), time='20141217010101')
             iden = node0[1].get('inet:netpost')
 
@@ -326,8 +321,7 @@ class InetModelTest(SynTest):
             self.eq(node0[1].get('inet:netpost'), node1[1].get('inet:netpost:replyto'))
 
     def test_model_inet_netmesg(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('inet:netmesg', ('VERTEX.link/visi', 'vertex.LINK/hehe', '20501217'), text='hehe haha')
             self.nn(node)
@@ -341,9 +335,7 @@ class InetModelTest(SynTest):
 
     def test_model_inet_netmemb(self):
 
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('inet:netmemb', ('VERTEX.link/visi', 'vertex.LINK/kenshoto'), joined='20501217')
 
@@ -358,9 +350,7 @@ class InetModelTest(SynTest):
 
     def test_model_inet_follows(self):
 
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             props = {'seen:min': '20501217', 'seen:max': '20501217'}
             node = core.formTufoByProp('inet:follows', ('VERTEX.link/visi', 'vertex.LINK/hehe'), **props)
@@ -372,12 +362,11 @@ class InetModelTest(SynTest):
             self.eq(node[1].get('inet:follows:seen:max'), 2554848000000)
 
     def test_model_inet_ipv4_raise(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.raises(BadTypeValu, core.formTufoByProp, 'inet:ipv4', 'lolololololol')
 
     def test_model_inet_urlfile(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             url = 'HTTP://visi:hehe@www.vertex.link:9999/'
             fguid = 32 * 'a'
@@ -394,9 +383,7 @@ class InetModelTest(SynTest):
             self.none(node[1].get('inet:urlfile:url:passwd'))
 
     def test_model_whois_contact(self):
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('inet:whois:contact', '(woot.com@20501217,admin)')
 
@@ -405,8 +392,7 @@ class InetModelTest(SynTest):
             self.eq(len(core.eval('inet:whois:contact:rec="woot.com@20501217"')), 1)
 
     def test_model_inet_whois_recns(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('inet:whois:rec', 'woot.com@20501217')
             form, pprop = s_tufo.ndef(node)
@@ -423,9 +409,7 @@ class InetModelTest(SynTest):
 
     def test_model_fqdn_punycode(self):
 
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('inet:fqdn', 'www.xn--heilpdagogik-wiki-uqb.de')
 
@@ -438,8 +422,7 @@ class InetModelTest(SynTest):
 
     def test_model_inet_weblogon(self):
 
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             tick = now()
 
             t0 = core.formTufoByProp('inet:web:logon', '*',

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -9,15 +9,13 @@ def initcomp(*args, **kwargs):
 class InfoTechTest(SynTest):
 
     def test_model_infotech_host(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             node = core.formTufoByProp('it:host', guid())
             self.nn(node)
             self.nn(node[1].get('it:host'))
 
     def test_model_infotech_cve(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('it:sec:cve', 'CVE-2013-9999', desc='This is a description')
             self.nn(node)
@@ -31,8 +29,7 @@ class InfoTechTest(SynTest):
             self.eq(node[1].get('it:sec:cve:desc'), 'This is a description')
 
     def test_model_infotech_av(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             bytesguid = '1234567890ABCDEFFEDCBA0987654321'
             orgname = 'Foo'
             signame = 'Bar.BAZ.faZ'
@@ -51,9 +48,7 @@ class InfoTechTest(SynTest):
             self.eq(tufo, None) # ou:alias will not be automatically formed at this time
 
     def test_model_infotech_hostname(self):
-
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('it:host', None, name='hehehaha')
             self.nn(node)
@@ -63,10 +58,7 @@ class InfoTechTest(SynTest):
             self.nn(node)
 
     def test_model_infotech_filepath(self):
-
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('file:path', '/Foo/Bar/Baz.exe')
 
@@ -105,9 +97,7 @@ class InfoTechTest(SynTest):
             self.eq(node[1].get('file:path'), '/foo/baz.json')
 
     def test_model_infotech_itdev(self):
-
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('it:dev:str', 'He He Ha Ha')
             self.nn(node)
@@ -140,9 +130,7 @@ class InfoTechTest(SynTest):
             self.eq(node[1].get('it:dev:regval:bytes'), iden)
 
     def test_model_infotech_hostexec(self):
-
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             exe = guid()
             port = 80

--- a/synapse/tests/test_model_language.py
+++ b/synapse/tests/test_model_language.py
@@ -3,9 +3,7 @@ from synapse.tests.common import *
 class LangTest(SynTest):
 
     def test_model_language_trans(self):
-
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             self.nn(core.getTufoByProp('syn:type', 'lang:trans'))
             self.nn(core.getTufoByProp('syn:form', 'lang:trans'))
@@ -17,9 +15,7 @@ class LangTest(SynTest):
             self.eq(node[1].get('lang:trans:desc:en'), 'Some English Desc')
 
     def test_model_language_idiom(self):
-
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             self.nn(core.getTufoByProp('syn:type', 'lang:idiom'))
             self.nn(core.getTufoByProp('syn:form', 'lang:idiom'))

--- a/synapse/tests/test_model_material.py
+++ b/synapse/tests/test_model_material.py
@@ -3,8 +3,7 @@ from synapse.tests.common import *
 class MatTest(SynTest):
 
     def test_model_mat_spec_item(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             node0 = core.formTufoByProp('mat:spec', guid(), name='F16 Fighter Jet')
             node1 = core.formTufoByProp('mat:item', guid(), name="Visi's F16 Fighter Jet")
 

--- a/synapse/tests/test_model_media.py
+++ b/synapse/tests/test_model_media.py
@@ -3,7 +3,7 @@ from synapse.tests.common import *
 class MediaTest(SynTest):
 
     def test_models_media_news(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.formTufoByProp('media:news', guid(), title='Synapse is Awesome!', url='http://www.VERTEX.link/synapse')
             self.nn(node)
             self.eq(node[1].get('media:news:org'), '??')

--- a/synapse/tests/test_model_orgs.py
+++ b/synapse/tests/test_model_orgs.py
@@ -5,9 +5,7 @@ from synapse.tests.common import *
 class OrgTest(SynTest):
 
     def test_model_orgs_seed_alias(self):
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node0 = core.formTufoByProp('ou:org:alias', 'wewtcorp', name='The Woot Corp')
 
@@ -19,9 +17,7 @@ class OrgTest(SynTest):
             self.eq(node0[0], node1[0])
 
     def test_model_orgs_seed_name(self):
-        with s_cortex.openurl('ram:///') as core:
-
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             node0 = core.formTufoByProp('ou:org:name', 'The Woot Corp')
             node1 = core.formTufoByProp('ou:org:name', 'the woot corp')

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -5,7 +5,7 @@ class PersonTest(SynTest):
 
     def test_model_person(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             dob = core.getTypeParse('time', '19700101000000001')
             node = core.formTufoByProp('ps:person', guid(), dob=dob[0], name='Kenshoto,Invisigoth')
             self.eq(node[1].get('ps:person:dob'), 1)
@@ -14,12 +14,12 @@ class PersonTest(SynTest):
             self.eq(node[1].get('ps:person:name:given'), 'invisigoth')
 
     def test_model_person_tokn(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.formTufoByProp('ps:tokn', 'Invisigoth')
             self.eq(node[1].get('ps:tokn'), 'invisigoth')
 
     def test_model_person_name(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.formTufoByProp('ps:name', 'Kenshoto,Invisigoth')
 
             self.eq(node[1].get('ps:name:sur'), 'kenshoto')
@@ -30,7 +30,7 @@ class PersonTest(SynTest):
 
     def test_model_person_2(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             node = core.formTufoByProp('ps:name', 'Kenshoto,Invisigoth')
 
             self.eq(node[1].get('ps:name'), 'kenshoto,invisigoth')
@@ -41,7 +41,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:tokn', 'invisigoth'))
 
     def test_model_person_has_user(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             iden = guid()
             node = core.formTufoByProp('ps:hasuser', '%s/visi' % iden)
 
@@ -52,7 +52,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('inet:user', 'visi'))
 
     def test_model_person_has_alias(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             iden = guid()
             node = core.formTufoByProp('ps:hasalias', '%s/Kenshoto,Invisigoth' % iden)
 
@@ -63,7 +63,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:name', 'kenshoto,invisigoth'))
 
     def test_model_person_has_phone(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             iden = guid()
             node = core.formTufoByProp('ps:hasphone', '%s/17035551212' % iden)
 
@@ -74,7 +74,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('tel:phone', 17035551212))
 
     def test_model_person_has_email(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             iden = guid()
             node = core.formTufoByProp('ps:hasemail', '%s/visi@VERTEX.link' % iden)
 
@@ -85,7 +85,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('inet:email', 'visi@vertex.link'))
 
     def test_model_person_has_netuser(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             iden = guid()
             node = core.formTufoByProp('ps:hasnetuser', '%s/ROOTKIT.com/visi' % iden)
 
@@ -98,7 +98,7 @@ class PersonTest(SynTest):
 
     def test_model_person_guidname(self):
 
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
 
             node = core.formTufoByProp('ps:person:guidname', 'visi')
             self.eq(node[1].get('ps:person:guidname'), 'visi')

--- a/synapse/tests/test_model_syn.py
+++ b/synapse/tests/test_model_syn.py
@@ -1,5 +1,3 @@
-import synapse.cortex as s_cortex
-
 from synapse.tests.common import *
 
 class SynModelTest(SynTest):
@@ -43,3 +41,57 @@ class SynModelTest(SynTest):
                 self.eq(len(core.getRowsById(fden)), 0)
                 self.eq(len(core.getRowsById(pden)), 0)
                 self.eq(len(core.getRowsById(mden)), 0)
+
+    def test_model_syn_201709191412(self):
+        data = {}
+        iden0 = guid()
+        iden1 = guid()
+        iden2 = guid()
+        iden3 = guid()
+        tick = now()
+        rows = [(iden0, 'inet:ipv4:type', '??', tick),
+                (iden0, 'inet:ipv4', 16909060, tick),
+                (iden0, 'tufo:form', 'inet:ipv4', tick),
+                (iden0, 'inet:ipv4:cc', '??', tick),
+                (iden0, 'inet:ipv4:asn', -1, tick),
+                (iden1, 'file:bytes', 'd41d8cd98f00b204e9800998ecf8427e', tick),
+                (iden1, 'file:bytes:mime', '??', tick),
+                (iden1, 'file:bytes:md5', 'd41d8cd98f00b204e9800998ecf8427e', tick),
+                (iden1, 'tufo:form', 'file:bytes', tick),
+                (iden2, 'file:txtref:xref:inet:ipv4', 16909060, tick),
+                (iden2, 'tufo:form', 'file:txtref', tick),
+                (iden2, 'file:txtref', 'd7b82a6328c2483bf583871031f573bf', tick),
+                (iden2, 'file:txtref:file', 'd41d8cd98f00b204e9800998ecf8427e', tick),
+                (iden2, 'file:txtref:xtype', 'inet:ipv4', tick),
+                (iden3, 'file:imgof:xref:inet:fqdn', 'woot.com', tick),
+                (iden3, 'tufo:form', 'file:imgof', tick),
+                (iden3, 'file:imgof', 'ccea21ac0a1442aeffde9fd3893625ab', tick),
+                (iden3, 'file:imgof:file', 'd41d8cd98f00b204e9800998ecf8427e', tick),
+                (iden3, 'file:imgof:xtype', 'inet:fqdn', tick),
+                ]
+
+        with s_cortex.openstore('ram:///') as stor:
+            # force model migration callbacks
+            stor.setModlVers('syn', 0)
+
+            def addrows(mesg):
+                stor.addRows(rows)
+                data['added'] = True
+
+            stor.on('modl:vers:rev', addrows, name='syn', vers=201709191412)
+
+            with s_cortex.fromstore(stor) as core:
+                nodes = core.eval('file:txtref')
+                self.eq(len(nodes), 1)
+                node = nodes[0]
+                self.eq(node[1].get('file:txtref:xref'), 'inet:ipv4=1.2.3.4')
+                self.eq(node[1].get('file:txtref:xref:intval'), 0x01020304)
+                self.notin('file:txtref:xref:inet:ipv4', node[1])
+                self.notin('file:txtref:xref:strval', node[1])
+                nodes = core.eval('file:imgof')
+                self.eq(len(nodes), 1)
+                node = nodes[0]
+                self.eq(node[1].get('file:imgof:xref'), 'inet:fqdn=woot.com')
+                self.eq(node[1].get('file:imgof:xref:strval'), 'woot.com')
+                self.notin('file:imgof:xref:inet:fqdn', node[1])
+                self.notin('file:imgof:xref:intval', node[1])

--- a/synapse/tests/test_model_syn.py
+++ b/synapse/tests/test_model_syn.py
@@ -86,6 +86,8 @@ class SynModelTest(SynTest):
                 node = nodes[0]
                 self.eq(node[1].get('file:txtref:xref'), 'inet:ipv4=1.2.3.4')
                 self.eq(node[1].get('file:txtref:xref:intval'), 0x01020304)
+                self.eq(node[1].get('file:txtref:xref:prop'), 'inet:ipv4')
+                self.notin('file:txtref:xref:xtype', node[1])
                 self.notin('file:txtref:xref:inet:ipv4', node[1])
                 self.notin('file:txtref:xref:strval', node[1])
                 nodes = core.eval('file:imgof')
@@ -93,5 +95,7 @@ class SynModelTest(SynTest):
                 node = nodes[0]
                 self.eq(node[1].get('file:imgof:xref'), 'inet:fqdn=woot.com')
                 self.eq(node[1].get('file:imgof:xref:strval'), 'woot.com')
+                self.eq(node[1].get('file:imgof:xref:prop'), 'inet:fqdn')
+                self.notin('file:imgof:xref:xtype', node[1])
                 self.notin('file:imgof:xref:inet:fqdn', node[1])
                 self.notin('file:imgof:xref:intval', node[1])

--- a/synapse/tests/test_model_syn.py
+++ b/synapse/tests/test_model_syn.py
@@ -48,6 +48,7 @@ class SynModelTest(SynTest):
         iden1 = guid()
         iden2 = guid()
         iden3 = guid()
+        iden4 = guid()
         tick = now()
         rows = [(iden0, 'inet:ipv4:type', '??', tick),
                 (iden0, 'inet:ipv4', 16909060, tick),
@@ -68,6 +69,10 @@ class SynModelTest(SynTest):
                 (iden3, 'file:imgof', 'ccea21ac0a1442aeffde9fd3893625ab', tick),
                 (iden3, 'file:imgof:file', 'd41d8cd98f00b204e9800998ecf8427e', tick),
                 (iden3, 'file:imgof:xtype', 'inet:fqdn', tick),
+                (iden4, 'file:imgof:xref:inet:fqdn', 'vertex.link', tick),
+                (iden4, 'tufo:form', 'file:imgof', tick),
+                (iden4, 'file:imgof', 'ccea21ac0a1442aeffde9fd3893625ab', tick),
+                (iden4, 'file:imgof:file', 'd41d8cd98f00b204e9800998ecf8427e', tick),
                 ]
 
         with s_cortex.openstore('ram:///') as stor:
@@ -90,11 +95,21 @@ class SynModelTest(SynTest):
                 self.notin('file:txtref:xref:xtype', node[1])
                 self.notin('file:txtref:xref:inet:ipv4', node[1])
                 self.notin('file:txtref:xref:strval', node[1])
+
                 nodes = core.eval('file:imgof')
-                self.eq(len(nodes), 1)
-                node = nodes[0]
+                self.eq(len(nodes), 2)
+
+                node = core.eval('guid({})'.format(iden3))[0]
                 self.eq(node[1].get('file:imgof:xref'), 'inet:fqdn=woot.com')
                 self.eq(node[1].get('file:imgof:xref:strval'), 'woot.com')
+                self.eq(node[1].get('file:imgof:xref:prop'), 'inet:fqdn')
+                self.notin('file:imgof:xref:xtype', node[1])
+                self.notin('file:imgof:xref:inet:fqdn', node[1])
+                self.notin('file:imgof:xref:intval', node[1])
+
+                node = core.eval('guid({})'.format(iden4))[0]
+                self.eq(node[1].get('file:imgof:xref'), 'inet:fqdn=vertex.link')
+                self.eq(node[1].get('file:imgof:xref:strval'), 'vertex.link')
                 self.eq(node[1].get('file:imgof:xref:prop'), 'inet:fqdn')
                 self.notin('file:imgof:xref:xtype', node[1])
                 self.notin('file:imgof:xref:inet:fqdn', node[1])

--- a/synapse/tests/test_model_telco.py
+++ b/synapse/tests/test_model_telco.py
@@ -3,14 +3,13 @@ from synapse.tests.common import *
 class TelcoTest(SynTest):
 
     def test_model_telco_phone(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
             node = core.formTufoByProp('tel:phone', '+1 (703) 555-1212')
             self.eq(node[1].get('tel:phone'), 17035551212)
             self.eq(node[1].get('tel:phone:cc'), 'us')
 
     def test_model_telco_cast_loc_us(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.eq(core.getTypeCast('tel:loc:us', '7035551212'), 17035551212)
             self.eq(core.getTypeCast('tel:loc:us', '17035551212'), 17035551212)
             self.eq(core.getTypeCast('tel:loc:us', '0017035551212'), 17035551212)

--- a/synapse/tests/test_model_temporal.py
+++ b/synapse/tests/test_model_temporal.py
@@ -5,7 +5,7 @@ from synapse.tests.common import *
 class InetModelTest(SynTest):
 
     def test_model_time_minmax(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.addType('foo:min', subof='time', ismin=1)
             core.addType('foo:max', subof='time', ismax=1)
             core.addTufoForm('foo', ptype='str')
@@ -27,6 +27,6 @@ class InetModelTest(SynTest):
             self.eq(tufo[1]['foo:latest'], 100)
 
     def test_model_time_from_unix(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.eq(core.getTypeCast('from:unix:epoch', 100), 100000)
             self.eq(core.getTypeCast('from:unix:epoch', '0x20'), 32000)

--- a/synapse/tests/test_runtime.py
+++ b/synapse/tests/test_runtime.py
@@ -26,7 +26,7 @@ class StormRunTest(SynTest):
         return core
 
     def test_storm_ram(self):
-        with s_cortex.openurl('ram://') as core:
+        with self.getRamCore() as core:
             self.prepStormCore(core)
             self.runStormStats(core)
             self.runStormBasics(core)

--- a/synapse/tests/test_tools_ingest.py
+++ b/synapse/tests/test_tools_ingest.py
@@ -14,7 +14,7 @@ class TestIngest(SynTest):
 
             link = dmon.listen('tcp://127.0.0.1:0/')
 
-            with s_cortex.openurl('ram:///') as core:
+            with self.getRamCore() as core:
 
                 dmon.share('core', core)
 

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -336,17 +336,17 @@ class DataTypesTest(SynTest):
         self.raises(BadTypeValu, tlib.getTypeParse, 'woot', 'qwer')
 
     def test_type_bases(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.eq(tuple(core.getTypeBases('inet:dns:look')), ('guid', 'inet:dns:look'))
 
     def test_type_issub(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             self.true(core.isSubType('inet:dns:look', 'guid'))
             self.false(core.isSubType('inet:dns:look', 'int'))
             self.true(core.isSubType('str', 'str'))
 
     def test_type_getTypeInfo(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             core.addType('foo:bar', subof='inet:ipv4')
             self.nn(core.getTypeInfo('foo:bar', 'ex'))
 
@@ -472,8 +472,7 @@ class DataTypesTest(SynTest):
         self.eq(tlib.getTypeCast('str:lwr', ' ASDF  '), 'asdf')
 
     def test_type_xref(self):
-        with s_cortex.openurl('ram://') as core:  # type: s_cores_common.Cortex
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             core.addType('foo:bar', subof='xref', source='org,ou:org')
             core.addTufoForm('foo:bar', ptype='foo:bar')
@@ -546,9 +545,7 @@ class DataTypesTest(SynTest):
         self.false(s_types.isguid('visi'))
 
     def test_types_guid_resolver(self):
-        with s_cortex.openurl('ram:///') as core:
-            core.setConfOpt('enforce', 1)
-
+        with self.getRamCore() as core:
             # use the seed constructor for an org
             onode = core.formTufoByProp('ou:org:alias', 'vertex')
 
@@ -565,7 +562,7 @@ class DataTypesTest(SynTest):
             self.eq(len(core.eval('ou:user:org=$vertex')), 1)
 
     def test_types_tagtime(self):
-        with s_cortex.openurl('ram:///') as core:
+        with self.getRamCore() as core:
             valu, subs = core.getTypeNorm('syn:tag', 'Foo.Bar@20161217-20171217')
 
             self.eq(valu, 'foo.bar')
@@ -644,8 +641,7 @@ class DataTypesTest(SynTest):
         tlib.getTypeNorm('syn:perm', 'foo:bar   baz=faz     hehe=haha')
 
     def test_types_propvalu(self):
-        with s_cortex.openurl('ram:///') as core:  # type: s_cores_common.Cortex
-            core.setConfOpt('enforce', 1)
+        with self.getRamCore() as core:
 
             tstmodl = {
                 'types': [

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -498,6 +498,11 @@ class DataTypesTest(SynTest):
             self.eq(subs.get('xref:strval'), None)
             self.eq(subs.get('xref:intval'), 0x01020304)
 
+            valu, subs = core.getTypeNorm('foo:bar', '98db59098e385f0bfdec8a6a0a6118b3|inet:passwd|oh=my=graph!')
+            self.eq(subs.get('xref'), 'inet:passwd=oh=my=graph!')
+            self.eq(subs.get('xref:strval'), 'oh=my=graph!')
+            self.eq(subs.get('xref:intval'), None)
+
             valu, subs = core.getTypeNorm('foo:bar', 4 * 'deadb33f')
             self.eq(valu, 4 * 'deadb33f')
             self.eq(subs, {})

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -498,7 +498,13 @@ class DataTypesTest(SynTest):
             self.eq(subs.get('xref:strval'), None)
             self.eq(subs.get('xref:intval'), 0x01020304)
 
+            valu, subs = core.getTypeNorm('foo:bar', 4 * 'deadb33f')
+            self.eq(valu, 4 * 'deadb33f')
+            self.eq(subs, {})
             self.raises(NoSuchType, core.getTypeNorm, 'foo:bar', '98db59098e385f0bfdec8a6a0a6118b3|inet:fqdn:zone|0')
+            self.raises(BadTypeValu, core.getTypeNorm, 'foo:bar', 1)
+            self.raises(BadTypeValu, core.getTypeNorm, 'foo:bar', ['oh', 'my', 'its', 'broked'])
+            self.raises(BadInfoValu, core.addType, 'foo:baz', subof='xref', source='ou=org')
 
     def test_types_isguid(self):
         self.true(s_types.isguid('98db59098e385f0bfdec8a6a0a6118b3'))

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -643,83 +643,8 @@ class DataTypesTest(SynTest):
     def test_types_propvalu(self):
         with self.getRamCore() as core:
 
-            tstmodl = {
-                'types': [
-                    [
-                        'foob',
-                        {
-                            'subof': 'str'
-                        }
-                    ],
-                ],
-                'forms': [
-                    [
-                        'foob',
-                        {},
-                        [
-                            [
-                                'xref',
-                                {
-                                    'ptype': 'propvalu',
-                                    'ro': 1,
-                                },
-                            ],
-                            [
-                                'xref:intval',
-                                {
-                                    'ptype': 'int',
-                                    'ro': 1,
-                                }
-                            ],
-                            [
-                                'xref:strval',
-                                {
-                                    'ptype': 'str',
-                                    'ro': 1
-                                }
-                            ],
-                            [
-                                'xref:prop',
-                                {
-                                    'ptype': 'str',
-                                    'ro': 1
-                                }
-                            ]
-                        ]
-                    ],
-                    [
-                        'pvform',
-                        {'ptype': 'propvalu'},
-                        [
-                            [
-                                'intval',
-                                {
-                                    'ptype': 'int',
-                                    'ro': 1,
-                                }
-                            ],
-                            [
-                                'strval',
-                                {
-                                    'ptype': 'str',
-                                    'ro': 1
-                                }
-                            ],
-                            [
-                                'prop',
-                                {
-                                    'ptype': 'str',
-                                    'ro': 1
-                                }
-                            ]
-                        ]
-                    ]
-                ]
-            }
-            core.addDataModel('pvtest', tstmodl)
-
             # Test a list of property/valu
-            valu, subs = core.getPropNorm('foob:xref', ['inet:ipv4', '1.2.3.4'])
+            valu, subs = core.getPropNorm('pvsub:xref', ['inet:ipv4', '1.2.3.4'])
             self.eq(valu, 'inet:ipv4=1.2.3.4')
             self.eq(subs.get('prop'), 'inet:ipv4')
             self.eq(subs.get('intval'), 0x01020304)
@@ -731,7 +656,7 @@ class DataTypesTest(SynTest):
                       ]
 
             for pvstr in pvstrs:
-                valu, subs = core.getPropNorm('foob:xref', pvstr)
+                valu, subs = core.getPropNorm('pvsub:xref', pvstr)
                 self.eq(valu, 'inet:ipv4=1.2.3.4')
                 self.eq(subs.get('intval'), 0x01020304)
                 self.eq(subs.get('prop'), 'inet:ipv4')
@@ -740,13 +665,14 @@ class DataTypesTest(SynTest):
             # Make some nodes, do a pivot
             node = core.formTufoByProp('inet:ipv4', 0x01020304)
             self.nn(node)
-            node = core.formTufoByProp('foob', 'blah', xref=['inet:ipv4', '1.2.3.4'])
+            node = core.formTufoByProp('pvsub', 'blah', xref=['inet:ipv4', '1.2.3.4'])
             self.nn(node)
-            self.eq(node[1].get('foob:xref'), 'inet:ipv4=1.2.3.4')
-            self.eq(node[1].get('foob:xref:intval'), 0x01020304)
-            self.eq(node[1].get('foob:xref:prop'), 'inet:ipv4')
+            self.eq(node[1].get('pvsub:xref'), 'inet:ipv4=1.2.3.4')
+            self.eq(node[1].get('pvsub:xref:prop'), 'inet:ipv4')
+            self.eq(node[1].get('pvsub:xref:intval'), 0x01020304)
+            self.eq(node[1].get('pvsub:xref:prop'), 'inet:ipv4')
 
-            nodes = core.eval('foob :xref:intval->inet:ipv4')
+            nodes = core.eval('pvsub :xref:intval->inet:ipv4')
             self.eq(len(nodes), 1)
             self.eq(nodes[0][1].get('inet:ipv4'), 0x01020304)
 
@@ -768,8 +694,8 @@ class DataTypesTest(SynTest):
             self.eq(t4[1].get('pvform:prop'), 'inet:netpost')
 
             # Bad values
-            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', 1234)
-            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', '  ')
-            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', 'inet:ipv4= 1.2.3.4')
-            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', '(inet:ipv4,1.2.3.4)')
-            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', ['inet:ipv4', '1.2.3.4', 'opps'])
+            self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', 1234)
+            self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', '  ')
+            self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', 'inet:ipv4= 1.2.3.4')
+            self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', '(inet:ipv4,1.2.3.4)')
+            self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', ['inet:ipv4', '1.2.3.4', 'opps'])

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -2,15 +2,14 @@
 from __future__ import absolute_import, unicode_literals
 import base64
 
-import synapse.cortex as s_cortex
+import synapse.cores.common as s_cores_common
+
 import synapse.lib.types as s_types
 
 from synapse.tests.common import *
 
 class DataTypesTest(SynTest):
-
     def test_datatype_basics(self):
-
         tlib = s_types.TypeLib()
         self.true(tlib.isDataType('inet:url'))
         self.true(isinstance(tlib.getDataType('inet:url'), s_types.DataType))
@@ -24,12 +23,14 @@ class DataTypesTest(SynTest):
         self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:url', 'newp')
         self.eq(tlib.getTypeNorm('inet:url', 'http://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
         self.eq(tlib.getTypeNorm('inet:url', 'HTTP://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
-        self.eq(tlib.getTypeNorm('inet:url', 'HttP://Visi:Secret@WoOt.com/HeHe&foo=10')[0], 'http://Visi:Secret@woot.com/HeHe&foo=10')
+        self.eq(tlib.getTypeNorm('inet:url', 'HttP://Visi:Secret@WoOt.com/HeHe&foo=10')[0],
+                'http://Visi:Secret@woot.com/HeHe&foo=10')
 
         self.raises(BadTypeValu, tlib.getTypeParse, 'inet:url', 'newp')
         self.eq(tlib.getTypeParse('inet:url', 'http://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
         self.eq(tlib.getTypeParse('inet:url', 'HTTP://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
-        self.eq(tlib.getTypeParse('inet:url', 'HttP://Visi:Secret@WoOt.com/HeHe&foo=10')[0], 'http://Visi:Secret@woot.com/HeHe&foo=10')
+        self.eq(tlib.getTypeParse('inet:url', 'HttP://Visi:Secret@WoOt.com/HeHe&foo=10')[0],
+                'http://Visi:Secret@woot.com/HeHe&foo=10')
 
         self.eq(tlib.getTypeRepr('inet:url', 'http://woot.com/HeHe'), 'http://woot.com/HeHe')
 
@@ -100,7 +101,8 @@ class DataTypesTest(SynTest):
         self.raises(BadTypeValu, tlib.getTypeNorm, 'guid', 'newp')
 
         self.eq(tlib.getTypeParse('guid', '000102030405060708090A0B0C0D0E0F')[0], '000102030405060708090a0b0c0d0e0f')
-        self.eq(tlib.getTypeParse('guid', '00010203-0405-0607-0809-0A0B0C0D0E0F')[0], '000102030405060708090a0b0c0d0e0f')
+        self.eq(tlib.getTypeParse('guid', '00010203-0405-0607-0809-0A0B0C0D0E0F')[0],
+                '000102030405060708090a0b0c0d0e0f')
         self.eq(tlib.getTypeNorm('guid', '000102030405060708090A0B0C0D0E0F')[0], '000102030405060708090a0b0c0d0e0f')
         self.eq(tlib.getTypeRepr('guid', '000102030405060708090a0b0c0d0e0f'), '000102030405060708090a0b0c0d0e0f')
 
@@ -122,7 +124,8 @@ class DataTypesTest(SynTest):
         self.raises(BadTypeValu, tlib.getTypeParse, 'hash:md5', 'newp')
         self.raises(BadTypeValu, tlib.getTypeNorm, 'hash:md5', 'newp')
 
-        self.eq(tlib.getTypeParse('hash:md5', '000102030405060708090A0B0C0D0E0F')[0], '000102030405060708090a0b0c0d0e0f')
+        self.eq(tlib.getTypeParse('hash:md5', '000102030405060708090A0B0C0D0E0F')[0],
+                '000102030405060708090a0b0c0d0e0f')
         self.eq(tlib.getTypeNorm('hash:md5', '000102030405060708090A0B0C0D0E0F')[0], '000102030405060708090a0b0c0d0e0f')
         self.eq(tlib.getTypeRepr('hash:md5', '000102030405060708090a0b0c0d0e0f'), '000102030405060708090a0b0c0d0e0f')
 
@@ -182,7 +185,7 @@ class DataTypesTest(SynTest):
     def test_datatype_str_hex(self):
         tlib = s_types.TypeLib()
 
-        #self.raises(BadTypeValu, tlib.getTypeNorm, 'str:hex', 0xFFF)
+        # self.raises(BadTypeValu, tlib.getTypeNorm, 'str:hex', 0xFFF)
         self.raises(BadTypeValu, tlib.getTypeNorm, 'str:hex', '0xFFF')
         self.eq(tlib.getTypeNorm('str:hex', 'FfF')[0], 'fff')
         self.eq(tlib.getTypeNorm('str:hex', '12345')[0], '12345')
@@ -194,7 +197,7 @@ class DataTypesTest(SynTest):
 
         tlib.addType('woot', subof='sepr', sep='/', fields='a,str:hex|b,str:hex')
         self.eq(tlib.getTypeNorm('woot', 'AAA/BBB')[0], 'aaa/bbb')
-        self.eq(tlib.getTypeNorm('woot', '123456/BBB')[0], '123456/bbb') # already str
+        self.eq(tlib.getTypeNorm('woot', '123456/BBB')[0], '123456/bbb')  # already str
         self.eq(tlib.getTypeNorm('woot', (123456, 'BBB'))[0], '1e240/bbb')
         self.raises(BadTypeValu, tlib.getTypeParse, 'woot', '123x/aaaa')
         self.raises(BadTypeValu, tlib.getTypeParse, 'woot', '0x123/aaaa')
@@ -396,7 +399,7 @@ class DataTypesTest(SynTest):
         self.eq(tlib.getTypeParse('time', '1970 0201 000001')[0], EPOCH_FEB_MS + SECOND_MS)
         self.eq(tlib.getTypeParse('time:epoch', '1970 0201 000001')[0], EPOCH_FEB_SEC + 1)
 
-        #self.raises(BadTypeValu, tlib.getTypeParse, 'time', 0)
+        # self.raises(BadTypeValu, tlib.getTypeParse, 'time', 0)
         self.raises(BadTypeValu, tlib.getTypeParse, 'time', '19700')
         self.eq(tlib.getTypeParse('time', '1970 0201 000000 0')[0], EPOCH_FEB_MS)
         self.eq(tlib.getTypeParse('time', '1970 0201 000000 1')[0], EPOCH_FEB_MS + 100)
@@ -407,7 +410,7 @@ class DataTypesTest(SynTest):
         self.eq(tlib.getTypeParse('time', '1970-01-01 00:00:00.010')[0], 10)
         self.eq(tlib.getTypeParse('time', '1q9w7e0r0t1y0u1i0o0p0a0s0d0f0g0h0j')[0], 0)
 
-        #self.raises(BadTypeValu, tlib.getTypeParse, 'time:epoch', 0)
+        # self.raises(BadTypeValu, tlib.getTypeParse, 'time:epoch', 0)braeking
         self.raises(BadTypeValu, tlib.getTypeParse, 'time:epoch', '19700')
         self.raises(BadTypeValu, tlib.getTypeParse, 'time:epoch', '1970 0201 000000 0')
         self.raises(BadTypeValu, tlib.getTypeParse, 'time:epoch', '1970 0201 000000 1')
@@ -418,8 +421,10 @@ class DataTypesTest(SynTest):
         self.raises(BadTypeValu, tlib.getTypeParse, 'time:epoch', '1970-01-01 00:00:00.010')
         self.raises(BadTypeValu, tlib.getTypeParse, 'time:epoch', '1q9w7e0r0t1y0u1i0o0p0a0s0d0f0g0h1j')
 
-        self.eq(tlib.getTypeParse('time', '1970')[0], tlib.getTypeParse('time:epoch', '1970')[0] * 1000) # time should = epoch*1000
-        self.eq(tlib.getTypeParse('time', '19700101 123456')[0], tlib.getTypeParse('time:epoch', '19700101 123456')[0] * 1000) # time should = epoch*1000
+        self.eq(tlib.getTypeParse('time', '1970')[0],
+                tlib.getTypeParse('time:epoch', '1970')[0] * 1000)  # time should = epoch*1000
+        self.eq(tlib.getTypeParse('time', '19700101 123456')[0],
+                tlib.getTypeParse('time:epoch', '19700101 123456')[0] * 1000)  # time should = epoch*1000
 
         self.eq(tlib.getTypeRepr('time', -1), '1969/12/31 23:59:59.999')
         self.eq(tlib.getTypeRepr('time:epoch', -1), '1969/12/31 23:59:59')
@@ -467,29 +472,40 @@ class DataTypesTest(SynTest):
         self.eq(tlib.getTypeCast('str:lwr', ' ASDF  '), 'asdf')
 
     def test_type_xref(self):
+        with s_cortex.openurl('ram://') as core:  # type: s_cores_common.Cortex
+            core.setConfOpt('enforce', 1)
 
-        tlib = s_types.TypeLib()
+            core.addType('foo:bar', subof='xref', source='org,ou:org')
 
-        tlib.addType('foo:bar', subof='xref', source='org,ou:org')
+            valu, subs = core.getTypeNorm('foo:bar', ('98db59098e385f0bfdec8a6a0a6118b3', 'inet:fqdn', 'woot.com'))
+            self.eq(subs.get('org'), '98db59098e385f0bfdec8a6a0a6118b3')
+            self.eq(subs.get('xtype'), 'inet:fqdn')
+            self.eq(subs.get('xref'), 'inet:fqdn=woot.com')
+            self.eq(subs.get('xref:strval'), 'woot.com')
+            self.eq(subs.get('xref:intval'), None)
 
-        valu, subs = tlib.getTypeNorm('foo:bar', ('98db59098e385f0bfdec8a6a0a6118b3', 'inet:fqdn', 'woot.com'))
-        self.eq(subs.get('org'), '98db59098e385f0bfdec8a6a0a6118b3')
-        self.eq(subs.get('xtype'), 'inet:fqdn')
-        self.eq(subs.get('xref:inet:fqdn'), 'woot.com')
+            valu, subs = core.getTypeNorm('foo:bar', '98db59098e385f0bfdec8a6a0a6118b3|inet:fqdn|wOOT.com')
+            self.eq(subs.get('org'), '98db59098e385f0bfdec8a6a0a6118b3')
+            self.eq(subs.get('xtype'), 'inet:fqdn')
+            self.eq(subs.get('xref'), 'inet:fqdn=woot.com')
+            self.eq(subs.get('xref:strval'), 'woot.com')
+            self.eq(subs.get('xref:intval'), None)
 
-        valu, subs = tlib.getTypeNorm('foo:bar', '98db59098e385f0bfdec8a6a0a6118b3|inet:fqdn|wOOT.com')
-        self.eq(subs.get('org'), '98db59098e385f0bfdec8a6a0a6118b3')
-        self.eq(subs.get('xtype'), 'inet:fqdn')
-        self.eq(subs.get('xref:inet:fqdn'), 'woot.com')
+            valu, subs = core.getTypeNorm('foo:bar', '98db59098e385f0bfdec8a6a0a6118b3|inet:ipv4|1.2.3.4')
+            self.eq(subs.get('org'), '98db59098e385f0bfdec8a6a0a6118b3')
+            self.eq(subs.get('xtype'), 'inet:ipv4')
+            self.eq(subs.get('xref'), 'inet:ipv4=1.2.3.4')
+            self.eq(subs.get('xref:strval'), None)
+            self.eq(subs.get('xref:intval'), 0x01020304)
+
+            self.raises(NoSuchType, core.getTypeNorm, 'foo:bar', '98db59098e385f0bfdec8a6a0a6118b3|inet:fqdn:zone|0')
 
     def test_types_isguid(self):
         self.true(s_types.isguid('98db59098e385f0bfdec8a6a0a6118b3'))
         self.false(s_types.isguid('visi'))
 
     def test_types_guid_resolver(self):
-
         with s_cortex.openurl('ram:///') as core:
-
             core.setConfOpt('enforce', 1)
 
             # use the seed constructor for an org
@@ -508,7 +524,6 @@ class DataTypesTest(SynTest):
             self.eq(len(core.eval('ou:user:org=$vertex')), 1)
 
     def test_types_tagtime(self):
-
         with s_cortex.openurl('ram:///') as core:
             valu, subs = core.getTypeNorm('syn:tag', 'Foo.Bar@20161217-20171217')
 
@@ -517,7 +532,6 @@ class DataTypesTest(SynTest):
             self.eq(subs['seen:max'], 1513468800000)
 
     def test_types_comp_optfields(self):
-
         tlib = s_types.TypeLib()
 
         tlib.addType('foo:bar', subof='comp', fields='foo=str,bar=int', optfields='baz=str,faz=int')
@@ -555,7 +569,6 @@ class DataTypesTest(SynTest):
         self.eq(subs, tuple(sorted(s3.items())))
 
     def test_types_comp_opt_only(self):
-
         tlib = s_types.TypeLib()
 
         tlib.addType('foo:bar', subof='comp', optfields='baz=str,faz=int')
@@ -588,3 +601,138 @@ class DataTypesTest(SynTest):
         self.raises(BadTypeValu, tlib.getTypeNorm, 'syn:perm', 'foo bar=(bar,baz)')
         tlib.getTypeNorm('syn:perm', 'foo:bar baz=faz')
         tlib.getTypeNorm('syn:perm', 'foo:bar   baz=faz     hehe=haha')
+
+    def test_types_propvalu(self):
+        with s_cortex.openurl('ram:///') as core:  # type: s_cores_common.Cortex
+            core.setConfOpt('enforce', 1)
+
+            tstmodl = {
+                'types': [
+                    [
+                        'foob',
+                        {
+                            'subof': 'str'
+                        }
+                    ],
+                ],
+                'forms': [
+                    [
+                        'foob',
+                        {},
+                        [
+                            [
+                                'xref',
+                                {
+                                    'ptype': 'propvalu',
+                                    'ro': 1,
+                                },
+                            ],
+                            [
+                                'xref:intval',
+                                {
+                                    'ptype': 'int',
+                                    'ro': 1,
+                                }
+                            ],
+                            [
+                                'xref:strval',
+                                {
+                                    'ptype': 'str',
+                                    'ro': 1
+                                }
+                            ],
+                            [
+                                'xref:prop',
+                                {
+                                    'ptype': 'str',
+                                    'ro': 1
+                                }
+                            ]
+                        ]
+                    ],
+                    [
+                        'pvform',
+                        {'ptype': 'propvalu'},
+                        [
+                            [
+                                'intval',
+                                {
+                                    'ptype': 'int',
+                                    'ro': 1,
+                                }
+                            ],
+                            [
+                                'strval',
+                                {
+                                    'ptype': 'str',
+                                    'ro': 1
+                                }
+                            ],
+                            [
+                                'prop',
+                                {
+                                    'ptype': 'str',
+                                    'ro': 1
+                                }
+                            ]
+                        ]
+                    ]
+                ]
+            }
+            core.addDataModel('pvtest', tstmodl)
+
+            # Test a list of property/valu
+            valu, subs = core.getPropNorm('foob:xref', ['inet:ipv4', '1.2.3.4'])
+            self.eq(valu, 'inet:ipv4=1.2.3.4')
+            self.eq(subs.get('prop'), 'inet:ipv4')
+            self.eq(subs.get('intval'), 0x01020304)
+            self.notin('strval', subs)
+
+            pvstrs = ['inet:ipv4=1.2.3.4',
+                      'inet:ipv4=16909060',
+                      'inet:ipv4=0x01020304'
+                      ]
+
+            for pvstr in pvstrs:
+                valu, subs = core.getPropNorm('foob:xref', pvstr)
+                self.eq(valu, 'inet:ipv4=1.2.3.4')
+                self.eq(subs.get('intval'), 0x01020304)
+                self.eq(subs.get('prop'), 'inet:ipv4')
+                self.notin('strval', subs)
+
+            # Make some nodes, do a pivot
+            node = core.formTufoByProp('inet:ipv4', 0x01020304)
+            self.nn(node)
+            node = core.formTufoByProp('foob', 'blah', xref=['inet:ipv4', '1.2.3.4'])
+            self.nn(node)
+            self.eq(node[1].get('foob:xref'), 'inet:ipv4=1.2.3.4')
+            self.eq(node[1].get('foob:xref:intval'), 0x01020304)
+            self.eq(node[1].get('foob:xref:prop'), 'inet:ipv4')
+
+            nodes = core.eval('foob :xref:intval->inet:ipv4')
+            self.eq(len(nodes), 1)
+            self.eq(nodes[0][1].get('inet:ipv4'), 0x01020304)
+
+            # Actually make some pvform nodes
+            t0 = core.formTufoByProp('pvform', 'inet:ipv4=1.2.3.4')
+            self.nn(t0)
+            t1 = core.formTufoByProp('pvform', 'pvform=inet:ipv4=1.2.3.4')
+            self.nn(t1)
+            t2 = core.formTufoByProp('pvform', ['pvform', 'inet:ipv4=1.2.3.4'])
+            self.nn(t2)
+            # We can also eat tuples - in this case our normed value is a str and not a int
+            t3 = core.formTufoByProp('pvform', ('inet:asn:name', 'Acme Corporation'))
+            self.eq(t3[1].get('pvform:strval'), 'acme corporation')
+            self.eq(t3[1].get('pvform:prop'), 'inet:asn:name')
+            self.notin('pvform:intval', t3[1])
+
+            # Test a comp type node made a as Provalu
+            t4 = core.formTufoByProp('pvform', 'inet:netpost=(vertex.link/pennywise,"Do you want your boat?")')
+            self.eq(t4[1].get('pvform:prop'), 'inet:netpost')
+
+            # Bad values
+            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', 1234)
+            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', '  ')
+            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', 'inet:ipv4= 1.2.3.4')
+            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', '(inet:ipv4,1.2.3.4)')
+            self.raises(BadTypeValu, core.getPropNorm, 'foob:xref', ['inet:ipv4', '1.2.3.4', 'opps'])


### PR DESCRIPTION
 Update XREFs to be better Synapse citizens. No more left-hand data!

Add refs() support for propvalu, supports using xrefs data types right away!

Add generic xref form migration function.  This will migrate all loaded xref form types when the syn migration is run.