### PR TITLE
Fix runt nodes which have missing syn:prop fields

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -228,13 +228,13 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
 
         s_ingest.IngestApi.__init__(self, self)
 
-    def addRuntNode(self, rform, valu, props=None):
+    def addRuntNode(self, form, valu, props=None):
         '''
         Add a "runtime" node which does not persist.
         This is used for ephemeral node "look aside" registration.
 
         Args:
-            rform (str): The primary property for the node
+            form (str): The primary property for the node
             valu (obj): The primary value for the node
             props (dict): The node secondary properties ( if modeled, they will be indexed )
 
@@ -245,20 +245,20 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         if props is None:
             props = {}
 
-        self.runt_forms.add(rform)
+        self.runt_forms.add(form)
 
         node = (None, {})
-        norm, subs = self.getPropNorm(rform, valu)
+        norm, subs = self.getPropNorm(form, valu)
 
-        node[1][rform] = norm
-        node[1]['tufo:form'] = rform
+        node[1][form] = norm
+        node[1]['tufo:form'] = form
 
-        self.runt_props[(rform, None)].append(node)
-        self.runt_props[(rform, norm)].append(node)
+        self.runt_props[(form, None)].append(node)
+        self.runt_props[(form, norm)].append(node)
 
         for prop, pval in props.items():
 
-            full = rform + ':' + prop
+            full = form + ':' + prop
             norm, subs = self.getPropNorm(full, pval)
 
             node[1][full] = norm

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -457,12 +457,12 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
 
             for tnam, tnfo in modl.get('types', ()):
                 tdef = self.getTypeDef(tnam)
-                self.addRuntNode('syn:type', tnam, tdef[1])
+                self.addRuntNode('syn:type', tnam, props=tdef[1])
 
             for fnam, fnfo, props in modl.get('forms', ()):
                 pdef = self.getPropDef(fnam)
-                self.addRuntNode('syn:form', fnam, pdef[1])
-                self.addRuntNode('syn:prop', fnam, pdef[1])
+                self.addRuntNode('syn:form', fnam, props=pdef[1])
+                self.addRuntNode('syn:prop', fnam, props=pdef[1])
 
                 for pnam, pnfo in props:
                     full = fnam + ':' + pnam

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -134,6 +134,7 @@ class DataModel(s_types.TypeLib):
         self.addTufoProp('syn:prop', 'form', ptype='syn:prop', req=1, doc='Synapse form which contains this property')
         self.addTufoProp('syn:prop', 'ptype', ptype='syn:type', req=1, doc='Synapse type for this field')
         self.addTufoProp('syn:prop', 'req', ptype='bool', defval=0, doc='Set to 1 if this property is required to form the node.')
+        self.addTufoProp('syn:prop', 'relname', ptype='str', doc='Relative name of the property.')
         self.addTufoProp('syn:prop', 'base', ptype='str', doc='Base name of the property.')
         self.addTufoProp('syn:prop', 'glob', ptype='bool', defval=0, doc='Set to 1 if this property defines a glob')
         self.addTufoProp('syn:prop', 'defval', doc='Set to the default value for this property')
@@ -296,17 +297,20 @@ class DataModel(s_types.TypeLib):
         if self.props.get(prop) is not None:
             raise s_common.DupPropName(name=prop)
 
-        info.setdefault('doc', None)
-        info.setdefault('req', False)
         info.setdefault('ptype', None)
-        info.setdefault('title', None)
+        info.setdefault('doc', self.getTypeInfo(info.get('ptype'), 'doc', ''))
+        info.setdefault('req', False)
+        info.setdefault('title', self.getTypeInfo(info.get('ptype'), 'title', ''))
         info.setdefault('defval', None)
 
         form = info.get('form')
-        base = prop[len(form) + 1:]
+        relname = prop[len(form) + 1:]
+        if relname:
+            info['relname'] = relname
 
-        if base:
-            info['base'] = base
+        if ':' in prop:
+            _, base = prop.rsplit(':', 1)
+            info.setdefault('base', base)
 
         defval = info.get('defval')
 
@@ -325,7 +329,7 @@ class DataModel(s_types.TypeLib):
             self.propsbytype[ptype].append(pdef)
 
         self.props[prop] = pdef
-        self.props[(form, base)] = pdef
+        self.props[(form, relname)] = pdef
 
         self.model['props'][prop] = pdef
 

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -115,7 +115,7 @@ class DataModel(s_types.TypeLib):
             'forms': [],
         }
 
-        s_types.TypeLib.__init__(self, load=load)
+        s_types.TypeLib.__init__(self, load=False)
 
         self.addTufoForm('syn:core', ptype='str')
 
@@ -130,9 +130,11 @@ class DataModel(s_types.TypeLib):
         self.addTufoForm('syn:prop', ptype='syn:prop')
         # TODO - Re-enable syn:prop:doc req = 1 after cleaning up property docstrings.
         self.addTufoProp('syn:prop', 'doc', ptype='str', req=0, doc='Description of the property definition')
+        self.addTufoProp('syn:prop', 'title', ptype='str', req=0, doc='A short description of the property definition')
         self.addTufoProp('syn:prop', 'form', ptype='syn:prop', req=1, doc='Synapse form which contains this property')
         self.addTufoProp('syn:prop', 'ptype', ptype='syn:type', req=1, doc='Synapse type for this field')
         self.addTufoProp('syn:prop', 'req', ptype='bool', defval=0, doc='Set to 1 if this property is required to form the node.')
+        self.addTufoProp('syn:prop', 'base', ptype='str', doc='Base name of the property.')
         self.addTufoProp('syn:prop', 'glob', ptype='bool', defval=0, doc='Set to 1 if this property defines a glob')
         self.addTufoProp('syn:prop', 'defval', doc='Set to the default value for this property')
 
@@ -169,6 +171,9 @@ class DataModel(s_types.TypeLib):
         self.addTufoProp('syn:seq', 'width', ptype='int', defval=0,
                          doc='How many digits to use to represent the number')
         self.addTufoProp('syn:seq', 'nextvalu', ptype='int', defval=0, doc='The next sequential value')
+
+        if load:
+            self.loadModModels()
 
     def getModelDict(self):
         '''
@@ -293,7 +298,6 @@ class DataModel(s_types.TypeLib):
 
         info.setdefault('doc', None)
         info.setdefault('req', False)
-        info.setdefault('uniq', False)
         info.setdefault('ptype', None)
         info.setdefault('title', None)
         info.setdefault('defval', None)
@@ -301,7 +305,8 @@ class DataModel(s_types.TypeLib):
         form = info.get('form')
         base = prop[len(form) + 1:]
 
-        info['base'] = base
+        if base:
+            info['base'] = base
 
         defval = info.get('defval')
 

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -115,66 +115,7 @@ class DataModel(s_types.TypeLib):
             'forms': [],
         }
 
-        s_types.TypeLib.__init__(self, load=False)
-
-        self.addTufoForm('syn:core', ptype='str')
-
-        self.addTufoForm('syn:form', ptype='syn:prop')
-        self.addTufoProp('syn:form', 'doc', ptype='str', doc='basic form definition')
-        self.addTufoProp('syn:form', 'ver', ptype='int', doc='form version within the model')
-        self.addTufoProp('syn:form', 'model', ptype='str', doc='which model defines a given form')
-        self.addTufoProp('syn:form', 'ptype', ptype='syn:type', req=1, doc='Synapse type for this form')
-        self.addTufoProp('syn:form', 'local', ptype='bool', defval=0,
-                         doc='Flag used to determine if a form should not be included in splices.')
-
-        self.addTufoForm('syn:prop', ptype='syn:prop')
-        # TODO - Re-enable syn:prop:doc req = 1 after cleaning up property docstrings.
-        self.addTufoProp('syn:prop', 'doc', ptype='str', req=0, doc='Description of the property definition')
-        self.addTufoProp('syn:prop', 'title', ptype='str', req=0, doc='A short description of the property definition')
-        self.addTufoProp('syn:prop', 'form', ptype='syn:prop', req=1, doc='Synapse form which contains this property')
-        self.addTufoProp('syn:prop', 'ptype', ptype='syn:type', req=1, doc='Synapse type for this field')
-        self.addTufoProp('syn:prop', 'req', ptype='bool', defval=0, doc='Set to 1 if this property is required to form the node.')
-        self.addTufoProp('syn:prop', 'relname', ptype='str', doc='Relative name of the property.')
-        self.addTufoProp('syn:prop', 'base', ptype='str', doc='Base name of the property.')
-        self.addTufoProp('syn:prop', 'glob', ptype='bool', defval=0, doc='Set to 1 if this property defines a glob')
-        self.addTufoProp('syn:prop', 'defval', doc='Set to the default value for this property')
-
-        self.addTufoForm('syn:tag', ptype='syn:tag')
-        self.addTufoProp('syn:tag', 'up', ptype='syn:tag')
-        self.addTufoProp('syn:tag', 'doc', defval='', ptype='str')
-        self.addTufoProp('syn:tag', 'depth', defval=0, ptype='int')
-        self.addTufoProp('syn:tag', 'title', defval='', ptype='str')
-        self.addTufoProp('syn:tag', 'base', ptype='str', ro=1)
-
-        self.addType('syn:tagform', subof='comp', fields='tag,syn:tag|form,syn:prop', ex="(foo.bar,baz:faz)")
-
-        self.addTufoForm('syn:tagform', ptype='syn:tagform', fields='tag,syn:tag|form,syn:prop')
-        self.addTufoProp('syn:tagform', 'tag', ptype='syn:tag', ro=1, doc='The tag being documented')
-        self.addTufoProp('syn:tagform', 'form', ptype='syn:prop', ro=1, doc='The the form that the tag applies to.')
-
-        self.addTufoProp('syn:tagform', 'doc', ptype='str:txt', defval='??',
-                         doc='The long form description for what the tag means on the given node form')
-        self.addTufoProp('syn:tagform', 'title', ptype='str:txt', defval='??',
-                         doc='The short name for what the tag means on the given node form')
-
-        self.addTufoForm('syn:model', ptype='str', doc='prefix for all forms within the model')
-        self.addTufoProp('syn:model', 'hash', ptype='guid', doc='version hash for the current model')
-        self.addTufoProp('syn:model', 'prefix', ptype='syn:prop', doc='prefix used by types/forms in the model')
-
-        self.addTufoForm('syn:type', ptype='syn:type')
-        self.addTufoProp('syn:type', 'ctor', ptype='str')
-        self.addTufoProp('syn:type', 'subof', ptype='syn:type')
-
-        self.addTufoProp('syn:type', '*', glob=1)
-
-        # used most commonly for sequential tag generation
-        self.addTufoForm('syn:seq', ptype='str:lwr', doc='A sequential id generation tracker')
-        self.addTufoProp('syn:seq', 'width', ptype='int', defval=0,
-                         doc='How many digits to use to represent the number')
-        self.addTufoProp('syn:seq', 'nextvalu', ptype='int', defval=0, doc='The next sequential value')
-
-        if load:
-            self.loadModModels()
+        s_types.TypeLib.__init__(self, load=load)
 
     def getModelDict(self):
         '''

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -893,6 +893,12 @@ class TypeLib:
         '''
         return list(self.typeinfo.items())
 
+    def getTypeDef(self, name):
+        info = self.typeinfo.get(name)
+        if info is None:
+            return None
+        return (name, info)
+
     def getTypeInfo(self, name, prop, defval=None):
         '''
         A helper to return an info prop for the type or it's parents.

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -894,6 +894,22 @@ class TypeLib:
         return list(self.typeinfo.items())
 
     def getTypeDef(self, name):
+        '''
+        Get the definition for a given type.
+
+        Args:
+            name (str): Name of the type to look up.
+
+        Examples:
+            Do stuff with the type definition of 'int'::
+
+                tdef = tlib.getTypeDef('int')
+                dostuff(tdef)
+
+        Returns:
+            ((str, dict)): The type definition tufo. The str is the name of the type, and the dictionary are any type
+             options (ctor and subof values). If the name is not a registered type, this is None.
+        '''
         info = self.typeinfo.get(name)
         if info is None:
             return None

--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -1,7 +1,6 @@
 from synapse.lib.module import CoreModule, modelrev
 
 class SynMod(CoreModule):
-
     @staticmethod
     def getBaseModels():
         modl = {
@@ -11,6 +10,7 @@ class SynMod(CoreModule):
                 ('syn:auth:user', {'subof': 'str'}),
                 ('syn:auth:role', {'subof': 'str'}),
                 ('syn:auth:userrole', {'subof': 'comp', 'fields': 'user=syn:auth:user,role=syn:auth:role'}),
+                ('syn:tagform', {'subof': 'comp', 'fields': 'tag,syn:tag|form,syn:prop', 'ex': '(foo.bar,baz:faz)'}),
             ),
 
             'forms': (
@@ -27,8 +27,10 @@ class SynMod(CoreModule):
                 )),
 
                 ('syn:auth:user', {'local': 1}, (
-                    ('storm:limit:lift', {'ptype': 'int', 'defval': 10000, 'doc': 'The storm query lift limit for the user'}),
-                    ('storm:limit:time', {'ptype': 'int', 'defval': 120, 'doc': 'The storm query time limit for the user'}),
+                    ('storm:limit:lift',
+                     {'ptype': 'int', 'defval': 10000, 'doc': 'The storm query lift limit for the user'}),
+                    ('storm:limit:time',
+                     {'ptype': 'int', 'defval': 120, 'doc': 'The storm query time limit for the user'}),
                 )),
 
                 ('syn:auth:role', {'local': 1}, (
@@ -47,15 +49,63 @@ class SynMod(CoreModule):
                     ('user', {'ptype': 'syn:auth:user'}),
                 )),
 
-            ),
+                ('syn:core', {'doc': 'A node representing a unique Cortex'}, ()),
+                ('syn:form', {'doc': 'The base form type.'}, (
+                    ('doc', {'ptype': 'str', 'doc': 'basic form definition'}),
+                    ('ver', {'ptype': 'int', 'doc': 'form version within the model'}),
+                    ('model', {'ptype': 'str', 'doc': 'which model defines a given form'}),
+                    ('ptype', {'ptype': 'syn:type', 'doc': 'Synapse type for this form'}),
+                    ('local', {'ptype': 'bool', 'defval': 0,
+                               'doc': 'Flag used to determine if a form should not be included in splices'}),
+                )),
+                ('syn:prop', {'doc': 'The base property type.'}, (
+                    ('doc', {'ptype': 'str', 'doc': 'Description of the property definition.'}),
+                    ('title', {'ptype': 'str', 'doc': 'A short description of the property definition.'}),
+                    ('form', {'ptype': 'syn:prop', 'doc': 'The form of the property.'}),
+                    ('ptype', {'ptype': 'syn:type', 'doc': 'Synapse type for this field'}),
+                    ('req', {'ptype': 'bool', 'doc': 'Set to 1 if this property is required to form teh node.'}),
+                    ('relname', {'ptype': 'str', 'doc': 'Relative name of the property'}),
+                    ('base', {'ptype': 'str', 'doc': 'Base name of the property'}),
+                    ('glob', {'ptype': 'bool', 'defval': 0, 'doc': 'Set to 1 if this property defines a glob'}),
+                    ('defval', {'doc': 'Set to the default value for this property', 'glob': 1}),
+                )),
+                ('syn:type', {'doc': 'The base type type.'}, (
+                    ('ctor', {'ptype': 'str', 'doc': 'Python path to the class used to instantiate the type.'}),
+                    ('subof', {'ptype': 'syn:type', 'doc': 'Type which this inherits from.'}),
+                    ('*', {'glob': 1})
+                )),
+                ('syn:tag', {'doc': 'The base form for a synapse tag.'}, (
+                    ('up', {'ptype': 'syn:tag', 'doc': ''}),
+                    ('doc', {'ptype': 'str', 'defval': '', }),
+                    ('depth', {'ptype': 'int', 'doc': 'How deep the tag is in the hierarchy', 'defval': 0}),
+                    ('title', {'ptype': 'str', 'doc': '', 'defval': ''}),
+                    ('base', {'ptype': 'str', 'doc': '', 'ro': 1}),
+
+                )),
+                ('syn:tagform', {'doc': 'A node describing the meaning of a tag on a specific form'}, (
+                    ('tag', {'ptype': 'syn:tag', 'doc': 'The tag being documented', 'ro': 1}),
+                    ('form', {'ptype': 'syn:prop', 'doc': 'The form that the tag applies too', 'ro': 1}),
+                    ('doc', {'ptype': 'str:txt', 'defval': '??',
+                             'doc': 'The long form description for what the tag means on the given node form'}),
+                    ('title', {'ptype': 'str:txt', 'defval': '??',
+                               'doc': 'The short name for what the tag means the given node form'}),
+                )),
+                ('syn:model', {'ptype': 'str', 'doc': 'prefix for all forms with in the model'}, (
+                    ('hash', {'ptype': 'guid', 'doc': 'version hash for the current model'}),
+                    ('prefix', {'ptype': 'syn:prop', 'doc': 'Prefix used by teh types/forms in the model'}),
+                )),
+                ('syn:seq', {'ptype': 'str:lwr', 'doc': 'A sequential id generation tracker'}, (
+                    ('width', {'ptype': 'int', 'defval': 0, 'doc': 'How many digits to use to represent the number'}),
+                    ('nextvalu', {'ptype': 'int', 'defval': 0, 'doc': 'The next sequential value'}),
+                ))
+            )
         }
 
         name = 'syn'
-        return ((name, modl), )
+        return ((name, modl),)
 
     @modelrev('syn', 201709051630)
     def _delOldModelNodes(self):
-
         types = self.core.getRowsByProp('syn:type')
         forms = self.core.getRowsByProp('syn:form')
         props = self.core.getRowsByProp('syn:prop')

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -219,7 +219,7 @@ class SynTest(unittest.TestCase):
             ),
             'forms': (
                 (
-                    'strform', {'ptype': 'str'},
+                    'strform', {'ptype': 'str', 'doc': 'A test str form'},
                     (
                         ('foo', {'ptype': 'str'}),
                         ('bar', {'ptype': 'str'}),
@@ -227,7 +227,7 @@ class SynTest(unittest.TestCase):
                     )
                 ),
                 (
-                    'intform', {'ptype': 'int'},
+                    'intform', {'ptype': 'int'},  # purposely missing doc
                     (
                         ('foo', {'ptype': 'str'}),
                         ('baz', {'ptype': 'int'}),

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -907,9 +907,10 @@ class CortexTest(SynTest):
             nodes = core.getTufosByProp('syn:form')
             for node in nodes:
                 self.isin('syn:form:ptype', node[1])
-                self.isin('syn:form:local', node[1])
                 if 'syn:form:doc' in node[1]:
                     self.isinstance(node[1].get('syn:form:doc'), str)
+                if 'syn:form:local' in node[1]:
+                    self.isinstance(node[1].get('syn:form:local'), int)
 
             nodes = core.getTufosByProp('syn:prop')
             for node in nodes:
@@ -930,7 +931,7 @@ class CortexTest(SynTest):
 
             # Some nodes are local, some are not
             node = core.getTufoByProp('syn:form', 'inet:ipv4')
-            self.eq(node[1].get('syn:form:local'), 0)
+            self.eq(node[1].get('syn:form:local'), None)
             node = core.getTufoByProp('syn:form', 'syn:splice')
             self.eq(node[1].get('syn:form:local'), 1)
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -927,6 +927,8 @@ class CortexTest(SynTest):
                     self.isinstance(node[1].get('syn:prop:title'), s_compat.strtypes)
                 if 'syn:prop:defval' in node[1]:
                     dv = node[1].get('syn:prop:defval')
+                    if dv is None:
+                        continue
                     self.true(s_common.canstor(dv))
 
             # Some nodes are local, some are not
@@ -935,11 +937,21 @@ class CortexTest(SynTest):
             node = core.getTufoByProp('syn:form', 'syn:splice')
             self.eq(node[1].get('syn:form:local'), 1)
 
-            # Some things have docs, others do not
+            # Check a few specific nodes
+            node = core.getTufoByProp('syn:prop', 'inet:ipv4')
+            self.isin('syn:prop:doc', node[1])
+            self.isin('syn:prop:base', node[1])
+            self.notin('syn:prop:relname', node[1])
+            node = core.getTufoByProp('syn:prop', 'inet:ipv4:type')
+            self.isin('syn:prop:doc', node[1])
+            self.isin('syn:prop:base', node[1])
+            self.isin('syn:prop:relname', node[1])
+
+            # Ensure things bubbled up during node / datamodel creation
             self.eq(core.getPropInfo('strform', 'doc'), 'A test str form')
             self.eq(core.getPropInfo('intform', 'doc'), 'The base integer type')
             self.eq(core.getTufoByProp('syn:prop', 'strform')[1].get('syn:prop:doc'), 'A test str form')
-            self.eq(core.getTufoByProp('syn:prop', 'intform')[1].get('syn:prop:doc'), None)
+            self.eq(core.getTufoByProp('syn:prop', 'intform')[1].get('syn:prop:doc'), 'The base integer type')
 
     def test_pg_encoding(self):
         with self.getPgCore() as core:
@@ -2491,7 +2503,7 @@ class CortexTest(SynTest):
                 )),
             )})
 
-            core.addRuntNode('hehe:haha', 'woot', hoho=20, lulz='rofl')
+            core.addRuntNode('hehe:haha', 'woot', props={'hoho': 20, 'lulz': 'rofl'})
 
             # test that nothing hit the storage layer...
             self.eq(len(core.getRowsByProp('hehe:haha')), 0)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2522,6 +2522,9 @@ class CortexTest(SynTest):
             self.nn(core.getTufoByProp('hehe:haha:hoho', 20))
             self.none(core.getTufoByProp('hehe:haha:lulz', 'rofl'))
 
+            node = core.addRuntNode('hehe:haha', 'ohmy')
+            self.eq(node[1].get('hehe:haha:hoho'), None)
+
     def test_cortex_trigger(self):
 
         with s_cortex.openurl('ram:///') as core:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -901,6 +901,45 @@ class CortexBaseTest(SynTest):
 
 class CortexTest(SynTest):
 
+    def test_cortex_datamodel_runt_consistency(self):
+        with self.getRamCore() as core:
+
+            nodes = core.getTufosByProp('syn:form')
+            for node in nodes:
+                self.isin('syn:form:ptype', node[1])
+                self.isin('syn:form:local', node[1])
+                if 'syn:form:doc' in node[1]:
+                    self.isinstance(node[1].get('syn:form:doc'), str)
+
+            nodes = core.getTufosByProp('syn:prop')
+            for node in nodes:
+                self.isin('syn:prop:form', node[1])
+                if 'syn:prop:glob' in node[1]:
+                    continue
+                self.isin('syn:prop:req', node[1])
+                self.isin('syn:prop:ptype', node[1])
+                if 'syn:prop:doc' in node[1]:
+                    self.isinstance(node[1].get('syn:prop:doc'), str)
+                if 'syn:prop:base' in node[1]:
+                    self.isinstance(node[1].get('syn:prop:base'), str)
+                if 'syn:prop:title' in node[1]:
+                    self.isinstance(node[1].get('syn:prop:title'), str)
+                if 'syn:prop:defval' in node[1]:
+                    dv = node[1].get('syn:prop:defval')
+                    self.true(s_common.canstor(dv))
+
+            # Some nodes are local, some are not
+            node = core.getTufoByProp('syn:form', 'inet:ipv4')
+            self.eq(node[1].get('syn:form:local'), 0)
+            node = core.getTufoByProp('syn:form', 'syn:splice')
+            self.eq(node[1].get('syn:form:local'), 1)
+
+            # Some things have docs, others do not
+            self.eq(core.getPropInfo('strform', 'doc'), 'A test str form')
+            self.eq(core.getPropInfo('intform', 'doc'), 'The base integer type')
+            self.eq(core.getTufoByProp('syn:prop', 'strform')[1].get('syn:prop:doc'), 'A test str form')
+            self.eq(core.getTufoByProp('syn:prop', 'intform')[1].get('syn:prop:doc'), None)
+
     def test_pg_encoding(self):
         with self.getPgCore() as core:
             res = core.store.select('SHOW SERVER_ENCODING')[0][0]

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -908,7 +908,7 @@ class CortexTest(SynTest):
             for node in nodes:
                 self.isin('syn:form:ptype', node[1])
                 if 'syn:form:doc' in node[1]:
-                    self.isinstance(node[1].get('syn:form:doc'), str)
+                    self.isinstance(node[1].get('syn:form:doc'), s_compat.strtypes)
                 if 'syn:form:local' in node[1]:
                     self.isinstance(node[1].get('syn:form:local'), int)
 
@@ -920,11 +920,11 @@ class CortexTest(SynTest):
                 self.isin('syn:prop:req', node[1])
                 self.isin('syn:prop:ptype', node[1])
                 if 'syn:prop:doc' in node[1]:
-                    self.isinstance(node[1].get('syn:prop:doc'), str)
+                    self.isinstance(node[1].get('syn:prop:doc'), s_compat.strtypes)
                 if 'syn:prop:base' in node[1]:
-                    self.isinstance(node[1].get('syn:prop:base'), str)
+                    self.isinstance(node[1].get('syn:prop:base'), s_compat.strtypes)
                 if 'syn:prop:title' in node[1]:
-                    self.isinstance(node[1].get('syn:prop:title'), str)
+                    self.isinstance(node[1].get('syn:prop:title'), s_compat.strtypes)
                 if 'syn:prop:defval' in node[1]:
                     dv = node[1].get('syn:prop:defval')
                     self.true(s_common.canstor(dv))

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -237,6 +237,21 @@ class DataModelTest(SynTest):
         self.eq(model.getTypeNorm('syn:tag', 'foo.BAR')[0], 'foo.bar')
         self.eq(model.getTypeParse('syn:tag', 'foo.BAR')[0], 'foo.bar')
 
+    def test_datamodel_forms(self):
+        model = s_datamodel.DataModel(load=False)
+        forms = model.getTufoForms()
+        self.isinstance(forms, list)
+        self.isin('syn:core', forms)
+        self.isin('syn:type', forms)
+        self.isin('syn:form', forms)
+        self.isin('syn:prop', forms)
+        self.notin('inet:ipv4', forms)
+
+        model = s_datamodel.DataModel()
+        forms = model.getTufoForms()
+        self.isin('syn:prop', forms)
+        self.isin('inet:ipv4', forms)
+
     def test_datamodel_getPropInfo(self):
         model = s_datamodel.DataModel()
 
@@ -245,8 +260,17 @@ class DataModelTest(SynTest):
 
         model.addTufoForm('foo')
         model.addTufoProp('foo', 'meow', ptype='foo:baz')
+        model.addTufoProp('foo', 'bark', doc='lala')
 
+        self.eq(model.getPropInfo('foo:meow', 'req'), False)
+        self.eq(model.getPropInfo('foo:meow', 'base'), 'meow')
+        self.eq(model.getPropInfo('foo:meow', 'defval'), None)
+        self.eq(model.getPropInfo('foo:meow', 'title'), None)
         self.eq(model.getPropInfo('foo:meow', 'doc'), 'foo bar doc')
+
+        self.eq(model.getPropInfo('foo:bark', 'doc'), 'lala')
+        self.eq(model.getPropInfo('foo:bark', 'title'), None)
+
         self.eq(model.getPropInfo('foo:nonexistent', 'doc'), None)
 
     def test_datamodel_getPropDef(self):
@@ -255,7 +279,7 @@ class DataModelTest(SynTest):
         model.addTufoForm('foo')
         model.addTufoProp('foo', 'meow', ptype='int')
 
-        self.eq(model.getPropDef('foo:meow'), ('foo:meow', {'doc': None, 'title': None, 'defval': None, 'form': 'foo', 'base': 'meow', 'uniq': False, 'ptype': 'int', 'req': False}))
+        self.eq(model.getPropDef('foo:meow'), ('foo:meow', {'doc': None, 'title': None, 'defval': None, 'form': 'foo', 'base': 'meow', 'ptype': 'int', 'req': False}))
         self.eq(model.getPropDef('foo:meow:nonexistent'), None)
         self.eq(model.getPropDef('foo:meow:nonexistent', glob=False), None)
 

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -241,10 +241,7 @@ class DataModelTest(SynTest):
         model = s_datamodel.DataModel(load=False)
         forms = model.getTufoForms()
         self.isinstance(forms, list)
-        self.isin('syn:core', forms)
-        self.isin('syn:type', forms)
-        self.isin('syn:form', forms)
-        self.isin('syn:prop', forms)
+        self.notin('syn:prop', forms)
         self.notin('inet:ipv4', forms)
 
         model = s_datamodel.DataModel()

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -265,11 +265,11 @@ class DataModelTest(SynTest):
         self.eq(model.getPropInfo('foo:meow', 'req'), False)
         self.eq(model.getPropInfo('foo:meow', 'base'), 'meow')
         self.eq(model.getPropInfo('foo:meow', 'defval'), None)
-        self.eq(model.getPropInfo('foo:meow', 'title'), None)
+        self.eq(model.getPropInfo('foo:meow', 'title'), '')
         self.eq(model.getPropInfo('foo:meow', 'doc'), 'foo bar doc')
 
         self.eq(model.getPropInfo('foo:bark', 'doc'), 'lala')
-        self.eq(model.getPropInfo('foo:bark', 'title'), None)
+        self.eq(model.getPropInfo('foo:bark', 'title'), '')
 
         self.eq(model.getPropInfo('foo:nonexistent', 'doc'), None)
 
@@ -279,7 +279,18 @@ class DataModelTest(SynTest):
         model.addTufoForm('foo')
         model.addTufoProp('foo', 'meow', ptype='int')
 
-        self.eq(model.getPropDef('foo:meow'), ('foo:meow', {'doc': None, 'title': None, 'defval': None, 'form': 'foo', 'base': 'meow', 'ptype': 'int', 'req': False}))
+        self.eq(model.getPropDef('foo:meow'),
+                ('foo:meow', {'title': '',
+                              'req': False,
+                              'form': 'foo',
+                              'relname': 'meow',
+                              'base': 'meow',
+                              'defval': None,
+                              'ptype': 'int',
+                              'doc': 'The base integer type',
+                              }
+                 )
+                )
         self.eq(model.getPropDef('foo:meow:nonexistent'), None)
         self.eq(model.getPropDef('foo:meow:nonexistent', glob=False), None)
 

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -258,15 +258,28 @@ class DataModelTest(SynTest):
         model.addTufoForm('foo')
         model.addTufoProp('foo', 'meow', ptype='foo:baz')
         model.addTufoProp('foo', 'bark', doc='lala')
+        model.addTufoProp('foo', 'meow:purr', ptype='foo:baz', title='purr', doc='The sound a purr makes')
 
         self.eq(model.getPropInfo('foo:meow', 'req'), False)
         self.eq(model.getPropInfo('foo:meow', 'base'), 'meow')
+        self.eq(model.getPropInfo('foo:meow', 'relname'), 'meow')
         self.eq(model.getPropInfo('foo:meow', 'defval'), None)
         self.eq(model.getPropInfo('foo:meow', 'title'), '')
         self.eq(model.getPropInfo('foo:meow', 'doc'), 'foo bar doc')
 
         self.eq(model.getPropInfo('foo:bark', 'doc'), 'lala')
         self.eq(model.getPropInfo('foo:bark', 'title'), '')
+        self.eq(model.getPropInfo('foo:bark', 'base'), 'bark')
+        self.eq(model.getPropInfo('foo:bark', 'relname'), 'bark')
+        self.eq(model.getPropInfo('foo:meow', 'defval'), None)
+        self.eq(model.getPropInfo('foo:meow', 'req'), False)
+
+        self.eq(model.getPropInfo('foo:meow:purr', 'req'), False)
+        self.eq(model.getPropInfo('foo:meow:purr', 'base'), 'purr')
+        self.eq(model.getPropInfo('foo:meow:purr', 'relname'), 'meow:purr')
+        self.eq(model.getPropInfo('foo:meow:purr', 'defval'), None)
+        self.eq(model.getPropInfo('foo:meow:purr', 'title'), 'purr')
+        self.eq(model.getPropInfo('foo:meow:purr', 'doc'), 'The sound a purr makes')
 
         self.eq(model.getPropInfo('foo:nonexistent', 'doc'), None)
 

--- a/synapse/tests/test_tools_autodoc.py
+++ b/synapse/tests/test_tools_autodoc.py
@@ -1,4 +1,3 @@
-
 from synapse.tests.common import *
 
 import synapse.tools.autodoc as s_autodoc
@@ -13,6 +12,11 @@ class TestAutoDoc(SynTest):
             outp = self.getTestOutp()
             argv = ['--doc-model', '--savefile', save]
             self.eq(s_autodoc.main(argv, outp=outp), 0)
+
+            with open(save, 'rb') as fd:
+                rst = fd.read().decode()
+
+            self.true('inet:ipv4:asn = <inet:asn> (default: -1)' in rst)
 
     def test_tools_autodoc_configable(self):
         with self.getTestDir() as path:

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -286,7 +286,7 @@ class DataTypesTest(SynTest):
         tlib = s_types.TypeLib()
 
         tnfo = tlib.getTypeDef('int')
-        self.nn(int)
+        self.nn(tnfo)
         self.eq(tnfo[0], 'int')
         self.notin('subof', tnfo[1])
         self.eq(tnfo[1].get('ctor'), 'synapse.lib.types.IntType')

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -282,6 +282,21 @@ class DataTypesTest(SynTest):
         self.true(tlib.addType('bar', subof='int'))
         self.nn(tlib.getDataType('foo'))
 
+    def test_type_gettdef(self):
+        tlib = s_types.TypeLib()
+
+        tnfo = tlib.getTypeDef('int')
+        self.nn(int)
+        self.eq(tnfo[0], 'int')
+        self.notin('subof', tnfo[1])
+        self.eq(tnfo[1].get('ctor'), 'synapse.lib.types.IntType')
+
+        tnfo = tlib.getTypeDef('str:txt')
+        self.notin('ctor', tnfo[1])
+        self.eq(tnfo[1].get('subof'), 'str')
+
+        self.none(tlib.getTypeDef('paperboat'))
+
     def test_type_sepr(self):
         tlib = s_types.TypeLib()
         tlib.addType('siteuser', subof='sepr', sep='/', fields='foo,inet:fqdn|bar,inet:user')


### PR DESCRIPTION
this is done by takng the already normalized and complete model dictionaries from the data model and using those to build the syn:type/syn:form/syn:prop nodes.

Also defer the model load done inside of TypeLib until after we've loaded the built in syn: items.  This allows some type safety to be in place when loading models inside of a cortex, allowing property normalization for syn: forms.