### PR TITLE
Inttype cap

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -271,6 +271,11 @@ class IntType(DataType):
         if not isinstance(valu, int):
             self._raiseBadValu(valu, mesg='Valu is not an int')
 
+        if valu < -9223372036854775808:
+            self._raiseBadValu(valu, mesg='Value less than 64bit signed integer minimum (-9223372036854775808)')
+        if valu > 9223372036854775807:
+            self._raiseBadValu(valu, mesg='Value greater than 64bit signed integer maximum (9223372036854775807)')
+
         if oldval is not None and self.minmax:
             valu = self.minmax(valu, oldval)
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -488,6 +488,16 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.eval('strform:foo')), 0)
         self.eq(len(core.eval('strform:bar')), 2)
 
+        # Ensure we can store data at the boundary of 64 bit integers
+        node = core.formTufoByProp('intform', -9223372036854775808)
+        self.nn(node)
+        core.delTufo(node)
+        node = core.formTufoByProp('intform', 9223372036854775807)
+        self.nn(node)
+        core.delTufo(node)
+        self.raises(BadTypeValu, core.formTufoByProp, 'intform', -9223372036854775809)
+        self.raises(BadTypeValu, core.formTufoByProp, 'intform', 9223372036854775808)
+
         # Disable on() events registered in the test.
         core.off('node:form', formtufo)
         core.off('node:form', formfqdn)

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -17,83 +17,6 @@ class DataTypesTest(SynTest):
         self.none(tlib.getDataType('newp'))
         self.raises(NoSuchType, tlib.reqDataType, 'newp')
 
-    def test_datatype_inet_url(self):
-        tlib = s_types.TypeLib()
-
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:url', 'newp')
-        self.eq(tlib.getTypeNorm('inet:url', 'http://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
-        self.eq(tlib.getTypeNorm('inet:url', 'HTTP://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
-        self.eq(tlib.getTypeNorm('inet:url', 'HttP://Visi:Secret@WoOt.com/HeHe&foo=10')[0],
-                'http://Visi:Secret@woot.com/HeHe&foo=10')
-
-        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:url', 'newp')
-        self.eq(tlib.getTypeParse('inet:url', 'http://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
-        self.eq(tlib.getTypeParse('inet:url', 'HTTP://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
-        self.eq(tlib.getTypeParse('inet:url', 'HttP://Visi:Secret@WoOt.com/HeHe&foo=10')[0],
-                'http://Visi:Secret@woot.com/HeHe&foo=10')
-
-        self.eq(tlib.getTypeRepr('inet:url', 'http://woot.com/HeHe'), 'http://woot.com/HeHe')
-
-    def test_datatype_inet_ipv4(self):
-        tlib = s_types.TypeLib()
-
-        self.eq(tlib.getTypeNorm('inet:ipv4', 0x01020304)[0], 0x01020304)
-        self.eq(tlib.getTypeNorm('inet:ipv4', '0x01020304')[0], 0x01020304)
-        self.eq(tlib.getTypeParse('inet:ipv4', '1.2.3.4')[0], 0x01020304)
-        self.eq(tlib.getTypeRepr('inet:ipv4', 0x01020304), '1.2.3.4')
-
-    def test_datatype_inet_tcp4(self):
-        tlib = s_types.TypeLib()
-
-        self.eq(tlib.getTypeNorm('inet:tcp4', '1.2.3.4:2')[0], 0x010203040002)
-        self.eq(tlib.getTypeNorm('inet:tcp4', 0x010203040002)[0], 0x010203040002)
-
-        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:tcp4', 'newp')
-        self.eq(tlib.getTypeParse('inet:tcp4', '1.2.3.4:2')[0], 0x010203040002)
-
-        self.eq(tlib.getTypeRepr('inet:tcp4', 0x010203040002), '1.2.3.4:2')
-
-    def test_datatype_inet_udp4(self):
-        tlib = s_types.TypeLib()
-
-        self.eq(tlib.getTypeNorm('inet:udp4', '1.2.3.4:2')[0], 0x010203040002)
-        self.eq(tlib.getTypeNorm('inet:udp4', 0x010203040002)[0], 0x010203040002)
-
-        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:udp4', 'newp')
-        self.eq(tlib.getTypeParse('inet:udp4', '1.2.3.4:2')[0], 0x010203040002)
-
-        self.eq(tlib.getTypeRepr('inet:udp4', 0x010203040002), '1.2.3.4:2')
-
-    def test_datatype_inet_port(self):
-        tlib = s_types.TypeLib()
-
-        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:port', '70000')
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:port', 0xffffffff)
-
-        self.eq(tlib.getTypeNorm('inet:port', 20)[0], 20)
-
-    def test_datatype_inet_mac(self):
-        tlib = s_types.TypeLib()
-
-        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:mac', 'newp')
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:mac', 'newp')
-
-        self.eq(tlib.getTypeNorm('inet:mac', 'FF:FF:FF:FF:FF:FF')[0], 'ff:ff:ff:ff:ff:ff')
-        self.eq(tlib.getTypeParse('inet:mac', 'FF:FF:FF:FF:FF:FF')[0], 'ff:ff:ff:ff:ff:ff')
-        self.eq(tlib.getTypeRepr('inet:mac', 'ff:ff:ff:ff:ff:ff'), 'ff:ff:ff:ff:ff:ff')
-
-    def test_datatype_inet_email(self):
-        tlib = s_types.TypeLib()
-
-        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:email', 'newp')
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:email', 'newp')
-
-        self.eq(tlib.getTypeParse('inet:email', 'ViSi@Woot.Com')[0], 'visi@woot.com')
-
-        self.eq(tlib.getTypeNorm('inet:email', 'ViSi@Woot.Com')[0], 'visi@woot.com')
-
-        self.eq(tlib.getTypeRepr('inet:email', 'visi@woot.com'), 'visi@woot.com')
-
     def test_datatype_guid(self):
         tlib = s_types.TypeLib()
 
@@ -128,40 +51,6 @@ class DataTypesTest(SynTest):
                 '000102030405060708090a0b0c0d0e0f')
         self.eq(tlib.getTypeNorm('hash:md5', '000102030405060708090A0B0C0D0E0F')[0], '000102030405060708090a0b0c0d0e0f')
         self.eq(tlib.getTypeRepr('hash:md5', '000102030405060708090a0b0c0d0e0f'), '000102030405060708090a0b0c0d0e0f')
-
-    def test_datatype_inet_ipv6(self):
-        tlib = s_types.TypeLib()
-
-        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:ipv6', 'newp')
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', 'newp')
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', '[fffffffffffffffffffffffff::2]:80')
-
-        self.eq(tlib.getTypeParse('inet:ipv6', 'AF:00::02')[0], 'af::2')
-        self.eq(tlib.getTypeNorm('inet:ipv6', 'AF:00::02')[0], 'af::2')
-        self.eq(tlib.getTypeRepr('inet:ipv6', 'af::2'), 'af::2')
-
-        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8::1:1:1:1:1')[0], '2001:db8:0:1:1:1:1:1')
-        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8:0:1:1:1:1:1')[0], '2001:db8:0:1:1:1:1:1')
-
-        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8::0:1')[0], '2001:db8::1')
-        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8:0:0:0:0:2:1')[0], '2001:db8::2:1')
-
-        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8::')[0], '2001:db8::')
-
-        self.eq(tlib.getTypeRepr('inet:srv6', '[af::2]:80'), '[af::2]:80')
-        self.eq(tlib.getTypeParse('inet:srv6', '[AF:00::02]:80')[0], '[af::2]:80')
-        self.eq(tlib.getTypeNorm('inet:srv6', '[AF:00::02]:80')[0], '[af::2]:80')
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', '[AF:00::02]:999999')
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', '[AF:00::02]:-1')
-
-    def test_datatype_inet_cidr(self):
-        tlib = s_types.TypeLib()
-
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:cidr4', '1.2.3.0/33')
-        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:cidr4', '1.2.3.0/-1')
-
-        self.eq(tlib.getTypeNorm('inet:cidr4', '1.2.3.0/24'), ('1.2.3.0/24', {'ipv4': 16909056, 'mask': 24}))
-        self.eq(tlib.getTypeRepr('inet:cidr4', '1.2.3.0/24'), '1.2.3.0/24')
 
     def test_datatype_str(self):
         tlib = s_types.TypeLib()

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -135,6 +135,31 @@ class DataTypesTest(SynTest):
         self.eq(subs.get('hehe'), 'woot.com')
         self.eq(subs.get('haha'), 0x01020304)
 
+    def test_datatype_int(self):
+        tlib = s_types.TypeLib()
+        self.eq(tlib.getTypeNorm('int', 1), (1, {}))
+        self.eq(tlib.getTypeNorm('int', -1), (-1, {}))
+        self.eq(tlib.getTypeNorm('int', 0), (0, {}))
+        self.eq(tlib.getTypeNorm('int', '1'), (1, {}))
+        self.eq(tlib.getTypeNorm('int', '0x01'), (1, {}))
+
+        self.eq(tlib.getTypeNorm('int', '-1'), (-1, {}))
+        self.eq(tlib.getTypeNorm('int', '0'), (0, {}))
+        # Bound checking
+        self.eq(tlib.getTypeNorm('int', -9223372036854775808), (-9223372036854775808, {}))
+        self.eq(tlib.getTypeNorm('int', 9223372036854775807), (9223372036854775807, {}))
+
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', 'hehe')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', 'one')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', 'one')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', 1.0)
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', '1.0')
+
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', {})
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', [])
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', 9223372036854775809)
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'int', 9223372036854775808)
+
     def test_datatype_int_minmax(self):
         tlib = s_types.TypeLib()
 

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -249,16 +249,6 @@ class DataTypesTest(SynTest):
         self.raises(BadTypeValu, tlib.getTypeNorm, 'json', {'hehe', 'haha'})
         self.raises(BadTypeValu, tlib.getTypeNorm, 'json', 'Wow"wow')
 
-    def test_type_phone(self):
-        tlib = s_types.TypeLib()
-        prop = 'tel:phone'
-
-        self.eq(tlib.getTypeNorm(prop, 1234567890)[0], 1234567890)
-        self.eq(tlib.getTypeParse(prop, '123 456 7890')[0], 1234567890)
-
-        self.eq(tlib.getTypeRepr(prop, 12345678901), '+1 (234) 567-8901')
-        self.eq(tlib.getTypeRepr(prop, 9999999999), '+9999999999')
-
     def test_type_time_timeepoch(self):
         tlib = s_types.TypeLib()
         SECOND_MS = 1000

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -7,6 +7,117 @@ from synapse.tests.common import *
 
 class InetModelTest(SynTest):
 
+    def test_model_type_inet_url(self):
+        tlib = s_types.TypeLib()
+
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:url', 'newp')
+        self.eq(tlib.getTypeNorm('inet:url', 'http://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
+        self.eq(tlib.getTypeNorm('inet:url', 'HTTP://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
+        self.eq(tlib.getTypeNorm('inet:url', 'HttP://Visi:Secret@WoOt.com/HeHe&foo=10')[0],
+                'http://Visi:Secret@woot.com/HeHe&foo=10')
+
+        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:url', 'newp')
+        self.eq(tlib.getTypeParse('inet:url', 'http://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
+        self.eq(tlib.getTypeParse('inet:url', 'HTTP://WoOt.com/HeHe')[0], 'http://woot.com/HeHe')
+        self.eq(tlib.getTypeParse('inet:url', 'HttP://Visi:Secret@WoOt.com/HeHe&foo=10')[0],
+                'http://Visi:Secret@woot.com/HeHe&foo=10')
+
+        self.eq(tlib.getTypeRepr('inet:url', 'http://woot.com/HeHe'), 'http://woot.com/HeHe')
+
+    def test_model_typeinet_ipv4(self):
+        tlib = s_types.TypeLib()
+
+        self.eq(tlib.getTypeNorm('inet:ipv4', 0x01020304)[0], 0x01020304)
+        self.eq(tlib.getTypeNorm('inet:ipv4', '0x01020304')[0], 0x01020304)
+        self.eq(tlib.getTypeParse('inet:ipv4', '1.2.3.4')[0], 0x01020304)
+        self.eq(tlib.getTypeRepr('inet:ipv4', 0x01020304), '1.2.3.4')
+
+    def tes_model_type_inet_tcp4(self):
+        tlib = s_types.TypeLib()
+
+        self.eq(tlib.getTypeNorm('inet:tcp4', '1.2.3.4:2')[0], 0x010203040002)
+        self.eq(tlib.getTypeNorm('inet:tcp4', 0x010203040002)[0], 0x010203040002)
+
+        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:tcp4', 'newp')
+        self.eq(tlib.getTypeParse('inet:tcp4', '1.2.3.4:2')[0], 0x010203040002)
+
+        self.eq(tlib.getTypeRepr('inet:tcp4', 0x010203040002), '1.2.3.4:2')
+
+    def test_model_type_inet_udp4(self):
+        tlib = s_types.TypeLib()
+
+        self.eq(tlib.getTypeNorm('inet:udp4', '1.2.3.4:2')[0], 0x010203040002)
+        self.eq(tlib.getTypeNorm('inet:udp4', 0x010203040002)[0], 0x010203040002)
+
+        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:udp4', 'newp')
+        self.eq(tlib.getTypeParse('inet:udp4', '1.2.3.4:2')[0], 0x010203040002)
+
+        self.eq(tlib.getTypeRepr('inet:udp4', 0x010203040002), '1.2.3.4:2')
+
+    def test_model_type_inet_port(self):
+        tlib = s_types.TypeLib()
+
+        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:port', '70000')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:port', 0xffffffff)
+
+        self.eq(tlib.getTypeNorm('inet:port', 20)[0], 20)
+
+    def test_model_type_inet_mac(self):
+        tlib = s_types.TypeLib()
+
+        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:mac', 'newp')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:mac', 'newp')
+
+        self.eq(tlib.getTypeNorm('inet:mac', 'FF:FF:FF:FF:FF:FF')[0], 'ff:ff:ff:ff:ff:ff')
+        self.eq(tlib.getTypeParse('inet:mac', 'FF:FF:FF:FF:FF:FF')[0], 'ff:ff:ff:ff:ff:ff')
+        self.eq(tlib.getTypeRepr('inet:mac', 'ff:ff:ff:ff:ff:ff'), 'ff:ff:ff:ff:ff:ff')
+
+    def test_model_type_inet_email(self):
+        tlib = s_types.TypeLib()
+
+        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:email', 'newp')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:email', 'newp')
+
+        self.eq(tlib.getTypeParse('inet:email', 'ViSi@Woot.Com')[0], 'visi@woot.com')
+
+        self.eq(tlib.getTypeNorm('inet:email', 'ViSi@Woot.Com')[0], 'visi@woot.com')
+
+        self.eq(tlib.getTypeRepr('inet:email', 'visi@woot.com'), 'visi@woot.com')
+
+    def test_model_type_inet_ipv6(self):
+        tlib = s_types.TypeLib()
+
+        self.raises(BadTypeValu, tlib.getTypeParse, 'inet:ipv6', 'newp')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', 'newp')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', '[fffffffffffffffffffffffff::2]:80')
+
+        self.eq(tlib.getTypeParse('inet:ipv6', 'AF:00::02')[0], 'af::2')
+        self.eq(tlib.getTypeNorm('inet:ipv6', 'AF:00::02')[0], 'af::2')
+        self.eq(tlib.getTypeRepr('inet:ipv6', 'af::2'), 'af::2')
+
+        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8::1:1:1:1:1')[0], '2001:db8:0:1:1:1:1:1')
+        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8:0:1:1:1:1:1')[0], '2001:db8:0:1:1:1:1:1')
+
+        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8::0:1')[0], '2001:db8::1')
+        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8:0:0:0:0:2:1')[0], '2001:db8::2:1')
+
+        self.eq(tlib.getTypeNorm('inet:ipv6', '2001:db8::')[0], '2001:db8::')
+
+        self.eq(tlib.getTypeRepr('inet:srv6', '[af::2]:80'), '[af::2]:80')
+        self.eq(tlib.getTypeParse('inet:srv6', '[AF:00::02]:80')[0], '[af::2]:80')
+        self.eq(tlib.getTypeNorm('inet:srv6', '[AF:00::02]:80')[0], '[af::2]:80')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', '[AF:00::02]:999999')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', '[AF:00::02]:-1')
+
+    def test_model_type_inet_cidr(self):
+        tlib = s_types.TypeLib()
+
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:cidr4', '1.2.3.0/33')
+        self.raises(BadTypeValu, tlib.getTypeNorm, 'inet:cidr4', '1.2.3.0/-1')
+
+        self.eq(tlib.getTypeNorm('inet:cidr4', '1.2.3.0/24'), ('1.2.3.0/24', {'ipv4': 16909056, 'mask': 24}))
+        self.eq(tlib.getTypeRepr('inet:cidr4', '1.2.3.0/24'), '1.2.3.0/24')
+
     def test_model_inet_email(self):
         with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:email', 'visi@vertex.link')

--- a/synapse/tests/test_model_telco.py
+++ b/synapse/tests/test_model_telco.py
@@ -1,6 +1,18 @@
+import synapse.lib.types as s_types
+
 from synapse.tests.common import *
 
 class TelcoTest(SynTest):
+
+    def test_model_type_phone(self):
+        tlib = s_types.TypeLib()
+        prop = 'tel:phone'
+
+        self.eq(tlib.getTypeNorm(prop, 1234567890)[0], 1234567890)
+        self.eq(tlib.getTypeParse(prop, '123 456 7890')[0], 1234567890)
+
+        self.eq(tlib.getTypeRepr(prop, 12345678901), '+1 (234) 567-8901')
+        self.eq(tlib.getTypeRepr(prop, 9999999999), '+9999999999')
 
     def test_model_telco_phone(self):
         with self.getRamCore() as core:


### PR DESCRIPTION
Cap inttype norm so that it does not produce system values which exceed our storage ability for psql/sqlite storage layers.