### PR TITLE
Discussion: Add SynTest.gcCollect()

### DIFF
--- a/synapse/lib/iq.py
+++ b/synapse/lib/iq.py
@@ -543,6 +543,17 @@ class SynTest(unittest.TestCase):
             for key, valu in old_data.items():
                 os.environ[key] = valu
 
+    def gcCollect(self):
+        '''
+        Run gc.collect()
+
+        Returns:
+            int: Number of collected objects.
+        '''
+        import gc
+        ret = gc.collect()
+        return ret
+
     def eq(self, x, y):
         '''
         Assert X is equal to Y

--- a/synapse/tests/test_tools_dmon.py
+++ b/synapse/tests/test_tools_dmon.py
@@ -50,6 +50,7 @@ class TestMain(SynTest):
 
     def test_main_lsboot(self):
         self.thisHostMustNot(platform='windows')
+        self.gcCollect()
 
         tfile = self.getTempConfig()
 
@@ -63,6 +64,7 @@ class TestMain(SynTest):
 
     def test_main_onboot(self):
         self.thisHostMustNot(platform='windows')
+        self.gcCollect()
 
         tfile = self.getTempConfig()
 


### PR DESCRIPTION
possible solution to forking causing out of memory exceptions in dmon tests