### PR TITLE
Telepath bug

### DIFF
--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -511,6 +511,7 @@ class Proxy(s_eventbus.EventBus):
         for (evnt, func), (iden, filt) in self._tele_ons.items():
             eper[evnt].append((iden, filt))
 
+        # XXX BOOM
         if eper:
             job = self._txTeleJob('tele:on', ons=eper.items(), name=self._tele_name)
             self.syncjob(job)

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -221,6 +221,7 @@ class Proxy(s_eventbus.EventBus):
         self._raw_on('job:done', self._tele_boss.dist)
         self._raw_on('sock:gzip', self._onSockGzip)
         self._raw_on('tele:call', self._onTeleCall)
+        self._raw_on('tele:sock:init', self._onTeleSockInit)
 
         self._tele_cthr = self.consume(self._tele_q)
 
@@ -486,6 +487,25 @@ class Proxy(s_eventbus.EventBus):
     def _syn_reflect(self):
         return self._tele_reflect
 
+    def _onTeleSockInit(self, mesg):
+        '''
+        Callback to allow the client to do anything neccesary after a Telepath
+        connection has been made with the remote.
+
+        This is in response to a tele:sock:init event. This occurs during
+        startup of the Proxy object or during reconnection.
+        '''
+        sock = mesg[1].get('sock')
+
+        # Reset any on handlers which the Proxy has registered with the remote
+        eper = collections.defaultdict(list)
+        for (evnt, func), (iden, filt) in self._tele_ons.items():
+            eper[evnt].append((iden, filt))
+
+        if eper:
+            job = self._txTeleJob('tele:on', ons=list(eper.items()), name=self._tele_name)
+            self.syncjob(job)
+
     def _teleSynAck(self, sock):
         '''
         Send a tele:syn to get a telepath session
@@ -506,15 +526,6 @@ class Proxy(s_eventbus.EventBus):
 
         if hisopts.get('sock:can:gzip'):
             sock.set('sock:can:gzip', True)
-
-        eper = collections.defaultdict(list)
-        for (evnt, func), (iden, filt) in self._tele_ons.items():
-            eper[evnt].append((iden, filt))
-
-        # XXX BOOM
-        if eper:
-            job = self._txTeleJob('tele:on', ons=eper.items(), name=self._tele_name)
-            self.syncjob(job)
 
     def _txTeleJob(self, msg, **msginfo):
         '''

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -573,7 +573,7 @@ class Proxy(s_eventbus.EventBus):
         return meth
 
     # some methods to avoid round trips...
-    def __nonzero__(self):
+    def __bool__(self):
         return True
 
     def __eq__(self, obj):

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -236,13 +236,14 @@ class TelePathTest(SynTest):
         data = {}
         def _onHehe(mesg):
             data['hehe'] = data.get('hehe', 0) + 1
+            data['haha'] = mesg[1].get('haha')
 
         prox.on('hehe', _onHehe)
         prox.fire('hehe', haha=1)
         self.eq(data.get('hehe'), 1)
+        self.eq(data.get('haha'), 1)
 
         waiter = self.getTestWait(prox, 1, 'tele:sock:init')
-
         # shut down the daemon
         tenv.dmon.fini()
 
@@ -254,8 +255,9 @@ class TelePathTest(SynTest):
 
         self.eq(prox.bar(10, 20), 30)
 
-        prox.fire('hehe', haha=1)
+        prox.fire('hehe', haha=3)
         self.eq(data.get('hehe'), 2)
+        self.eq(data.get('haha'), 3)
 
         prox.fini()
         dmon.fini()

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -61,6 +61,12 @@ class TelePathTest(SynTest):
         self.true(s_telepath.isProxy(foo))
         self.false(s_telepath.isProxy(self))
 
+        # Test magic methods
+        self.true(bool(foo) is True)
+        self.true(foo == foo)
+        self.false(foo == 1)
+        self.true(foo != 1)
+
         s = time.time()
         for i in range(1000):
             foo.speed()

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -233,6 +233,14 @@ class TelePathTest(SynTest):
         url = 'tcp://127.0.0.1:%d/foo' % (port,)
         self.eq(prox.bar(10, 20), 30)
 
+        data = {}
+        def _onHehe(mesg):
+            data['hehe'] = data.get('hehe', 0) + 1
+
+        prox.on('hehe', _onHehe)
+        prox.fire('hehe', haha=1)
+        self.eq(data.get('hehe'), 1)
+
         waiter = self.getTestWait(prox, 1, 'tele:sock:init')
 
         # shut down the daemon
@@ -245,6 +253,9 @@ class TelePathTest(SynTest):
         waiter.wait()
 
         self.eq(prox.bar(10, 20), 30)
+
+        prox.fire('hehe', haha=1)
+        self.eq(data.get('hehe'), 2)
 
         prox.fini()
         dmon.fini()


### PR DESCRIPTION
Telepath's Proxy object was unable to reset on() handlers after a reconnect event occurred.  This moves the reset to be performed in a callback which occurs after the telepath session has been reconnected AND the new socket has been placed into the Proxy's multiplexor for management.

Also updated the Proxy datamodel to be python3 friendly and add tests for the Proxy magic methods.