### PR TITLE
Update libiq

### DIFF
--- a/synapse/lib/iq.py
+++ b/synapse/lib/iq.py
@@ -319,7 +319,12 @@ class SynTest(unittest.TestCase):
         '''
         with s_cortex.openurl('ram:///') as core:
             self.addTstForms(core)
-            yield core
+            try:
+                yield core
+            except:  # pragma: no cover
+                raise
+            finally:
+                core.fini()
 
     @contextlib.contextmanager
     def getDmonCore(self):
@@ -341,11 +346,14 @@ class SynTest(unittest.TestCase):
         s_scope.set('syn:test:link', link)
         s_scope.set('syn:cmd:core', prox)
 
-        yield prox
-
-        prox.fini()
-        core.fini()
-        dmon.fini()
+        try:
+            yield prox
+        except:  # pragma: no cover
+            raise
+        finally:
+            prox.fini()
+            core.fini()
+            dmon.fini()
 
     @contextlib.contextmanager
     def getTestDir(self):
@@ -357,8 +365,12 @@ class SynTest(unittest.TestCase):
             str: The path to a temporary directory.
         '''
         tempdir = tempfile.mkdtemp()
-        yield tempdir
-        shutil.rmtree(tempdir, ignore_errors=True)
+        try:
+            yield tempdir
+        except:  # pragma: no cover
+            raise
+        finally:
+            shutil.rmtree(tempdir, ignore_errors=True)
 
     @contextlib.contextmanager
     def getLoggerStream(self, logname):
@@ -385,8 +397,12 @@ class SynTest(unittest.TestCase):
         handler = logging.StreamHandler(stream)
         slogger = logging.getLogger(logname)
         slogger.addHandler(handler)
-        yield stream
-        slogger.removeHandler(handler)
+        try:
+            yield stream
+        except:  # pragma: no cover
+            raise
+        finally:
+            slogger.removeHandler(handler)
 
     def eq(self, x, y):
         '''

--- a/synapse/tests/test_lib_iq.py
+++ b/synapse/tests/test_lib_iq.py
@@ -112,6 +112,20 @@ class IqTest(SynTest):
         mesgs = stream.read()
         self.isin('ruh roh', mesgs)
 
+    def test_iq_syntest_envars(self):
+        os.environ['foo'] = '1'
+        os.environ['bar'] = '2'
+
+        with self.setTstEnvars(foo=1, bar='joke', baz=1234) as cm:
+            self.none(cm)
+            self.eq(os.environ.get('foo'), '1')
+            self.eq(os.environ.get('bar'), 'joke')
+            self.eq(os.environ.get('baz'), '1234')
+
+        self.eq(os.environ.get('foo'), '1')
+        self.eq(os.environ.get('bar'), '2')
+        self.none(os.environ.get('baz'))
+
     def test_iq_outp(self):
         outp = TstOutPut()
         outp.printf('Test message #1!')


### PR DESCRIPTION
Ensure context managers cleanup after themselves
Add a test helper to set envars during testing.