### PR TITLE
Discussion: Autoadd safe to address #459

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2703,7 +2703,10 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
                 if self.isRuntForm(stype):
                     continue
 
-                if self.isTufoForm(stype):
+                if not self.isTufoForm(stype):
+                    continue
+
+                if self.isAutoAddSafe(stype):
                     toadd.add((stype, valu))
 
         for form, valu in toadd:

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2436,6 +2436,13 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
 
             tufo = core.formTufoByProp('inet:fqdn','woot.com')
 
+        Notes:
+            <something about guid types = None to skip deconfliction>
+
+        Returns:
+            ((str, dict)): The newly formed tufo, or the existing tufo if
+            the node already exists. If the ephemeral property '.new' is
+            present in the tufo, the tufo was newly made.
         '''
         ctor = self.seedctors.get(prop)
         if ctor is not None:

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -155,6 +155,12 @@ class NoSuchData(SynErr): pass
 class FileExists(SynErr): pass
 class NotEmpty(SynErr): pass
 class NotSupported(SynErr): pass
+class NotAutoAddSafe(SynErr):
+    '''
+    Raised by DataModel.reqAutoAddSafe to indicate a Synapse Type is not safe to be automatically added to a
+    Cortex as a result of autoadd events.
+    '''
+    pass
 
 class BadAtomFile(SynErr):
     '''

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -549,6 +549,10 @@ class XrefType(DataType):
             'xref': pvval,
         }
 
+        for k, v in vsub.items():
+            k = self._sorc_name + ':' + k
+            subs[k] = v
+
         for k, v in pvsub.items():
             k = 'xref:' + k
             subs[k] = v

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -773,3 +773,26 @@ class DataTypesTest(SynTest):
             self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', 'inet:ipv4= 1.2.3.4')
             self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', '(inet:ipv4,1.2.3.4)')
             self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', ['inet:ipv4', '1.2.3.4', 'opps'])
+
+    def test_types_autoaddsafe(self):
+        with self.getRamCore() as core:
+            self.false(core.isAutoAddSafe('guid'))
+            self.false(core.isAutoAddSafe('comp'))
+            self.false(core.isAutoAddSafe('xref'))
+
+            self.true(core.isAutoAddSafe('int'))
+            self.true(core.isAutoAddSafe('str'))
+            self.true(core.isAutoAddSafe('str:lwr'))
+            self.true(core.isAutoAddSafe('sepr'))
+
+            self.true(core.reqAutoAddSafe('str'))
+            self.raises(NotAutoAddSafe, core.reqAutoAddSafe, 'guid')
+
+            # Try some model-specific sub types
+            self.true(core.isAutoAddSafe('inet:ipv4'))
+            self.true(core.isAutoAddSafe('inet:web:acct'))
+            self.false(core.isAutoAddSafe('it:host'))
+            self.false(core.isAutoAddSafe('ps:person'))
+
+            self.true(core.reqAutoAddSafe('inet:ipv4'))
+            self.raises(NotAutoAddSafe, core.reqAutoAddSafe, 'it:host')

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -393,6 +393,16 @@ class InetModelTest(SynTest):
             self.eq(pr0[1].get('inet:web:postref:xref:strval'), fiden)
             self.eq(pr0[1].get('inet:web:postref:xref:intval'), None)
 
+    def test_model_inet_postref_postmissingprops(self):
+        with self.getRamCore() as core:
+
+            postref_tufo = core.formTufoByProp('inet:web:postref', (('vertex.link/user', 'mypost 0.0.0.0'), ('inet:ipv4', 0)))
+            post_tufo = core.formTufoByProp('inet:web:post', ('vertex.link/user', 'mypost 0.0.0.0'))
+            # This feels wrong...
+
+            self.eq(post_tufo[1].get('inet:web:post:acct'), 'vertex.link/user')
+            self.eq(post_tufo[1].get('inet:web:post:text'), 'mypost 0.0.0.0')
+
     def test_model_inet_web_mesg(self):
         with self.getRamCore() as core:
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -397,11 +397,17 @@ class InetModelTest(SynTest):
         with self.getRamCore() as core:
 
             postref_tufo = core.formTufoByProp('inet:web:postref', (('vertex.link/user', 'mypost 0.0.0.0'), ('inet:ipv4', 0)))
-            post_tufo = core.formTufoByProp('inet:web:post', ('vertex.link/user', 'mypost 0.0.0.0'))
-            # This feels wrong...
+            self.none(core.getTufoByProp('inet:web:post', ('vertex.link/user', 'mypost 0.0.0.0')))  # NOTE: the post will not be formed by forming the postref.
 
-            self.eq(post_tufo[1].get('inet:web:post:acct'), 'vertex.link/user')
-            self.eq(post_tufo[1].get('inet:web:post:text'), 'mypost 0.0.0.0')
+            self.eq(postref_tufo[1]['tufo:form'], 'inet:web:postref')
+            self.eq(postref_tufo[1]['inet:web:postref'], '804ec63392f4ea031bb3fd004dee209d')
+            self.eq(postref_tufo[1]['inet:web:postref:post'], '68bc4607f0518963165536921d6e86fa')
+            self.eq(postref_tufo[1]['inet:web:postref:xref'], 'inet:ipv4=0.0.0.0')
+            self.eq(postref_tufo[1]['inet:web:postref:xref:prop'], 'inet:ipv4')
+            self.eq(postref_tufo[1]['inet:web:postref:xref:intval'], 0)
+
+            post_tufo = core.formTufoByProp('inet:web:post', ('vertex.link/user', 'mypost 0.0.0.0'))
+            self.eq(post_tufo[1]['inet:web:post'], postref_tufo[1]['inet:web:postref:post'])
 
     def test_model_inet_web_mesg(self):
         with self.getRamCore() as core:

--- a/synapse/tests/test_model_orgs.py
+++ b/synapse/tests/test_model_orgs.py
@@ -34,6 +34,6 @@ class OrgTest(SynTest):
             self.eq(node[1].get('ou:haswebacct:web:acct'), 'rootkit.com/visi')
             self.eq(node[1].get('ou:haswebacct:org'), iden)
 
-            self.nn(core.getTufoByProp('ou:org', iden))
+            # self.nn(core.getTufoByProp('ou:org', iden))  # XXX This is no longer valid with isAutoAddSafe()
             self.nn(core.getTufoByProp('inet:user', 'visi'))
             self.nn(core.getTufoByProp('inet:web:acct', 'rootkit.com/visi'))

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -48,7 +48,7 @@ class PersonTest(SynTest):
             self.eq(node[1].get('ps:hasuser:user'), 'visi')
             self.eq(node[1].get('ps:hasuser:person'), iden)
 
-            self.nn(core.getTufoByProp('ps:person', iden))
+            # self.nn(core.getTufoByProp('ps:person', iden))  # XXX This is no longer valid with isAutoAddSafe()
             self.nn(core.getTufoByProp('inet:user', 'visi'))
 
     def test_model_person_has_alias(self):
@@ -59,7 +59,7 @@ class PersonTest(SynTest):
             self.eq(node[1].get('ps:hasalias:alias'), 'kenshoto,invisigoth')
             self.eq(node[1].get('ps:hasalias:person'), iden)
 
-            self.nn(core.getTufoByProp('ps:person', iden))
+            # self.nn(core.getTufoByProp('ps:person', iden))  # XXX This is no longer valid with isAutoAddSafe()
             self.nn(core.getTufoByProp('ps:name', 'kenshoto,invisigoth'))
 
     def test_model_person_has_phone(self):
@@ -70,7 +70,7 @@ class PersonTest(SynTest):
             self.eq(node[1].get('ps:hasphone:phone'), 17035551212)
             self.eq(node[1].get('ps:hasphone:person'), iden)
 
-            self.nn(core.getTufoByProp('ps:person', iden))
+            # self.nn(core.getTufoByProp('ps:person', iden))  # XXX This is no longer valid with isAutoAddSafe()
             self.nn(core.getTufoByProp('tel:phone', 17035551212))
 
     def test_model_person_has_email(self):
@@ -81,7 +81,7 @@ class PersonTest(SynTest):
             self.eq(node[1].get('ps:hasemail:email'), 'visi@vertex.link')
             self.eq(node[1].get('ps:hasemail:person'), iden)
 
-            self.nn(core.getTufoByProp('ps:person', iden))
+            # self.nn(core.getTufoByProp('ps:person', iden))  # XXX This is no longer valid with isAutoAddSafe()
             self.nn(core.getTufoByProp('inet:email', 'visi@vertex.link'))
 
     def test_model_person_has_webacct(self):
@@ -92,7 +92,7 @@ class PersonTest(SynTest):
             self.eq(node[1].get('ps:haswebacct:web:acct'), 'rootkit.com/visi')
             self.eq(node[1].get('ps:haswebacct:person'), iden)
 
-            self.nn(core.getTufoByProp('ps:person', iden))
+            # self.nn(core.getTufoByProp('ps:person', iden))  # XXX This is no longer valid with isAutoAddSafe()
             self.nn(core.getTufoByProp('inet:user', 'visi'))
             self.nn(core.getTufoByProp('inet:web:acct', 'rootkit.com/visi'))
 


### PR DESCRIPTION
This is one potential way to address the issue raised in #459.  It allows us to flag certain types as not being safe to have autoadds run on them, so as to prevent the Cortex autoadds from making those nodes.

At the moment this is NOT complete as it is still a proposed solution.  This would still require as a study of different ctors NOT defined in synapse/lib/types.py in order to identify other data types which would need to be marked as not autoadd safe.

Closes #459