### PR TITLE
Add a larger window for tests of the "now" time normalizer.

### DIFF
--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -78,7 +78,7 @@ class StormTest(SynTest):
             currenttime = now()
             cmd = 'inet:web:acct=vertex.link/pennywise setprop(:seen:max="now")'
             node = core.eval(cmd)[0]
-            self.le(node[1].get('inet:web:acct:seen:max') - currenttime, 2)
+            self.le(node[1].get('inet:web:acct:seen:max') - currenttime, 1000)
 
             # old / bad syntax fails
             # kwlist key/val syntax is no longer valid in setprop()

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -367,8 +367,8 @@ class DataTypesTest(SynTest):
         currenttime = now()
         valu = tlib.getTypeNorm('time', 'now')[0]
         # Allow for a potential context switch / system load during test
-        #  to push the valu 2 second past currenttime
-        self.le(valu - currenttime, 2)
+        #  to push the valu within 1000 milliseconds past currenttime
+        self.le(valu - currenttime, 1000)
 
     def test_type_cast(self):
         tlib = s_types.TypeLib()


### PR DESCRIPTION
this could cause periodic test failures