### PR TITLE
Address an axon startup race by waiting for our clones to come online

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -645,6 +645,10 @@ class Axon(s_config.Config, AxonMixin):
 
             self._initAxonClone(iden)
 
+            # Wait for our clone to come online
+            waiter = self.waiter(1, 'syn:axon:clone:ready')
+            waiter.wait(60)
+
         self._findAxonClones()
 
     def _waitClonesReady(self, timeout=None):


### PR DESCRIPTION
before entering into self._findAxonClones.