### PR TITLE
Allow the EventBus.main() to catch SIGTERM and gracefully exit.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,15 +1,8 @@
 environment:
 
   matrix:
-
-    - PYTHON: "C:\\Python27"
-
-    - PYTHON: "C:\\Python27-x64"
-
-    - PYTHON: "C:\\Python34"
-
-    - PYTHON: "C:\\Python34-x64"
-
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35-x64"
     # TODO
     #- PYTHON: "C:\\Python36"
     #- PYTHON: "C:\\Python36-x64"
@@ -33,4 +26,4 @@ build: off
 
 test_script:
   # Run the project tests
-  - "%CMD_IN_ENV% %PYTHON%\\python.exe -m unittest discover -v --fail"
+  - "%CMD_IN_ENV% %PYTHON%\\python.exe -m unittest discover -v"

--- a/synapse/eventbus.py
+++ b/synapse/eventbus.py
@@ -274,7 +274,7 @@ class EventBus(object):
 
         try:
             signal.signal(signal.SIGTERM, sighandler)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             logger.exception('Unable to register SIGTERM handler in eventbus.')
 
         try:

--- a/synapse/eventbus.py
+++ b/synapse/eventbus.py
@@ -1,5 +1,6 @@
 import gc
 import atexit
+import signal
 import logging
 import threading
 import traceback
@@ -267,6 +268,13 @@ class EventBus(object):
             # we have now fini()d
 
         '''
+
+        def sighandler(signum, frame):
+            print('Caught signal {}, shutting down'.format(signum))
+            self.fini()
+
+        signal.signal(signal.SIGTERM, sighandler)
+
         try:
             self.waitfini()
         except KeyboardInterrupt as e:

--- a/synapse/eventbus.py
+++ b/synapse/eventbus.py
@@ -268,12 +268,14 @@ class EventBus(object):
             # we have now fini()d
 
         '''
-
         def sighandler(signum, frame):
             print('Caught signal {}, shutting down'.format(signum))
             self.fini()
 
-        signal.signal(signal.SIGTERM, sighandler)
+        try:
+            signal.signal(signal.SIGTERM, sighandler)
+        except Exception as e:
+            logger.exception('Unable to register SIGTERM handler in eventbus.')
 
         try:
             self.waitfini()

--- a/synapse/eventbus.py
+++ b/synapse/eventbus.py
@@ -260,13 +260,21 @@ class EventBus(object):
 
     def main(self):
         '''
-        Helper function to block until shutdown ( and handle ctrl-c etc ).
+        Helper function to block until shutdown ( and handle ctrl-c and SIGTERM).
 
-        Example:
+        Examples:
+            Run a event bus, wait until main() has returned, then do other stuff::
 
-            dmon.main()
-            # we have now fini()d
+                foo = EventBus()
+                foo.main()
+                dostuff()
 
+        Notes:
+            This does fire a 'ebus:main' event prior to entering the
+            waitfini() loop.
+
+        Returns:
+            None
         '''
         def sighandler(signum, frame):
             print('Caught signal {}, shutting down'.format(signum))
@@ -278,6 +286,7 @@ class EventBus(object):
             logger.exception('Unable to register SIGTERM handler in eventbus.')
 
         try:
+            self.fire('ebus:main')
             self.waitfini()
         except KeyboardInterrupt as e:
             print('ctrl-c caught: shutting down')

--- a/synapse/tests/test_eventbus.py
+++ b/synapse/tests/test_eventbus.py
@@ -9,17 +9,26 @@ from synapse.tests.common import *
 
 @firethread
 def send_sig(pid, sig, wait=0.1):
+    '''
+    Sent a signal to a process.
+
+    Args:
+        pid (int): Process id to send the signal too.
+        sig (int): Signal to send.
+        wait (float): Time to sleep before sending the signal.
+
+    Returns:
+        None
+    '''
     time.sleep(wait)
     os.kill(pid, sig)
 
 def block_processing(evt):
     '''
+    Function to make an eventbus and call main().  Used as a Process target.
 
     Args:
         evt (multiprocessing.Event): event to twiddle
-
-    Returns:
-
     '''
     bus = s_eventbus.EventBus()
     evt.set()


### PR DESCRIPTION
Add a SIGTERM handler to eventbus.main so that daemon / dmon run code (such as a docker container) will cleanly attempt to tear down any objects.