### PR TITLE
Fini shared ebus objects when the DmonConf is torn down in LIFO order.

### DIFF
--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -103,7 +103,8 @@ class DmonConf:
         for name in list(self.forks.keys()):
             self.killDmonFork(name, perm=True)
 
-        for item in self._fini_items:
+        # reverse the ebus items to fini them in LIFO order
+        for item in reversed(self._fini_items):
             item.fini()
         self._fini_items = []
 
@@ -241,8 +242,8 @@ class DmonConf:
 
             self.locs[name] = item
             if isinstance(item, EventBus):
-                # Insert ebus items in LIFO order for fini
-                self._fini_items.insert(0, item)
+                # Insert ebus items in FIFO order
+                self._fini_items.append(item)
 
             # check for a ctor opt that wants us to load a config dict by name
             cfgname = copts.get('config')

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -77,6 +77,7 @@ class DmonConf:
 
         self.forkperm = {}
         self.evalcache = {}
+        self._fini_items = []
 
         self.onfini(self._onDmonFini)
 
@@ -101,6 +102,10 @@ class DmonConf:
     def _onDmonFini(self):
         for name in list(self.forks.keys()):
             self.killDmonFork(name, perm=True)
+
+        for item in self._fini_items:
+            item.fini()
+        self._fini_items = []
 
     def _addConfValu(self, conf, prop):
         valu = conf.get(prop)
@@ -236,7 +241,8 @@ class DmonConf:
 
             self.locs[name] = item
             if isinstance(item, EventBus):
-                self.onfini(item.fini)
+                # Insert ebus items in LIFO order for fini
+                self._fini_items.insert(0, item)
 
             # check for a ctor opt that wants us to load a config dict by name
             cfgname = copts.get('config')


### PR DESCRIPTION
This allows us to tear objects down in reverse order as they are defined in a daemon config file.