### PR TITLE
Fixes incorrect regex parsing of some unicode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
         'pyOpenSSL>=16.2.0',
         'msgpack-python>=0.4.2',
         'xxhash>=1.0.1',
-        'lmdb>=0.92'
+        'lmdb>=0.92',
+        'regex>=2017.9.23'
     ],
 
     classifiers=[

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -1,6 +1,5 @@
 import io
 import os
-import re
 import sys
 import json
 import time
@@ -15,6 +14,8 @@ import traceback
 import collections
 
 from binascii import hexlify
+
+import regex
 
 import synapse.exc as s_exc
 
@@ -70,7 +71,7 @@ def guid(valu=None):
     byts = msgenpack(valu)
     return hashlib.md5(byts).hexdigest()
 
-guidre = re.compile('^[0-9a-f]{32}$')
+guidre = regex.compile('^[0-9a-f]{32}$')
 def isguid(text):
     return guidre.match(text) is not None
 

--- a/synapse/cores/sqlite.py
+++ b/synapse/cores/sqlite.py
@@ -1,7 +1,8 @@
-import re
 import queue
 import logging
 import sqlite3
+
+import regex
 
 import synapse.common as s_common
 
@@ -11,7 +12,7 @@ import synapse.cores.storage as s_cores_storage
 
 logger = logging.getLogger(__name__)
 
-stashre = re.compile('{{([A-Z]+)}}')
+stashre = regex.compile('{{([A-Z]+)}}')
 
 int_t = type(0)
 str_t = type('synapse')

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -1,11 +1,12 @@
 '''
 An API to assist with the creation and enforcement of cortex data models.
 '''
-import re
 import fnmatch
 import functools
 import collections
 import logging
+
+import regex
 
 import synapse.common as s_common
 
@@ -14,8 +15,8 @@ import synapse.lib.types as s_types
 
 logger = logging.getLogger(__name__)
 
-hexre = re.compile('^[0-9a-z]+$')
-propre = re.compile('^[0-9a-z:_]+$')
+hexre = regex.compile('^[0-9a-z]+$')
+propre = regex.compile('^[0-9a-z:_]+$')
 
 tlib = s_types.TypeLib()
 

--- a/synapse/lib/ingest.py
+++ b/synapse/lib/ingest.py
@@ -1,11 +1,12 @@
 import os
-import re
 import csv
 import json
 import codecs
 import logging
 
 import xml.etree.ElementTree as x_etree
+
+import regex
 
 import synapse.common as s_common
 
@@ -84,11 +85,11 @@ def _fmt_lines(fd, gest):
 
     skipstr = gest.get('format:lines:skipre')
     if skipstr is not None:
-        skipre = re.compile(skipstr)
+        skipre = regex.compile(skipstr)
 
     muststr = gest.get('format:lines:mustre')
     if muststr is not None:
-        mustre = re.compile(muststr)
+        mustre = regex.compile(muststr)
 
     for line in fd:
 
@@ -314,12 +315,12 @@ class Ingest(EventBus):
         self._i_glab = s_gene.GeneLab()
 
         self._tvar_cache = {}
-        self._tvar_regex = re.compile('{{(\w+)}}')
+        self._tvar_regex = regex.compile('{{(\w+)}}')
 
-    def _re_compile(self, regex):
-        ret = self._i_res.get(regex)
+    def _re_compile(self, regexp):
+        ret = self._i_res.get(regexp)
         if ret is None:
-            self._i_res[regex] = ret = re.compile(regex)
+            self._i_res[regexp] = ret = regex.compile(regexp)
         return ret
 
     def get(self, name, defval=None):

--- a/synapse/lib/scrape.py
+++ b/synapse/lib/scrape.py
@@ -1,5 +1,7 @@
-import re
 import json
+
+import regex
+
 import synapse.data as s_data
 import synapse.common as s_common
 
@@ -9,7 +11,7 @@ tldlist.sort(key=lambda x: len(x))
 tldlist.reverse()
 
 tldcat = '|'.join(tldlist)
-fqdn_re = r'((?:[a-z0-9_-]{1,63}\.){1,10}(?:%s))' % tldcat
+fqdn_re = regex.compile(r'((?:[a-z0-9_-]{1,63}\.){1,10}(?:%s))' % tldcat)
 
 scrape_types = [
     ('hash:md5', r'(?=(?:[^A-Za-z0-9]|^)([A-Fa-f0-9]{32})(?:[^A-Za-z0-9]|$))', {}),
@@ -23,7 +25,7 @@ scrape_types = [
     ('inet:email', r'(?:[^a-z0-9_.+-]|^)([a-z0-9_\.\-+]{1,256}@(?:[a-z0-9_-]{1,63}\.){1,10}(?:%s))(?:[^a-z0-9_.-]|$)' % tldcat, {}),
 ]
 
-regexes = {name: re.compile(rule, re.IGNORECASE) for (name, rule, opts) in scrape_types}
+regexes = {name: regex.compile(rule, regex.IGNORECASE) for (name, rule, opts) in scrape_types}
 
 def scrape(text):
     '''

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1,8 +1,9 @@
-import re
 import time
 import fnmatch
 import logging
 import collections
+
+import regex
 
 import synapse.common as s_common
 
@@ -443,7 +444,7 @@ class Runtime(Configable):
         self.setOperFunc('show:cols', self._stormOperShowCols)
 
         # Cache compiled regex objects.
-        self._rt_regexcache = s_cache.FixedCache(1024, re.compile)
+        self._rt_regexcache = s_cache.FixedCache(1024, regex.compile)
 
     @staticmethod
     @confdef(name='storm')

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -1,8 +1,9 @@
-import re
 import json
 import base64
 import logging
 import collections
+
+import regex
 
 import synapse.common as s_common
 import synapse.dyndeps as s_dyndeps
@@ -179,13 +180,13 @@ class StrType(DataType):
         if enumstr is not None:
             self.envals = enumstr.split(',')
 
-        regex = info.get('regex')
-        if regex is not None:
-            self.regex = re.compile(regex)
+        regexp = info.get('regex')
+        if regexp is not None:
+            self.regex = regex.compile(regexp)
 
         restrip = info.get('restrip')
         if restrip is not None:
-            self.restrip = re.compile(restrip)
+            self.restrip = regex.compile(restrip)
 
         frobintfmt = info.get('frob_int_fmt')
         if frobintfmt is not None:
@@ -668,7 +669,7 @@ class BoolType(DataType):
     def repr(self, valu):
         return repr(bool(valu))
 
-tagre = re.compile(r'^([\w]+\.)*[\w]+$')
+tagre = regex.compile(r'^([\w]+\.)*[\w]+$')
 
 class TagType(DataType):
 

--- a/synapse/lib/version.py
+++ b/synapse/lib/version.py
@@ -2,8 +2,9 @@
 Synapse utilites for dealing with Semvar versioning.
 This includes the Synapse version information.
 '''
-import re
 import string
+
+import regex
 
 # This module is imported during synapse.__init__.  As such, we can't pull
 # arbitrary modules from Synapse here. synapse.exc is currently safe,
@@ -13,7 +14,7 @@ import synapse.exc as s_exc
 vseps = ('.', '-', '_', '+')
 mask20 = 0xFFFFF
 mask60 = 0xFFFFFFFFFFFFFFF
-semver_re = r'''^(?P<maj>(0(?![0-9])|[1-9][0-9]*))\.(?P<min>(0(?![0-9])|[1-9][0-9]*))\.(?P<pat>(0(?![0-9])|[1-9][0-9]*))(\-(?P<pre>([0-9A-Za-z\-\.]+)))?(\+(?P<bld>([0-9A-Za-z\.\-]+)))?$'''
+semver_re = regex.compile(r'''^(?P<maj>(0(?![0-9])|[1-9][0-9]*))\.(?P<min>(0(?![0-9])|[1-9][0-9]*))\.(?P<pat>(0(?![0-9])|[1-9][0-9]*))(\-(?P<pre>([0-9A-Za-z\-\.]+)))?(\+(?P<bld>([0-9A-Za-z\.\-]+)))?$''')
 
 def parseSemver(text):
     '''
@@ -37,7 +38,7 @@ def parseSemver(text):
     txt = text.strip().lstrip('vV')
     ret = {}
 
-    m = re.match(semver_re, txt)
+    m = semver_re.match(txt)
     if not m:
         return None
     d = m.groupdict()
@@ -161,12 +162,12 @@ def parseVersionParts(text, seps=vseps):
     text = text.lstrip(string.ascii_letters)
     # Strip off any leading separator which may be present
     text = text.lstrip(seps)
-    pattern = r'^(\d+)([{}]+|$)'.format(re.escape(seps))
+    pattern = r'^(\d+)([{}]+|$)'.format(regex.escape(seps))
     parts = []
     ret = {}
     off = 0
     while True:
-        m = re.search(pattern, text[off:])
+        m = regex.search(pattern, text[off:])
         if not m:
             break
         off += m.end()

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -1,8 +1,9 @@
-import re
 import socket
 import struct
 import hashlib
 import logging
+
+import regex
 
 import synapse.common as s_common
 import synapse.lib.tufo as s_tufo
@@ -64,7 +65,7 @@ class IPv4Type(DataType):
     def repr(self, valu):
         return ipv4str(valu)
 
-fqdnre = re.compile(r'^[\w._-]+$', re.U)
+fqdnre = regex.compile(r'^[\w._-]+$', regex.U)
 
 class FqdnType(DataType):
     subprops = (
@@ -170,7 +171,7 @@ class Srv4Type(DataType):
                                mesg='Srv4 Port number is out of bounds')
         return (addr << 16) | port, {'port': port, 'ipv4': addr}
 
-srv6re = re.compile('^\[([a-f0-9:]+)\]:(\d+)$')
+srv6re = regex.compile('^\[([a-f0-9:]+)\]:(\d+)$')
 
 class Srv6Type(DataType):
     '''

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -1,4 +1,4 @@
-import re
+import regex
 
 import synapse.lib.cmdr as s_cmdr
 import synapse.cmds.cortex as s_cmds_cortex
@@ -46,7 +46,7 @@ class SynCmdCoreTest(SynTest):
             terms = ('oplog', 'took', 'options', 'limits')
 
             for term in terms:
-                self.nn(re.search(term, outp))
+                self.nn(regex.search(term, outp))
 
     def test_cmds_ask_props(self):
         with self.getDmonCore() as core:
@@ -60,7 +60,7 @@ class SynCmdCoreTest(SynTest):
             terms = ('fqdn = vertex.link', 'user = visi')
 
             for term in terms:
-                self.nn(re.search(term, outp))
+                self.nn(regex.search(term, outp))
 
     def test_cmds_ask_tagtime(self):
 
@@ -74,8 +74,8 @@ class SynCmdCoreTest(SynTest):
 
             lines = [s.strip() for s in str(outp).split('\n')]
 
-            self.true(any([re.search('^#baz.faz \(added [0-9/: \.]+\)$', l) for l in lines]))
-            self.true(any([re.search('^#foo.bar \(added [0-9/: \.]+\) 2011/01/01 00:00:00.000  -  2016/01/01 00:00:00.000$', l) for l in lines]))
+            self.true(any([regex.search('^#baz.faz \(added [0-9/: \.]+\)$', l) for l in lines]))
+            self.true(any([regex.search('^#foo.bar \(added [0-9/: \.]+\) 2011/01/01 00:00:00.000  -  2016/01/01 00:00:00.000$', l) for l in lines]))
 
     def test_cmds_ask_mutual_exclusive(self):
         with self.getDmonCore() as core:
@@ -111,7 +111,7 @@ class SynCmdCoreTest(SynTest):
                      'options:',
                      'limits:')
             for term in terms:
-                self.nn(re.search(term, outp))
+                self.nn(regex.search(term, outp))
 
     def test_cmds_ask_raw(self):
         with self.getDmonCore() as core:
@@ -124,7 +124,7 @@ class SynCmdCoreTest(SynTest):
             outp = str(outp)
             terms = ('"tufo:form": "inet:email"', '"inet:email:user": "visi"')
             for term in terms:
-                self.nn(re.search(term, outp))
+                self.nn(regex.search(term, outp))
 
     def test_cmds_ask_multilift(self):
         with self.getDmonCore() as core:
@@ -139,14 +139,14 @@ class SynCmdCoreTest(SynTest):
             terms = ('0.0.0.0', 'hehe')
 
             for term in terms:
-                self.nn(re.search(term, outp))
+                self.nn(regex.search(term, outp))
 
     def test_cmds_ask_noopts(self):
         with self.getDmonCore() as core:
             outp = s_output.OutPutStr()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             cmdr.runCmdLine('ask')
-            self.nn(re.search('Examples:', str(outp)))
+            self.nn(regex.search('Examples:', str(outp)))
 
     def test_cmds_guid(self):
         with self.getDmonCore() as core:

--- a/synapse/tests/test_model_dns.py
+++ b/synapse/tests/test_model_dns.py
@@ -17,6 +17,11 @@ class DnsModelTest(SynTest):
             self.eq(t1[1].get('inet:dns:a:fqdn'), 'foo.com')
             self.eq(t1[1].get('inet:dns:a:ipv4'), 0x05060708)
 
+            t2 = core.formTufoByProp('inet:dns:a', 'www.\u0915\u0949\u092e/1.2.3.4')
+            self.eq(t2[1].get('inet:dns:a'), 'www.\u0915\u0949\u092e/1.2.3.4')
+            self.eq(t2[1].get('inet:dns:a:fqdn'), 'www.xn--11b4c3d')
+            self.eq(t2[1].get('inet:dns:a:ipv4'), 0x01020304)
+
     def test_model_dns_aaaa(self):
         with self.getRamCore() as core:
             t0 = core.formTufoByProp('inet:dns:aaaa', 'WOOT.com/FF::56')


### PR DESCRIPTION
Closes #170 

- Adds `regex` module to third-party requirements
- Updates all modules to use `regex` module instead of `re`
- Adds regression test
- Changes a few variable names from `regex` to `regexp` to avoid namespace collision
- Changes all uses of regular expressions to be pre-compiled where possible

The bug here is actually in python's builtin `re` module. The issue is that one of the characters in the TLD is not recognized by `re` as a word character. This bug does not exist in the `regex` module. Further information in the referenced issue.