### PR TITLE
inet:net* to inet:web:* migration

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -507,6 +507,9 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         self.store.fire('modl:vers:rev', name=name, vers=vers)
 
         func()
+        mesg = 'Finished updating model [{}] to [{}].'.format(name, vers)
+        logger.warning(mesg)
+        self.log(logging.WARNING, mesg=mesg, name=name, curv=curv, vers=vers)
 
         self.setModlVers(name, vers)
         return True

--- a/synapse/cores/postgres.py
+++ b/synapse/cores/postgres.py
@@ -81,6 +81,8 @@ class PsqlStorage(s_cores_sqlite.SqliteStorage):
 
     _t_getrows_by_idens = 'SELECT * FROM {{TABLE}} WHERE iden IN {{VALU}}'
 
+    _t_uprows_by_prop_val_str = 'UPDATE {{TABLE}} SET strval={{NEWVALU}} WHERE prop={{PROP}} and MD5(strval)=MD5({{OLDVALU}})'
+
     def _initDbConn(self):
         import psycopg2
         self._psycopg2 = psycopg2

--- a/synapse/cores/ram.py
+++ b/synapse/cores/ram.py
@@ -221,7 +221,6 @@ class RamStorage(s_cores_storage.Storage):
             rowsid[row[0]].add(row)
             rowsbv[row[1], row[2]].add(row)
 
-#        ids = {i for i, p, v, t in rows}
         nrows = {(i, newprop, v, t) for i, p, v, t in rows}
         nrowsid = collections.defaultdict(set)
         nrowsbv = collections.defaultdict(set)

--- a/synapse/cores/ram.py
+++ b/synapse/cores/ram.py
@@ -211,7 +211,7 @@ class RamStorage(s_cores_storage.Storage):
 
         # Bail if we don't have the oldprop valu
         if oldprop not in self.rowsbyprop:
-            return
+            return 0
 
         # Collect / prep sets of data up front
         rows = self.rowsbyprop.pop(oldprop)

--- a/synapse/cores/ram.py
+++ b/synapse/cores/ram.py
@@ -204,48 +204,6 @@ class RamStorage(s_cores_storage.Storage):
     def getStoreType(self):
         return 'ram'
 
-    def _updateProperty(self, oldprop, newprop):
-        # Make sure new prop is interned
-        newprop = sys.intern(newprop)
-        oldprop = sys.intern(oldprop)
-
-        # Bail if we don't have the oldprop valu
-        if oldprop not in self.rowsbyprop:
-            return 0
-
-        # Collect / prep sets of data up front
-        rows = self.rowsbyprop.pop(oldprop)
-        rowsid = collections.defaultdict(set)
-        rowsbv = collections.defaultdict(set)
-        for row in rows:
-            rowsid[row[0]].add(row)
-            rowsbv[row[1], row[2]].add(row)
-
-        nrows = {(i, newprop, v, t) for i, p, v, t in rows}
-        nrowsid = collections.defaultdict(set)
-        nrowsbv = collections.defaultdict(set)
-        for row in nrows:
-            nrowsid[row[0]].add(row)
-            nrowsbv[row[1], row[2]].add(row)
-
-        # Update rowsbyprop
-        # We have to account for renaming a property into a existing set
-        self.rowsbyprop[newprop].update(nrows)
-
-        # update rowsbyid
-        for iden, _orowsid in rowsid.items():
-            _nrowsid = nrowsid.get(iden)
-            self.rowsbyid[iden].update(_nrowsid)
-            self.rowsbyid[iden].difference_update(_orowsid)
-
-        #update rowsbyvalu
-        for pv in rowsbv:
-            self.rowsbyvalu.pop(pv)
-        for pv, _nrowsbv in nrowsbv.items():
-            self.rowsbyvalu[pv].update(_nrowsbv)
-
-        return len(nrows)
-
     def _getBlobValu(self, key):
         ret = self._blob_store.get(key)
         return ret

--- a/synapse/cores/ram.py
+++ b/synapse/cores/ram.py
@@ -206,8 +206,8 @@ class RamStorage(s_cores_storage.Storage):
 
     def _updateProperty(self, oldprop, newprop):
         # Make sure new prop is interned
-        newprop = intern(newprop)
-        oldprop = intern(oldprop)
+        newprop = sys.intern(newprop)
+        oldprop = sys.intern(oldprop)
 
         # Bail if we don't have the oldprop valu
         if oldprop not in self.rowsbyprop:

--- a/synapse/cores/sqlite.py
+++ b/synapse/cores/sqlite.py
@@ -255,6 +255,8 @@ class SqliteStorage(s_cores_storage.Storage):
     _t_uprows_by_iden_prop_str = 'UPDATE {{TABLE}} SET strval={{VALU}} WHERE iden={{IDEN}} and prop={{PROP}}'
     _t_uprows_by_iden_prop_int = 'UPDATE {{TABLE}} SET intval={{VALU}} WHERE iden={{IDEN}} and prop={{PROP}}'
     _t_uprows_by_prop_prop = 'UPDATE {{TABLE}} SET prop={{NEWVALU}} WHERE prop={{OLDVALU}}'
+    _t_uprows_by_prop_val_int = 'UPDATE {{TABLE}} SET intval={{NEWVALU}} WHERE prop={{PROP}} and intval={{OLDVALU}}'
+    _t_uprows_by_prop_val_str = 'UPDATE {{TABLE}} SET strval={{NEWVALU}} WHERE prop={{PROP}} and strval={{OLDVALU}}'
 
     def _initDbInfo(self):
         name = self._link[1].get('path')[1:]
@@ -537,6 +539,8 @@ class SqliteStorage(s_cores_storage.Storage):
         self._q_uprows_by_iden_prop_str = self._prepQuery(self._t_uprows_by_iden_prop_str)
         self._q_uprows_by_iden_prop_int = self._prepQuery(self._t_uprows_by_iden_prop_int)
         self._q_uprows_by_prop_prop = self._prepQuery(self._t_uprows_by_prop_prop)
+        self._q_uprows_by_prop_val_str = self._prepQuery(self._t_uprows_by_prop_val_str)
+        self._q_uprows_by_prop_val_int = self._prepQuery(self._t_uprows_by_prop_val_int)
 
         self._q_getjoin_by_range_str = self._prepQuery(self._t_getjoin_by_range_str)
         self._q_getjoin_by_range_int = self._prepQuery(self._t_getjoin_by_range_int)
@@ -717,6 +721,11 @@ class SqliteStorage(s_cores_storage.Storage):
 
     def _updateProperty(self, oldprop, newprop):
         return self.update(self._q_uprows_by_prop_prop, oldvalu=oldprop, newvalu=newprop)
+
+    def _updatePropertyValu(self, prop, oldval, newval):
+        if isinstance(oldval, int):
+            return self.update(self._q_uprows_by_prop_val_int, oldvalu=oldval, newvalu=newval, prop=prop)
+        return self.update(self._q_uprows_by_prop_val_str, oldvalu=oldval, newvalu=newval, prop=prop)
 
     def _genStoreRows(self, **kwargs):
         '''

--- a/synapse/cores/sqlite.py
+++ b/synapse/cores/sqlite.py
@@ -254,6 +254,7 @@ class SqliteStorage(s_cores_storage.Storage):
     ################################################################################
     _t_uprows_by_iden_prop_str = 'UPDATE {{TABLE}} SET strval={{VALU}} WHERE iden={{IDEN}} and prop={{PROP}}'
     _t_uprows_by_iden_prop_int = 'UPDATE {{TABLE}} SET intval={{VALU}} WHERE iden={{IDEN}} and prop={{PROP}}'
+    _t_uprows_by_prop_prop = 'UPDATE {{TABLE}} SET prop={{NEWVALU}} WHERE prop={{OLDVALU}}'
 
     def _initDbInfo(self):
         name = self._link[1].get('path')[1:]
@@ -535,6 +536,7 @@ class SqliteStorage(s_cores_storage.Storage):
 
         self._q_uprows_by_iden_prop_str = self._prepQuery(self._t_uprows_by_iden_prop_str)
         self._q_uprows_by_iden_prop_int = self._prepQuery(self._t_uprows_by_iden_prop_int)
+        self._q_uprows_by_prop_prop = self._prepQuery(self._t_uprows_by_prop_prop)
 
         self._q_getjoin_by_range_str = self._prepQuery(self._t_getjoin_by_range_str)
         self._q_getjoin_by_range_int = self._prepQuery(self._t_getjoin_by_range_int)
@@ -712,6 +714,9 @@ class SqliteStorage(s_cores_storage.Storage):
 
     def _delRowsByProp(self, prop, valu=None, mintime=None, maxtime=None):
         self._runPropQuery('delrowsbyprop', prop, valu=valu, mintime=mintime, maxtime=maxtime, meth=self.delete, nolim=True)
+
+    def _updateProperty(self, oldprop, newprop):
+        return self.update(self._q_uprows_by_prop_prop, oldvalu=oldprop, newvalu=newprop)
 
     def _genStoreRows(self, **kwargs):
         '''

--- a/synapse/cores/storage.py
+++ b/synapse/cores/storage.py
@@ -722,6 +722,29 @@ class Storage(s_config.Config):
         for rows in self._genStoreRows(**kwargs):
             yield rows
 
+    def updateProperty(self, oldprop, newprop):
+        '''
+        Do a whole replacement of one property with another property.
+
+        Args:
+            oldprop (str):
+            newprop (str):
+
+        Examples:
+            pass
+
+        Returns:
+            None
+        '''
+        if oldprop == newprop:
+            raise s_common.BadPropName(mesg='OldProp and newprop cannot be the same.',
+                                       oldprop=oldprop, newprop=newprop)
+
+        if not isinstance(newprop, str):
+            raise s_common.BadPropName('')
+
+        return self._updateProperty(oldprop, newprop)
+
     # The following MUST be implemented by the storage layer in order to
     # support the basic idea of a cortex
 
@@ -1031,6 +1054,19 @@ class Storage(s_config.Config):
             rows = self.getRowsById(iden)
             ret.extend(rows)
         return ret
+
+    def _updateProperty(self, oldprop, newprop):
+        '''
+        Entrypoint for doing in-place property update type operations.
+        This is called by self.updateProperty() to do the actual property update.
+        '''
+        adds = []
+        for i, p, v, t in self.getRowsByProp(oldprop):
+            adds.append((i, newprop, v, t))
+
+        if adds:
+            self.addRows(adds)
+            self.delRowsByProp(oldprop)
 
     # these helpers allow a storage layer to simply implement
     # and register _getTufosByGe and _getTufosByLe

--- a/synapse/cores/storage.py
+++ b/synapse/cores/storage.py
@@ -724,7 +724,7 @@ class Storage(s_config.Config):
 
     def updateProperty(self, oldprop, newprop):
         '''
-        Do a whole replacement of one property with another property.
+        Do a wholesale replacement of one property with another property.
 
         Args:
             oldprop (str):
@@ -734,7 +734,7 @@ class Storage(s_config.Config):
             pass
 
         Returns:
-            None
+            int: Number of rows updated in place.
         '''
         if oldprop == newprop:
             raise s_common.BadPropName(mesg='OldProp and newprop cannot be the same.',
@@ -1067,6 +1067,7 @@ class Storage(s_config.Config):
         if adds:
             self.addRows(adds)
             self.delRowsByProp(oldprop)
+        return len(adds)
 
     # these helpers allow a storage layer to simply implement
     # and register _getTufosByGe and _getTufosByLe

--- a/synapse/cores/storage.py
+++ b/synapse/cores/storage.py
@@ -727,7 +727,6 @@ class Storage(s_config.Config):
         oldprop = mesg[1].get('oldprop')
         newprop = mesg[1].get('newprop')
         self._updateProperty(oldprop, newprop)
-        self._updateTagForm(oldprop, newprop)
 
     def updateProperty(self, oldprop, newprop):
         '''
@@ -760,29 +759,8 @@ class Storage(s_config.Config):
         self.savebus.fire('core:save:updateproperty', oldprop=oldprop, newprop=newprop)
         self.fire('syn:core:store:updateprop:pre', oldprop=oldprop, newprop=newprop)
         nrows = self._updateProperty(oldprop, newprop)
-        self._updateTagForm(oldprop, newprop)
         self.fire('syn:core:store:updateprop:post', oldprop=oldprop, newprop=newprop, nrows=nrows)
         return nrows
-
-    def _updateTagForm(self, oldform, newform):
-        adds, dels, darks = [], [], []
-        for i, p, v, t in self.getRowsByProp('syn:tagform:form', oldform):
-            adds.append((i, p, newform, t),)
-            dels.append((i, p, v),)
-
-            for _, _, tag, _ in self.getRowsByIdProp(i, 'syn:tagform:tag'):
-                oldark = '_:*%s#%s' % (oldform, tag)
-                newdark = '_:*%s#%s' % (newform, tag)
-                darks.append((oldark, newdark),)
-
-        if adds:
-            self._addRows(adds)
-
-        for i, p, v in dels:
-            self._delRowsByIdProp(i, p, v)
-
-        for olddark, newdark in darks:
-            self.updateProperty(olddark, newdark)
 
     # The following MUST be implemented by the storage layer in order to
     # support the basic idea of a cortex

--- a/synapse/cores/storage.py
+++ b/synapse/cores/storage.py
@@ -87,8 +87,8 @@ class Storage(s_config.Config):
         self.loadbus.on('core:save:del:rows:by:prop', self._loadDelRowsByProp)
         self.loadbus.on('core:save:set:rows:by:idprop', self._loadSetRowsByIdProp)
         self.loadbus.on('core:save:del:rows:by:idprop', self._loadDelRowsByIdProp)
-        self.loadbus.on('core:save:updateproperty', self._loadUpdateProperty)
-        self.loadbus.on('core:save:updatepropertyvalu', self._loadUpdatePropertyValu)
+        self.loadbus.on('core:save:set:up:prop', self._loadUpdateProperty)
+        self.loadbus.on('core:save:set:up:propvalu', self._loadUpdatePropertyValu)
         self.loadbus.on('syn:core:blob:set', self._onSetBlobValu)
         self.loadbus.on('syn:core:blob:del', self._onDelBlobValu)
 
@@ -743,7 +743,7 @@ class Storage(s_config.Config):
                 nrows = store.updateProperty('inet:tcp4:port', 'inet:tcp4:foobar')
 
         Notes:
-            This API does  fire syn:core:store:updateprop:pre and syn:core:store:updateprop:post events with the old
+            This API does  fire syn:core:store:up:prop:pre and syn:core:store:up:prop:post events with the old
             and new property names in it, before and after the property update is done. This API is primarily designed
             for assisting with Cortex data migrations.
 
@@ -757,10 +757,10 @@ class Storage(s_config.Config):
         if not isinstance(newprop, str):
             raise s_common.BadPropName(mesg='newprop must be a str', newprop=newprop)
 
-        self.savebus.fire('core:save:updateproperty', oldprop=oldprop, newprop=newprop)
-        self.fire('syn:core:store:updateprop:pre', oldprop=oldprop, newprop=newprop)
+        self.savebus.fire('core:save:set:up:prop', oldprop=oldprop, newprop=newprop)
+        self.fire('syn:core:store:up:prop:pre', oldprop=oldprop, newprop=newprop)
         nrows = self._updateProperty(oldprop, newprop)
-        self.fire('syn:core:store:updateprop:post', oldprop=oldprop, newprop=newprop, nrows=nrows)
+        self.fire('syn:core:store:up:prop:post', oldprop=oldprop, newprop=newprop, nrows=nrows)
         return nrows
 
     def _loadUpdatePropertyValu(self, mesg):
@@ -784,7 +784,7 @@ class Storage(s_config.Config):
                 nrows = store.updatePropertyValu('tufo:form', 'inet:tcp4', 'inet:tcp4000')
 
         Notes:
-            This API does fire syn:core:store:updatepropertvalu:pre and syn:core:store:updatepropertvalu:post
+            This API does fire syn:core:store:up:propval:pre and syn:core:store:up:propval:post
             events with the property, old value and new values in it; before and after update is done. This API is
             primarily designed for assisting with Cortex data migrations.  The oldval and newval must be of the same
             type.
@@ -802,10 +802,10 @@ class Storage(s_config.Config):
             raise s_common.BadPropValu(mesg='oldval and newval must be of the same type',
                                        newval=newval, oldval=oldval)
 
-        self.savebus.fire('core:save:updatepropertyvalu', prop=prop, oldval=oldval, newval=newval)
-        self.fire('syn:core:store:updatepropertyvalu:pre', prop=prop, oldval=oldval, newval=newval)
+        self.savebus.fire('core:save:set:up:propvalu', prop=prop, oldval=oldval, newval=newval)
+        self.fire('syn:core:store:up:propval:pre', prop=prop, oldval=oldval, newval=newval)
         nrows = self._updatePropertyValu(prop, oldval, newval)
-        self.fire('syn:core:store:updatepropertyvalu:post', prop=prop, oldval=oldval, newval=newval, nrows=nrows)
+        self.fire('syn:core:store:up:propval:post', prop=prop, oldval=oldval, newval=newval, nrows=nrows)
         return nrows
 
     # The following MUST be implemented by the storage layer in order to

--- a/synapse/lib/ingest.py
+++ b/synapse/lib/ingest.py
@@ -437,7 +437,7 @@ class Ingest(EventBus):
                             ["link", { "props":{"tld":1} } ],
                         ]],
 
-                        ["inet:netuser",[
+                        ["inet:web:acct",[
                             ["rootkit.com/metr0", { "props":{"email":"metr0@kenshoto.com"} } ],
                             ["twitter.com/invisig0th", { "props":{"email":"visi@vertex.link"} } ]
                         ]],

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -535,8 +535,26 @@ class InetMod(CoreModule):
 
             ('ou:hasnetuser:netuser', 'ou:haswebacct:acct'),
             ('ou:hasnetuser:org', 'ou:haswebacct:org'),
-
         ]
+
+        def _updateTufoForm(oldform, newform):
+            # FIXME this can be optimized in storage layer like updateProperty
+
+            while True:
+                rows = self.core.getRowsByProp('tufo:form', oldform, limit=1000)
+                if not rows:
+                    break
+
+                adds, dels = [], []
+                for i, p, v, t in rows:
+                    adds.append((i, p, newform, t),)
+                    dels.append((i, p, v),)
+
+                if adds:
+                    self.core.addRows(adds)
+
+                for i, p, v in dels:
+                    self.core.delRowsByIdProp(i, p, v)
 
         def _updateTagForm(oldform, newform):
             adds, dels, darks = [], [], []
@@ -620,6 +638,7 @@ class InetMod(CoreModule):
                     continue
 
                 self.core.store.updateProperty(old, new)
+                _updateTufoForm(old, new)
                 _updateTagForm(old, new)
                 _updateXref(xref_propsrc, old, new)
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -537,44 +537,20 @@ class InetMod(CoreModule):
             ('ou:hasnetuser:org', 'ou:haswebacct:org'),
         ]
 
-        def _updateTufoForm(oldform, newform):
-            # FIXME this can be optimized in storage layer like updateProperty
+        def _updateTagForm(old, new):
 
-            while True:
-                rows = self.core.getRowsByProp('tufo:form', oldform, limit=1000)
-                if not rows:
-                    break
+            darks = []
 
-                adds, dels = [], []
-                for i, p, v, t in rows:
-                    adds.append((i, p, newform, t),)
-                    dels.append((i, p, v),)
-
-                if adds:
-                    self.core.addRows(adds)
-
-                for i, p, v in dels:
-                    self.core.delRowsByIdProp(i, p, v)
-
-        def _updateTagForm(oldform, newform):
-            adds, dels, darks = [], [], []
-            for i, p, v, t in self.core.getRowsByProp('syn:tagform:form', oldform):
-                adds.append((i, p, newform, t),)
-                dels.append((i, p, v),)
-
+            for i, _, _, _ in self.core.getRowsByProp('syn:tagform:form', old):
                 for _, _, tag, _ in self.core.getRowsByIdProp(i, 'syn:tagform:tag'):
-                    oldark = '_:*%s#%s' % (oldform, tag)
-                    newdark = '_:*%s#%s' % (newform, tag)
+                    oldark = '_:*%s#%s' % (old, tag)
+                    newdark = '_:*%s#%s' % (new, tag)
                     darks.append((oldark, newdark),)
-
-            if adds:
-                self.core.addRows(adds)
-
-            for i, p, v in dels:
-                self.core.delRowsByIdProp(i, p, v)
 
             for olddark, newdark in darks:
                 self.core.store.updateProperty(olddark, newdark)
+
+            self.core.store.updatePropertyValu('syn:tagform:form', old, new)
 
         def _getXrefPropSrc():
             retval = []
@@ -638,7 +614,7 @@ class InetMod(CoreModule):
                     continue
 
                 self.core.store.updateProperty(old, new)
-                _updateTufoForm(old, new)
+                self.core.store.updatePropertyValu('tufo:form', old, new)
                 _updateTagForm(old, new)
                 _updateXref(xref_propsrc, old, new)
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -647,6 +647,9 @@ class InetMod(CoreModule):
 
                 ('inet:web:post',
                  {'subof': 'comp', 'fields': 'acct,inet:web:acct|text,str:txt', 'doc': 'A post made by a web account'}),
+                ('inet:web:postref',
+                 {'subof': 'xref', 'source': 'post,inet:web:post', 'doc': 'The web post refereneces the given node'}),
+
                 ('inet:web:file', {'subof': 'comp', 'fields': 'acct,inet:web:acct|file,file:bytes',
                                   'doc': 'A file posted by a web account'}),
                 ('inet:web:memb', {'subof': 'comp', 'fields': 'acct,inet:web:acct|group,inet:web:group'}),
@@ -884,6 +887,13 @@ class InetMod(CoreModule):
 
                     ('url', {'ptype': 'inet:url', 'doc': 'The (optional) URL where the post is published/visible'}),
                     ('file', {'ptype': 'file:bytes', 'doc': 'The (optional) file which was posted'}),
+                ]),
+                ('inet:web:postref', {}, [
+                    ('post', {'ptype': 'inet:web:post', 'ro': 1}),
+                    ('xref', {'ptype': 'propvalu', 'ro': 1}),
+                    ('xref:prop', {'ptype': 'str', 'ro': 1}),
+                    ('xref:intval', {'ptype': 'int', 'ro': 1}),
+                    ('xref:strval', {'ptype': 'str', 'ro': 1}),
                 ]),
 
                 ('inet:web:mesg', {}, [

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -670,8 +670,11 @@ class InetMod(CoreModule):
                                   'doc': 'A user account at a given web address', 'ex': 'twitter.com/invisig0th'}),
                 ('inet:web:logon', {'subof': 'guid',
                                    'doc': 'An instance of a user account authenticating to a service.', }),
+
                 ('inet:web:action', {'subof': 'guid',
                                    'doc': 'An instance of a user account performing an action.'}),
+                ('inet:web:actref',
+                 {'subof': 'xref', 'source': 'act,inet:web:action', 'doc': 'The web action refereneces the given node'}),
 
                 ('inet:web:group', {'subof': 'sepr', 'sep': '/', 'fields': 'site,inet:fqdn|name,ou:name',
                                    'doc': 'A group within an online community'}),
@@ -903,6 +906,13 @@ class InetMod(CoreModule):
                     ('time', {'ptype': 'time', 'doc': 'The time the netuser performed the action'}),
                     ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The source IPv4 address of the action'}),
                     ('ipv6', {'ptype': 'inet:ipv6', 'doc': 'The source IPv6 address of the action'}),
+                ]),
+                ('inet:web:actref', {}, [
+                    ('act', {'ptype': 'inet:web:action', 'ro': 1}),
+                    ('xref', {'ptype': 'propvalu', 'ro': 1}),
+                    ('xref:prop', {'ptype': 'str', 'ro': 1}),
+                    ('xref:intval', {'ptype': 'int', 'ro': 1}),
+                    ('xref:strval', {'ptype': 'str', 'ro': 1}),
                 ]),
 
                 ('inet:web:group', {}, [

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -464,7 +464,7 @@ class InetMod(CoreModule):
         forms = [
             ('inet:netuser', 'inet:web:acct'),
             ('inet:netgroup', 'inet:web:group'),
-            #('inet:netmemb', 'inet:web:memb'),
+            ('inet:netmemb', 'inet:web:memb'),
             #('inet:follows', 'inet:web:follows'),
             #('inet:netpost', 'inet:web:post'),
             #('inet:netfile', 'inet:web:file'),
@@ -484,7 +484,7 @@ class InetMod(CoreModule):
             ('inet:netuser:phone', 'inet:web:acct:phone'),
             ('inet:netuser:signup', 'inet:web:acct:signup'),
             ('inet:netuser:signup:ipv4', 'inet:web:acct:signup:ipv4'),
-            ('inet:netuser:passwd', 'inet:web:acct:passwn'),
+            ('inet:netuser:passwd', 'inet:web:acct:passwd'),
             ('inet:netuser:seen:min', 'inet:web:acct:seen:min'),
             ('inet:netuser:seen:max', 'inet:web:acct:seen:max'),
 
@@ -494,9 +494,16 @@ class InetMod(CoreModule):
             ('inet:netgroup:url', 'inet:web:group:url'),
             ('inet:netgroup:webpage', 'inet:web:group:webpage'),
             ('inet:netgroup:avatar', 'inet:web:group:avatar'),
+
+            ('inet:netmemb:user', 'inet:web:group:acct'),  # renamed from user -> acct
+            ('inet:netmemb:group', 'inet:web:group:group'),
+            ('inet:netmemb:title', 'inet:web:group:title'),
+            ('inet:netmemb:joined', 'inet:web:group:joined'),
+            ('inet:netmemb:seen:min', 'inet:web:group:seen:min'),
+            ('inet:netmemb:seen:max', 'inet:web:group:seen:max'),
         ]
 
-        adds, dels = [], []  # for ro props, valus, etc
+        adds, dels = [], []  # for ro props, valus, etc  # FIXME use setRowsByIdProp instead
         for old, new in forms:
 
             # rename tagforms and dark tags
@@ -580,15 +587,15 @@ class InetMod(CoreModule):
                                    'doc': 'A group within an online community'}),
 
                 ('inet:web:post',
-                 {'subof': 'comp', 'fields': 'netuser,inet:web:acct|text,str:txt', 'doc': 'A post made by a netuser'}),
-                ('inet:web:file', {'subof': 'comp', 'fields': 'netuser,inet:web:acct|file,file:bytes',
-                                  'doc': 'A file posted by a netuser'}),
-                ('inet:web:memb', {'subof': 'comp', 'fields': 'user,inet:web:acct|group,inet:web:group'}),
+                 {'subof': 'comp', 'fields': 'acct,inet:web:acct|text,str:txt', 'doc': 'A post made by a web account'}),
+                ('inet:web:file', {'subof': 'comp', 'fields': 'acct,inet:web:acct|file,file:bytes',
+                                  'doc': 'A file posted by a web account'}),
+                ('inet:web:memb', {'subof': 'comp', 'fields': 'acct,inet:web:acct|group,inet:web:group'}),
                 ('inet:web:follows', {'subof': 'comp', 'fields': 'follower,inet:web:acct|followee,inet:web:acct'}),
 
                 ('inet:web:mesg', {'subof': 'comp',
                                   'fields': 'from,inet:web:acct|to,inet:web:acct|time,time',
-                                  'doc': 'A message sent from one netuser to another',
+                                  'doc': 'A message sent from one web account to another',
                                   'ex': 'twitter.com/invisig0th|twitter.com/gobbles|20041012130220'}),
 
                 ('inet:ssl:tcp4cert', {'subof': 'sepr', 'sep': '/', 'fields': 'tcp4,inet:tcp4|cert,file:bytes',
@@ -762,35 +769,35 @@ class InetMod(CoreModule):
 
                     ('dob', {'ptype': 'time'}),
 
-                    # ('bio:bt',{'ptype':'wtf','doc':'The netusers self documented blood type'}),
+                    # ('bio:bt',{'ptype':'wtf','doc':'The web account's self documented blood type'}),
 
                     ('url', {'ptype': 'inet:url'}),
                     ('webpage', {'ptype': 'inet:url'}),
                     ('avatar', {'ptype': 'file:bytes'}),
 
-                    ('tagline', {'ptype': 'str:txt', 'doc': 'A netuser status/tag line text'}),
-                    ('occupation', {'ptype': 'str:txt', 'doc': 'A netuser self declared occupation'}),
+                    ('tagline', {'ptype': 'str:txt', 'doc': 'A web account status/tag line text'}),
+                    ('occupation', {'ptype': 'str:txt', 'doc': 'A web account self declared occupation'}),
                     # ('gender',{'ptype':'inet:fqdn','ro':1}),
 
                     ('name', {'ptype': 'inet:user'}),
                     ('realname', {'ptype': 'ps:name'}),
                     ('email', {'ptype': 'inet:email'}),
                     ('phone', {'ptype': 'tel:phone'}),
-                    ('signup', {'ptype': 'time', 'doc': 'The time the netuser account was registered'}),
+                    ('signup', {'ptype': 'time', 'doc': 'The time the web account was registered'}),
                     ('signup:ipv4', {'ptype': 'inet:ipv4', 'doc': 'The original ipv4 address used to sign up for the account'}),
-                    ('passwd', {'ptype': 'inet:passwd', 'doc': 'The current passwd for the netuser account'}),
+                    ('passwd', {'ptype': 'inet:passwd', 'doc': 'The current passwd for the web account'}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 ]),
 
                 ('inet:web:logon', {'ptype': 'inet:web:logon'}, [
-                    ('netuser', {'ptype': 'inet:web:acct', 'doc': 'The netuser associated with the logon event.', }),
-                    ('netuser:site', {'ptype': 'inet:fqdn', }),
-                    ('netuser:user', {'ptype': 'inet:user', }),
-                    ('time', {'ptype': 'time', 'doc': 'The time the netuser logged into the service', }),
+                    ('acct', {'ptype': 'inet:web:acct', 'doc': 'The account associated with the logon event.', }),
+                    ('acct:site', {'ptype': 'inet:fqdn', }),
+                    ('acct:user', {'ptype': 'inet:user', }),
+                    ('time', {'ptype': 'time', 'doc': 'The time the account logged into the service', }),
                     ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The source IPv4 address of the logon.'}),
                     ('ipv6', {'ptype': 'inet:ipv6', 'doc': 'The source IPv6 address of the logon.'}),
-                    ('logout', {'ptype': 'time', 'doc': 'The time the netuser logged out of the service.'})
+                    ('logout', {'ptype': 'time', 'doc': 'The time the account logged out of the service.'})
                 ]),
 
                 ('inet:web:group', {}, [
@@ -806,11 +813,11 @@ class InetMod(CoreModule):
 
                 ('inet:web:post', {}, [
 
-                    ('netuser', {'ptype': 'inet:web:acct', 'ro': 1}),  # FIXME rename?
+                    ('acct', {'ptype': 'inet:web:acct', 'ro': 1}),
                     ('text', {'ptype': 'str:txt', 'ro': 1, 'doc': 'The text of the actual post'}),
 
-                    ('netuser:site', {'ptype': 'inet:fqdn', 'ro': 1}),  # FIXME rename?
-                    ('netuser:user', {'ptype': 'inet:user', 'ro': 1}),  # FIXME rename?
+                    ('acct:site', {'ptype': 'inet:fqdn', 'ro': 1}),
+                    ('acct:user', {'ptype': 'inet:user', 'ro': 1}),
 
                     ('time', {'ptype': 'time'}),
 
@@ -841,7 +848,7 @@ class InetMod(CoreModule):
 
                 ('inet:web:memb', {}, [
 
-                    ('user', {'ptype': 'inet:web:acct', 'ro': 1}),  # FIXME rename?
+                    ('acct', {'ptype': 'inet:web:acct', 'ro': 1}),
                     ('group', {'ptype': 'inet:web:group', 'ro': 1}),
 
                     ('title', {'ptype': 'str:lwr'}),
@@ -854,9 +861,9 @@ class InetMod(CoreModule):
 
                 ('inet:web:file', {}, [
 
-                    ('netuser', {'ptype': 'inet:web:acct', 'ro': 1}),  # FIXME rename?
-                    ('netuser:site', {'ptype': 'inet:fqdn', 'ro': 1}),  # FIXME rename?
-                    ('netuser:user', {'ptype': 'inet:user', 'ro': 1}),  # FIXME rename?
+                    ('acct', {'ptype': 'inet:web:acct', 'ro': 1}),
+                    ('acct:site', {'ptype': 'inet:fqdn', 'ro': 1}),
+                    ('acct:user', {'ptype': 'inet:user', 'ro': 1}),
 
                     ('file', {'ptype': 'file:bytes', 'ro': 1}),
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -867,6 +867,7 @@ class InetMod(CoreModule):
                     ('avatar', {'ptype': 'file:bytes'}),
 
                     ('tagline', {'ptype': 'str:txt', 'doc': 'A web account status/tag line text'}),
+                    ('loc', {'ptype': 'str:lwr', 'doc': 'The web account self declared location'}),
                     ('occupation', {'ptype': 'str:txt', 'doc': 'A web account self declared occupation'}),
                     # ('gender',{'ptype':'inet:fqdn','ro':1}),
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -895,10 +895,11 @@ class InetMod(CoreModule):
                 ]),
 
                 ('inet:web:action', {'ptype': 'inet:web:action'}, [
-                    ('action', {'ptype': 'str:lwr', 'doc': 'The action performed'}),
-                    ('acct', {'ptype': 'inet:web:acct', 'doc': 'The web account associated with the action'}),
-                    ('acct:site', {'ptype': 'inet:fqdn'}),
-                    ('acct:user', {'ptype': 'inet:user'}),
+                    ('act', {'ptype': 'str:lwr', 'req': 1, 'doc': 'The action performed'}),
+                    ('acct', {'ptype': 'inet:web:acct', 'req': 1, 'ro': 1, 'doc': 'The web account associated with the action'}),
+                    ('acct:site', {'ptype': 'inet:fqdn', 'ro': 1}),
+                    ('acct:user', {'ptype': 'inet:user', 'ro': 1}),
+                    ('info', {'ptype': 'json', 'doc': 'Other information about the action'}),
                     ('time', {'ptype': 'time', 'doc': 'The time the netuser performed the action'}),
                     ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The source IPv4 address of the action'}),
                     ('ipv6', {'ptype': 'inet:ipv6', 'doc': 'The source IPv6 address of the action'}),

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -530,6 +530,10 @@ class InetMod(CoreModule):
             ('inet:netfile:seen:min', 'inet:web:file:seen:min'),
             ('inet:netfile:seen:max', 'inet:web:file:seen:max'),
 
+            ('inet:web:logon:netuser', 'inet:web:logon:acct'),
+            ('inet:web:logon:netuser:site', 'inet:web:logon:acct:site'),
+            ('inet:web:logon:netuser:user', 'inet:web:logon:acct:user'),
+
             ('ps:hasnetuser:netuser', 'ps:haswebacct:acct'),
             ('ps:hasnetuser:person', 'ps:haswebacct:person'),
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -646,14 +646,16 @@ class InetMod(CoreModule):
         with self.core.getCoreXact() as xact:
 
             xref_propsrc = _getXrefPropSrc()
-            for old, new in forms + props:
-                if old == new:
-                    continue
 
-                self.core.store.updateProperty(old, new)
+            for old, new in forms:
                 self.core.store.updatePropertyValu('tufo:form', old, new)
                 _updateTagForm(old, new)
                 _updateXref(xref_propsrc, old, new)
+
+            for old, new in forms + props:
+                if old == new:
+                    continue
+                self.core.store.updateProperty(old, new)
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -539,6 +539,39 @@ class InetMod(CoreModule):
 
             ('ou:hasnetuser:netuser', 'ou:haswebacct:acct'),
             ('ou:hasnetuser:org', 'ou:haswebacct:org'),
+
+            # The following props are extra-model which may have been created if enforce=0 was set on a cortex.
+            ('inet:netgroup:site:domain', 'inet:web:group:site:domain'),
+            ('inet:netgroup:site:host', 'inet:web:group:site:host'),
+
+            ('inet:netmemb:group:name', 'inet:web:memb:group:name'),
+            ('inet:netmemb:group:site', 'inet:web:memb:group:site'),
+            ('inet:netmemb:group:site:domain', 'inet:web:memb:group:site:domain'),
+            ('inet:netmemb:group:site:host', 'inet:web:memb:group:site:hos'),
+            ('inet:netmemb:user:site', 'inet:web:memb:acct:site'),
+            ('inet:netmemb:user:site:domain', 'inet:web:memb:acct:site:domain'),
+            ('inet:netmemb:user:site:host', 'inet:web:memb:acct:site:host'),
+            ('inet:netmemb:user:user', 'inet:web:memb:acct:user'),
+
+            ('inet:netpost:netuser:site:domain', 'inet:web:post:acct:site:domain'),
+            ('inet:netpost:netuser:site:host', 'inet:web:post:acct:acctquit:site:host'),
+
+            ('inet:netuser:site:domain', 'inet:acct:site:domain'),
+            ('inet:netuser:site:host', 'inet:acct:site:host'),
+
+            ('inet:web:logon:netuser:site:domain', 'inet:web:logon:acct:site:domain'),
+            ('inet:web:logon:netuser:site:host', 'inet:web:logon:acct:site:host'),
+
+            ('ou:hasnetuser:netuser:site', 'ou:haswebacct:acct:site'),
+            ('ou:hasnetuser:netuser:site:domain', 'ou:haswebacct:acct:domain'),
+            ('ou:hasnetuser:netuser:site:host', 'ou:haswebacct:acct:host'),
+            ('ou:hasnetuser:netuser:user', 'ou:haswebacct:acct:user'),
+
+            ('ps:hasnetuser:netuser:site', 'ps:haswebacct:acct:site'),
+            ('ps:hasnetuser:netuser:site:domain', 'ps:haswebacct:acct:site:domain'),
+            ('ps:hasnetuser:netuser:site:host', 'ps:haswebacct:acct:site:host'),
+            ('ps:hasnetuser:netuser:user', 'ps:haswebacct:acct:user'),
+
         ]
 
         def _updateTagForm(old, new):

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -465,9 +465,9 @@ class InetMod(CoreModule):
             ('inet:netuser', 'inet:web:acct'),
             ('inet:netgroup', 'inet:web:group'),
             ('inet:netmemb', 'inet:web:memb'),
-            #('inet:follows', 'inet:web:follows'),
-            #('inet:netpost', 'inet:web:post'),
-            #('inet:netfile', 'inet:web:file'),
+            ('inet:follows', 'inet:web:follows'),
+            ('inet:netpost', 'inet:web:post'),
+            ('inet:netfile', 'inet:web:file'),
         ]
         props = [
             ('inet:netuser:site', 'inet:web:acct:site'),
@@ -495,12 +495,38 @@ class InetMod(CoreModule):
             ('inet:netgroup:webpage', 'inet:web:group:webpage'),
             ('inet:netgroup:avatar', 'inet:web:group:avatar'),
 
-            ('inet:netmemb:user', 'inet:web:group:acct'),  # renamed from user -> acct
-            ('inet:netmemb:group', 'inet:web:group:group'),
-            ('inet:netmemb:title', 'inet:web:group:title'),
-            ('inet:netmemb:joined', 'inet:web:group:joined'),
-            ('inet:netmemb:seen:min', 'inet:web:group:seen:min'),
-            ('inet:netmemb:seen:max', 'inet:web:group:seen:max'),
+            ('inet:netmemb:user', 'inet:web:memb:acct'),  # renamed from user -> acct
+            ('inet:netmemb:group', 'inet:web:memb:group'),
+            ('inet:netmemb:title', 'inet:web:memb:title'),
+            ('inet:netmemb:joined', 'inet:web:memb:joined'),
+            ('inet:netmemb:seen:min', 'inet:web:memb:seen:min'),
+            ('inet:netmemb:seen:max', 'inet:web:memb:seen:max'),
+
+            ('inet:follows:follower', 'inet:web:follows:follower'),
+            ('inet:follows:followee', 'inet:web:follows:followee'),
+            ('inet:follows:seen:min', 'inet:web:follows:seen:min'),
+            ('inet:follows:seen:max', 'inet:web:follows:seen:max'),
+
+            ('inet:netpost:netuser', 'inet:web:post:acct'), # renamed from netuser -> acct
+            ('inet:netpost:netuser:site', 'inet:web:post:acct:site'), # renamed from netuser -> acct
+            ('inet:netpost:netuser:user', 'inet:web:post:acct:user'), # renamed from netuser -> acct
+            ('inet:netpost:text', 'inet:web:post:text'),
+            ('inet:netpost:replyto', 'inet:web:post:replyto'),
+            ('inet:netpost:url', 'inet:web:post:url'),
+            ('inet:netpost:file', 'inet:web:post:file'),
+            ('inet:netpost:time', 'inet:web:post:time'),
+
+            ('inet:netfile:file', 'inet:web:file:file'),
+            ('inet:netfile:netuser', 'inet:web:file:acct'), # renamed from netuser -> acct
+            ('inet:netfile:netuser:site', 'inet:web:file:acct:site'), # renamed from netuser -> acct
+            ('inet:netfile:netuser:user', 'inet:web:file:acct:user'), # renamed from netuser -> acct
+            ('inet:netfile:name', 'inet:web:file:name'),
+            ('inet:netfile:posted', 'inet:web:file:posted'),
+            ('inet:netfile:ipv4', 'inet:web:file:ipv4'),
+            ('inet:netfile:ipv6', 'inet:web:file:ipv6'),
+            ('inet:netfile:seen:min', 'inet:web:file:seen:min'),
+            ('inet:netfile:seen:max', 'inet:web:file:seen:max'),
+
         ]
 
         adds, dels = [], []  # for ro props, valus, etc  # FIXME use setRowsByIdProp instead

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -469,6 +469,8 @@ class InetMod(CoreModule):
             ('inet:follows', 'inet:web:follows'),
             ('inet:netpost', 'inet:web:post'),
             ('inet:netfile', 'inet:web:file'),
+            ('ps:hasnetuser', 'ps:haswebacct'),
+            ('ou:hasnetuser', 'ou:haswebacct'),
         ]
         props = [
             ('inet:netuser:site', 'inet:web:acct:site'),
@@ -527,6 +529,12 @@ class InetMod(CoreModule):
             ('inet:netfile:ipv6', 'inet:web:file:ipv6'),
             ('inet:netfile:seen:min', 'inet:web:file:seen:min'),
             ('inet:netfile:seen:max', 'inet:web:file:seen:max'),
+
+            ('ps:hasnetuser:netuser', 'ps:haswebacct:acct'),
+            ('ps:hasnetuser:person', 'ps:haswebacct:person'),
+
+            ('ou:hasnetuser:netuser', 'ou:haswebacct:acct'),
+            ('ou:hasnetuser:org', 'ou:haswebacct:org'),
 
         ]
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -670,6 +670,8 @@ class InetMod(CoreModule):
                                   'doc': 'A user account at a given web address', 'ex': 'twitter.com/invisig0th'}),
                 ('inet:web:logon', {'subof': 'guid',
                                    'doc': 'An instance of a user account authenticating to a service.', }),
+                ('inet:web:action', {'subof': 'guid',
+                                   'doc': 'An instance of a user account performing an action.'}),
 
                 ('inet:web:group', {'subof': 'sepr', 'sep': '/', 'fields': 'site,inet:fqdn|name,ou:name',
                                    'doc': 'A group within an online community'}),
@@ -890,6 +892,16 @@ class InetMod(CoreModule):
                     ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The source IPv4 address of the logon.'}),
                     ('ipv6', {'ptype': 'inet:ipv6', 'doc': 'The source IPv6 address of the logon.'}),
                     ('logout', {'ptype': 'time', 'doc': 'The time the account logged out of the service.'})
+                ]),
+
+                ('inet:web:action', {'ptype': 'inet:web:action'}, [
+                    ('action', {'ptype': 'str:lwr', 'doc': 'The action performed'}),
+                    ('acct', {'ptype': 'inet:web:acct', 'doc': 'The web account associated with the action'}),
+                    ('acct:site', {'ptype': 'inet:fqdn'}),
+                    ('acct:user', {'ptype': 'inet:user'}),
+                    ('time', {'ptype': 'time', 'doc': 'The time the netuser performed the action'}),
+                    ('ipv4', {'ptype': 'inet:ipv4', 'doc': 'The source IPv4 address of the action'}),
+                    ('ipv6', {'ptype': 'inet:ipv6', 'doc': 'The source IPv6 address of the action'}),
                 ]),
 
                 ('inet:web:group', {}, [

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -43,7 +43,7 @@ class OuMod(CoreModule):
                 ('ou:hashost', {'subof': 'comp', 'fields': 'org,ou:org|host,it:host'}),
                 ('ou:hasemail', {'subof': 'comp', 'fields': 'org,ou:org|email,inet:email'}),
                 ('ou:hasphone', {'subof': 'comp', 'fields': 'org,ou:org|phone,tel:phone'}),
-                ('ou:hasnetuser', {'subof': 'comp', 'fields': 'org,ou:org|netuser,inet:netuser'}),
+                ('ou:hasnetuser', {'subof': 'comp', 'fields': 'org,ou:org|netuser,inet:web:acct'}),
 
             ),
 
@@ -121,7 +121,7 @@ class OuMod(CoreModule):
                 ]),
                 ('ou:hasnetuser', {}, [
                     ('org', {'ptype': 'ou:org', 'ro': 1}),
-                    ('netuser', {'ptype': 'inet:netuser', 'ro': 1}),
+                    ('netuser', {'ptype': 'inet:web:acct', 'ro': 1}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 ]),

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -43,7 +43,7 @@ class OuMod(CoreModule):
                 ('ou:hashost', {'subof': 'comp', 'fields': 'org,ou:org|host,it:host'}),
                 ('ou:hasemail', {'subof': 'comp', 'fields': 'org,ou:org|email,inet:email'}),
                 ('ou:hasphone', {'subof': 'comp', 'fields': 'org,ou:org|phone,tel:phone'}),
-                ('ou:hasnetuser', {'subof': 'comp', 'fields': 'org,ou:org|netuser,inet:web:acct'}),
+                ('ou:haswebacct', {'subof': 'comp', 'fields': 'org,ou:org|web:acct,inet:web:acct'}),
 
             ),
 
@@ -119,9 +119,9 @@ class OuMod(CoreModule):
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 ]),
-                ('ou:hasnetuser', {}, [
+                ('ou:haswebacct', {}, [
                     ('org', {'ptype': 'ou:org', 'ro': 1}),
-                    ('netuser', {'ptype': 'inet:web:acct', 'ro': 1}),
+                    ('web:acct', {'ptype': 'inet:web:acct', 'ro': 1}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 ]),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -63,7 +63,7 @@ class PsMod(CoreModule):
                 ('ps:hasalias', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|alias,ps:name'}),
                 ('ps:hasphone', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|phone,tel:phone'}),
                 ('ps:hasemail', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|email,inet:email'}),
-                ('ps:hasnetuser', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|netuser,inet:web:acct'}),
+                ('ps:haswebacct', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|web:acct,inet:web:acct'}),
 
                 ('ps:image', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|file,file:bytes'}),
 
@@ -116,9 +116,9 @@ class PsMod(CoreModule):
                     ('email', {'ptype': 'inet:email'}),
                 )),
 
-                ('ps:hasnetuser', {'ptype': 'ps:hasnetuser'}, (
+                ('ps:haswebacct', {'ptype': 'ps:haswebacct'}, (
                     ('person', {'ptype': 'ps:person'}),
-                    ('netuser', {'ptype': 'inet:web:acct'}),
+                    ('web:acct', {'ptype': 'inet:web:acct'}),
                 )),
             ),
         }

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -63,7 +63,7 @@ class PsMod(CoreModule):
                 ('ps:hasalias', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|alias,ps:name'}),
                 ('ps:hasphone', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|phone,tel:phone'}),
                 ('ps:hasemail', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|email,inet:email'}),
-                ('ps:hasnetuser', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|netuser,inet:netuser'}),
+                ('ps:hasnetuser', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|netuser,inet:web:acct'}),
 
                 ('ps:image', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|file,file:bytes'}),
 
@@ -118,7 +118,7 @@ class PsMod(CoreModule):
 
                 ('ps:hasnetuser', {'ptype': 'ps:hasnetuser'}, (
                     ('person', {'ptype': 'ps:person'}),
-                    ('netuser', {'ptype': 'inet:netuser'}),
+                    ('netuser', {'ptype': 'inet:web:acct'}),
                 )),
             ),
         }

--- a/synapse/tests/test_cache.py
+++ b/synapse/tests/test_cache.py
@@ -243,7 +243,7 @@ class CacheTest(SynTest):
             ('foo', 'bar'),
             ('knight', 'ni'),
             ('clown', 'pennywise'),
-            ('inet:netuser', 'vertex.link/pennywise')
+            ('inet:web:acct', 'vertex.link/pennywise')
         )
         # puts
         rd.puts(kvs)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -174,6 +174,7 @@ class CortexBaseTest(SynTest):
         self.runsnaps(core)
         self.rundarks(core)
         self.runblob(core)
+        # runstore should be run last as it may do destructive actions to data in the Cortex.
         self.runstore(core)
 
     def rundsets(self, core):
@@ -698,6 +699,24 @@ class CortexBaseTest(SynTest):
             self.isin('inet:tcp4:ipv4', node[1])
             self.isin('inet:tcp4:gatenumber', node[1])
             self.notin('inet:tcp4:port', node[1])
+
+        # Do a updatePropertValu call to replace a named property with another valu
+        unodes = core.getTufosByProp('tufo:form', 'inet:tcp4')
+        self.len(10, unodes)
+        n = core.store.updatePropertyValu('tufo:form', 'inet:tcp4', 'inet:stateful4')
+        self.eq(n, 10)
+        unodes = core.getTufosByProp('tufo:form', 'inet:tcp4')
+        self.len(0, unodes)
+        unodes = core.getTufosByProp('inet:tcp4')
+        self.len(10, unodes)
+        for node in unodes:
+            self.eq(node[1].get('tufo:form'), 'inet:stateful4')
+            self.isin('inet:tcp4', node[1])
+        unodes = core.getTufosByProp('tufo:form', 'inet:stateful4')
+        self.len(10, unodes)
+        for node in unodes:
+            self.eq(node[1].get('tufo:form'), 'inet:stateful4')
+            self.isin('inet:tcp4', node[1])
 
     def runtufobydefault(self, core):
         # Failures should be expected for unknown names

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -681,14 +681,23 @@ class CortexBaseTest(SynTest):
 
         # form some nodes for doing in-place prop updates on with store.updateProperty()
         nodes = [core.formTufoByProp('inet:tcp4', '10.1.2.{}:80'.format(i)) for i in range(10)]
-        core.store.updateProperty('inet:tcp4:port', 'inet:tcp4:sewernumber')
-        unodes = core.getTufosByProp('inet:tcp4:sewernumber')
+        ret = core.store.updateProperty('inet:tcp4:port', 'inet:tcp4:gatenumber')
+        self.eq(ret, 10)
+
+        # Ensure prop and propvalu indexes are updated
+        self.len(10, core.getRowsByProp('inet:tcp4:gatenumber'))
+        self.len(10, core.getRowsByProp('inet:tcp4:gatenumber', 80))
+        self.len(0, core.getRowsByProp('inet:tcp4:port'))
+        self.len(0, core.getRowsByProp('inet:tcp4:port', 80))
+
+        # Join operations typically involving pivoting by iden so this ensures that iden based indexes are updated
+        unodes = core.getTufosByProp('inet:tcp4:gatenumber')
         self.len(10, unodes)
-        node = unodes[0]
-        self.isin('inet:tcp4', node[1])
-        self.isin('inet:tcp4:ipv4', node[1])
-        self.isin('inet:tcp4:sewernumber', node[1])
-        self.notin('inet:tcp4:port', node[1])
+        for node in unodes:
+            self.isin('inet:tcp4', node[1])
+            self.isin('inet:tcp4:ipv4', node[1])
+            self.isin('inet:tcp4:gatenumber', node[1])
+            self.notin('inet:tcp4:port', node[1])
 
     def runtufobydefault(self, core):
         # Failures should be expected for unknown names

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -679,6 +679,17 @@ class CortexBaseTest(SynTest):
             ('ffffffffffffffffffffffffffffffff', 'tufo:form', 'inet:asn', tick),
         ])
 
+        # form some nodes for doing in-place prop updates on with store.updateProperty()
+        nodes = [core.formTufoByProp('inet:tcp4', '10.1.2.{}:80'.format(i)) for i in range(10)]
+        core.store.updateProperty('inet:tcp4:port', 'inet:tcp4:sewernumber')
+        unodes = core.getTufosByProp('inet:tcp4:sewernumber')
+        self.len(10, unodes)
+        node = unodes[0]
+        self.isin('inet:tcp4', node[1])
+        self.isin('inet:tcp4:ipv4', node[1])
+        self.isin('inet:tcp4:sewernumber', node[1])
+        self.notin('inet:tcp4:port', node[1])
+
     def runtufobydefault(self, core):
         # Failures should be expected for unknown names
         self.raises(NoSuchGetBy, core.getTufosBy, 'clowns', 'inet:ipv4', 0x01020304)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -832,7 +832,7 @@ class CortexBaseTest(SynTest):
         # By TYPE using COMP nodes
         self.eq(len(core.getTufosBy('type', 'inet:netmemb', '(vertex.link/pennywise,vertex.link/eldergods)')), 1)
         self.eq(len(core.getTufosBy('type', 'inet:netmemb', ('vertex.link/invisig0th', 'vertex.link/eldergods'))), 1)
-        self.eq(len(core.getTufosBy('type', 'inet:netuser', 'vertex.link/invisig0th')), 2)
+        self.eq(len(core.getTufosBy('type', 'inet:web:acct', 'vertex.link/invisig0th')), 2)
 
         # BY CIDR
         tlib = s_types.TypeLib()
@@ -1024,11 +1024,11 @@ class CortexTest(SynTest):
             self.eq(len(core.getTufosByProp('strform:bar', valu='zap')), 1)
 
         # Try using setprops with an built-in model which type subprops
-        t0 = core.formTufoByProp('inet:netuser', 'vertex.link/pennywise')
-        self.notin('inet:netuser:email', t0[1])
+        t0 = core.formTufoByProp('inet:web:acct', 'vertex.link/pennywise')
+        self.notin('inet:web:acct:email', t0[1])
         props = {'email': 'pennywise@vertex.link'}
         core.setTufoProps(t0, **props)
-        self.isin('inet:netuser:email', t0[1])
+        self.isin('inet:web:acct:email', t0[1])
         t1 = core.getTufoByProp('inet:email', 'pennywise@vertex.link')
         self.nn(t1)
 
@@ -2090,8 +2090,8 @@ class CortexTest(SynTest):
 
     def test_cortex_norm_fail(self):
         with self.getRamCore() as core:
-            core.formTufoByProp('inet:netuser', 'vertex.link/visi')
-            self.raises(BadTypeValu, core.eval, 'inet:netuser="totally invalid input"')
+            core.formTufoByProp('inet:web:acct', 'vertex.link/visi')
+            self.raises(BadTypeValu, core.eval, 'inet:web:acct="totally invalid input"')
 
     def test_cortex_local(self):
         splices = []

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -728,15 +728,15 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.getTufosBy('in', 'inet:ipv4', ['10.2.3.5', '10.2.3.6', '10.2.3.7'])), 1)
 
         # By IN using COMP type nodes
-        nmb1 = core.formTufoByProp('inet:netmemb', '(vertex.link/pennywise,vertex.link/eldergods)')
-        nmb2 = core.formTufoByProp('inet:netmemb', ('vertex.link/invisig0th', 'vertex.link/eldergods'))
-        nmb3 = core.formTufoByProp('inet:netmemb', ['vertex.link/pennywise', 'vertex.link/clowns'])
+        nmb1 = core.formTufoByProp('inet:web:memb', '(vertex.link/pennywise,vertex.link/eldergods)')
+        nmb2 = core.formTufoByProp('inet:web:memb', ('vertex.link/invisig0th', 'vertex.link/eldergods'))
+        nmb3 = core.formTufoByProp('inet:web:memb', ['vertex.link/pennywise', 'vertex.link/clowns'])
 
-        self.eq(len(core.getTufosBy('in', 'inet:netmemb', ['(vertex.link/pennywise,vertex.link/eldergods)'])), 1)
-        self.eq(len(core.getTufosBy('in', 'inet:netmemb:group', ['vertex.link/eldergods'])), 2)
-        self.eq(len(core.getTufosBy('in', 'inet:netmemb:group', ['vertex.link/eldergods'])), 2)
-        self.eq(len(core.getTufosBy('in', 'inet:netmemb:group', ['vertex.link/eldergods', 'vertex.link/clowns'])), 3)
-        self.eq(len(core.getTufosBy('in', 'inet:netmemb', ['(vertex.link/pennywise,vertex.link/eldergods)', ('vertex.link/pennywise', 'vertex.link/clowns')])), 2)
+        self.eq(len(core.getTufosBy('in', 'inet:web:memb', ['(vertex.link/pennywise,vertex.link/eldergods)'])), 1)
+        self.eq(len(core.getTufosBy('in', 'inet:web:memb:group', ['vertex.link/eldergods'])), 2)
+        self.eq(len(core.getTufosBy('in', 'inet:web:memb:group', ['vertex.link/eldergods'])), 2)
+        self.eq(len(core.getTufosBy('in', 'inet:web:memb:group', ['vertex.link/eldergods', 'vertex.link/clowns'])), 3)
+        self.eq(len(core.getTufosBy('in', 'inet:web:memb', ['(vertex.link/pennywise,vertex.link/eldergods)', ('vertex.link/pennywise', 'vertex.link/clowns')])), 2)
 
         # By LT/LE/GE/GT
         self.eq(len(core.getTufosBy('lt', 'default_foo:p0', 6)), 3)
@@ -819,8 +819,8 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.getTufosBy('eq', 'inet:ipv4:asn', -1)), 5)
         self.eq(len(core.getTufosBy('eq', 'inet:ipv4', 0x0)), 0)
         self.eq(len(core.getTufosBy('eq', 'inet:ipv4', '0.0.0.0')), 0)
-        self.eq(len(core.getTufosBy('eq', 'inet:netmemb', '(vertex.link/pennywise,vertex.link/eldergods)')), 1)
-        self.eq(len(core.getTufosBy('eq', 'inet:netmemb', ('vertex.link/invisig0th', 'vertex.link/eldergods'))), 1)
+        self.eq(len(core.getTufosBy('eq', 'inet:web:memb', '(vertex.link/pennywise,vertex.link/eldergods)')), 1)
+        self.eq(len(core.getTufosBy('eq', 'inet:web:memb', ('vertex.link/invisig0th', 'vertex.link/eldergods'))), 1)
 
         # By TYPE - this requires data model introspection
         fook = core.formTufoByProp('inet:dns:a', 'derry.vertex.link/10.2.3.6')
@@ -830,8 +830,8 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.getTufosBy('type', 'inet:ipv4', 0x0a020306)), 3)
 
         # By TYPE using COMP nodes
-        self.eq(len(core.getTufosBy('type', 'inet:netmemb', '(vertex.link/pennywise,vertex.link/eldergods)')), 1)
-        self.eq(len(core.getTufosBy('type', 'inet:netmemb', ('vertex.link/invisig0th', 'vertex.link/eldergods'))), 1)
+        self.eq(len(core.getTufosBy('type', 'inet:web:memb', '(vertex.link/pennywise,vertex.link/eldergods)')), 1)
+        self.eq(len(core.getTufosBy('type', 'inet:web:memb', ('vertex.link/invisig0th', 'vertex.link/eldergods'))), 1)
         self.eq(len(core.getTufosBy('type', 'inet:web:acct', 'vertex.link/invisig0th')), 2)
 
         # BY CIDR

--- a/synapse/tests/test_lib_ingest.py
+++ b/synapse/tests/test_lib_ingest.py
@@ -738,7 +738,7 @@ class IngTest(SynTest):
                                 ["link", {"props": {"tld": 1}}],
                             ]],
 
-                            ["inet:netuser", [
+                            ["inet:web:acct", [
                                 ["rootkit.com/metr0", {"props": {"email": "metr0@kenshoto.com"}}],
                                 ["twitter.com/invisig0th", {"props": {"email": "visi@vertex.link"}}]
                             ]],
@@ -754,11 +754,11 @@ class IngTest(SynTest):
             gest = s_ingest.Ingest(info)
             gest.ingest(core)
 
-            self.nn(core.getTufoByProp('inet:netuser', 'rootkit.com/metr0'))
-            self.nn(core.getTufoByProp('inet:netuser', 'twitter.com/invisig0th'))
+            self.nn(core.getTufoByProp('inet:web:acct', 'rootkit.com/metr0'))
+            self.nn(core.getTufoByProp('inet:web:acct', 'twitter.com/invisig0th'))
 
-            self.len(1, core.eval('inet:netuser:email="visi@vertex.link"'))
-            self.len(1, core.eval('inet:netuser:email="metr0@kenshoto.com"'))
+            self.len(1, core.eval('inet:web:acct:email="visi@vertex.link"'))
+            self.len(1, core.eval('inet:web:acct:email="metr0@kenshoto.com"'))
 
             node = core.eval('inet:email*tag=foo.bar')[0]
             self.eq(node[1].get('inet:email'), 'visi@vertex.link')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -60,18 +60,18 @@ class StormTest(SynTest):
         with self.getRamCore() as core:
 
             # relative key/val syntax, explicitly relative vals
-            node = core.formTufoByProp('inet:netuser', 'vertex.link/pennywise')
-            node = core.formTufoByProp('inet:netuser', 'vertex.link/visi')
-            node = core.eval('inet:netuser=vertex.link/pennywise setprop(:realname="Robert Gray")')[0]
+            node = core.formTufoByProp('inet:web:acct', 'vertex.link/pennywise')
+            node = core.formTufoByProp('inet:web:acct', 'vertex.link/visi')
+            node = core.eval('inet:web:acct=vertex.link/pennywise setprop(:realname="Robert Gray")')[0]
 
-            self.eq(node[1].get('inet:netuser'), 'vertex.link/pennywise')
-            self.eq(node[1].get('inet:netuser:realname'), 'robert gray')
+            self.eq(node[1].get('inet:web:acct'), 'vertex.link/pennywise')
+            self.eq(node[1].get('inet:web:acct:realname'), 'robert gray')
 
             # Can set multiple props at once
-            cmd = 'inet:netuser=vertex.link/pennywise setprop(:seen:min="2000", :seen:max="2017")'
+            cmd = 'inet:web:acct=vertex.link/pennywise setprop(:seen:min="2000", :seen:max="2017")'
             node = core.eval(cmd)[0]
-            self.nn(node[1].get('inet:netuser:seen:min'))
-            self.nn(node[1].get('inet:netuser:seen:max'))
+            self.nn(node[1].get('inet:web:acct:seen:min'))
+            self.nn(node[1].get('inet:web:acct:seen:max'))
 
             # old / bad syntax fails
             # kwlist key/val syntax is no longer valid in setprop()
@@ -82,7 +82,7 @@ class StormTest(SynTest):
             bad_cmd = 'inet:fqdn=vertex.link setprop(:typocreated="2016-05-05")'
             self.raises(BadSyntaxError, core.eval, bad_cmd)
             # full prop syntax is not acceptable
-            bad_cmd = 'inet:netuser=vertex.link/pennywise setprop(inet:netuser:signup="1970-01-01")'
+            bad_cmd = 'inet:web:acct=vertex.link/pennywise setprop(inet:web:acct:signup="1970-01-01")'
             self.raises(BadSyntaxError, core.eval, bad_cmd)
 
     def test_storm_filt_regex(self):
@@ -317,7 +317,7 @@ class StormTest(SynTest):
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
             node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
-            node4 = core.formTufoByProp('inet:netuser', 'clowntown.link/pennywise')
+            node4 = core.formTufoByProp('inet:web:acct', 'clowntown.link/pennywise')
 
             core.addTufoTags(node1, ['aka.bar.baz',
                                      'aka.duck.quack.loud',
@@ -360,7 +360,7 @@ class StormTest(SynTest):
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
             node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
-            node4 = core.formTufoByProp('inet:netuser', 'clowntown.link/pennywise')
+            node4 = core.formTufoByProp('inet:web:acct', 'clowntown.link/pennywise')
 
             core.addTufoTags(node1, ['aka.bar.baz',
                                      'aka.duck.quack.loud',
@@ -403,7 +403,7 @@ class StormTest(SynTest):
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
             node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
-            node4 = core.formTufoByProp('inet:netuser', 'clowntown.link/pennywise')
+            node4 = core.formTufoByProp('inet:web:acct', 'clowntown.link/pennywise')
             core.addTufoTags(node1, ['aka.bar.baz',
                                      'aka.duck.quack.loud',
                                      'loc.milkyway.galactic_arm_a.sol.earth.us.ca.san_francisco'])
@@ -465,7 +465,7 @@ class StormTest(SynTest):
             node1 = core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
             node2 = core.formTufoByProp('inet:fqdn', 'vertex.vis')
             node3 = core.formTufoByProp('inet:url', 'https://vertex.link')
-            node4 = core.formTufoByProp('inet:netuser', 'clowntown.link/pennywise')
+            node4 = core.formTufoByProp('inet:web:acct', 'clowntown.link/pennywise')
 
             core.addTufoDark(node1, 'hehe', 'haha')
             core.addTufoDark(node2, 'hehe', 'haha')
@@ -838,19 +838,19 @@ class StormTest(SynTest):
             self.notin('inet:fqdn:updated', t0[1])
 
             # Cannot delete "ro" props via delprop
-            t1 = core.formTufoByProp('inet:netuser', 'vertex.link/pennywise')
-            self.isin('inet:netuser:user', t1[1])
+            t1 = core.formTufoByProp('inet:web:acct', 'vertex.link/pennywise')
+            self.isin('inet:web:acct:user', t1[1])
             # Operator syntax requires force=1
-            result = core.ask('inet:netuser [ -:user ]')
+            result = core.ask('inet:web:acct [ -:user ]')
             self.eq(result.get('data'), [])
             self.eq(result.get('oplog')[1].get('excinfo').get('err'), 'CantDelProp')
-            t1 = core.getTufoByProp('inet:netuser', 'vertex.link/pennywise')
-            self.isin('inet:netuser:user', t1[1])
-            result = core.ask('inet:netuser delprop(:user, force=1)')
+            t1 = core.getTufoByProp('inet:web:acct', 'vertex.link/pennywise')
+            self.isin('inet:web:acct:user', t1[1])
+            result = core.ask('inet:web:acct delprop(:user, force=1)')
             self.eq(result.get('data'), [])
             self.eq(result.get('oplog')[1].get('excinfo').get('err'), 'CantDelProp')
-            t1 = core.getTufoByProp('inet:netuser', 'vertex.link/pennywise')
-            self.isin('inet:netuser:user', t1[1])
+            t1 = core.getTufoByProp('inet:web:acct', 'vertex.link/pennywise')
+            self.isin('inet:web:acct:user', t1[1])
 
             # Syntax errors
             self.raises(BadSyntaxError, core.eval, 'inet:fqdn=vertex.link delprop()')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -649,12 +649,12 @@ class StormTest(SynTest):
             self.notin('.new', node1[1])
             self.eq(node0[0], node1[0])
 
-            node2 = core.eval('addnode(ps:hasnetuser, ((guidname="bob gray"),vertex.link/pennywise))')[0]
-            self.eq(node2[1].get('ps:hasnetuser'), 'faebe657f7a5839ecda3f8af15293893/vertex.link/pennywise')
+            node2 = core.eval('addnode(ps:haswebacct, ((guidname="bob gray"),vertex.link/pennywise))')[0]
+            self.eq(node2[1].get('ps:haswebacct'), 'faebe657f7a5839ecda3f8af15293893/vertex.link/pennywise')
 
-            node3 = core.eval('addnode(ou:hasnetuser, ((alias="vertex"),vertex.link/pennywise))')[0]
-            self.eq(node3[1].get('ou:hasnetuser'), 'e0d1c290732ac433444afe7b5825f94d')
-            self.eq(node3[1].get('ou:hasnetuser:netuser'), 'vertex.link/pennywise')
+            node3 = core.eval('addnode(ou:haswebacct, ((alias="vertex"),vertex.link/pennywise))')[0]
+            self.eq(node3[1].get('ou:haswebacct'), 'e0d1c290732ac433444afe7b5825f94d')
+            self.eq(node3[1].get('ou:haswebacct:web:acct'), 'vertex.link/pennywise')
 
     def test_storm_task(self):
         with self.getRamCore() as core:

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -333,64 +333,64 @@ class InetModelTest(SynTest):
             node = core.formTufoByProp('inet:url', 'HTTP://1.2.3.4/')
             self.eq(node[1].get('inet:url:ipv4'), 0x01020304)
 
-    def test_model_inet_netpost(self):
+    def test_model_inet_web_post(self):
 
         with self.getRamCore() as core:
-            node0 = core.formTufoByProp('inet:netpost', ('vertex.link/visi', 'knock knock'), time='20141217010101')
-            iden = node0[1].get('inet:netpost')
+            node0 = core.formTufoByProp('inet:web:post', ('vertex.link/visi', 'knock knock'), time='20141217010101')
+            iden = node0[1].get('inet:web:post')
 
-            node1 = core.formTufoByProp('inet:netpost', ('vertex.link/visi', 'whos there'), time='20141217010102', replyto=iden)
+            node1 = core.formTufoByProp('inet:web:post', ('vertex.link/visi', 'whos there'), time='20141217010102', replyto=iden)
 
             self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/visi'))
 
-            self.eq(node0[1].get('inet:netpost:netuser:user'), 'visi')
-            self.eq(node1[1].get('inet:netpost:netuser:user'), 'visi')
+            self.eq(node0[1].get('inet:web:post:acct:user'), 'visi')
+            self.eq(node1[1].get('inet:web:post:acct:user'), 'visi')
 
-            self.eq(node0[1].get('inet:netpost:netuser:site'), 'vertex.link')
-            self.eq(node1[1].get('inet:netpost:netuser:site'), 'vertex.link')
+            self.eq(node0[1].get('inet:web:post:acct:site'), 'vertex.link')
+            self.eq(node1[1].get('inet:web:post:acct:site'), 'vertex.link')
 
-            self.eq(node0[1].get('inet:netpost'), node1[1].get('inet:netpost:replyto'))
+            self.eq(node0[1].get('inet:web:post'), node1[1].get('inet:web:post:replyto'))
 
-    def test_model_inet_netmesg(self):
+    def test_model_inet_web_mesg(self):
         with self.getRamCore() as core:
 
-            node = core.formTufoByProp('inet:netmesg', ('VERTEX.link/visi', 'vertex.LINK/hehe', '20501217'), text='hehe haha')
+            node = core.formTufoByProp('inet:web:mesg', ('VERTEX.link/visi', 'vertex.LINK/hehe', '20501217'), text='hehe haha')
             self.nn(node)
-            self.eq(node[1].get('inet:netmesg:from'), 'vertex.link/visi')
-            self.eq(node[1].get('inet:netmesg:to'), 'vertex.link/hehe')
-            self.eq(node[1].get('inet:netmesg:time'), 2554848000000)
-            self.eq(node[1].get('inet:netmesg:text'), 'hehe haha')
+            self.eq(node[1].get('inet:web:mesg:from'), 'vertex.link/visi')
+            self.eq(node[1].get('inet:web:mesg:to'), 'vertex.link/hehe')
+            self.eq(node[1].get('inet:web:mesg:time'), 2554848000000)
+            self.eq(node[1].get('inet:web:mesg:text'), 'hehe haha')
 
             self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/visi'))
             self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/hehe'))
 
-    def test_model_inet_netmemb(self):
+    def test_model_inet_web_memb(self):
 
         with self.getRamCore() as core:
 
-            node = core.formTufoByProp('inet:netmemb', ('VERTEX.link/visi', 'vertex.LINK/kenshoto'), joined='20501217')
+            node = core.formTufoByProp('inet:web:memb', ('VERTEX.link/visi', 'vertex.LINK/kenshoto'), joined='20501217')
 
             self.nn(node)
 
-            self.eq(node[1].get('inet:netmemb:joined'), 2554848000000)
-            self.eq(node[1].get('inet:netmemb:user'), 'vertex.link/visi')
-            self.eq(node[1].get('inet:netmemb:group'), 'vertex.link/kenshoto')
+            self.eq(node[1].get('inet:web:memb:joined'), 2554848000000)
+            self.eq(node[1].get('inet:web:memb:acct'), 'vertex.link/visi')
+            self.eq(node[1].get('inet:web:memb:group'), 'vertex.link/kenshoto')
 
             self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/visi'))
             self.nn(core.getTufoByProp('inet:web:group', 'vertex.link/kenshoto'))
 
-    def test_model_inet_follows(self):
+    def test_model_inet_web_follows(self):
 
         with self.getRamCore() as core:
 
             props = {'seen:min': '20501217', 'seen:max': '20501217'}
-            node = core.formTufoByProp('inet:follows', ('VERTEX.link/visi', 'vertex.LINK/hehe'), **props)
+            node = core.formTufoByProp('inet:web:follows', ('VERTEX.link/visi', 'vertex.LINK/hehe'), **props)
 
             self.nn(node)
-            self.eq(node[1].get('inet:follows:follower'), 'vertex.link/visi')
-            self.eq(node[1].get('inet:follows:followee'), 'vertex.link/hehe')
-            self.eq(node[1].get('inet:follows:seen:min'), 2554848000000)
-            self.eq(node[1].get('inet:follows:seen:max'), 2554848000000)
+            self.eq(node[1].get('inet:web:follows:follower'), 'vertex.link/visi')
+            self.eq(node[1].get('inet:web:follows:followee'), 'vertex.link/hehe')
+            self.eq(node[1].get('inet:web:follows:seen:min'), 2554848000000)
+            self.eq(node[1].get('inet:web:follows:seen:max'), 2554848000000)
 
     def test_model_inet_ipv4_raise(self):
         with self.getRamCore() as core:
@@ -451,25 +451,22 @@ class InetModelTest(SynTest):
 
             self.raises(BadTypeValu, core.getTypeNorm, 'inet:fqdn', '!@#$%')
 
-    def test_model_inet_weblogon(self):
+    def test_model_inet_web_logon(self):
 
         with self.getRamCore() as core:
             tick = now()
 
-            t0 = core.formTufoByProp('inet:web:logon', '*',
-                                     netuser='vertex.link/pennywise',
-                                     time=tick)
-
+            t0 = core.formTufoByProp('inet:web:logon', '*', acct='vertex.link/pennywise', time=tick)
             self.nn(t0)
 
             self.eq(t0[1].get('inet:web:logon:time'), tick)
-            self.eq(t0[1].get('inet:web:logon:netuser'), 'vertex.link/pennywise')
-            self.eq(t0[1].get('inet:web:logon:netuser:user'), 'pennywise')
-            self.eq(t0[1].get('inet:web:logon:netuser:site'), 'vertex.link')
+            self.eq(t0[1].get('inet:web:logon:acct'), 'vertex.link/pennywise')
+            self.eq(t0[1].get('inet:web:logon:acct:user'), 'pennywise')
+            self.eq(t0[1].get('inet:web:logon:acct:site'), 'vertex.link')
 
-            # Pivot from a netuser to the netlogon forms via storm
+            # Pivot from an inet:web:acct to the inet:web:logon forms via storm
             self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/pennywise'))
-            nodes = core.eval('inet:web:acct=vertex.link/pennywise inet:web:acct -> inet:web:logon:netuser')
+            nodes = core.eval('inet:web:acct=vertex.link/pennywise inet:web:acct -> inet:web:logon:acct')
             self.eq(len(nodes), 1)
 
             t0 = core.setTufoProps(t0, ipv4=0x01020304, logout=tick + 1, ipv6='0:0:0:0:0:0:0:1')

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -863,6 +863,38 @@ class InetModelTest(SynTest):
         adds.extend(_addTag('hehe.hoho', 'file:txtref'))
         adds.extend(_addTag('hehe', 'file:txtref'))
 
+        iden = guid()
+        dark_iden = iden[::-1]
+        tick = now()
+        adds.extend([
+            (iden, 'ps:hasnetuser:netuser', 'vertex.link/heheman', tick),
+            (iden, 'ps:hasnetuser:person', '00000000000000000000000000000000', tick),
+            (iden, 'tufo:form', 'ps:hasnetuser', tick),
+            (iden, 'ps:hasnetuser', '00000000000000000000000000000000/vertex.link/heheman', tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*ps:hasnetuser#hehe.hoho', tick, tick),
+            (dark_iden, '_:*ps:hasnetuser#hehe', tick, tick),
+        ])
+        adds.extend(_addTag('hehe.hoho', 'ps:hasnetuser'))
+        adds.extend(_addTag('hehe', 'ps:hasnetuser'))
+
+        iden = guid()
+        dark_iden = iden[::-1]
+        tick = now()
+        adds.extend([
+            (iden, 'ou:hasnetuser:netuser', 'vertex.link/heheman', tick),
+            (iden, 'ou:hasnetuser:org', '00000000000000000000000000000000', tick),
+            (iden, 'tufo:form', 'ou:hasnetuser', tick),
+            (iden, 'ou:hasnetuser', '4016087db1b71ecc56db535a5ee9e86e', tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*ou:hasnetuser#hehe.hoho', tick, tick),
+            (dark_iden, '_:*ou:hasnetuser#hehe', tick, tick),
+        ])
+        adds.extend(_addTag('hehe.hoho', 'ou:hasnetuser'))
+        adds.extend(_addTag('hehe', 'ou:hasnetuser'))
+
         with s_cortex.openstore('ram:///') as stor:
 
             # force model migration callbacks
@@ -1073,3 +1105,39 @@ class InetModelTest(SynTest):
                 # assert that no old data remains
                 tufos = core.getTufosByProp('file:txtref', txtref_valu)
                 self.len(0, tufos)
+
+                # ps:hasnetuser -> ps:haswebacct
+                # assert that the correct number of users and groups were migrated
+                tufos = core.getTufosByProp('ps:haswebacct')
+                self.len(1, tufos)
+
+                # check that properties were correctly migrated and tags were not damaged
+                tufo = core.getTufoByProp('ps:haswebacct', '00000000000000000000000000000000/vertex.link/heheman')
+                self.eq(tufo[1]['ps:haswebacct'], '00000000000000000000000000000000/vertex.link/heheman')
+                self.eq(tufo[1]['ps:haswebacct:acct'], 'vertex.link/heheman')
+                self.eq(tufo[1]['ps:haswebacct:person'], '00000000000000000000000000000000')
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+
+                # assert that no old data remains
+                tufos = core.getTufosByProp('ps:hasnetuser')
+                self.len(0, tufos)
+                rows = core.getJoinByProp('ps:hasnetuser')
+                self.len(0, rows)
+
+                # ou:hasnetuser -> ou:haswebacct
+                # assert that the correct number of users and groups were migrated
+                tufos = core.getTufosByProp('ou:haswebacct')
+                self.len(1, tufos)
+
+                # check that properties were correctly migrated and tags were not damaged
+                tufo = core.getTufoByProp('ou:haswebacct', '4016087db1b71ecc56db535a5ee9e86e')
+                self.eq(tufo[1]['ou:haswebacct'], '4016087db1b71ecc56db535a5ee9e86e')
+                self.eq(tufo[1]['ou:haswebacct:acct'], 'vertex.link/heheman')
+                self.eq(tufo[1]['ou:haswebacct:org'], '00000000000000000000000000000000')
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+
+                # assert that no old data remains
+                tufos = core.getTufosByProp('ou:hasnetuser')
+                self.len(0, tufos)
+                rows = core.getJoinByProp('ou:hasnetuser')
+                self.len(0, rows)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -533,6 +533,25 @@ class InetModelTest(SynTest):
             self.raises(PropNotFound, core.formTufoByProp, 'inet:web:action', '*', acct='vertex.link/pennywise', time=tick)
             self.raises(PropNotFound, core.formTufoByProp, 'inet:web:action', '*', act='didathing', time=tick)
 
+    def test_model_inet_web_actref(self):
+        with self.getRamCore() as core:
+
+            fnod = core.formTufoByProp('file:bytes', 'd41d8cd98f00b204e9800998ecf8427e')
+            anod = core.formTufoByProp('inet:web:action', '*', act='laughed', acct='vertex.link/user1')
+
+            fiden = fnod[1].get('file:bytes')
+            aiden = anod[1].get('inet:web:action')
+
+            ar0 = core.formTufoByProp('inet:web:actref', (aiden, ('file:bytes', fiden)))
+            ar1 = core.formTufoByProp('inet:web:actref', '(%s,file:bytes=%s)' % (aiden, fiden))
+
+            self.eq(ar0[0], ar1[0])
+            self.eq(ar0[1].get('inet:web:actref:act'), aiden)
+            self.eq(ar0[1].get('inet:web:actref:xref'), 'file:bytes=' + fiden)
+            self.eq(ar0[1].get('inet:web:actref:xref:prop'), 'file:bytes')
+            self.eq(ar0[1].get('inet:web:actref:xref:strval'), fiden)
+            self.eq(ar0[1].get('inet:web:actref:xref:intval'), None)
+
     def test_model_inet_201706121318(self):
 
         iden0 = guid()

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -333,6 +333,16 @@ class InetModelTest(SynTest):
             node = core.formTufoByProp('inet:url', 'HTTP://1.2.3.4/')
             self.eq(node[1].get('inet:url:ipv4'), 0x01020304)
 
+    def test_model_inet_web_acct(self):
+
+        with self.getRamCore() as core:
+            t0 = core.formTufoByProp('inet:web:acct', 'vertex.link/person1')
+            self.eq(t0[1].get('inet:web:acct'), 'vertex.link/person1')
+            self.eq(t0[1].get('inet:web:acct:site'), 'vertex.link')
+            self.eq(t0[1].get('inet:web:acct:user'), 'person1')
+            t0 = core.setTufoProp(t0, 'loc', 'HAHA')
+            self.eq(t0[1].get('inet:web:acct:loc'), 'haha')
+
     def test_model_inet_web_post(self):
 
         with self.getRamCore() as core:

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -509,23 +509,29 @@ class InetModelTest(SynTest):
         with self.getRamCore() as core:
             tick = now()
 
-            t0 = core.formTufoByProp('inet:web:action', '*', action='didathing', acct='vertex.link/pennywise', time=tick)
+            t0 = core.formTufoByProp('inet:web:action', '*', act='didathing', acct='vertex.link/pennywise', time=tick)
             self.nn(t0)
 
             self.eq(t0[1].get('inet:web:action:time'), tick)
             self.eq(t0[1].get('inet:web:action:acct'), 'vertex.link/pennywise')
             self.eq(t0[1].get('inet:web:action:acct:user'), 'pennywise')
             self.eq(t0[1].get('inet:web:action:acct:site'), 'vertex.link')
-            self.eq(t0[1].get('inet:web:action:action'), 'didathing')
+            self.eq(t0[1].get('inet:web:action:act'), 'didathing')
 
             # Pivot from an inet:web:acct to the inet:web:action forms via storm
             self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/pennywise'))
             nodes = core.eval('inet:web:acct=vertex.link/pennywise inet:web:acct -> inet:web:action:acct')
             self.eq(len(nodes), 1)
 
-            t0 = core.setTufoProps(t0, ipv4=0x01020304, ipv6='0:0:0:0:0:0:0:1')
+            t0 = core.setTufoProps(t0, ipv4=0x01020304, ipv6='0:0:0:0:0:0:0:1', acct='vertex.link/user2')
             self.eq(t0[1].get('inet:web:action:ipv4'), 0x01020304)
             self.eq(t0[1].get('inet:web:action:ipv6'), '::1')
+            self.eq(t0[1].get('inet:web:action:acct'), 'vertex.link/pennywise')
+            self.eq(t0[1].get('inet:web:action:acct:user'), 'pennywise')
+            self.eq(t0[1].get('inet:web:action:acct:site'), 'vertex.link')
+
+            self.raises(PropNotFound, core.formTufoByProp, 'inet:web:action', '*', acct='vertex.link/pennywise', time=tick)
+            self.raises(PropNotFound, core.formTufoByProp, 'inet:web:action', '*', act='didathing', time=tick)
 
     def test_model_inet_201706121318(self):
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -614,6 +614,20 @@ class InetModelTest(SynTest):
                 (iden, 'inet:netuser:site', 'vertex.link', tick),
                 (iden, 'inet:netuser:user', user, tick),
                 (iden, 'inet:netuser:dob', 1337, tick),
+                (iden, 'inet:netuser:url', 'https://vertex.link/url', tick),
+                (iden, 'inet:netuser:webpage', 'https://vertex.link/webpage', tick),
+                (iden, 'inet:netuser:avatar', 'd41d8cd98f00b204e9800998ecf8427e', tick),
+                (iden, 'inet:netuser:tagline', 'a tagline', tick),
+                (iden, 'inet:netuser:occupation', 'entertainer', tick),
+                (iden, 'inet:netuser:name', 'my name', tick),
+                (iden, 'inet:netuser:realname', 'my real name', tick),
+                (iden, 'inet:netuser:email', 'email@vertex.link', tick),
+                (iden, 'inet:netuser:phone', '17035551212', tick),
+                (iden, 'inet:netuser:signup', 7331, tick),
+                (iden, 'inet:netuser:signup:ipv4', 0x01020304, tick),
+                (iden, 'inet:netuser:passwd', 'hunter2', tick),
+                (iden, 'inet:netuser:seen:min', 0, tick),
+                (iden, 'inet:netuser:seen:max', 1, tick),
                 (iden, '#hehe.hoho', tick, tick),
                 (iden, '#hehe', tick, tick),
                 (dark_iden, '_:*inet:netuser#hehe.hoho', tick, tick),
@@ -633,6 +647,9 @@ class InetModelTest(SynTest):
                 (iden, 'inet:netgroup:site', 'vertex.link', tick),
                 (iden, 'inet:netgroup:name', group, tick),
                 (iden, 'inet:netgroup:desc', 'hehe', tick),
+                (iden, 'inet:netgroup:url', 'https://vertex.link/url', tick),
+                (iden, 'inet:netgroup:webpage', 'https://vertex.link/webpage', tick),
+                (iden, 'inet:netgroup:avatar', 'd41d8cd98f00b204e9800998ecf8427e', tick),
                 (iden, '#hehe.hoho', tick, tick),
                 (iden, '#hehe', tick, tick),
                 (dark_iden, '_:*inet:netgroup#hehe.hoho', tick, tick),
@@ -640,6 +657,95 @@ class InetModelTest(SynTest):
             ])
         adds.extend(_addTag('hehe.hoho', 'inet:netgroup'))
         adds.extend(_addTag('hehe', 'inet:netgroup'))
+
+        iden = guid()
+        acct1 = 'vertex.link/person1'
+        acct2 = 'vertex.link/person2'
+        follow_valu = '4ebc93255f8582a9d6c38dbba952dc9b'
+        dark_iden = iden[::-1]
+        tick = now()
+        adds.extend([
+            (iden, 'tufo:form', 'inet:follows', tick),
+            (iden, 'inet:follows', follow_valu, tick),
+            (iden, 'inet:follows:follower', acct1, tick),
+            (iden, 'inet:follows:followee', acct2, tick),
+            (iden, 'inet:follows:seen:min', 0, tick),
+            (iden, 'inet:follows:seen:max', 1, tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*inet:follows#hehe.hoho', tick, tick),
+            (dark_iden, '_:*inet:follows#hehe', tick, tick),
+        ])
+        adds.extend(_addTag('hehe.hoho', 'inet:follows'))
+        adds.extend(_addTag('hehe', 'inet:follows'))
+
+        iden = guid()
+        webmemb_valu = '7d8675f29b54cf71e3c36d4448aaa842'
+        dark_iden = iden[::-1]
+        tick = now()
+        adds.extend([
+            (iden, 'tufo:form', 'inet:netmemb', tick),
+            (iden, 'inet:netmemb', webmemb_valu, tick),
+            (iden, 'inet:netmemb:user', 'vertex.link/person1', tick),
+            (iden, 'inet:netmemb:group', 'vertex.link/group0', tick),
+            (iden, 'inet:netmemb:title', 'a title', tick),
+            (iden, 'inet:netmemb:joined', 123, tick),
+            (iden, 'inet:netmemb:seen:min', 0, tick),
+            (iden, 'inet:netmemb:seen:max', 1, tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*inet:netmemb#hehe.hoho', tick, tick),
+            (dark_iden, '_:*inet:netmemb#hehe', tick, tick),
+        ])
+        adds.extend(_addTag('hehe.hoho', 'inet:netmemb'))
+        adds.extend(_addTag('hehe', 'inet:netmemb'))
+
+        iden = guid()
+        webpost_valu = '19abe9969d6712318370f7c4d943f8ea'
+        dark_iden = iden[::-1]
+        tick = now()
+        adds.extend([
+            (iden, 'tufo:form', 'inet:netpost', tick),
+            (iden, 'inet:netpost', webpost_valu, tick),
+            (iden, 'inet:netpost:netuser', 'vertex.link/person1', tick),
+            (iden, 'inet:netpost:netuser:site', 'vertex.link', tick),
+            (iden, 'inet:netpost:netuser:user', 'person1', tick),
+            (iden, 'inet:netpost:text', 'my cool post', tick),
+            (iden, 'inet:netpost:replyto', '0' * 32, tick),
+            (iden, 'inet:netpost:url', 'https://vertex.link/blog/1', tick),
+            (iden, 'inet:netpost:file', 'd41d8cd98f00b204e9800998ecf8427e', tick),
+            (iden, 'inet:netpost:time', 12345, tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*inet:netpost#hehe.hoho', tick, tick),
+            (dark_iden, '_:*inet:netpost#hehe', tick, tick),
+        ])
+        adds.extend(_addTag('hehe.hoho', 'inet:netpost'))
+        adds.extend(_addTag('hehe', 'inet:netpost'))
+
+        iden = guid()
+        webfile_valu = '1f91e1492718d2cbccae1f27c54409ed'
+        dark_iden = iden[::-1]
+        tick = now()
+        adds.extend([
+            (iden, 'tufo:form', 'inet:netfile', tick),
+            (iden, 'inet:netfile', webfile_valu, tick),
+            (iden, 'inet:netfile:file', '0' * 32, tick),
+            (iden, 'inet:netfile:netuser', 'vertex.link/person1', tick),
+            (iden, 'inet:netfile:netuser:site', 'vertex.link', tick),
+            (iden, 'inet:netfile:netuser:user', 'person1', tick),
+            (iden, 'inet:netfile:name', 'my cool file', tick),
+            (iden, 'inet:netfile:posted', 123456, tick),
+            (iden, 'inet:netfile:ipv4', 0, tick),
+            (iden, 'inet:netfile:ipv6', '::1', tick),
+            (iden, 'inet:netfile:seen:min', 0, tick),
+            (iden, 'inet:netfile:seen:max', 1, tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*inet:netfile#hehe.hoho', tick, tick),
+            (dark_iden, '_:*inet:netfile#hehe', tick, tick),
+        ])
+        adds.extend(_addTag('hehe.hoho', 'inet:netpost'))
 
         with s_cortex.openstore('ram:///') as stor:
 
@@ -662,7 +768,20 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:acct'], 'vertex.link/pennywise0')
                 self.eq(tufo[1]['inet:web:acct:user'], 'pennywise0')
                 self.eq(tufo[1]['inet:web:acct:site'], 'vertex.link')
-                self.eq(tufo[1]['inet:web:acct:dob'], 1337)
+                self.eq(tufo[1]['inet:web:acct:url'], 'https://vertex.link/url')
+                self.eq(tufo[1]['inet:web:acct:webpage'], 'https://vertex.link/webpage')
+                self.eq(tufo[1]['inet:web:acct:avatar'], 'd41d8cd98f00b204e9800998ecf8427e')
+                self.eq(tufo[1]['inet:web:acct:tagline'], 'a tagline')
+                self.eq(tufo[1]['inet:web:acct:occupation'], 'entertainer')
+                self.eq(tufo[1]['inet:web:acct:name'], 'my name')
+                self.eq(tufo[1]['inet:web:acct:realname'], 'my real name')
+                self.eq(tufo[1]['inet:web:acct:email'], 'email@vertex.link')
+                self.eq(tufo[1]['inet:web:acct:phone'], '17035551212')
+                self.eq(tufo[1]['inet:web:acct:signup'], 7331)
+                self.eq(tufo[1]['inet:web:acct:signup:ipv4'], 16909060)
+                self.eq(tufo[1]['inet:web:acct:passwd'], 'hunter2')
+                self.eq(tufo[1]['inet:web:acct:seen:min'], 0)
+                self.eq(tufo[1]['inet:web:acct:seen:max'], 1)
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
                 self.len(0, core.getRowsByProp('_:*inet:netuser#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:netuser#hehe'))
@@ -686,6 +805,9 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:group:site'], 'vertex.link')
                 self.eq(tufo[1]['inet:web:group:name'], 'group0')
                 self.eq(tufo[1]['inet:web:group:desc'], 'hehe')
+                self.eq(tufo[1]['inet:web:group:url'], 'https://vertex.link/url')
+                self.eq(tufo[1]['inet:web:group:webpage'], 'https://vertex.link/webpage')
+                self.eq(tufo[1]['inet:web:group:avatar'], 'd41d8cd98f00b204e9800998ecf8427e')
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
                 self.len(0, core.getRowsByProp('_:*inet:netgroup#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:netgroup#hehe'))
@@ -698,22 +820,102 @@ class InetModelTest(SynTest):
                 rows = core.getJoinByProp('inet:netgroup')
                 self.len(0, rows)
 
-                # FIXME inet:netmemb -> inet:web:memb
+                # inet:netmemb -> inet:web:memb
                 # assert that the correct number of users and groups were migrated
-                # check that properties were correctly migrated and tags were not damaged
-                # assert that no old data remains
+                tufos = core.getTufosByProp('inet:web:memb')
+                self.len(1, tufos)
 
-                # FIXME inet:follows -> inet:web:follows
-                # assert that the correct number of users and groups were migrated
                 # check that properties were correctly migrated and tags were not damaged
-                # assert that no old data remains
+                tufo = core.getTufoByProp('inet:web:memb', webmemb_valu)
+                self.eq(tufo[1]['inet:web:memb'], webmemb_valu)
+                self.eq(tufo[1]['inet:web:memb:acct'], 'vertex.link/person1')
+                self.eq(tufo[1]['inet:web:memb:group'], 'vertex.link/group0')
+                self.eq(tufo[1]['inet:web:memb:title'], 'a title')
+                self.eq(tufo[1]['inet:web:memb:joined'], 123)
+                self.eq(tufo[1]['inet:web:memb:seen:min'], 0)
+                self.eq(tufo[1]['inet:web:memb:seen:max'], 1)
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('_:*inet:netmemb#hehe.hoho'))
+                self.len(0, core.getRowsByProp('_:*inet:netmemb#hehe'))
+                self.len(1, core.getRowsByProp('_:*inet:web:memb#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*inet:web:memb#hehe'))
 
-                # FIXME inet:netpost -> inet:web:post
-                # assert that the correct number of users and groups were migrated
-                # check that properties were correctly migrated and tags were not damaged
                 # assert that no old data remains
+                tufos = core.getTufosByProp('inet:netmemb')
+                self.len(0, tufos)
+                rows = core.getJoinByProp('inet:netmemb')
+                self.len(0, rows)
 
-                # FIXME inet:netfile -> inet:web:file
-                # assert that the correct number of users and groups were migrated
+                # inet:follows -> inet:web:follows
+                # assert that the correct number of follow relationships were migrated
+                tufos = core.getTufosByProp('inet:web:follows')
+                self.len(1, tufos)
+
                 # check that properties were correctly migrated and tags were not damaged
+                tufo = core.getTufoByProp('inet:web:follows', follow_valu)
+                self.eq(tufo[1]['inet:web:follows'], follow_valu)
+                self.eq(tufo[1]['inet:web:follows:follower'], acct1)
+                self.eq(tufo[1]['inet:web:follows:followee'], acct2)
+                self.eq(tufo[1]['inet:web:follows:seen:min'], 0)
+                self.eq(tufo[1]['inet:web:follows:seen:max'], 1)
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('_:*inet:follows#hehe.hoho'))
+                self.len(0, core.getRowsByProp('_:*inet:follows#hehe'))
+                self.len(1, core.getRowsByProp('_:*inet:web:follows#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*inet:web:follows#hehe'))
+
                 # assert that no old data remains
+                tufos = core.getTufosByProp('inet:follows')
+                self.len(0, tufos)
+                rows = core.getJoinByProp('inet:follows')
+                self.len(0, rows)
+
+                # inet:netpost -> inet:web:post
+                # assert that the correct number of users and groups were migrated
+                tufos = core.getTufosByProp('inet:web:post')
+                self.len(1, tufos)
+
+                # check that properties were correctly migrated and tags were not damaged
+                tufo = core.getTufoByProp('inet:web:post', webpost_valu)
+                self.eq(tufo[1]['inet:web:post'], webpost_valu)
+                self.eq(tufo[1]['inet:web:post:acct'], 'vertex.link/person1')
+                self.eq(tufo[1]['inet:web:post:acct:site'], 'vertex.link')
+                self.eq(tufo[1]['inet:web:post:acct:user'], 'person1')
+                self.eq(tufo[1]['inet:web:post:text'], 'my cool post')
+                self.eq(tufo[1]['inet:web:post:replyto'], '0' * 32)
+                self.eq(tufo[1]['inet:web:post:url'], 'https://vertex.link/blog/1')
+                self.eq(tufo[1]['inet:web:post:file'], 'd41d8cd98f00b204e9800998ecf8427e')
+                self.eq(tufo[1]['inet:web:post:time'], 12345)
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+
+                # assert that no old data remains
+                tufos = core.getTufosByProp('inet:netpost')
+                self.len(0, tufos)
+                rows = core.getJoinByProp('inet:netpost')
+                self.len(0, rows)
+
+                # inet:netfile -> inet:web:file
+                # assert that the correct number of users and groups were migrated
+                tufos = core.getTufosByProp('inet:web:file')
+                self.len(1, tufos)
+
+                # check that properties were correctly migrated and tags were not damaged
+                tufo = core.getTufoByProp('inet:web:file', webfile_valu)
+                self.eq(tufo[1]['inet:web:file'], webfile_valu)
+                self.eq(tufo[1]['inet:web:file:acct'], 'vertex.link/person1')
+                self.eq(tufo[1]['inet:web:file:acct:site'], 'vertex.link')
+                self.eq(tufo[1]['inet:web:file:acct:user'], 'person1')
+                self.eq(tufo[1]['inet:web:file:file'], '0' * 32)
+                self.eq(tufo[1]['inet:web:file:name'], 'my cool file')
+                self.eq(tufo[1]['inet:web:file:posted'], 123456)
+                self.eq(tufo[1]['inet:web:file:ipv4'], 0)
+                self.eq(tufo[1]['inet:web:file:ipv6'], '::1')
+                self.eq(tufo[1]['inet:web:file:seen:min'], 0)
+                self.eq(tufo[1]['inet:web:file:seen:max'], 1)
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+
+                # assert that no old data remains
+                tufos = core.getTufosByProp('inet:netfile')
+                self.len(0, tufos)
+                rows = core.getJoinByProp('inet:netfile')
+                self.len(0, rows)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -504,6 +504,29 @@ class InetModelTest(SynTest):
             self.eq(t0[1].get('inet:web:logon:logout') - t0[1].get('inet:web:logon:time'), 1)
             self.eq(t0[1].get('inet:web:logon:ipv6'), '::1')
 
+    def test_model_inet_web_action(self):
+
+        with self.getRamCore() as core:
+            tick = now()
+
+            t0 = core.formTufoByProp('inet:web:action', '*', action='didathing', acct='vertex.link/pennywise', time=tick)
+            self.nn(t0)
+
+            self.eq(t0[1].get('inet:web:action:time'), tick)
+            self.eq(t0[1].get('inet:web:action:acct'), 'vertex.link/pennywise')
+            self.eq(t0[1].get('inet:web:action:acct:user'), 'pennywise')
+            self.eq(t0[1].get('inet:web:action:acct:site'), 'vertex.link')
+            self.eq(t0[1].get('inet:web:action:action'), 'didathing')
+
+            # Pivot from an inet:web:acct to the inet:web:action forms via storm
+            self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/pennywise'))
+            nodes = core.eval('inet:web:acct=vertex.link/pennywise inet:web:acct -> inet:web:action:acct')
+            self.eq(len(nodes), 1)
+
+            t0 = core.setTufoProps(t0, ipv4=0x01020304, ipv6='0:0:0:0:0:0:0:1')
+            self.eq(t0[1].get('inet:web:action:ipv4'), 0x01020304)
+            self.eq(t0[1].get('inet:web:action:ipv6'), '::1')
+
     def test_model_inet_201706121318(self):
 
         iden0 = guid()

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -892,8 +892,19 @@ class InetModelTest(SynTest):
             (dark_iden, '_:*ou:hasnetuser#hehe.hoho', tick, tick),
             (dark_iden, '_:*ou:hasnetuser#hehe', tick, tick),
         ])
-        adds.extend(_addTag('hehe.hoho', 'ou:hasnetuser'))
-        adds.extend(_addTag('hehe', 'ou:hasnetuser'))
+
+        # inet:web:logon is already in the inet:web:logon space but needs to account for the netuser move
+        iden = guid()
+        tick = now()
+        adds.extend([
+            (iden, 'inet:web:logon', 'cf672b42e342f49d6afee00341de1ebd', tick),
+            (iden, 'inet:web:logon:netuser', 'vertex.link/pennywise', tick),
+            (iden, 'inet:web:logon:netuser:site', 'vertex.link', tick),
+            (iden, 'inet:web:logon:netuser:user', 'pennywise', tick),
+            (iden, 'inet:web:logon:ipv4', 16909060, tick),
+            (iden, 'inet:web:logon:time', 1505001600000, tick),
+            (iden, 'tufo:form', 'inet:web:logon', tick),
+        ])
 
         with s_cortex.openstore('ram:///') as stor:
 
@@ -1151,3 +1162,13 @@ class InetModelTest(SynTest):
                 self.len(0, tufos)
                 rows = core.getJoinByProp('ou:hasnetuser')
                 self.len(0, rows)
+
+                # ensure inet:web:logon:netuser was moved over
+                tufo = core.getTufoByProp('inet:web:logon')
+                self.eq(tufo[1].get('tufo:form'), 'inet:web:logon')
+                self.eq(tufo[1].get('inet:web:logon:acct'), 'vertex.link/pennywise')
+                self.eq(tufo[1].get('inet:web:logon:acct:site'), 'vertex.link')
+                self.eq(tufo[1].get('inet:web:logon:acct:user'), 'pennywise')
+                self.notin('inet:web:logon:netuser', tufo[1])
+                self.notin('inet:web:logon:netuser:site', tufo[1])
+                self.notin('inet:web:logon:netuser:user', tufo[1])

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -204,11 +204,11 @@ class InetModelTest(SynTest):
             self.eq(unicode_tufo, idna_tufo)
 
         with self.getRamCore() as core:
-            prop = 'inet:netuser'
+            prop = 'inet:web:acct'
             valu = '%s/%s' % ('xn--tst-6la.xn--xampl-3raf.link', 'user')
             tufo = core.formTufoByProp(prop, valu)
-            self.eq(tufo[1].get('inet:netuser:site'), 'xn--tst-6la.xn--xampl-3raf.link')
-            self.eq(tufo[1].get('inet:netuser'), 'tèst.èxamplè.link/user')
+            self.eq(tufo[1].get('inet:web:acct:site'), 'xn--tst-6la.xn--xampl-3raf.link')
+            self.eq(tufo[1].get('inet:web:acct'), 'tèst.èxamplè.link/user')
             idna_valu = 'xn--tst-6la.xn--xampl-3raf.link'
 
         with self.getRamCore() as core:
@@ -341,7 +341,7 @@ class InetModelTest(SynTest):
 
             node1 = core.formTufoByProp('inet:netpost', ('vertex.link/visi', 'whos there'), time='20141217010102', replyto=iden)
 
-            self.nn(core.getTufoByProp('inet:netuser', 'vertex.link/visi'))
+            self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/visi'))
 
             self.eq(node0[1].get('inet:netpost:netuser:user'), 'visi')
             self.eq(node1[1].get('inet:netpost:netuser:user'), 'visi')
@@ -361,8 +361,8 @@ class InetModelTest(SynTest):
             self.eq(node[1].get('inet:netmesg:time'), 2554848000000)
             self.eq(node[1].get('inet:netmesg:text'), 'hehe haha')
 
-            self.nn(core.getTufoByProp('inet:netuser', 'vertex.link/visi'))
-            self.nn(core.getTufoByProp('inet:netuser', 'vertex.link/hehe'))
+            self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/visi'))
+            self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/hehe'))
 
     def test_model_inet_netmemb(self):
 
@@ -376,8 +376,8 @@ class InetModelTest(SynTest):
             self.eq(node[1].get('inet:netmemb:user'), 'vertex.link/visi')
             self.eq(node[1].get('inet:netmemb:group'), 'vertex.link/kenshoto')
 
-            self.nn(core.getTufoByProp('inet:netuser', 'vertex.link/visi'))
-            self.nn(core.getTufoByProp('inet:netgroup', 'vertex.link/kenshoto'))
+            self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/visi'))
+            self.nn(core.getTufoByProp('inet:web:group', 'vertex.link/kenshoto'))
 
     def test_model_inet_follows(self):
 
@@ -468,8 +468,8 @@ class InetModelTest(SynTest):
             self.eq(t0[1].get('inet:web:logon:netuser:site'), 'vertex.link')
 
             # Pivot from a netuser to the netlogon forms via storm
-            self.nn(core.getTufoByProp('inet:netuser', 'vertex.link/pennywise'))
-            nodes = core.eval('inet:netuser=vertex.link/pennywise inet:netuser -> inet:web:logon:netuser')
+            self.nn(core.getTufoByProp('inet:web:acct', 'vertex.link/pennywise'))
+            nodes = core.eval('inet:web:acct=vertex.link/pennywise inet:web:acct -> inet:web:logon:netuser')
             self.eq(len(nodes), 1)
 
             t0 = core.setTufoProps(t0, ipv4=0x01020304, logout=tick + 1, ipv6='0:0:0:0:0:0:0:1')
@@ -588,3 +588,102 @@ class InetModelTest(SynTest):
                 self.eq(node[1].get('inet:whois:recns:ns'), 'ns1.vertex.link')
                 self.eq(node[1].get('inet:whois:recns:rec:fqdn'), 'vertex.link')
                 self.eq(node[1].get('inet:whois:recns:rec:asof'), 1505746860000)
+
+    def test_model_inet_201709271521(self):
+
+        N = 2
+        adds = []
+
+        tag1_iden = guid()
+        tag2_iden = guid()
+        tag1_tick = now()
+        tag2_tick = now()
+
+        adds.extend([
+            (tag1_iden, 'syn:tagform:title', '??', tag1_tick),
+            (tag1_iden, 'syn:tagform', guid(), tag1_tick),
+            (tag1_iden, 'tufo:form', 'syn:tagform', tag1_tick),
+            (tag1_iden, 'syn:tagform:tag', 'hehe.hoho', tag1_tick),
+            (tag1_iden, 'syn:tagform:form', 'inet:netuser', tag1_tick),
+            (tag1_iden, 'syn:tagform:doc', '??', tag1_tick),
+
+            (tag2_iden, 'syn:tagform:title', '??', tag2_tick),
+            (tag2_iden, 'syn:tagform', guid(), tag2_tick),
+            (tag2_iden, 'tufo:form', 'syn:tagform', tag2_tick),
+            (tag2_iden, 'syn:tagform:tag', 'hehe', tag2_tick),
+            (tag2_iden, 'syn:tagform:form', 'inet:netuser', tag2_tick),
+            (tag2_iden, 'syn:tagform:doc', '??', tag2_tick),
+        ])
+
+        for i in range(N):
+            user = 'pennywise%d' % i
+            iden = guid()
+            dark_iden = iden[::-1]
+            tick = now()
+            adds.extend([
+                (iden, 'tufo:form', 'inet:web:acct', tick),
+                (iden, 'inet:netuser', 'vertex.link/' + user, tick),
+                (iden, 'inet:netuser:site', 'vertex.link', tick),
+                (iden, 'inet:netuser:user', user, tick),
+                (iden, 'inet:netuser:dob', 1337, tick),
+                (iden, '#hehe.hoho', tick, tick),
+                (iden, '#hehe', tick, tick),
+                (dark_iden, '_:*inet:netuser#hehe.hoho', tick, tick),
+                (dark_iden, '_:*inet:netuser#hehe', tick, tick),
+            ])
+
+        for i in range(N):
+            group = 'group%d' % i
+            iden = guid()
+            tick = now()
+            adds.extend([
+                (iden, 'tufo:form', 'inet:netgroup', tick),
+                (iden, 'inet:netgroup', 'vertex.link/' + group, tick),
+                (iden, 'inet:netgroup:site', 'vertex.link', tick),
+                (iden, 'inet:netgroup:name', group, tick),
+                (iden, 'inet:netgroup:desc', 'hehe', tick),
+                (iden, '#hehe.hoho', tick, tick),
+                (iden, '#hehe', tick, tick),
+            ])
+
+        with s_cortex.openstore('ram:///') as stor:
+
+            # force model migration callbacks
+            stor.setModlVers('inet', 0)
+
+            def addrows(mesg):
+                stor.addRows(adds)
+            stor.on('modl:vers:rev', addrows, name='inet', vers=201709271521)
+
+            with s_cortex.fromstore(stor) as core:
+
+                # assert that the correct number of users and groups were migrated
+                tufos = core.getTufosByProp('inet:web:acct')
+                self.len(N, tufos)
+                tufos = core.getTufosByProp('inet:web:group')
+                self.len(N, tufos)
+
+                # check that properties were correctly migrated and tags were not damaged
+                tufo = core.getTufoByProp('inet:web:acct', 'vertex.link/pennywise0')
+                self.eq(tufo[1]['inet:web:acct'], 'vertex.link/pennywise0')
+                self.eq(tufo[1]['inet:web:acct:user'], 'pennywise0')
+                self.eq(tufo[1]['inet:web:acct:site'], 'vertex.link')
+                self.eq(tufo[1]['inet:web:acct:dob'], 1337)
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('_:*inet:netuser#hehe.hoho'))
+                self.len(0, core.getRowsByProp('_:*inet:netuser#hehe'))
+                self.len(2, core.getRowsByProp('_:*inet:web:acct#hehe.hoho'))
+                self.len(2, core.getRowsByProp('_:*inet:web:acct#hehe'))
+
+                tufo = core.getTufoByProp('inet:web:group', 'vertex.link/group0')
+                self.eq(tufo[1]['inet:web:group'], 'vertex.link/group0')
+                self.eq(tufo[1]['inet:web:group:site'], 'vertex.link')
+                self.eq(tufo[1]['inet:web:group:name'], 'group0')
+                self.eq(tufo[1]['inet:web:group:desc'], 'hehe')
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+
+                # assert that no inet:web:acct remains
+                tufos = core.getTufosByProp('inet:netuser')
+                self.len(0, tufos)
+                rows = core.getJoinByProp('inet:netuser')
+                self.len(0, rows)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -351,6 +351,25 @@ class InetModelTest(SynTest):
 
             self.eq(node0[1].get('inet:web:post'), node1[1].get('inet:web:post:replyto'))
 
+    def test_model_inet_postref(self):
+        with self.getRamCore() as core:
+
+            fnod = core.formTufoByProp('file:bytes', 'd41d8cd98f00b204e9800998ecf8427e')
+            pnod = core.formTufoByProp('inet:web:post', ('vertex.link/user1', 'txt about a file'))
+
+            fiden = fnod[1].get('file:bytes')
+            piden = pnod[1].get('inet:web:post')
+
+            pr0 = core.formTufoByProp('inet:web:postref', (piden, ('file:bytes', fiden)))
+            pr1 = core.formTufoByProp('inet:web:postref', '(%s,file:bytes=%s)' % (piden, fiden))
+
+            self.eq(pr0[0], pr1[0])
+            self.eq(pr0[1].get('inet:web:postref:post'), piden)
+            self.eq(pr0[1].get('inet:web:postref:xref'), 'file:bytes=' + fiden)
+            self.eq(pr0[1].get('inet:web:postref:xref:prop'), 'file:bytes')
+            self.eq(pr0[1].get('inet:web:postref:xref:strval'), fiden)
+            self.eq(pr0[1].get('inet:web:postref:xref:intval'), None)
+
     def test_model_inet_web_mesg(self):
         with self.getRamCore() as core:
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -686,7 +686,7 @@ class InetModelTest(SynTest):
             dark_iden = iden[::-1]
             tick = now()
             adds.extend([
-                (iden, 'tufo:form', 'inet:web:acct', tick),
+                (iden, 'tufo:form', 'inet:netuser', tick),
                 (iden, 'inet:netuser', 'vertex.link/' + user, tick),
                 (iden, 'inet:netuser:site', 'vertex.link', tick),
                 (iden, 'inet:netuser:user', user, tick),
@@ -913,6 +913,7 @@ class InetModelTest(SynTest):
 
                 # check that properties were correctly migrated and tags were not damaged
                 tufo = core.getTufoByProp('inet:web:acct', 'vertex.link/pennywise0')
+                self.eq(tufo[1]['tufo:form'], 'inet:web:acct')
                 self.eq(tufo[1]['inet:web:acct'], 'vertex.link/pennywise0')
                 self.eq(tufo[1]['inet:web:acct:user'], 'pennywise0')
                 self.eq(tufo[1]['inet:web:acct:site'], 'vertex.link')
@@ -949,6 +950,7 @@ class InetModelTest(SynTest):
 
                 # check that properties were correctly migrated and tags were not damaged
                 tufo = core.getTufoByProp('inet:web:group', 'vertex.link/group0')
+                self.eq(tufo[1]['tufo:form'], 'inet:web:group')
                 self.eq(tufo[1]['inet:web:group'], 'vertex.link/group0')
                 self.eq(tufo[1]['inet:web:group:site'], 'vertex.link')
                 self.eq(tufo[1]['inet:web:group:name'], 'group0')
@@ -975,6 +977,7 @@ class InetModelTest(SynTest):
 
                 # check that properties were correctly migrated and tags were not damaged
                 tufo = core.getTufoByProp('inet:web:memb', webmemb_valu)
+                self.eq(tufo[1]['tufo:form'], 'inet:web:memb')
                 self.eq(tufo[1]['inet:web:memb'], webmemb_valu)
                 self.eq(tufo[1]['inet:web:memb:acct'], 'vertex.link/person1')
                 self.eq(tufo[1]['inet:web:memb:group'], 'vertex.link/group0')
@@ -1001,6 +1004,7 @@ class InetModelTest(SynTest):
 
                 # check that properties were correctly migrated and tags were not damaged
                 tufo = core.getTufoByProp('inet:web:follows', follow_valu)
+                self.eq(tufo[1]['tufo:form'], 'inet:web:follows')
                 self.eq(tufo[1]['inet:web:follows'], follow_valu)
                 self.eq(tufo[1]['inet:web:follows:follower'], acct1)
                 self.eq(tufo[1]['inet:web:follows:followee'], acct2)
@@ -1025,6 +1029,7 @@ class InetModelTest(SynTest):
 
                 # check that properties were correctly migrated and tags were not damaged
                 tufo = core.getTufoByProp('inet:web:post', webpost_valu)
+                self.eq(tufo[1]['tufo:form'], 'inet:web:post')
                 self.eq(tufo[1]['inet:web:post'], webpost_valu)
                 self.eq(tufo[1]['inet:web:post:acct'], 'vertex.link/person1')
                 self.eq(tufo[1]['inet:web:post:acct:site'], 'vertex.link')
@@ -1049,6 +1054,7 @@ class InetModelTest(SynTest):
 
                 # check that properties were correctly migrated and tags were not damaged
                 tufo = core.getTufoByProp('inet:web:file', webfile_valu)
+                self.eq(tufo[1]['tufo:form'], 'inet:web:file')
                 self.eq(tufo[1]['inet:web:file'], webfile_valu)
                 self.eq(tufo[1]['inet:web:file:acct'], 'vertex.link/person1')
                 self.eq(tufo[1]['inet:web:file:acct:site'], 'vertex.link')
@@ -1076,6 +1082,7 @@ class InetModelTest(SynTest):
                 # check that properties were correctly migrated and tags were not damaged
                 new_imgof_valu = 'fd415d0895e9ce466d8292c3d55c6bf5'  # NOTE: valu changes because we change the prop name
                 tufo = core.getTufoByProp('file:imgof', new_imgof_valu)
+                self.eq(tufo[1]['tufo:form'], 'file:imgof')
                 self.eq(tufo[1]['file:imgof'], new_imgof_valu)
                 self.eq(tufo[1]['file:imgof:file'], '0' * 32)
                 self.eq(tufo[1]['file:imgof:xref'], 'inet:web:acct=vertex.link/person1')
@@ -1095,6 +1102,7 @@ class InetModelTest(SynTest):
                 # check that properties were correctly migrated and tags were not damaged
                 new_txtref_valu = 'd4f8fbb792d127422a0dc788588f8f7a'  # NOTE: valu changes because we change the prop name
                 tufo = core.getTufoByProp('file:txtref', new_txtref_valu)
+                self.eq(tufo[1]['tufo:form'], 'file:txtref')
                 self.eq(tufo[1]['file:txtref'], new_txtref_valu)
                 self.eq(tufo[1]['file:txtref:file'], '0' * 32)
                 self.eq(tufo[1]['file:txtref:xref'], 'inet:web:group=vertex.link/group0')
@@ -1113,6 +1121,7 @@ class InetModelTest(SynTest):
 
                 # check that properties were correctly migrated and tags were not damaged
                 tufo = core.getTufoByProp('ps:haswebacct', '00000000000000000000000000000000/vertex.link/heheman')
+                self.eq(tufo[1]['tufo:form'], 'ps:haswebacct')
                 self.eq(tufo[1]['ps:haswebacct'], '00000000000000000000000000000000/vertex.link/heheman')
                 self.eq(tufo[1]['ps:haswebacct:acct'], 'vertex.link/heheman')
                 self.eq(tufo[1]['ps:haswebacct:person'], '00000000000000000000000000000000')
@@ -1131,6 +1140,7 @@ class InetModelTest(SynTest):
 
                 # check that properties were correctly migrated and tags were not damaged
                 tufo = core.getTufoByProp('ou:haswebacct', '4016087db1b71ecc56db535a5ee9e86e')
+                self.eq(tufo[1]['tufo:form'], 'ou:haswebacct')
                 self.eq(tufo[1]['ou:haswebacct'], '4016087db1b71ecc56db535a5ee9e86e')
                 self.eq(tufo[1]['ou:haswebacct:acct'], 'vertex.link/heheman')
                 self.eq(tufo[1]['ou:haswebacct:org'], '00000000000000000000000000000000')

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -746,6 +746,45 @@ class InetModelTest(SynTest):
             (dark_iden, '_:*inet:netfile#hehe', tick, tick),
         ])
         adds.extend(_addTag('hehe.hoho', 'inet:netpost'))
+        adds.extend(_addTag('hehe', 'inet:netpost'))
+
+        iden = guid()
+        imgof_valu = 'b873597b32ce4adb836d8d4aae1831f6'
+        dark_iden = iden[::-1]
+        tick = now()
+        adds.extend([
+            (iden, 'tufo:form', 'file:imgof', tick),
+            (iden, 'file:imgof', imgof_valu, tick),
+            (iden, 'file:imgof:file', '0' * 32, tick),
+            (iden, 'file:imgof:xref', 'inet:netuser=vertex.link/person1', tick),
+            (iden, 'file:imgof:xref:prop', 'inet:netuser', tick),
+            (iden, 'file:imgof:xref:strval', 'vertex.link/person1', tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*file:imgof#hehe.hoho', tick, tick),
+            (dark_iden, '_:*file:imgof#hehe', tick, tick),
+        ])
+        adds.extend(_addTag('hehe.hoho', 'file:imgof'))
+        adds.extend(_addTag('hehe', 'file:imgof'))
+
+        iden = guid()
+        txtref_valu = 'c10d26ad2467bb72320ad1fc501ec40b'
+        dark_iden = iden[::-1]
+        tick = now()
+        adds.extend([
+            (iden, 'tufo:form', 'file:txtref', tick),
+            (iden, 'file:txtref', txtref_valu, tick),
+            (iden, 'file:txtref:file', '0' * 32, tick),
+            (iden, 'file:txtref:xref', 'inet:netgroup=vertex.link/group0', tick),
+            (iden, 'file:txtref:xref:prop', 'inet:netgroup', tick),
+            (iden, 'file:txtref:xref:strval', 'vertex.link/group0', tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*file:imgof#hehe.hoho', tick, tick),
+            (dark_iden, '_:*file:imgof#hehe', tick, tick),
+        ])
+        adds.extend(_addTag('hehe.hoho', 'file:txtref'))
+        adds.extend(_addTag('hehe', 'file:txtref'))
 
         with s_cortex.openstore('ram:///') as stor:
 
@@ -919,3 +958,41 @@ class InetModelTest(SynTest):
                 self.len(0, tufos)
                 rows = core.getJoinByProp('inet:netfile')
                 self.len(0, rows)
+
+                # file:imgof
+                # assert that the correct number of users and groups were migrated
+                tufos = core.getTufosByProp('file:imgof')
+                self.len(1, tufos)
+
+                # check that properties were correctly migrated and tags were not damaged
+                new_imgof_valu = 'fd415d0895e9ce466d8292c3d55c6bf5'  # NOTE: valu changes because we change the prop name
+                tufo = core.getTufoByProp('file:imgof', new_imgof_valu)
+                self.eq(tufo[1]['file:imgof'], new_imgof_valu)
+                self.eq(tufo[1]['file:imgof:file'], '0' * 32)
+                self.eq(tufo[1]['file:imgof:xref'], 'inet:web:acct=vertex.link/person1')
+                self.eq(tufo[1]['file:imgof:xref:prop'], 'inet:web:acct')
+                self.eq(tufo[1]['file:imgof:xref:strval'], 'vertex.link/person1')
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+
+                # assert that no old data remains
+                tufos = core.getTufosByProp('file:imgof', imgof_valu)
+                self.len(0, tufos)
+
+                # file:txtref
+                # assert that the correct number of users and groups were migrated
+                tufos = core.getTufosByProp('file:txtref')
+                self.len(1, tufos)
+
+                # check that properties were correctly migrated and tags were not damaged
+                new_txtref_valu = 'd4f8fbb792d127422a0dc788588f8f7a'  # NOTE: valu changes because we change the prop name
+                tufo = core.getTufoByProp('file:txtref', new_txtref_valu)
+                self.eq(tufo[1]['file:txtref'], new_txtref_valu)
+                self.eq(tufo[1]['file:txtref:file'], '0' * 32)
+                self.eq(tufo[1]['file:txtref:xref'], 'inet:web:group=vertex.link/group0')
+                self.eq(tufo[1]['file:txtref:xref:prop'], 'inet:web:group')
+                self.eq(tufo[1]['file:txtref:xref:strval'], 'vertex.link/group0')
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+
+                # assert that no old data remains
+                tufos = core.getTufosByProp('file:txtref', txtref_valu)
+                self.len(0, tufos)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -753,8 +753,7 @@ class InetModelTest(SynTest):
             (dark_iden, '_:*inet:follows#hehe.hoho', tick, tick),
             (dark_iden, '_:*inet:follows#hehe', tick, tick),
         ])
-        adds.extend(_addTag('hehe.hoho', 'inet:follows'))
-        adds.extend(_addTag('hehe', 'inet:follows'))
+        # NOTE: we do not add the tagform here on purpose to make sure the dark rows migrate
 
         iden = guid()
         webmemb_valu = '7d8675f29b54cf71e3c36d4448aaa842'
@@ -1044,8 +1043,9 @@ class InetModelTest(SynTest):
 
                 # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                # NOTE: both tagforms here are 0. If it wasn't originally there, we wont migrate/create it.
                 self.len(0, core.getRowsByProp('syn:tagform:form', 'inet:follows'))
-                self.len(2, core.getRowsByProp('syn:tagform:form', 'inet:web:follows'))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'inet:web:follows'))
                 self.len(0, core.getRowsByProp('_:*inet:follows#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:follows#hehe'))
                 self.len(1, core.getRowsByProp('_:*inet:web:follows#hehe.hoho'))

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -822,8 +822,8 @@ class InetModelTest(SynTest):
             (dark_iden, '_:*inet:netfile#hehe.hoho', tick, tick),
             (dark_iden, '_:*inet:netfile#hehe', tick, tick),
         ])
-        adds.extend(_addTag('hehe.hoho', 'inet:netpost'))
-        adds.extend(_addTag('hehe', 'inet:netpost'))
+        adds.extend(_addTag('hehe.hoho', 'inet:netfile'))
+        adds.extend(_addTag('hehe', 'inet:netfile'))
 
         iden = guid()
         imgof_valu = 'b873597b32ce4adb836d8d4aae1831f6'
@@ -857,8 +857,8 @@ class InetModelTest(SynTest):
             (iden, 'file:txtref:xref:strval', 'vertex.link/group0', tick),
             (iden, '#hehe.hoho', tick, tick),
             (iden, '#hehe', tick, tick),
-            (dark_iden, '_:*file:imgof#hehe.hoho', tick, tick),
-            (dark_iden, '_:*file:imgof#hehe', tick, tick),
+            (dark_iden, '_:*file:txtref#hehe.hoho', tick, tick),
+            (dark_iden, '_:*file:txtref#hehe', tick, tick),
         ])
         adds.extend(_addTag('hehe.hoho', 'file:txtref'))
         adds.extend(_addTag('hehe', 'file:txtref'))
@@ -892,6 +892,8 @@ class InetModelTest(SynTest):
             (dark_iden, '_:*ou:hasnetuser#hehe.hoho', tick, tick),
             (dark_iden, '_:*ou:hasnetuser#hehe', tick, tick),
         ])
+        adds.extend(_addTag('hehe.hoho', 'ou:hasnetuser'))
+        adds.extend(_addTag('hehe', 'ou:hasnetuser'))
 
         # inet:web:logon is already in the inet:web:logon space but needs to account for the netuser move
         iden = guid()
@@ -904,7 +906,13 @@ class InetModelTest(SynTest):
             (iden, 'inet:web:logon:ipv4', 16909060, tick),
             (iden, 'inet:web:logon:time', 1505001600000, tick),
             (iden, 'tufo:form', 'inet:web:logon', tick),
+            (iden, '#hehe.hoho', tick, tick),
+            (iden, '#hehe', tick, tick),
+            (dark_iden, '_:*inet:web:logon#hehe.hoho', tick, tick),
+            (dark_iden, '_:*inet:web:logon#hehe', tick, tick),
         ])
+        adds.extend(_addTag('hehe.hoho', 'inet:web:logon'))
+        adds.extend(_addTag('hehe', 'inet:web:logon'))
 
         with s_cortex.openstore('ram:///') as stor:
 
@@ -942,7 +950,11 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:acct:passwd'], 'hunter2')
                 self.eq(tufo[1]['inet:web:acct:seen:min'], 0)
                 self.eq(tufo[1]['inet:web:acct:seen:max'], 1)
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'inet:netuser'))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'inet:web:acct'))
                 self.len(0, core.getRowsByProp('_:*inet:netuser#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:netuser#hehe'))
                 self.len(2, core.getRowsByProp('_:*inet:web:acct#hehe.hoho'))
@@ -969,7 +981,11 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:group:url'], 'https://vertex.link/url')
                 self.eq(tufo[1]['inet:web:group:webpage'], 'https://vertex.link/webpage')
                 self.eq(tufo[1]['inet:web:group:avatar'], 'd41d8cd98f00b204e9800998ecf8427e')
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'inet:netgroup'))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'inet:web:group'))
                 self.len(0, core.getRowsByProp('_:*inet:netgroup#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:netgroup#hehe'))
                 self.len(2, core.getRowsByProp('_:*inet:web:group#hehe.hoho'))
@@ -996,7 +1012,11 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:memb:joined'], 123)
                 self.eq(tufo[1]['inet:web:memb:seen:min'], 0)
                 self.eq(tufo[1]['inet:web:memb:seen:max'], 1)
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'inet:netmemb'))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'inet:web:memb'))
                 self.len(0, core.getRowsByProp('_:*inet:netmemb#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:netmemb#hehe'))
                 self.len(1, core.getRowsByProp('_:*inet:web:memb#hehe.hoho'))
@@ -1021,7 +1041,11 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:follows:followee'], acct2)
                 self.eq(tufo[1]['inet:web:follows:seen:min'], 0)
                 self.eq(tufo[1]['inet:web:follows:seen:max'], 1)
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'inet:follows'))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'inet:web:follows'))
                 self.len(0, core.getRowsByProp('_:*inet:follows#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:follows#hehe'))
                 self.len(1, core.getRowsByProp('_:*inet:web:follows#hehe.hoho'))
@@ -1050,7 +1074,11 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:post:url'], 'https://vertex.link/blog/1')
                 self.eq(tufo[1]['inet:web:post:file'], 'd41d8cd98f00b204e9800998ecf8427e')
                 self.eq(tufo[1]['inet:web:post:time'], 12345)
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'inet:netpost'))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'inet:web:post'))
                 self.len(0, core.getRowsByProp('_:*inet:netpost#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:netpost#hehe'))
                 self.len(1, core.getRowsByProp('_:*inet:web:post#hehe.hoho'))
@@ -1081,7 +1109,11 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:file:ipv6'], '::1')
                 self.eq(tufo[1]['inet:web:file:seen:min'], 0)
                 self.eq(tufo[1]['inet:web:file:seen:max'], 1)
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'inet:netfile'))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'inet:web:file'))
                 self.len(0, core.getRowsByProp('_:*inet:netfile#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*inet:netfile#hehe'))
                 self.len(1, core.getRowsByProp('_:*inet:web:file#hehe.hoho'))
@@ -1107,7 +1139,10 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['file:imgof:xref'], 'inet:web:acct=vertex.link/person1')
                 self.eq(tufo[1]['file:imgof:xref:prop'], 'inet:web:acct')
                 self.eq(tufo[1]['file:imgof:xref:strval'], 'vertex.link/person1')
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'file:imgof'))
                 self.len(1, core.getRowsByProp('_:*file:imgof#hehe.hoho'))
                 self.len(1, core.getRowsByProp('_:*file:imgof#hehe'))  # NOTE: dark rows should stay the same
 
@@ -1129,7 +1164,10 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['file:txtref:xref'], 'inet:web:group=vertex.link/group0')
                 self.eq(tufo[1]['file:txtref:xref:prop'], 'inet:web:group')
                 self.eq(tufo[1]['file:txtref:xref:strval'], 'vertex.link/group0')
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'file:txtref'))
                 self.len(1, core.getRowsByProp('_:*file:txtref#hehe.hoho'))
                 self.len(1, core.getRowsByProp('_:*file:txtref#hehe'))  # NOTE: dark rows should stay the same
 
@@ -1148,7 +1186,11 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['ps:haswebacct'], '00000000000000000000000000000000/vertex.link/heheman')
                 self.eq(tufo[1]['ps:haswebacct:acct'], 'vertex.link/heheman')
                 self.eq(tufo[1]['ps:haswebacct:person'], '00000000000000000000000000000000')
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'ps:hasnetuser'))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'ps:haswebacct'))
                 self.len(0, core.getRowsByProp('_:*ps:hasnetuser#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*ps:hasnetuser#hehe'))
                 self.len(1, core.getRowsByProp('_:*ps:haswebacct#hehe.hoho'))
@@ -1171,7 +1213,11 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['ou:haswebacct'], '4016087db1b71ecc56db535a5ee9e86e')
                 self.eq(tufo[1]['ou:haswebacct:acct'], 'vertex.link/heheman')
                 self.eq(tufo[1]['ou:haswebacct:org'], '00000000000000000000000000000000')
+
+                # check that tags were correctly migrated
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('syn:tagform:form', 'ou:hasnetuser'))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'ou:haswebacct'))
                 self.len(0, core.getRowsByProp('_:*ou:hasnetuser#hehe.hoho'))
                 self.len(0, core.getRowsByProp('_:*ou:hasnetuser#hehe'))
                 self.len(1, core.getRowsByProp('_:*ou:haswebacct#hehe.hoho'))
@@ -1192,5 +1238,9 @@ class InetModelTest(SynTest):
                 self.notin('inet:web:logon:netuser', tufo[1])
                 self.notin('inet:web:logon:netuser:site', tufo[1])
                 self.notin('inet:web:logon:netuser:user', tufo[1])
+
+                # check that tags were correctly migrated
+                self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(2, core.getRowsByProp('syn:tagform:form', 'inet:web:logon'))
                 self.len(1, core.getRowsByProp('_:*inet:web:logon#hehe.hoho'))
                 self.len(1, core.getRowsByProp('_:*inet:web:logon#hehe'))

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -1051,6 +1051,10 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:post:file'], 'd41d8cd98f00b204e9800998ecf8427e')
                 self.eq(tufo[1]['inet:web:post:time'], 12345)
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('_:*inet:netpost#hehe.hoho'))
+                self.len(0, core.getRowsByProp('_:*inet:netpost#hehe'))
+                self.len(1, core.getRowsByProp('_:*inet:web:post#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*inet:web:post#hehe'))
 
                 # assert that no old data remains
                 tufos = core.getTufosByProp('inet:netpost')
@@ -1078,6 +1082,10 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['inet:web:file:seen:min'], 0)
                 self.eq(tufo[1]['inet:web:file:seen:max'], 1)
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('_:*inet:netfile#hehe.hoho'))
+                self.len(0, core.getRowsByProp('_:*inet:netfile#hehe'))
+                self.len(1, core.getRowsByProp('_:*inet:web:file#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*inet:web:file#hehe'))
 
                 # assert that no old data remains
                 tufos = core.getTufosByProp('inet:netfile')
@@ -1100,6 +1108,8 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['file:imgof:xref:prop'], 'inet:web:acct')
                 self.eq(tufo[1]['file:imgof:xref:strval'], 'vertex.link/person1')
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(1, core.getRowsByProp('_:*file:imgof#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*file:imgof#hehe'))  # NOTE: dark rows should stay the same
 
                 # assert that no old data remains
                 tufos = core.getTufosByProp('file:imgof', imgof_valu)
@@ -1120,6 +1130,8 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['file:txtref:xref:prop'], 'inet:web:group')
                 self.eq(tufo[1]['file:txtref:xref:strval'], 'vertex.link/group0')
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(1, core.getRowsByProp('_:*file:txtref#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*file:txtref#hehe'))  # NOTE: dark rows should stay the same
 
                 # assert that no old data remains
                 tufos = core.getTufosByProp('file:txtref', txtref_valu)
@@ -1137,6 +1149,10 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['ps:haswebacct:acct'], 'vertex.link/heheman')
                 self.eq(tufo[1]['ps:haswebacct:person'], '00000000000000000000000000000000')
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('_:*ps:hasnetuser#hehe.hoho'))
+                self.len(0, core.getRowsByProp('_:*ps:hasnetuser#hehe'))
+                self.len(1, core.getRowsByProp('_:*ps:haswebacct#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*ps:haswebacct#hehe'))
 
                 # assert that no old data remains
                 tufos = core.getTufosByProp('ps:hasnetuser')
@@ -1156,6 +1172,10 @@ class InetModelTest(SynTest):
                 self.eq(tufo[1]['ou:haswebacct:acct'], 'vertex.link/heheman')
                 self.eq(tufo[1]['ou:haswebacct:org'], '00000000000000000000000000000000')
                 self.eq(['hehe', 'hehe.hoho'], sorted(s_tufo.tags(tufo)))
+                self.len(0, core.getRowsByProp('_:*ou:hasnetuser#hehe.hoho'))
+                self.len(0, core.getRowsByProp('_:*ou:hasnetuser#hehe'))
+                self.len(1, core.getRowsByProp('_:*ou:haswebacct#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*ou:haswebacct#hehe'))
 
                 # assert that no old data remains
                 tufos = core.getTufosByProp('ou:hasnetuser')
@@ -1172,3 +1192,5 @@ class InetModelTest(SynTest):
                 self.notin('inet:web:logon:netuser', tufo[1])
                 self.notin('inet:web:logon:netuser:site', tufo[1])
                 self.notin('inet:web:logon:netuser:user', tufo[1])
+                self.len(1, core.getRowsByProp('_:*inet:web:logon#hehe.hoho'))
+                self.len(1, core.getRowsByProp('_:*inet:web:logon#hehe'))

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -532,6 +532,10 @@ class InetModelTest(SynTest):
             self.eq(t0[1].get('inet:web:action:acct:user'), 'pennywise')
             self.eq(t0[1].get('inet:web:action:acct:site'), 'vertex.link')
 
+            d = {'key': 1, 'valu': ['oh', 'my']}
+            t0 = core.setTufoProps(t0, info=d)
+            self.eq(json.loads(t0[1].get('inet:web:action:info')), d)
+
             self.raises(PropNotFound, core.formTufoByProp, 'inet:web:action', '*', acct='vertex.link/pennywise', time=tick)
             self.raises(PropNotFound, core.formTufoByProp, 'inet:web:action', '*', act='didathing', time=tick)
 

--- a/synapse/tests/test_model_orgs.py
+++ b/synapse/tests/test_model_orgs.py
@@ -25,3 +25,15 @@ class OrgTest(SynTest):
             self.eq(node0[1].get('ou:org:name'), 'the woot corp')
 
             self.eq(node0[0], node1[0])
+
+    def test_model_org_has_webacct(self):
+        with self.getRamCore() as core:
+            iden = guid()
+            node = core.formTufoByProp('ou:haswebacct', (iden, 'ROOTKIT.com/visi'))
+
+            self.eq(node[1].get('ou:haswebacct:web:acct'), 'rootkit.com/visi')
+            self.eq(node[1].get('ou:haswebacct:org'), iden)
+
+            self.nn(core.getTufoByProp('ou:org', iden))
+            self.nn(core.getTufoByProp('inet:user', 'visi'))
+            self.nn(core.getTufoByProp('inet:web:acct', 'rootkit.com/visi'))

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -94,7 +94,7 @@ class PersonTest(SynTest):
 
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('inet:user', 'visi'))
-            self.nn(core.getTufoByProp('inet:netuser', 'rootkit.com/visi'))
+            self.nn(core.getTufoByProp('inet:web:acct', 'rootkit.com/visi'))
 
     def test_model_person_guidname(self):
 

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -84,13 +84,13 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('inet:email', 'visi@vertex.link'))
 
-    def test_model_person_has_netuser(self):
+    def test_model_person_has_webacct(self):
         with self.getRamCore() as core:
             iden = guid()
-            node = core.formTufoByProp('ps:hasnetuser', '%s/ROOTKIT.com/visi' % iden)
+            node = core.formTufoByProp('ps:haswebacct', '%s/ROOTKIT.com/visi' % iden)
 
-            self.eq(node[1].get('ps:hasnetuser:netuser'), 'rootkit.com/visi')
-            self.eq(node[1].get('ps:hasnetuser:person'), iden)
+            self.eq(node[1].get('ps:haswebacct:web:acct'), 'rootkit.com/visi')
+            self.eq(node[1].get('ps:haswebacct:person'), iden)
 
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('inet:user', 'visi'))
@@ -105,10 +105,10 @@ class PersonTest(SynTest):
 
             iden = node[1].get('ps:person')
 
-            node = core.formTufoByProp('ps:hasnetuser', '$visi/rootkit.com/visi')
+            node = core.formTufoByProp('ps:haswebacct', '$visi/rootkit.com/visi')
 
-            self.eq(node[1].get('ps:hasnetuser:netuser'), 'rootkit.com/visi')
-            self.eq(node[1].get('ps:hasnetuser:person'), iden)
+            self.eq(node[1].get('ps:haswebacct:web:acct'), 'rootkit.com/visi')
+            self.eq(node[1].get('ps:haswebacct:person'), iden)
 
             self.nn(core.getTufoByProp('ps:person', iden))
 


### PR DESCRIPTION
- [x] Migrates forms/props from `inet:net*` to `inet:web:*`
    - `inet:net4` and `inet:net6` are not changed.
    - props referring to `netuser` are renamed to `acct`
- [x] Adds `inet:web:postref` xref form
- [x] Adds `:loc` prop to `inet:web:acct`
- [x] Handle ps/ou:hasnetuser