### PR TITLE
Add the current Synapse version to a Cortex blobstore

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,7 +5,7 @@ tag = True
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:synapse/__init__.py]
+[bumpversion:file:synapse/lib/version.py]
 serialize = {major}, {minor}, {patch}
 parse = (?P<major>\d+),\s(?P<minor>\d+),\s(?P<patch>\d+)
 

--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -18,8 +18,8 @@ if msgpack.version < (0, 4, 2):
 if tornado.version_info < (3, 2, 2):
     raise Exception('synapse requires tornado >= 3.2.2')
 
-version = (0, 0, 26)
-verstring = '.'.join([str(x) for x in version])
+from synapse.lib.version import version
+from synapse.lib.version import verstring
 
 # load all the synapse builtin modules
 # the built-in cortex modules...
@@ -80,6 +80,4 @@ s_datamodel.rebuildTlib()
 
 # load any modules which register dyndeps aliases...
 # ( order matters...)
-import synapse.axon
-import synapse.cortex
-#import synapse.cores.common as s_cores_common
+import synapse.axon  # synapse.axon brings in synapse.cortex's dyndep registration.

--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -18,8 +18,7 @@ if msgpack.version < (0, 4, 2):
 if tornado.version_info < (3, 2, 2):
     raise Exception('synapse requires tornado >= 3.2.2')
 
-from synapse.lib.version import version
-from synapse.lib.version import verstring
+from synapse.lib.version import version, verstring
 
 # load all the synapse builtin modules
 # the built-in cortex modules...

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -8,7 +8,6 @@ import synapse.common as s_common
 import synapse.dyndeps as s_dyndeps
 import synapse.reactor as s_reactor
 import synapse.telepath as s_telepath
-import synapse.datamodel as s_datamodel
 
 import synapse.cores.storage as s_storage
 
@@ -23,7 +22,7 @@ import synapse.lib.hashset as s_hashset
 import synapse.lib.threads as s_threads
 import synapse.lib.modules as s_modules
 import synapse.lib.trigger as s_trigger
-import synapse.lib.hashitem as s_hashitem
+import synapse.lib.version as s_version
 import synapse.lib.interval as s_interval
 
 from synapse.eventbus import EventBus
@@ -233,6 +232,8 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         self.onfini(self._finiCoreMods)
 
         s_ingest.IngestApi.__init__(self, self)
+
+        self.setBlobValu('syn:core:synapse:version', s_version.version)
 
     def addRuntNode(self, form, valu, props=None):
         '''

--- a/synapse/lib/__init__.py
+++ b/synapse/lib/__init__.py
@@ -1,0 +1,2 @@
+# This __init__.py should remain empty so importing individual modules from
+# synapse.lib does not have unexpected side effects.

--- a/synapse/lib/version.py
+++ b/synapse/lib/version.py
@@ -1,0 +1,10 @@
+'''
+Synapse utilites for dealing with Semvar versioning.
+This includes the Synapse version information.
+'''
+
+##############################################################################
+# The following are touched during the release process by bumpversion.
+# Do not modify these directly.
+version = (0, 0, 26)
+verstring = '.'.join([str(x) for x in version])

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -24,6 +24,7 @@ import synapse.lib.tags as s_tags
 import synapse.lib.tufo as s_tufo
 import synapse.lib.types as s_types
 import synapse.lib.threads as s_threads
+import synapse.lib.version as s_version
 
 import synapse.models.syn as s_models_syn
 
@@ -579,6 +580,8 @@ class CortexBaseTest(SynTest):
     def runblob(self, core):
         # Do we have default cortex blob values?
         self.true(core.hasBlobValu('syn:core:created'))
+        cvers = core.getBlobValu('syn:core:synapse:version')
+        self.eq(cvers, s_version.version)
 
         kvs = (
             ('syn:meta', 1),

--- a/synapse/tests/test_dyndeps.py
+++ b/synapse/tests/test_dyndeps.py
@@ -13,6 +13,10 @@ def woot(x, y=30):
 
 class DynDepsTest(SynTest):
 
+    def test_dyndeps_expected_aliases(self):
+        self.isin('syn:axon', s_dyndeps.aliases)
+        self.isin('syn:cortex', s_dyndeps.aliases)
+
     def test_dyndeps_dynmod(self):
         self.none(s_dyndeps.getDynMod('- -'))
         self.nn(s_dyndeps.getDynMod('sys'))

--- a/synapse/tests/test_lib_version.py
+++ b/synapse/tests/test_lib_version.py
@@ -1,0 +1,20 @@
+"""
+synapse - test_lib_version.py
+Created on 10/6/17.
+"""
+
+import synapse.lib.version as s_version
+
+from synapse.tests.common import *
+
+class VersionTest(SynTest):
+
+    def test_version_basics(self):
+        self.isinstance(s_version.version, tuple)
+        self.len(3, s_version.version)
+        for v in s_version.version:
+            self.isinstance(v, int)
+
+        self.isinstance(s_version.verstring, str)
+        tver = tuple([int(p) for p in s_version.verstring.split('.')])
+        self.eq(tver, s_version.version)


### PR DESCRIPTION
This will eventually allow us to enforce release/migration paths for data in cores.

- Move the synapse version string information to synapse.lib.version
- Import the version/verstring variables from synapse.lib.version directly into synaspe.__init__
- Set the blobstore key syn:core:synapse:version to the synapse.lib.version.version tuple
- Remove duplicate/commented out code from synapse.__init__