### PR TITLE
Use 4096 rsa keys

### DIFF
--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -14,7 +14,6 @@ def iterFqdnUp(fqdn):
         yield '.'.join(levs[i:])
 
 class CertDir:
-    CRYPTO_NUMBITS = 4096
 
     def __init__(self, path=None):
         self.crypto_numbits = 4096

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import synapse.common as s_common
 
@@ -15,6 +14,7 @@ def iterFqdnUp(fqdn):
         yield '.'.join(levs[i:])
 
 class CertDir:
+    CRYPTO_NUMBITS = 4096
 
     def __init__(self, path=None):
 
@@ -103,7 +103,7 @@ class CertDir:
 
         if pkey is None:
             pkey = crypto.PKey()
-            pkey.generate_key(crypto.TYPE_RSA, 2048)
+            pkey.generate_key(crypto.TYPE_RSA, CertDir.CRYPTO_NUMBITS)
 
         cert = crypto.X509()
         cert.set_pubkey(pkey)
@@ -260,7 +260,7 @@ class CertDir:
 
     def _genPkeyCsr(self, name, mode, outp=None):
         pkey = crypto.PKey()
-        pkey.generate_key(crypto.TYPE_RSA, 2048)
+        pkey.generate_key(crypto.TYPE_RSA, CertDir.CRYPTO_NUMBITS)
 
         xcsr = crypto.X509Req()
         xcsr.get_subject().CN = name

--- a/synapse/tests/test_lib_certdir.py
+++ b/synapse/tests/test_lib_certdir.py
@@ -25,6 +25,9 @@ class CertDirTest(SynTest):
             self.true(cdir.isCaCert('syntest'))
             self.false(cdir.isCaCert('newpnewp'))
 
+            # Make sure the ca cert was generated with the expected number of bits
+            self.eq(cdir.getCaCert('syntest').get_pubkey().bits(), s_certdir.CertDir.CRYPTO_NUMBITS)
+
     def test_certdir_user(self):
         with self.getCertDir() as cdir:
             cdir.genCaCert('syntest')
@@ -42,6 +45,10 @@ class CertDirTest(SynTest):
 
             self.true(cdir.isUserCert('visi@vertex.link'))
             self.true(cdir.isClientCert('visi@vertex.link'))
+
+            # Make sure the certs was generated with the expected number of bits
+            self.eq(cdir.getUserKey('visi@vertex.link').bits(), s_certdir.CertDir.CRYPTO_NUMBITS)
+            self.eq(cdir.getUserCert('visi@vertex.link').get_pubkey().bits(), s_certdir.CertDir.CRYPTO_NUMBITS)
 
     def test_certdir_host(self):
         with self.getCertDir() as cdir:


### PR DESCRIPTION
Bumping the default rsa keysize from 2048 to 4096. Also added tests to verify that the correct keysize was correctly generated.