### PR TITLE
Bug svcbus 

### DIFF
--- a/synapse/lib/service.py
+++ b/synapse/lib/service.py
@@ -37,10 +37,9 @@ class SvcBus(s_eventbus.EventBus):
         self.on('syn:svc:fini', self._onSynSvcFini)
 
     def _onSynSvcFini(self, mesg):
-        name = mesg[1].get('name')
-        props = mesg[1].get('props')
-
-        self.bytag.pop(name)
+        svcfo = mesg[1].get('svcfo')
+        iden = svcfo[0]
+        self.bytag.pop(iden)
 
     def iAmSynSvc(self, iden, props):
         '''
@@ -162,7 +161,7 @@ class SvcProxy(s_eventbus.EventBus):
         self.idenprox[iden] = IdenProxy(self, svcfo)
 
         self.bytag.put(iden, tags)
-        self.bytag.put(iden, (name,))
+        self.fire('syn:svcprox:init', svcfo=svcfo)
 
     def _onSynSvcFini(self, mesg):
         svcfo = mesg[1].get('svcfo')
@@ -170,11 +169,12 @@ class SvcProxy(s_eventbus.EventBus):
         iden = svcfo[0]
         name = svcfo[1].get('name', iden)
 
-        self.bytag.pop(svcfo[0])
-        self.idenprox.pop(svcfo[0], None)
+        self.bytag.pop(iden)
+        self.idenprox.pop(iden, None)
 
         self.byname.pop(name, None)
         self.byiden.pop(iden, None)
+        self.fire('syn:svcprox:fini', svcfo=svcfo)
 
     def setSynSvcTimeout(self, timeout):
         self.timeout = timeout

--- a/synapse/lib/service.py
+++ b/synapse/lib/service.py
@@ -57,9 +57,12 @@ class SvcBus(s_eventbus.EventBus):
         sock = s_scope.get('sock')
         if sock is not None:
             def onfini():
-                oldsvc = self.services.pop(iden, None)
-                self.bytag.pop(iden)
-                self.fire('syn:svc:fini', svcfo=oldsvc)
+                # MULTIPLEXOR - don't block
+                def _onfini():
+                    oldsvc = self.services.pop(iden, None)
+                    self.bytag.pop(iden)
+                    self.fire('syn:svc:fini', svcfo=oldsvc)
+                s_glob.pool.call(_onfini)
 
             sock.onfini(onfini)
 

--- a/synapse/tests/test_lib_service.py
+++ b/synapse/tests/test_lib_service.py
@@ -39,6 +39,89 @@ class SvcTest(SynTest):
                 job = prox.callx(svcs[0][0], dyntask)
                 self.eq(prox.syncjob(job), 40)
 
+    def test_service_proxy_bounce(self):
+
+        with s_daemon.Daemon() as dmon:
+
+            sbus = s_service.SvcBus()
+            dmon.share('syn.svcbus', sbus, fini=True)
+
+            link = dmon.listen('tcp://127.0.0.1:0/')
+
+            port = link[1].get('port')
+            sprox0 = s_service.SvcProxy(s_telepath.openurl('tcp://127.0.0.1/syn.svcbus', port=port))
+            sprox1 = s_service.SvcProxy(s_telepath.openurl('tcp://127.0.0.1/syn.svcbus', port=port))
+
+            woot0 = Woot()
+            woot1 = Woot()
+
+            w0 = sprox0.waiter(2, 'syn:svcprox:init')
+            w1 = sprox0.waiter(2, 'syn:svcprox:init')
+
+            sprox0.runSynSvc('woots.woot0', woot0, tags=('foo.bar',))
+            sprox1.runSynSvc('woots.woot1', woot1, tags=('foo.bar',))
+
+            w0.wait(1)
+            w1.wait(1)
+
+            # Both SvcProxy objects know about both objects and they are not None
+            r = sprox0.getSynSvcsByTag('foo.bar')
+            self.len(2, r)
+            for svcfo in r:
+                self.nn(svcfo)
+            r = sprox1.getSynSvcsByTag('foo.bar')
+            self.len(2, r)
+            for svcfo in r:
+                self.nn(svcfo)
+
+            r = [_r for _r in sprox0.callByTag('foo.bar', gentask('foo', 1))]
+            self.len(2, r)
+            for svcfo, result in r:
+                self.eq(result, 11)
+
+            # Tear down sprox1 - it will fini the woots.woot1 service
+            w0 = sprox0.waiter(1, 'syn:svcprox:fini')
+            sprox1.fini()
+            w0.wait(1)
+
+            r = sprox0.getSynSvcsByTag('foo.bar')
+            self.len(1, r)
+            for svcfo in r:
+                self.nn(svcfo)
+
+            # woots.woot1 is still around
+            r = sprox0.callByName('woots.woot0', gentask('foo', 1))
+            self.eq(r, 11)
+            # Poor woots.woot1 is gone though
+            self.raises(NoSuchObj, sprox0.callByName, 'woots.woot1', gentask('foo', 1))
+
+            # We can recreate sprox1, reshare woot1 and use it
+            sprox1 = s_service.SvcProxy(s_telepath.openurl('tcp://127.0.0.1/syn.svcbus', port=port))
+
+            w0 = sprox0.waiter(1, 'syn:svcprox:init')
+            w1 = sprox1.waiter(1, 'syn:svcprox:init')
+
+            sprox1.runSynSvc('woots.woot1', woot1, tags=('foo.bar',))
+            w0.wait(1)
+            w1.wait(1)
+
+            # Both SvcProxy objects know about both objects
+            r = sprox0.getSynSvcsByTag('foo.bar')
+            self.len(2, r)
+            for svcfo in r:
+                self.nn(svcfo)
+            r = sprox1.getSynSvcsByTag('foo.bar')
+            self.len(2, r)
+            for svcfo in r:
+                self.nn(svcfo)
+
+            # We can call woots1 from sprox0 again and by name
+            r = sprox0.callByName('woots.woot1', gentask('foo', 1))
+            self.eq(r, 11)
+
+            sprox0.fini()
+            sprox1.fini()
+
     def test_service_proxy(self):
 
         with s_daemon.Daemon() as dmon:


### PR DESCRIPTION
svcproxy would register a service by name. this was unintentional and would case a service which was fini'd to leave additional tags present in the bytag helper.

also move the sock.onfini function to be called from the global threadpool to prevent blocking on the multiplexor thread, since it fires events which could case daemon OnHelp handlers to fire the events to SvcProxy objects (not a blocking operation, but not something that needs to be done from the multiplexor thread).