### PR TITLE
Fix bad reference.

### DIFF
--- a/synapse/eventbus.py
+++ b/synapse/eventbus.py
@@ -29,7 +29,7 @@ def _fini_atexit(): # pragma: no cover
             item.fini()
 
         except Exception as e:
-            logger.exception('atexit fini fail: %r' % (ebus,))
+            logger.exception('atexit fini fail: %r' % (item,))
 
 atexit.register(_fini_atexit)
 


### PR DESCRIPTION
``ebus`` is not an object.