### PR TITLE
Storm join operator improvements

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1103,15 +1103,19 @@ class Runtime(Configable):
     def _stormOperJoin(self, query, oper):
 
         args = oper[1].get('args')
-        opts = dict(oper[1].get('kwlist'))
-        limit = opts.get('limit')
-
         if len(args) is 2:
             srcp, dstp = args[0], args[1]
         elif len(args) is 1:
             srcp, dstp = args[0], args[0]
         else:
             raise s_common.BadSyntaxError(mesg='join(<srcprop>,<dstprop>)')
+
+        opts = dict(oper[1].get('kwlist'))
+        limit = opts.get('limit')
+        if limit is not None and limit < 0:
+            raise s_common.BadOperArg(oper='join', name='limit', mesg='must be >= 0')
+        elif limit is 0:
+            limit = None
 
         vals = list({t[1].get(srcp) for t in query.data() if t is not None and t[1].get(srcp) is not None})
         [query.add(tufo) for tufo in self.stormTufosBy('in', dstp, vals, limit=limit)]
@@ -1540,7 +1544,7 @@ class Runtime(Configable):
             raise s_common.BadOperArg(oper='tree', name='recurlim', mesg=e.errinfo.get('mesg'))
 
         if recurlim < 0:
-            raise s_common.BadOperArg(oper='tree', name='recurlim', mesg='must be a positive integer >= 0')
+            raise s_common.BadOperArg(oper='tree', name='recurlim', mesg='must be >= 0')
 
         srcp = None
         dstp = args[0]

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1023,12 +1023,18 @@ class Runtime(Configable):
         args = oper[1].get('args')
         opts = dict(oper[1].get('kwlist'))
 
-        srcp = None
-        dstp = args[0]
+        if len(args) is 1:
+            srcp, dstp = None, args[0]
 
-        if len(args) > 1:
-            srcp = args[0]
-            dstp = args[1]
+        elif len(args) is 2:
+            srcp, dstp = args[0], args[1]
+
+        else:
+            raise s_common.BadSyntaxError(mesg='pivot(<srcprop>,<dstprop>)')
+
+        limit = opts.get('limit')
+        if limit is not None and limit < 0:
+            raise s_common.BadOperArg(oper='pivot', name='limit', mesg='must be >= 0')
 
         # do we have a relative source property?
         relsrc = srcp is not None and srcp.startswith(':')
@@ -1063,7 +1069,7 @@ class Runtime(Configable):
         core = self.getStormCore()
         if core.isRuntProp(dstp):
 
-            limt = self.getLiftLimitHelp(opts.get('limit'))
+            limt = self.getLiftLimitHelp(limit)
             for valu in vals:
 
                 # the base "eq" handler is aware of runts...
@@ -1077,7 +1083,7 @@ class Runtime(Configable):
 
             return
 
-        [query.add(t)for t in self.stormTufosBy('in', dstp, list(vals), limit=opts.get('limit'))]
+        [query.add(t)for t in self.stormTufosBy('in', dstp, list(vals), limit=limit)]
 
     def _stormOperNextSeq(self, query, oper):
         name = None
@@ -1103,22 +1109,69 @@ class Runtime(Configable):
     def _stormOperJoin(self, query, oper):
 
         args = oper[1].get('args')
-        if len(args) is 2:
+        opts = dict(oper[1].get('kwlist'))
+
+        if len(args) is 1:
+            srcp, dstp = None, args[0]
+
+        elif len(args) is 2:
             srcp, dstp = args[0], args[1]
-        elif len(args) is 1:
-            srcp, dstp = args[0], args[0]
+
         else:
             raise s_common.BadSyntaxError(mesg='join(<srcprop>,<dstprop>)')
 
-        opts = dict(oper[1].get('kwlist'))
         limit = opts.get('limit')
         if limit is not None and limit < 0:
             raise s_common.BadOperArg(oper='join', name='limit', mesg='must be >= 0')
-        elif limit is 0:
-            limit = None
 
-        vals = list({t[1].get(srcp) for t in query.data() if t is not None and t[1].get(srcp) is not None})
-        [query.add(tufo) for tufo in self.stormTufosBy('in', dstp, vals, limit=limit)]
+        # do we have a relative source property?
+        relsrc = srcp is not None and srcp.startswith(':')
+
+        vals = set()
+        tufs = query.data()
+
+        if srcp is not None and not relsrc:
+
+            for tufo in tufs:
+                valu = tufo[1].get(srcp)
+                if valu is not None:
+                    vals.add(valu)
+
+        elif not relsrc:
+
+            for tufo in tufs:
+                form = tufo[1].get('tufo:form')
+                valu = tufo[1].get(form)
+                if valu is not None:
+                    vals.add(valu)
+
+        else:
+
+            for tufo in tufs:
+                form = tufo[1].get('tufo:form')
+                valu = tufo[1].get(form + srcp)
+                if valu is not None:
+                    vals.add(valu)
+
+        # do not use fancy by handlers for runt nodes...
+        core = self.getStormCore()
+        if core.isRuntProp(dstp):
+
+            limt = self.getLiftLimitHelp(limit)
+            for valu in vals:
+
+                # the base "eq" handler is aware of runts...
+                news = self.stormTufosBy('eq', dstp, valu, limit=limt.get())
+                limt.dec(len(news))
+
+                [query.add(n) for n in news]
+
+                if limt.reached():
+                    break
+
+            return
+
+        [query.add(t) for t in self.stormTufosBy('in', dstp, list(vals), limit=limit)]
 
     def _stormOperAddXref(self, query, oper):
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1104,15 +1104,17 @@ class Runtime(Configable):
 
         args = oper[1].get('args')
         opts = dict(oper[1].get('kwlist'))
-        if len(args) != 2:
-            raise s_common.BadSyntaxError(mesg='join(<dstprop>,<srcprop>)')
+        limit = opts.get('limit')
 
-        dstp = args[0]
-        srcp = args[1]
+        if len(args) is 2:
+            srcp, dstp = args[0], args[1]
+        elif len(args) is 1:
+            srcp, dstp = args[0], args[0]
+        else:
+            raise s_common.BadSyntaxError(mesg='join(<srcprop>,<dstprop>)')
 
-        # use the more optimal "in" mechanism once we have the pivot vals
         vals = list({t[1].get(srcp) for t in query.data() if t is not None and t[1].get(srcp) is not None})
-        [query.add(tufo) for tufo in self.stormTufosBy('in', dstp, vals, limit=opts.get('limit'))]
+        [query.add(tufo) for tufo in self.stormTufosBy('in', dstp, vals, limit=limit)]
 
     def _stormOperAddXref(self, query, oper):
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1104,15 +1104,14 @@ class Runtime(Configable):
 
         args = oper[1].get('args')
         opts = dict(oper[1].get('kwlist'))
+        if len(args) != 2:
+            raise s_common.BadSyntaxError(mesg='join(<dstprop>,<srcprop>)')
 
         dstp = args[0]
-        srcp = args[0]
-
-        if len(args) > 1:
-            srcp = args[1]
+        srcp = args[1]
 
         # use the more optimal "in" mechanism once we have the pivot vals
-        vals = list({t[1].get(srcp) for t in query.data() if t is not None})
+        vals = list({t[1].get(srcp) for t in query.data() if t is not None and t[1].get(srcp) is not None})
         [query.add(tufo) for tufo in self.stormTufosBy('in', dstp, vals, limit=opts.get('limit'))]
 
     def _stormOperAddXref(self, query, oper):

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -679,6 +679,13 @@ def parse(text, off=0):
             ret.append(oper('pivot', name))
             continue
 
+        # join() macro with no src prop:   <- foo:bar
+        if nextstr(text, off, '<-'):
+            _, off = nom(text, off + 2, whites)
+            name, off = nom(text, off, varset)
+            ret.append(oper('join', name))
+            continue
+
         # lift by tag alone macro
         if nextstr(text, off, '#'):
             _, off = nom(text, off + 1, whites)
@@ -769,6 +776,22 @@ def parse(text, off=0):
                 pivn, off = nom(text, off + 1, varset)
 
             inst[1]['args'].append(pivn)
+
+            ret.append(inst)
+            continue
+
+        # macro foo:bar<-baz:faz prop join
+        if nextstr(text, off, '<-'):
+
+            joinn, off = nom(text, off + 2, varset)
+            inst = ('join', {'args': [name], 'kwlist': []})
+
+            # FIXME make a parser for foo.bar/baz:faz*blah#40
+            if nextchar(text, off, '/'):
+                inst[1]['kwlist'].append(('from', joinn))
+                joinn, off = nom(text, off + 1, varset)
+
+            inst[1]['args'].append(joinn)
 
             ret.append(inst)
             continue

--- a/synapse/tests/test_lib_syntax.py
+++ b/synapse/tests/test_lib_syntax.py
@@ -93,6 +93,16 @@ class StormSyntaxTest(SynTest):
         insts = s_syntax.parse('foo:bar -> hehe.haha/baz:faz')
         self.eq(insts[0], ('pivot', {'args': ['foo:bar', 'baz:faz'], 'kwlist': [('from', 'hehe.haha')]}))
 
+        insts = s_syntax.parse(' -> baz:faz')
+        self.eq(insts[0], ('pivot', {'args': ('baz:faz',), 'kwlist': []}))
+
+    def test_storm_syntax_join(self):
+        insts = s_syntax.parse('foo:bar <- hehe.haha/baz:faz')
+        self.eq(insts[0], ('join', {'args': ['foo:bar', 'baz:faz'], 'kwlist': [('from', 'hehe.haha')]}))
+
+        insts = s_syntax.parse(' <- baz:faz')
+        self.eq(insts[0], ('join', {'args': ('baz:faz',), 'kwlist': []}))
+
     def test_storm_syntax_whites(self):
         insts = s_syntax.parse('inet:fqdn     =      "1.2.3.4"')
         self.eq(insts[0], s_syntax.oper('lift', 'inet:fqdn', '1.2.3.4', by='eq'))

--- a/synapse/tests/test_runtime.py
+++ b/synapse/tests/test_runtime.py
@@ -80,7 +80,8 @@ class StormRunTest(SynTest):
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 inet:dns:a:fqdn->inet:fqdn'), [t6, t7])
 
         # test join operator basics
-        self.sorteq(core.eval('inet:ipv4="127.0.0.1" join(inet:ipv4:cc)'), [t0, t1, t2])
+        self.raises(BadSyntaxError, core.eval, 'inet:ipv4="127.0.0.1" join(inet:ipv4:cc)')
+        self.sorteq(core.eval('inet:ipv4="127.0.0.1" join(inet:ipv4:cc,inet:ipv4:cc)'), [t0, t1, t2])
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:fqdn","inet:dns:a:fqdn")'), [t4, t5, t6, t7])
 
         # test filt #####################################################

--- a/synapse/tests/test_runtime.py
+++ b/synapse/tests/test_runtime.py
@@ -80,9 +80,12 @@ class StormRunTest(SynTest):
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 inet:dns:a:fqdn->inet:fqdn'), [t6, t7])
 
         # test join operator basics
-        self.raises(BadSyntaxError, core.eval, 'inet:ipv4="127.0.0.1" join(inet:ipv4:cc)')
+        self.raises(BadSyntaxError, core.eval, 'inet:ipv4="127.0.0.1" join()')
+        self.raises(BadSyntaxError, core.eval, 'inet:ipv4="127.0.0.1" join(inet:ipv4:cc,inet:ipv4:cc,inet:ipv4:cc)')
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" join(inet:ipv4:cc,inet:ipv4:cc)'), [t0, t1, t2])
-        self.sorteq(core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:fqdn","inet:dns:a:fqdn")'), [t4, t5, t6, t7])
+        self.sorteq(core.eval('inet:ipv4="127.0.0.1" join(inet:ipv4:cc)'), [t0, t1, t2])
+        self.sorteq(core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn")'), [t4, t5, t6, t7])
+        # FIXME test limits
 
         # test filt #####################################################
 

--- a/synapse/tests/test_runtime.py
+++ b/synapse/tests/test_runtime.py
@@ -82,18 +82,19 @@ class StormRunTest(SynTest):
         # test join operator basics
         self.raises(BadSyntaxError, core.eval, 'inet:ipv4="127.0.0.1" join()')
         self.raises(BadSyntaxError, core.eval, 'inet:ipv4="127.0.0.1" join(inet:ipv4:cc,inet:ipv4:cc,inet:ipv4:cc)')
+        self.raises(BadTypeValu, core.eval, 'inet:ipv4="127.0.0.1" join(inet:ipv4:cc)')
+
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" join(inet:ipv4:cc,inet:ipv4:cc)'), [t0, t1, t2])
-        self.sorteq(core.eval('inet:ipv4="127.0.0.1" join(inet:ipv4:cc)'), [t0, t1, t2])
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn")'), [t4, t5, t6, t7])
 
-        # Test limits
+        # Test join limits
         self.len(1, core.eval('inet:ipv4="127.0.0.1"'))
         self.len(2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4'))  # query data will contain 2 nodes after this step
         self.len(2 + 2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn")'))  # join will join 2 more fqdns
         self.len(2 + 2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=3)'))
         self.len(2 + 2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=2)'))
         self.len(2 + 1, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=1)'))
-        self.len(2 + 2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=0)'))
+        self.len(2 + 0, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=0)'))
         self.raises(BadOperArg, core.eval, 'inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=-1)')
 
         # test filt #####################################################

--- a/synapse/tests/test_runtime.py
+++ b/synapse/tests/test_runtime.py
@@ -85,7 +85,16 @@ class StormRunTest(SynTest):
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" join(inet:ipv4:cc,inet:ipv4:cc)'), [t0, t1, t2])
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" join(inet:ipv4:cc)'), [t0, t1, t2])
         self.sorteq(core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn")'), [t4, t5, t6, t7])
-        # FIXME test limits
+
+        # Test limits
+        self.len(1, core.eval('inet:ipv4="127.0.0.1"'))
+        self.len(2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4'))  # query data will contain 2 nodes after this step
+        self.len(2 + 2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn")'))  # join will join 2 more fqdns
+        self.len(2 + 2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=3)'))
+        self.len(2 + 2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=2)'))
+        self.len(2 + 1, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=1)'))
+        self.len(2 + 2, core.eval('inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=0)'))
+        self.raises(BadOperArg, core.eval, 'inet:ipv4="127.0.0.1" inet:ipv4->inet:dns:a:ipv4 join("inet:dns:a:fqdn","inet:fqdn", limit=-1)')
 
         # test filt #####################################################
 


### PR DESCRIPTION
- missing props in query data won't break the entire query
- reversed dst,src to src,dst to match pivot
- fixed limit (no limit -> unlimited, limit 0 -> 0 rows, negative limit -> error, any other number gets passed down to the call to lift the nodes)