### PR TITLE
Explicitly skip the scripts directory during package creation for pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ setup(
     url='https://github.com/vertexproject/synapse',
     license='Apache License 2.0',
 
-    packages=find_packages(exclude=['*.tests', '*.tests.*']),
+    packages=find_packages(exclude=['*.tests',
+                                    '*.tests.*',
+                                    'scripts',
+                                    ]),
 
     include_package_data=True,
 


### PR DESCRIPTION
This was accidentally included in redistributed packages and collides with https://pypi.python.org/pypi/scripts