### PR TITLE
Fix stable guid generation for sepr types

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -298,6 +298,8 @@ class MultiFieldType(DataType):
 
     def __init__(self, tlib, name, **info):
         DataType.__init__(self, tlib, name, **info)
+        # TODO figure out what to do about tlib vs core issues
+        self._getPropType = getattr(tlib, 'getPropType', None)
         self.fields = None
 
     def _norm_fields(self, valu):
@@ -335,6 +337,10 @@ class MultiFieldType(DataType):
                     for part in fields.split('|'):
                         fname, ftype = part.split(',')
                         fitem = self.tlib.getTypeInst(ftype)
+                        if self.prop:
+                            _fitem = self._getPropType(ftype)
+                            if _fitem:
+                                fitem = _fitem
                         self.fields.append((fname, fitem))
 
                 return self.fields

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -380,7 +380,8 @@ class CompType(DataType):
 
     def __init__(self, tlib, name, **info):
         DataType.__init__(self, tlib, name, **info)
-
+        # TODO figure out what to do about tlib vs core issues
+        self._getPropNorm = getattr(tlib, 'getPropNorm', None)
         self.fields = []
         self.optfields = []
 
@@ -436,7 +437,10 @@ class CompType(DataType):
         vals = valu[:self.fsize]
         for v, (name, tname) in s_common.iterzip(vals, self.fields):
 
-            norm, ssubs = self.tlib.getTypeNorm(tname, v)
+            if self.prop:
+                norm, ssubs = self._getPropNorm(tname, v)
+            else:
+                norm, ssubs = self.tlib.getTypeNorm(tname, v)
 
             subs[name] = norm
             for subkey, subval in ssubs.items():

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -649,6 +649,9 @@ class StormTest(SynTest):
             self.notin('.new', node1[1])
             self.eq(node0[0], node1[0])
 
+            node2 = core.eval('addnode(ps:hasnetuser, ((guidname="bob gray"),vertex.link/pennywise))')[0]
+            self.eq(node2[1].get('ps:hasnetuser'), 'faebe657f7a5839ecda3f8af15293893/vertex.link/pennywise')
+
     def test_storm_task(self):
         with self.getRamCore() as core:
             foo = []

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -652,6 +652,10 @@ class StormTest(SynTest):
             node2 = core.eval('addnode(ps:hasnetuser, ((guidname="bob gray"),vertex.link/pennywise))')[0]
             self.eq(node2[1].get('ps:hasnetuser'), 'faebe657f7a5839ecda3f8af15293893/vertex.link/pennywise')
 
+            node3 = core.eval('addnode(ou:hasnetuser, ((alias="vertex"),vertex.link/pennywise))')[0]
+            self.eq(node3[1].get('ou:hasnetuser'), 'e0d1c290732ac433444afe7b5825f94d')
+            self.eq(node3[1].get('ou:hasnetuser:netuser'), 'vertex.link/pennywise')
+
     def test_storm_task(self):
         with self.getRamCore() as core:
             foo = []


### PR DESCRIPTION
Make sepr type normalization (in multifield types) prefer the .prop version of a DataType instance when norming a .prop.

This allows a sepr type to contain a guid type for doing norming during stable guid generation.  Also fixes comp types.