### PR TITLE
Bug storage limit

### DIFF
--- a/synapse/cores/lmdb.py
+++ b/synapse/cores/lmdb.py
@@ -607,6 +607,8 @@ class LmdbStorage(s_cores_storage.Storage):
             if not cursor.set_range(first_key):
                 raise s_common.BadCoreStore(store='lmdb', mesg='Missing sentinel')
             while True:
+                if limit is not None and count >= limit:
+                    break
                 key, pk_enc = cursor.item()
                 if do_fast_compare:
                     if key[:len(first_key)] != first_key:
@@ -622,8 +624,6 @@ class LmdbStorage(s_cores_storage.Storage):
                     if not do_count_only:
                         rows.append(row)
                 count += 1
-                if limit is not None and count >= limit:
-                    break
                 if not cursor.next():
                     raise s_common.BadCoreStore(store='lmdb', mesg='Missing sentinel')
 
@@ -754,11 +754,12 @@ class LmdbStorage(s_cores_storage.Storage):
             for key, value in it:
                 if term_cmp(key[:len(last_key)].tobytes(), last_key):
                     break
-                count += 1
-                if not do_count_only:
-                    ret.append(self._getRowByPkValEnc(txn, value))
                 if limit is not None and count >= limit:
                     break
+                if not do_count_only:
+                    ret.append(self._getRowByPkValEnc(txn, value))
+                count += 1
+
         return count if do_count_only else ret
 
     def _genStoreRows(self, **kwargs):

--- a/synapse/cores/ram.py
+++ b/synapse/cores/ram.py
@@ -172,6 +172,9 @@ class RamStorage(s_cores_storage.Storage):
         # This was originally a set, but sets are mutable and throw
         # runtimeerrors if their size changes during iteration
         for row in tuple(rows):
+            if limit is not None and c >= limit:
+                break
+
             if mintime is not None and row[3] < mintime:
                 continue
 
@@ -181,8 +184,6 @@ class RamStorage(s_cores_storage.Storage):
             yield row
 
             c += 1
-            if limit is not None and c >= limit:
-                break
 
     def getSizeByProp(self, prop, valu=None, mintime=None, maxtime=None):
         if valu is None:

--- a/synapse/cores/storage.py
+++ b/synapse/cores/storage.py
@@ -1046,6 +1046,9 @@ class Storage(s_config.Config):
         if len(valus) == 0:
             return []
 
+        if limit is not None and limit < 1:
+                return []
+
         rows = []
         for valu in valus:
             _rows = list(self.getJoinByProp(prop, valu, limit=limit))

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1392,8 +1392,11 @@ class CortexTest(SynTest):
         self.eq(rofl[1].get('syn:tag:base'), 'rofl')
 
         tags = core.getTufosByProp('syn:tag:base', 'rofl')
-
-        self.eq(len(tags), 2)
+        self.len(2, tags)
+        tags = core.getTufosByProp('syn:tag:base', 'rofl', limit=1)
+        self.len(1, tags)
+        tags = core.getTufosByProp('syn:tag:base', 'rofl', limit=0)
+        self.len(0, tags)
 
         wait = core.waiter(2, 'node:tag:del')
         hehe = core.delTufoTag(hehe, 'lulz.rofl')

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -744,6 +744,8 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.getTufosBy('in', 'default_foo:p0', [5])), 2)
         self.eq(len(core.getTufosBy('in', 'default_foo:p0', [4, 5])), 3)
         self.eq(len(core.getTufosBy('in', 'default_foo:p0', [4, 5, 6, 7], limit=4)), 4)
+        self.eq(len(core.getTufosBy('in', 'default_foo:p0', [4, 5, 6, 7], limit=1)), 1)
+        self.eq(len(core.getTufosBy('in', 'default_foo:p0', [4, 5, 6, 7], limit=0)), 0)
         self.eq(len(core.getTufosBy('in', 'default_foo:p0', [5], limit=1)), 1)
         self.eq(len(core.getTufosBy('in', 'default_foo:p0', [], limit=1)), 0)
 
@@ -775,6 +777,19 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.getTufosBy('gt', 'default_foo:p0', 6)), 1)
         self.eq(len(core.getTufosBy('ge', 'default_foo:p0', 6)), 2)
         self.eq(len(core.getTufosBy('ge', 'default_foo:p0', 5)), 4)
+        # By LT/LE/GE/GT with limits
+        self.len(1, core.getTufosBy('lt', 'default_foo:p0', 6, limit=1))
+        self.len(1, core.getTufosBy('le', 'default_foo:p0', 6, limit=1))
+        self.len(1, core.getTufosBy('le', 'default_foo:p0', 7, limit=1))
+        self.len(1, core.getTufosBy('gt', 'default_foo:p0', 6, limit=1))
+        self.len(1, core.getTufosBy('ge', 'default_foo:p0', 6, limit=1))
+        self.len(1, core.getTufosBy('ge', 'default_foo:p0', 5, limit=1))
+        self.len(0, core.getTufosBy('lt', 'default_foo:p0', 6, limit=0))
+        self.len(0, core.getTufosBy('le', 'default_foo:p0', 6, limit=0))
+        self.len(0, core.getTufosBy('le', 'default_foo:p0', 7, limit=0))
+        self.len(0, core.getTufosBy('gt', 'default_foo:p0', 6, limit=0))
+        self.len(0, core.getTufosBy('ge', 'default_foo:p0', 6, limit=0))
+        self.len(0, core.getTufosBy('ge', 'default_foo:p0', 5, limit=0))
 
         # By LT/LE/GE/GT requiring type normalization
         foog = core.formTufoByProp('inet:ipv4', '10.2.3.5')
@@ -801,6 +816,7 @@ class CortexBaseTest(SynTest):
         tufs = core.getTufosBy('range', 'intform', (5, 15))
         self.eq(len(tufs), 1)
         self.eq(tufs[0][0], t0[0])
+        self.len(0, core.getTufosBy('range', 'intform', (5, 15), limit=0))
         # Do a range lift requiring prop normalization (using a built-in data type) to work
         t2 = core.formTufoByProp('inet:ipv4', '1.2.3.3')
         tufs = core.getTufosBy('range', 'inet:ipv4', (0x01020301, 0x01020309))
@@ -823,6 +839,9 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.getTufosBy('has', 'inet:ipv4', valu=None)), 5)
         self.eq(len(core.getTufosBy('has', 'syn:tag', valu=None)), 0)
 
+        self.len(1, core.getTufosBy('has', 'default_foo', valu='knight', limit=1))
+        self.len(0, core.getTufosBy('has', 'default_foo', valu='knight', limit=0))
+
         # By TAG
         core.addTufoTag(fooa, 'color.white')
         core.addTufoTag(fooa, 'color.black')
@@ -839,6 +858,8 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.getTufosBy('tag', 'inet:ipv4', 'color.green')), 2)
         self.eq(len(core.getTufosBy('tag', 'inet:ipv4', 'color.white')), 1)
         self.eq(len(core.getTufosBy('tag', None, 'color.white')), 2)
+        self.len(1, core.getTufosBy('tag', None, 'color.white', limit=1))
+        self.len(0, core.getTufosBy('tag', None, 'color.white', limit=0))
 
         # By EQ
         self.eq(len(core.getTufosBy('eq', 'default_foo', 'bar')), 1)
@@ -851,6 +872,8 @@ class CortexBaseTest(SynTest):
         self.eq(len(core.getTufosBy('eq', 'inet:ipv4', '0.0.0.0')), 0)
         self.eq(len(core.getTufosBy('eq', 'inet:web:memb', '(vertex.link/pennywise,vertex.link/eldergods)')), 1)
         self.eq(len(core.getTufosBy('eq', 'inet:web:memb', ('vertex.link/invisig0th', 'vertex.link/eldergods'))), 1)
+        self.len(1, core.getTufosBy('eq', 'inet:ipv4:asn', -1, limit=1))
+        self.len(0, core.getTufosBy('eq', 'inet:ipv4:asn', -1, limit=0))
 
         # By TYPE - this requires data model introspection
         fook = core.formTufoByProp('inet:dns:a', 'derry.vertex.link/10.2.3.6')
@@ -858,6 +881,8 @@ class CortexBaseTest(SynTest):
         # self.eq(len(core.getTufosBy('type', 'inet:ipv4', None)), 7)
         self.eq(len(core.getTufosBy('type', 'inet:ipv4', '10.2.3.6')), 3)
         self.eq(len(core.getTufosBy('type', 'inet:ipv4', 0x0a020306)), 3)
+        self.len(1, core.getTufosBy('type', 'inet:ipv4', '10.2.3.6', limit=1))
+        self.len(0, core.getTufosBy('type', 'inet:ipv4', '10.2.3.6', limit=0))
 
         # By TYPE using COMP nodes
         self.eq(len(core.getTufosBy('type', 'inet:web:memb', '(vertex.link/pennywise,vertex.link/eldergods)')), 1)
@@ -930,6 +955,9 @@ class CortexBaseTest(SynTest):
         self.eq(test_repr, '10.2.1.8')
         test_repr = core.getTypeRepr('inet:ipv4', nodes[-1][1].get('inet:ipv4'))
         self.eq(test_repr, '10.2.1.15')
+        # Ensure limits are respected
+        self.len(1, core.getTufosBy('inet:cidr', 'inet:ipv4', '10.2.1.8/29', limit=1))
+        self.len(0, core.getTufosBy('inet:cidr', 'inet:ipv4', '10.2.1.8/29', limit=0))
 
         # 10.2.1.1/28 is 10.2.1.0 -> 10.2.1.15 but we don't have 10.2.1.0 in the core
         nodes = core.getTufosBy('inet:cidr', 'inet:ipv4', '10.2.1.1/28')


### PR DESCRIPTION
Ensure limit=0 API calls behavior in a consistent manner.  Previously LMDB, Sqlite and RAM cortexes would behave differently.