### PR TITLE
make PropValuType use reqPropNorm instead of getPropNorm 

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -715,7 +715,7 @@ class PropValuType(DataType):
     def __init__(self, tlib, name, **info):
         DataType.__init__(self, tlib, name, **info)
         # TODO figure out what to do about tlib vs core issues
-        self._getPropNorm = getattr(tlib, 'getPropNorm', None)
+        self._reqPropNorm = getattr(tlib, 'reqPropNorm', None)
         self._getPropRepr = getattr(tlib, 'getPropRepr', None)
 
     def norm(self, valu, oldval=None):
@@ -749,8 +749,8 @@ class PropValuType(DataType):
         prop, valu = valu
 
         try:
-            nvalu, nsubs = self._getPropNorm(prop, valu, oldval=oldval)
-        except s_common.BadTypeValu as e:
+            nvalu, nsubs = self._reqPropNorm(prop, valu, oldval=oldval)
+        except (s_common.BadTypeValu, s_common.NoSuchProp) as e:
             logger.exception('Failed to norm PropValu.')
             self._raiseBadValu(valu, mesg='Unable to norm PropValu', prop=prop)
 

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -775,8 +775,8 @@ class DataTypesTest(SynTest):
             self.notin('pvform:intval', t3[1])
 
             # Test a comp type node made a as Provalu
-            t4 = core.formTufoByProp('pvform', 'inet:netpost=(vertex.link/pennywise,"Do you want your boat?")')
-            self.eq(t4[1].get('pvform:prop'), 'inet:netpost')
+            t4 = core.formTufoByProp('pvform', 'inet:web:post=(vertex.link/pennywise,"Do you want your boat?")')
+            self.eq(t4[1].get('pvform:prop'), 'inet:web:post')
 
             # Bad values
             self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', 1234)
@@ -784,3 +784,5 @@ class DataTypesTest(SynTest):
             self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', 'inet:ipv4= 1.2.3.4')
             self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', '(inet:ipv4,1.2.3.4)')
             self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', ['inet:ipv4', '1.2.3.4', 'opps'])
+            # Non-existent valu
+            self.raises(BadTypeValu, core.getPropNorm, 'pvsub:xref', 'inet:ip=1.2.3.4')


### PR DESCRIPTION
enforce the fact that the leftside data in a propvalue valu must be a modeled property.