### PR TITLE
Make daemon errors more useful. 

### DIFF
--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -662,7 +662,8 @@ class Daemon(EventBus, DmonConf):
             return sock.tx(s_common.tufo('job:done', jid=jid, ret=True))
 
         except Exception as e:
-            sock.tx(s_common.tufo('job:done', jid=jid, **s_common.excinfo(e)))
+            errinfo = s_common.excinfo(e)
+            sock.tx(s_common.tufo('job:done', jid=jid, err=errinfo.get('err'), errinfo=errinfo))
 
     def _onTeleOffMesg(self, sock, mesg):
         # set the socket tx method as the callback
@@ -683,7 +684,8 @@ class Daemon(EventBus, DmonConf):
             return sock.tx(s_common.tufo('job:done', jid=jid, ret=True))
 
         except Exception as e:
-            return sock.tx(s_common.tufo('job:done', jid=jid, **s_common.excinfo(e)))
+            errinfo = s_common.excinfo(e)
+            sock.tx(s_common.tufo('job:done', jid=jid, err=errinfo.get('err'), errinfo=errinfo))
 
     def _reqUserAllowed(self, user, *perms):
         if not self._isUserAllowed(user, *perms):
@@ -793,7 +795,8 @@ class Daemon(EventBus, DmonConf):
                 sock.tx(s_common.tufo('job:done', jid=jid, ret=ret))
 
             except Exception as e:
-                sock.tx(s_common.tufo('job:done', jid=jid, **s_common.excinfo(e)))
+                errinfo = s_common.excinfo(e)
+                sock.tx(s_common.tufo('job:done', jid=jid, err=errinfo.get('err'), errinfo=errinfo))
 
     def listen(self, linkurl, **opts):
         '''

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -1,11 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
-from contextlib import contextmanager
-
-import synapse.cortex as s_cortex
-import synapse.daemon as s_daemon
-import synapse.telepath as s_telepath
 
 import synapse.lib.cmdr as s_cmdr
 import synapse.cmds.cortex as s_cmds_cortex
@@ -13,29 +8,6 @@ import synapse.cmds.cortex as s_cmds_cortex
 from synapse.tests.common import *
 
 class SynCmdCoreTest(SynTest):
-
-    @contextmanager
-    def getDmonCore(self):
-
-        dmon = s_daemon.Daemon()
-        core = s_cortex.openurl('ram:///')
-        self.addTstForms(core)
-
-        link = dmon.listen('tcp://127.0.0.1:0/')
-        dmon.share('core00', core)
-        port = link[1].get('port')
-        prox = s_telepath.openurl('tcp://127.0.0.1/core00', port=port)
-
-        s_scope.set('syn:test:link', link)
-        #s_scope.set('syn:test:dmon',dmon)
-
-        s_scope.set('syn:cmd:core', prox)
-
-        yield prox
-
-        prox.fini()
-        core.fini()
-        dmon.fini()
 
     def getCoreCmdr(self, core):
         outp = s_output.OutPutStr()

--- a/synapse/tests/test_daemon.py
+++ b/synapse/tests/test_daemon.py
@@ -25,6 +25,16 @@ class Blah:
 
 class DaemonTest(SynTest):
 
+    def test_daemon_error(self):
+        with self.getDmonCore() as core:
+            try:
+                # Ask for a unserializaoble object. Don't do this in real code.
+                xact = core.getCoreXact()
+            except SynErr as e:
+                self.eq(e.errinfo.get('excname'), 'TypeError')
+                self.isin('msgpack', e.errinfo.get('errfile'))
+                self.isin("can't serialize", e.errinfo.get('errmsg'))
+
     def test_daemon_timeout(self):
 
         daemon = s_daemon.Daemon()


### PR DESCRIPTION
 This makes the errinfo expected by the caller adhere to the convention the async jobret function expects, so more verbose error information is made available.