### PR TITLE
Adds Dockerfile to Synapse to be built by Docker Cloud

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,15 @@
 **/*.pyc
 **/__pycache__
+build
+.cache
+.coverage
+coverage
+.coveragerc
+dist
+.git
+htmlcov
+.idea
+*.egg-info
+.eggs
+*.swo
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir /syndata \
     cron \
     libffi-dev \
     libssl-dev \
+    libpq-dev \
     locales \
  && apt-get clean \
  && apt-get purge \
@@ -18,6 +19,7 @@ RUN mkdir /syndata \
  && locale-gen en_US.UTF-8 \
  && dpkg-reconfigure locales \
  && /usr/sbin/update-locale LANG=en_US.UTF-8 \
+ && pip install "psycopg2>=2.7,<3" \
  && cd /root/git/synapse && python setup.py install \
  && cp synapse/docker/cortex/ram_dmon.json /syndata/dmon.json
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8" LC_ALL="en_US.UTF-8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # vim:set ft=dockerfile:
 FROM python:3.6.3-slim
 
-ENV DEBIAN_FRONTEND="noninteractive"
+ENV DEBIAN_FRONTEND="noninteractive" SYN_DMON_LOG_LEVEL="WARNING"
 
 COPY . /root/git/synapse
 RUN mkdir /syndata \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# vim:set ft=dockerfile:
+FROM python:3.6
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+COPY . /root/git/synapse
+RUN mkdir /syndata \
+ && apt-get update -q \
+ && apt-get install -yq --no-install-recommends \
+    build-essential \
+    cron \
+    libffi-dev \
+    libssl-dev \
+    locales \
+ && apt-get clean \
+ && apt-get purge \
+ && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+ && locale-gen en_US.UTF-8 \
+ && dpkg-reconfigure locales \
+ && /usr/sbin/update-locale LANG=en_US.UTF-8 \
+ && cd /root/git/synapse && python setup.py install \
+ && cp synapse/docker/cortex/ram_dmon.json /syndata/dmon.json
+ENV LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8" LC_ALL="en_US.UTF-8"
+
+VOLUME /syndata
+VOLUME /root/git/synapse
+
+WORKDIR /root/git/synapse
+EXPOSE 47322
+ENTRYPOINT ["python", "-m", "synapse.tools.dmon", "/syndata/dmon.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM python:3.6
+FROM python:3.6.3-slim
 
 ENV DEBIAN_FRONTEND="noninteractive"
 


### PR DESCRIPTION
I don't think we need to maintain a separate repo for the `Dockerfile`s or that we need to rebuild old images (at least not automatically every time there is a push to master).

This PR (along with change to the Docker ~Hub~ Cloud build) will make it so that instead of every push to master resulting in a build of master and every tag from all time, a push to master will only build master, and a push to a specific tag will only build that specific tag. Also, you can review the Dockerfile in the same repo as the code.

If this PR is accepted and merged, I will delete the https://github.com/vertexproject/docker-synapse repo and remove the webhooks.