### PR TITLE
Update the Cortex axon:url to allow point to a axonbus

### DIFF
--- a/synapse/lib/reflect.py
+++ b/synapse/lib/reflect.py
@@ -47,8 +47,23 @@ def getItemInfo(item):
     '''
     Get "reflection info" dict for the given object.
 
-    NOTE: classes may implement _syn_reflect(self): to
-          return explicit values (for example, telepath proxy)
+    Args:
+        item: Item to inspect.
+
+    Examples:
+        Find out what classes a Telepath Proxy object inherits::
+
+            info = getItemInfo(prox)
+            classes = info.get('inherits')
+
+    Notes:
+        Classes may implement a ``def _syn_reflect(self):`` function
+        in order to return explicit values. The Telepath Proxy object
+        is one example of doing this, in order to allow a remote caller
+        to identify what classes the Proxy object represents.
+
+    Returns:
+        dict: Dictionary of reflection information.
     '''
     func = getattr(item, '_syn_reflect', None)
     if func is not None:

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -124,8 +124,13 @@ class FileModelTest(SynTest):
 
             conf = {
                 'ctors': (
-                    ('axon00', 'syn:axon', {'datadir': dirname}),
-                    ('core00', 'syn:cortex', {'url': 'ram:///', 'axon:url': 'dmon://axon00'}),
+                    ('axon00',
+                     'syn:axon',
+                     {'datadir': dirname}),
+                    ('core00',
+                     'syn:cortex',
+                     {'url': 'ram:///',
+                      'axon:url': 'dmon://axon00'}),
                 ),
 
                 'share': (


### PR DESCRIPTION
Determine if the proxy object represents a service bus or a Axon.  Add tests to the axon test suite to show that this works.