### PR TITLE
Improves Storm test coverage

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -151,27 +151,3 @@ class AskCmd(s_cli.Cmd):
         self.printf('(%d results)' % (len(nodes),))
 
         return resp
-
-class NextSeqCmd(s_cli.Cmd):
-    '''
-    Generate and display the next id in the named sequence.
-
-    Usage:
-
-        nextseq <name>
-
-    '''
-    _cmd_name = 'nextseq'
-    _cmd_syntax = (
-        ('name', {'type': 'valu'}),
-    )
-
-    def runCmdOpts(self, opts):
-        name = opts.get('name')
-        if name is None:
-            self.printf(self.__doc__)
-            return
-
-        core = self.getCmdItem()
-        valu = core.nextSeqValu(name)
-        self.printf('next in sequence (%s): %s' % (name, valu))

--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -388,7 +388,9 @@ class KeyCache(collections.defaultdict):
 
     def __missing__(self, key):
         valu = self.lookmeth(key)
-        self[key] = valu
+        if valu is not None:
+            self[key] = valu
+
         return valu
 
     def pop(self, key):

--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -373,7 +373,7 @@ class OnDem(collections.defaultdict):
 
 class KeyCache(collections.defaultdict):
     '''
-    A fast key/val lookup cache.
+    A fast key/val lookup cache. Does not cache the valu `None`.
 
     Example:
 
@@ -393,14 +393,8 @@ class KeyCache(collections.defaultdict):
 
         return valu
 
-    def pop(self, key):
-        return collections.defaultdict.pop(self, key, None)
-
     def get(self, key):
         return self[key]
-
-    def put(self, key, val):
-        self[key] = val
 
 class RefDict(EventBus):
     '''

--- a/synapse/lib/cmdr.py
+++ b/synapse/lib/cmdr.py
@@ -5,9 +5,7 @@ import synapse.lib.reflect as s_reflect
 # Add our commands to the mixins registry
 s_mixins.addSynMixin('cmdr', 'synapse.eventbus.EventBus', 'synapse.cmds.common.PyCmd')
 s_mixins.addSynMixin('cmdr', 'synapse.eventbus.EventBus', 'synapse.cmds.common.GuidCmd')
-
 s_mixins.addSynMixin('cmdr', 'synapse.cores.common.Cortex', 'synapse.cmds.cortex.AskCmd')
-s_mixins.addSynMixin('cmdr', 'synapse.cores.common.Cortex', 'synapse.cmds.cortex.NextSeqCmd')
 
 
 def getItemCmdr(item, outp=None, **opts):

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -876,7 +876,7 @@ class Runtime(Configable):
 
             minv = tufo[1].get(minp)
             if minv is None or minv > tick:
-                return False
+                return False  # FIXME cover
 
             maxv = tufo[1].get(maxp)
             if maxv is None or maxv <= tick:
@@ -897,11 +897,11 @@ class Runtime(Configable):
 
             minv = tufo[1].get(minp)
             if minv is None:
-                return False
+                return False  # FIXME cover
 
             maxv = tufo[1].get(maxp)
             if maxv is None:
-                return False
+                return False  # FIXME cover
 
             return s_interval.overlap(ival, (minv, maxv))
 
@@ -913,7 +913,7 @@ class Runtime(Configable):
 
         order = opts.get('order')
         if order is not None:
-            query.results['show']['order'] = order
+            query.results['show']['order'] = order  # FIXME cover
 
         query.results['show']['columns'] = oper[1].get('args')
 
@@ -924,13 +924,13 @@ class Runtime(Configable):
 
         [query.add(t) for t in query.take() if cmpr(t)]
 
-    def _stormOperOr(self, query, oper):
+    def _stormOperOr(self, query, oper):  # FIXME cover
         funcs = [self.getCmprFunc(op) for op in oper[1].get('args')]
         for tufo in query.take():
             if any([func(tufo) for func in funcs]):
                 query.add(tufo)
 
-    def _stormOperAnd(self, query, oper):
+    def _stormOperAnd(self, query, oper):  # FIXME cover
         funcs = [self.getCmprFunc(op) for op in oper[1].get('args')]
         for tufo in query.take():
             if any([func(tufo) for func in funcs]):
@@ -961,7 +961,7 @@ class Runtime(Configable):
 
             func = self.operfuncs.get(oper[0])
             if func is None:
-                raise s_common.NoSuchOper(name=oper[0])
+                raise s_common.NoSuchOper(name=oper[0])  # FIXME cover
 
             try:
 
@@ -1085,7 +1085,7 @@ class Runtime(Configable):
 
         [query.add(t)for t in self.stormTufosBy('in', dstp, list(vals), limit=limit)]
 
-    def _stormOperNextSeq(self, query, oper):
+    def _stormOperNextSeq(self, query, oper):  # FIXME cover
         name = None
 
         args = oper[1].get('args')
@@ -1173,7 +1173,7 @@ class Runtime(Configable):
 
         [query.add(t) for t in self.stormTufosBy('in', dstp, list(vals), limit=limit)]
 
-    def _stormOperAddXref(self, query, oper):
+    def _stormOperAddXref(self, query, oper):  # FIXME cover
 
         args = oper[1].get('args')
         if len(args) != 3:
@@ -1294,7 +1294,7 @@ class Runtime(Configable):
         # addnode(<form>,<valu>,**props)
         args = oper[1].get('args')
         if len(args) != 2:
-            raise s_common.BadSyntaxError(mesg='addnode(<form>,<valu>,[:<prop>=<pval>, ...])')
+            raise s_common.BadSyntaxError(mesg='addnode(<form>,<valu>,[:<prop>=<pval>, ...])')  # FIXME cover
 
         kwlist = oper[1].get('kwlist')
 

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -18,13 +18,25 @@ class SynCmdCoreTest(SynTest):
 
     def test_cmds_ask_showcols(self):
         with self.getDmonCore() as core:
+            core.formTufoByProp('inet:email', 'visi@vertex.link')
+            core.formTufoByProp('inet:email', 'vertexmc@vertex.link')
+            core.formTufoByProp('inet:email', 'z@a.vertex.link')
+            core.formTufoByProp('inet:email', 'a@vertex.link')
+
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            core.formTufoByProp('inet:email', 'visi@vertex.link')
             line = 'ask inet:email="visi@vertex.link" show:cols(inet:email:fqdn,inet:email:user,node:ndef)'
             resp = cmdr.runCmdLine(line)
             self.len(1, resp['data'])
             self.true(outp.expect('vertex.link visi a20979f71b90cf2ae1c53933675b5c3c'))
+
+            outp = self.getTestOutp()
+            cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+            line = 'ask inet:email show:cols(inet:email, order=inet:email:fqdn)'
+            resp = cmdr.runCmdLine(line)
+            self.len(4, resp['data'])
+            result = [mesg.strip() for mesg in outp.mesgs]
+            self.eq(result, ['z@a.vertex.link', 'a@vertex.link', 'vertexmc@vertex.link', 'visi@vertex.link', '(4 results)'])
 
     def test_cmds_ask_debug(self):
         with self.getDmonCore() as core:
@@ -137,18 +149,3 @@ class SynCmdCoreTest(SynTest):
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             cmdr.runCmdLine('ask')
             self.nn(regex.search('Examples:', str(outp)))
-
-    def test_cmds_nextseq(self):
-        with self.getDmonCore() as core:
-            outp = self.getTestOutp()
-            cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask --props [syn:seq=foo]')
-            self.true(outp.expect(':nextvalu = 0'))
-
-            cmdr.runCmdLine('nextseq foo')
-            self.true(outp.expect('next in sequence (foo): foo0'))
-            cmdr.runCmdLine('nextseq foo')
-            self.true(outp.expect('next in sequence (foo): foo1'))
-
-            cmdr.runCmdLine('nextseq')
-            self.true(outp.expect('Generate and display the next id in the named sequence.'))

--- a/synapse/tests/test_lib_cache.py
+++ b/synapse/tests/test_lib_cache.py
@@ -111,10 +111,14 @@ class CacheTest(SynTest):
         cache = s_cache.KeyCache(getfoo)
 
         self.eq(cache[10], 'asdf')
-        # Ensure put/pop methods work.
-        cache.put(20, 'wasd')
-        self.eq(cache[20], 'wasd')
-        self.eq(cache.pop(20), 'wasd')
+        self.eq(cache.get(10), 'asdf')
+        self.eq(cache.get(20), None)
+
+        foo = {10: 'asdf', 20: 'abcd'}
+        self.eq(cache.get(20), 'abcd')
+
+        foo = {10: 'asdf'}
+        self.eq(cache.get(20), 'abcd')
 
     def test_cache_fixed(self):
 


### PR DESCRIPTION
- Removes redundant `nextseq` command
- Removes unused `or` and `and` operators
- Fixes bugs in `nexttag` and `addxref` operators