### PR TITLE
 Avoids potential double-close of db connection

### DIFF
--- a/synapse/lib/db.py
+++ b/synapse/lib/db.py
@@ -102,8 +102,9 @@ class Xact(s_eventbus.EventBus):
         self.refs -= 1
         if self.refs == 0:
 
-            self.curs.close()
-            self.db.commit()
+            if not self.isfini:
+                self.curs.close()
+                self.db.commit()
 
             if self.lockd:
                 self.lockd = False


### PR DESCRIPTION
This PR adds a self.isfini check to xact's `__exit__` and does not try to close its connection if the xact is fini. Without this PR, it is possible for sqlite3 errors to be raised when an xact with-block exits if the xact's pool is finid while the block is open.