### PR TITLE
Add a _norm_list function to guid type generation.

### DIFF
--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -267,7 +267,7 @@ class DataModel(s_types.TypeLib):
         ptype = info.get('ptype')
         if ptype is not None:
             dtyp = self.reqDataType(ptype)
-            pdtyp = dtyp.extend(name=dtyp.name, ppath=prop, **dtyp.info)
+            pdtyp = dtyp.extend(dtyp.name, prop=prop)
             self.propsbytype[ptype].append(pdef)
             self.propsdtyp[prop] = pdtyp
 

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -103,6 +103,7 @@ class DataModel(s_types.TypeLib):
         self.defvals = collections.defaultdict(list)
         self.subprops = collections.defaultdict(list)
         self.propsbytype = collections.defaultdict(list)
+        self.propsdtyp = {}
 
         self.globs = []
         self.cache = {} # for globs
@@ -265,8 +266,10 @@ class DataModel(s_types.TypeLib):
 
         ptype = info.get('ptype')
         if ptype is not None:
-            self.reqDataType(ptype)
+            dtyp = self.reqDataType(ptype)
+            pdtyp = dtyp.extend(name=dtyp.name, ppath=prop, **dtyp.info)
             self.propsbytype[ptype].append(pdef)
+            self.propsdtyp[prop] = pdtyp
 
         self.props[prop] = pdef
         self.props[(form, relname)] = pdef
@@ -473,12 +476,22 @@ class DataModel(s_types.TypeLib):
 
     def getPropType(self, prop):
         '''
-        Return the data model type instance for the given property,
-         or None if the data model doesn't have an entry for the property.
+        Return the data model type instance for the given property, or
+        None if the data model doesn't have an entry for the property.
 
-        Example:
-            ptype = model.getPropType('foo:bar')
+        Args:
+            prop (str): Property to get the DataType instance for.
+
+        Returns:
+            s_types.DataType: A DataType for a given property.
         '''
+
+        # Default to pulling dtype from the propsdtyp dict
+        dtyp = self.propsdtyp.get(prop)
+        if dtyp:
+            return dtyp
+
+        # Otherwise, fall back on getPropDef/getDataType methods.
         pdef = self.getPropDef(prop)
         if pdef is None:
             return None

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -147,6 +147,7 @@ class GuidType(DataType):
             valid_props.add(pnfo.get('relname'))
 
         vals = []
+        subs = {}
 
         for kv in valu:
             if not isinstance(kv, (list, tuple)) or not len(kv) == 2:
@@ -155,13 +156,14 @@ class GuidType(DataType):
             if k not in valid_props:
                 self._raiseBadValu(valu, k=k, mesg='Non-model property provided when making a stable guid.')
             fullprop = self.name + ':' + k
-            v, _ = self._getPropNorm(fullprop, v)
+            v, ssubs = self._getPropNorm(fullprop, v)
+            subs.update({':'.join([k, _k]): _v for _k, _v in ssubs.items()})
             vals.append((k, v))
 
         # Stable sort based on the property
         vals.sort(key=lambda x: x[0])
         valu = s_common.guid(valu=vals)
-        subs = dict(vals)
+        subs.update(vals)
         return valu, subs
 
 class StrType(DataType):

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -28,7 +28,7 @@ class DataType:
         self.tlib = tlib
         self.name = name
         self.info = info
-        self.ppath = self.info.get('ppath', '')
+        self.prop = self.info.get('prop')
         s_common.reqStorDict(info)
 
     def _raiseBadValu(self, valu, **info):
@@ -136,6 +136,10 @@ class GuidType(DataType):
         if not valu:
             self._raiseBadValu(valu=valu, mesg='No valus present in list to make a guid with')
 
+        if not self.prop:
+            self._raiseBadValu(valu,
+                               mesg='Unable to norm a list for a guidtype which is not associated with a property.')
+
         vals = []
         subs = {}
 
@@ -143,7 +147,7 @@ class GuidType(DataType):
             if not isinstance(kv, (list, tuple)) or not len(kv) == 2:
                 self._raiseBadValu(valu, kv=kv, mesg='Expected a list or tuple of length 2')
             k, v = kv
-            fullprop = self.ppath + ':' + k
+            fullprop = self.prop + ':' + k
             try:
                 v, ssubs = self._reqPropNorm(fullprop, v)
             except s_common.NoSuchProp:

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -28,6 +28,7 @@ class DataType:
         self.tlib = tlib
         self.name = name
         self.info = info
+        self.ppath = self.info.get('ppath', '')
         s_common.reqStorDict(info)
 
     def _raiseBadValu(self, valu, **info):
@@ -142,7 +143,7 @@ class GuidType(DataType):
             if not isinstance(kv, (list, tuple)) or not len(kv) == 2:
                 self._raiseBadValu(valu, kv=kv, mesg='Expected a list or tuple of length 2')
             k, v = kv
-            fullprop = self.name + ':' + k
+            fullprop = self.ppath + ':' + k
             try:
                 v, ssubs = self._reqPropNorm(fullprop, v)
             except s_common.NoSuchProp:
@@ -936,6 +937,15 @@ class TypeLib:
     def reqDataType(self, name):
         '''
         Return a reference to the named DataType or raise NoSuchType.
+
+        Args:
+            name (str): Name of the type to get a reference for.
+
+        Returns:
+            DataType: Instance of a DataType for that name.
+
+        Raises:
+            NoSuchType: If the type is not valid.
         '''
         item = self.getDataType(name)
         if item is None:

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -112,7 +112,7 @@ class GuidType(DataType):
         if text[0] != '$':
             retn = text.lower().replace('-', '')
             if not isguid(retn):
-                self._raiseBadValu(text)
+                self._raiseBadValu(text, mesg='Expected a 32 char guid string')
 
             return retn, {}
 

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -213,7 +213,7 @@ class SynTest(unittest.TestCase):
             ),
             'forms': (
                 (
-                    'strform', {'ptype': 'str', 'doc': 'A test str form'},
+                    'strform', {'ptype': 'strform', 'doc': 'A test str form'},
                     (
                         ('foo', {'ptype': 'str'}),
                         ('bar', {'ptype': 'str'}),
@@ -221,7 +221,7 @@ class SynTest(unittest.TestCase):
                     )
                 ),
                 (
-                    'intform', {'ptype': 'int'},  # purposely missing doc
+                    'intform', {'ptype': 'intform'},  # purposely missing doc
                     (
                         ('foo', {'ptype': 'str'}),
                         ('baz', {'ptype': 'int'}),
@@ -234,7 +234,7 @@ class SynTest(unittest.TestCase):
                     )
                 ),
                 (
-                    'guidform', {'ptype': 'guid'},
+                    'guidform', {'ptype': 'guidform'},
                     (
                         ('foo', {'ptype': 'str'}),
                         ('baz', {'ptype': 'int'}),

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -77,13 +77,13 @@ class DataModelTest(SynTest):
         self.eq(tufo0[0], tufo1[0])
 
         tufos = core.getTufosByProp('foo')
-        self.eq(len(tufos), 3)
+        self.len(3, tufos)
 
         tufos = core.getTufosByProp('foo:bar', valu=30, limit=20)
-        self.eq(len(tufos), 1)
+        self.len(1, tufos)
 
         tufos = core.getTufosByProp('foo:bar', valu=99, limit=20)
-        self.eq(len(tufos), 1)
+        self.len(1, tufos)
 
     def test_datamodel_subs(self):
         model = s_datamodel.DataModel()
@@ -93,7 +93,7 @@ class DataModelTest(SynTest):
 
         subs = model.getSubProps('foo')
 
-        self.eq(len(subs), 1)
+        self.len(1, subs)
         self.eq(subs[0][0], 'foo:bar')
 
         model.addTufoProp('foo', 'baz', ptype='int', defval=20)

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -377,3 +377,9 @@ class DataModelTest(SynTest):
         self.eq(base, 'baz')
 
         self.raises(NoSuchProp, modl.getPropFormBase, 'newp:newp')
+
+    def test_datamodel_reqpropnorm(self):
+        with self.getRamCore() as core:
+            v, _ = core.reqPropNorm('strform:foo', '1')
+            self.eq(v, '1')
+            self.raises(NoSuchProp, core.reqPropNorm, 'strform:beepbeep', '1')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -615,7 +615,7 @@ class StormTest(SynTest):
                 ['1.2.3.4', 'vv', '#foo.bar'],
             ])
 
-    def test_storm_guid(self):
+    def test_storm_guid_operator(self):
         with self.getRamCore() as core:
             node0 = core.formTufoByProp('inet:ipv4', '1.2.3.4')
             node1 = core.formTufoByProp('inet:ipv4', '4.5.6.7')
@@ -635,6 +635,19 @@ class StormTest(SynTest):
             nodes = core.eval('guid(%s)' % node0[0][::-1])
             self.len(1, nodes)
             self.eq(node0[0], nodes[0][0][::-1])
+
+    def test_storm_guid_stablegen(self):
+        with self.getRamCore() as core:
+            node0 = core.eval(' [ guidform = (foo="1") ] ')[0]
+            self.nn(node0)
+            self.isin('.new', node0[1])
+            self.eq(node0[1].get('guidform:foo'), '1')
+            self.none(node0[1].get('guidform:baz'))
+
+            node1 = core.eval('addnode(guidform, (foo="1"))')[0]
+            self.nn(node1)
+            self.notin('.new', node1[1])
+            self.eq(node0[0], node1[0])
 
     def test_storm_task(self):
         with self.getRamCore() as core:

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -582,6 +582,29 @@ class DataTypesTest(SynTest):
             self.eq(subs5.get('a:ipv4'), 0x01020304)
             self.eq(subs5.get('time'), 1506902400000)
 
+            # Add a custom form which is a subtype of guid itself without a separate form
+            # which has subs which also include a guid!
+            core.addTufoForm('bobboblaw', ptype='guid')
+            core.addTufoProp('bobboblaw', 'foo', ptype='str')
+            core.addTufoProp('bobboblaw', 'baz', ptype='int')
+            core.addTufoProp('bobboblaw', 'ohmai', ptype='guid')
+            core.addTufoProp('bobboblaw', 'ohmai:s', ptype='str')
+            core.addTufoProp('bobboblaw', 'ohmai:i', ptype='int')
+            v6, subs6 = core.getPropNorm('bobboblaw', '(foo="1",baz=2)')
+            self.eq(v0, v6)
+            self.eq(subs0, subs6)
+
+            # And now with nested subs!
+            v7, subs7 = core.getPropNorm('bobboblaw', '(foo="1",baz=2,ohmai=(s=foo, i=137))')
+            self.ne(v0, v7)
+            self.eq(v7, '706f471a707370fdb8fc3d0590b4dce1')
+            self.isin('foo', subs7)
+            self.isin('baz', subs7)
+            self.isin('ohmai', subs7)
+            self.isin('ohmai:s', subs7)
+            self.isin('ohmai:i', subs7)
+            self.eq(subs7.get('ohmai'), '59cbcbc1b5593d719aeae1e75d05cabf')
+
             # Bad input
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', '   ')
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', '()')

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -557,6 +557,7 @@ class DataTypesTest(SynTest):
             v0, subs0 = core.getPropNorm('guidform', '(foo="1",baz=2)')
             v1, subs1 = core.getPropNorm('guidform', (['baz', '2'], ('foo', '1')))
             v2, _ = core.getPropNorm('guidform', '  (foo="1",baz=2) ')
+            self.eq(v0, '1312b101a21bdfd0d96f896ecc5cc113')
             self.eq(v0, v1)
             self.eq(v0, v2)
             self.len(2, subs0)
@@ -566,10 +567,20 @@ class DataTypesTest(SynTest):
             # Do partial subs
             v3, subs3 = core.getPropNorm('guidform', '(foo="1")')
             v4, _ = core.getPropNorm('guidform', [['foo', '1']])
+            self.eq(v3, '9d13c5c5f307199cfd9861584bac35f2')
             self.eq(v3, v4)
-            self.ne(v3, v0)
             self.eq(subs0.get('foo'), subs3.get('foo'))
             self.none(subs3.get('baz'))
+
+            # Test a model form with nested subs from a guid type
+            v5, subs5 = core.getPropNorm('inet:dns:look', '(time="20171002",a="woot.com/1.2.3.4")')
+            self.eq(v5, '78241202d9af8b1403e9e391336922a1')
+            self.eq(subs5.get('a'), 'woot.com/1.2.3.4')
+            self.eq(subs5.get('a:fqdn'), 'woot.com')
+            self.eq(subs5.get('a:fqdn:domain'), 'com')
+            self.eq(subs5.get('a:fqdn:host'), 'woot')
+            self.eq(subs5.get('a:ipv4'), 0x01020304)
+            self.eq(subs5.get('time'), 1506902400000)
 
             # Bad input
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', '   ')

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -632,8 +632,8 @@ class DataTypesTest(SynTest):
             self.eq(unode[1].get('ou:user'), '%s/visi' % iden)
             self.eq(unode[1].get('ou:user:org'), iden)
 
-            self.eq(len(core.eval('ou:org=$vertex')), 1)
-            self.eq(len(core.eval('ou:user:org=$vertex')), 1)
+            self.len(1, core.eval('ou:org=$vertex'))
+            self.len(1, core.eval('ou:user:org=$vertex'))
 
     def test_types_tagtime(self):
         with self.getRamCore() as core:
@@ -747,7 +747,7 @@ class DataTypesTest(SynTest):
             self.eq(node[1].get('pvsub:xref:prop'), 'inet:ipv4')
 
             nodes = core.eval('pvsub :xref:intval->inet:ipv4')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
             self.eq(nodes[0][1].get('inet:ipv4'), 0x01020304)
 
             # Actually make some pvform nodes

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -589,6 +589,7 @@ class DataTypesTest(SynTest):
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', '(foo, bar)')
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', (['baz', '2'], ('foo', '1', 'blerp')))
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', '(foo="1",junkProp=2)')
+            self.raises(BadTypeValu, core.getPropNorm, 'guidform', '(foo="1",somevalu)')
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', 'totally not a guid')
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', 1234)
             self.raises(BadTypeValu, core.getPropNorm, 'guidform', '$1234')


### PR DESCRIPTION
 This allows for stable guid generation from strings using a storm list syntax. Add test coverage for the guid generation via API and storm.