### PR TITLE
Make storm tasks() introspectable

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -461,6 +461,20 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         if path is not None and os.path.isdir(path):
             shutil.rmtree(path, ignore_errors=True)
 
+    def getCoreTasks(self):
+        '''
+        Get a list of tasks which have been registered on the Cortex.
+
+        Returns:
+            list: A list of tasks which may be tasked via storm task() command.
+        '''
+        ret = set()
+        for name, funcs in list(self._syn_funcs.items()):
+            if name.startswith('task:'):
+                ret.add(name.split('task:')[1])
+        ret = sorted(ret)
+        return ret
+
     def isRuntProp(self, prop):
         '''
         Return True if the given property name is a runtime node prop.

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -468,11 +468,8 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         Returns:
             list: A list of tasks which may be tasked via storm task() command.
         '''
-        ret = set()
-        for name, funcs in list(self._syn_funcs.items()):
-            if name.startswith('task:'):
-                ret.add(name.split('task:')[1])
-        ret = sorted(ret)
+        ret = [name.split('task:')[1] for name in list(self._syn_funcs.keys()) if name.startswith('task:')]
+        ret.sort()
         return ret
 
     def isRuntProp(self, prop):

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -441,6 +441,8 @@ class Runtime(Configable):
         self.setOperFunc('fromtags', self._stormOperFromTags)
         self.setOperFunc('jointags', self._stormOperJoinTags)
 
+        self.setOperFunc('get:tasks', self._stormOperGetTasks)
+
         self.setOperFunc('show:cols', self._stormOperShowCols)
 
         # Cache compiled regex objects.
@@ -1513,6 +1515,15 @@ class Runtime(Configable):
         for tname in args:
             evt = ':'.join(['task', tname])
             core.fire(evt, nodes=nodes, storm=True, **opts)
+
+    def _stormOperGetTasks(self, query, oper):
+
+        core = self.getStormCore()
+        tasks = core.getCoreTasks()
+
+        for task in tasks:
+            node = s_tufo.ephem('task', task)
+            query.add(node)
 
     def _stormOperTree(self, query, oper):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -3016,6 +3016,24 @@ class CortexTest(SynTest):
             # We cannot add a universal prop which is associated with a form
             self.raises(BadPropConf, core.addPropDef, 'node:poorform', univ=1, req=1, ptype='bool', form='file:bytes')
 
+    def test_cortex_gettasks(self):
+        with self.getRamCore() as core:
+
+            def f1(mesg):
+                pass
+
+            def f2(mesg):
+                pass
+
+            core.on('task:hehe:haha', f1)
+            core.on('task:hehe:haha', f2)
+            core.on('task:wow', f1)
+
+            tasks = core.getCoreTasks()
+            self.len(2, tasks)
+            self.isin('hehe:haha', tasks)
+            self.isin('wow', tasks)
+
 class StorageTest(SynTest):
 
     def test_nonexist_ctor(self):

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -758,6 +758,10 @@ class StormTest(SynTest):
             # We have to know queue names to add nodes too
             self.raises(BadSyntaxError, core.eval, 'inet:ipv4 task()')
 
+            # We have some task names too!
+            nodes = core.eval('get:tasks()')
+            self.len(4, nodes)
+
     def test_storm_task_telepath(self):
         with self.getDmonCore() as core_prox:
             foo = []

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1002,6 +1002,26 @@ class StormTest(SynTest):
             gtor = core._getPropGtor('inet:fqdn:zone')
             self.eq(gtor(fqdn), ('inet:fqdn:zone', 1))
 
+    def test_storm_gettasks(self):
+        with self.getRamCore() as core:
+
+            def f1(mesg):
+                pass
+
+            def f2(mesg):
+                pass
+
+            core.on('task:hehe:haha', f1)
+            core.on('task:hehe:haha', f2)
+            core.on('task:wow', f1)
+
+            nodes = core.eval('get:tasks()')
+            self.len(2, nodes)
+            for node in nodes:
+                self.none(node[0])
+                self.eq(node[1].get('tufo:form'), 'task')
+                self.isin(node[1].get('task'), ('hehe:haha', 'wow'))
+
 class LimitTest(SynTest):
     def test_limit_default(self):
         # LimitHelper would normally be used with the kwlist arg limit,


### PR DESCRIPTION
Add a macro function and an API for introspecting tasks which have been registered on a Cortex.