### PR TITLE
Breaktest

### DIFF
--- a/synapse/async.py
+++ b/synapse/async.py
@@ -1,4 +1,5 @@
 import time
+import logging
 import traceback
 import threading
 
@@ -9,6 +10,8 @@ import synapse.lib.scope as s_scope
 import synapse.lib.threads as s_threads
 
 from synapse.eventbus import EventBus
+
+logger = logging.getLogger(__name__)
 
 def jobid():
     return s_common.guid()

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -75,6 +75,7 @@ class AxonHost(s_config.Config):
         url = self.getConfOpt('axon:axonbus')
         if url:
             self.axonbus = s_service.openurl(url)
+            self.onfini(self.axonbus.fini)
             self.axonbus.runSynSvc(s_common.guid(), self)
 
     @staticmethod
@@ -582,6 +583,7 @@ class Axon(s_config.Config, AxonMixin):
         busurl = self.getConfOpt('axon:axonbus')
         if busurl:
             self.axonbus = s_service.openurl(busurl)
+            self.onfini(self.axonbus.fini)
 
             props = {'link': self.link, 'tags': self.tags}
             self.axonbus.runSynSvc(self.iden, self, **props)

--- a/synapse/lib/msgpack.py
+++ b/synapse/lib/msgpack.py
@@ -22,7 +22,11 @@ def en(item):
     '''
     if pakr is None:  # pragma: no cover
         return msgpack.packb(item, use_bin_type=True, encoding='utf8')
-    return pakr.pack(item)
+    try:
+        return pakr.pack(item)
+    except Exception as e:
+        pakr.reset()
+        raise
 
 def un(byts):
     '''

--- a/synapse/lib/threads.py
+++ b/synapse/lib/threads.py
@@ -253,7 +253,7 @@ class Pool(EventBus):
                 func(*args, **kwargs)
 
             except Exception as e:
-                logger.exception('error running task')
+                logger.exception('error running task for [%s]', work)
 
     def _onPoolFini(self):
         threads = list(self._pool_threads.values())

--- a/synapse/lib/threads.py
+++ b/synapse/lib/threads.py
@@ -5,8 +5,6 @@ import traceback
 import contextlib
 import collections
 
-logger = logging.Logger(__name__)
-
 from functools import wraps
 
 import synapse.common as s_common
@@ -15,6 +13,8 @@ import synapse.lib.task as s_task
 import synapse.lib.queue as s_queue
 
 from synapse.eventbus import EventBus
+
+logger = logging.getLogger(__name__)
 
 def current():
     return threading.currentThread()

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -28,14 +28,26 @@ telever = (2, 0)
 
 def openurl(url, **opts):
     '''
-    Construct a telepath proxy from a url.
+    Construct a Telepath Proxy from a URL.
 
-    Example:
+    Args:
+        url (str): A URL to parser into a link tufo.
+        **opts: Additional options which are added to the link tufo.
 
-        foo = openurl('tcp://1.2.3.4:90/foo')
+    Examples:
+        Get a proxy object from a URL, call a function then close the object::
 
-        foo.dostuff(30) # call remote method
+            foo = openurl('tcp://1.2.3.4:90/foo')
+            foo.dostuff(30) # call remote method
+            foo.fini()
 
+        Get a proxy object as a context manager, which will result in the object being automatically closed::
+
+            with openurl('tcp://1.2.3.4:90/foo') as foo:
+                foo.dostuff(30)
+
+    Returns:
+        Proxy: A Proxy object for calling remote tasks.
     '''
     #plex = opts.pop('plex',None)
     #return openclass(Proxy,url,**opts)
@@ -46,13 +58,25 @@ def openurl(url, **opts):
 
 def openlink(link):
     '''
-    Construct a telepath proxy from a link tufo.
+    Construct a Telepath Proxy from a link tufo.
 
-    Example:
+    Args:
+        link ((str, dict)): A link dictionary.
 
-        foo = openlink(link)
-        foo.bar(20)
+    Examples:
+        Get a proxy object, call a function then close the object::
 
+            foo = openlink(link)
+            foo.bar(20)
+            foo.fini()
+
+        Get a proxy object as a context manager, which will result in the object being automatically closed::
+
+            with openlink as foo:
+                foo.dostuff(30)
+
+    Returns:
+        Proxy: A Proxy object for calling remote tasks.
     '''
     # special case for dmon://fooname/ which refers to a
     # named object within whatever dmon is currently in scope

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -102,12 +102,11 @@ class AxonTest(SynTest):
                 with s_axon.Axon(dirname) as axon:
                     dmon.share('axon', axon, fini=True)
 
-                    prox = s_telepath.openurl('tcp://127.0.0.1/axon', port=port)
-
-                    with io.BytesIO(b'vertex') as fd:
-                        blob = prox.eatfd(fd)
-                        self.eq(blob[1]['axon:blob:sha256'],
-                                'e1b683e26a3aad218df6aa63afe9cf57fdb5dfaf5eb20cddac14305d67f48a02')
+                    with s_telepath.openurl('tcp://127.0.0.1/axon', port=port) as prox:
+                        with io.BytesIO(b'vertex') as fd:
+                            blob = prox.eatfd(fd)
+                            self.eq(blob[1]['axon:blob:sha256'],
+                                    'e1b683e26a3aad218df6aa63afe9cf57fdb5dfaf5eb20cddac14305d67f48a02')
 
     def test_axon_eatbytes(self):
         self.thisHostMustNot(platform='windows')
@@ -643,6 +642,7 @@ class AxonClusterTest(SynTest):
             host1.fini()
             host2.fini()
 
+        svcprox.fini()
         dmon.fini()
 
     def test_axon_cluster_cortex(self):
@@ -729,6 +729,7 @@ class AxonClusterTest(SynTest):
             host1.fini()
             host2.fini()
 
+        svcprox.fini()
         dmon.fini()
 
 class AxonFSTest(SynTest):

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -351,6 +351,12 @@ class AxonHostTest(SynTest):
             host0.fini()
             host1.fini()
             host2.fini()
+
+            # Ensure the axonhost fini'd its objects
+            self.true(host0.axonbus.isfini)
+            for axon in host0.axons.values():
+                self.true(axon.isfini)
+
         dmon.fini()
 
     def test_axon_clone_large(self):

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -100,6 +100,7 @@ class TelePathTest(SynTest):
         newp = s_telepath.openurl('tcp://localhost:%d/newp' % (port,))
         self.raises(SynErr, newp.foo)
 
+        newp.fini()
         dmon.fini()
 
     def test_telepath_call(self):
@@ -163,6 +164,7 @@ class TelePathTest(SynTest):
         job = foo.callx('baz', ('faz', (30,), {'y': 40}), )
 
         self.eq(foo.syncjob(job), '30:40')
+        foo.fini()
 
     def test_telepath_fakesync(self):
         env = self.getFooEnv()
@@ -212,6 +214,9 @@ class TelePathTest(SynTest):
         prox1 = s_telepath.openurl('tcp://127.0.0.1/bar', port=port)
 
         self.eq(prox1.bar(33, 44), 77)
+
+        prox0.fini()
+        prox1.fini()
 
         env0.fini()
         env1.fini()
@@ -385,6 +390,9 @@ class TelePathTest(SynTest):
                 self.eq(counters['p1'], 3)
                 self.eq(counters['f0'], 1)
 
+                proxy0.fini()
+                proxy1.fini()
+
     def test_telepath_clientside(self):
 
         with s_daemon.Daemon() as dmon:
@@ -448,3 +456,5 @@ class TelePathTest(SynTest):
             prox._tele_sock.fini()
             self.true(evnt.wait(timeout=1))
             self.eq(mind.sent[0][0], 'foo:bar')
+
+            prox.fini()


### PR DESCRIPTION
Increase logging for task failures so they can be more accurately traced
Rewrite Telepath openurl / openlink docstrings
Close more dangling Telepath Proxy objects during unit tests.

@MichaelSquires gets credit for pushing me towards fixing some of the unit test issues in #521.