### PR TITLE
Bump msgpack minimum version to v0.5.0, update methods to use tell()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         'tornado>=3.2.2',
         'pyOpenSSL>=16.2.0',
-        'msgpack-python>=0.4.2',
+        'msgpack>=0.5.0',
         'xxhash>=1.0.1',
         'lmdb>=0.92',
         'regex>=2017.9.23'

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         'tornado>=3.2.2',
         'pyOpenSSL>=16.2.0',
-        'msgpack>=0.5.0',
+        'msgpack>=0.5.1',
         'xxhash>=1.0.1',
         'lmdb>=0.92',
         'regex>=2017.9.23'

--- a/synapse/lib/msgpack.py
+++ b/synapse/lib/msgpack.py
@@ -109,8 +109,9 @@ class Unpk:
 
             try:
                 item = self.unpk.unpack()
-                retn.append((self.unpk.tell() - self.size, item))
-                self.size = self.unpk.tell()
+                tell = self.unpk.tell()
+                retn.append((tell - self.size, item))
+                self.size = tell
 
             except msgpack.exceptions.OutOfData:
                 break

--- a/synapse/lib/msgpack.py
+++ b/synapse/lib/msgpack.py
@@ -103,17 +103,14 @@ class Unpk:
         '''
         self.unpk.feed(byts)
 
-        def sizeof(b):
-            self.size += len(b)
-
         retn = []
 
         while True:
 
             try:
-                item = self.unpk.unpack(write_bytes=sizeof)
-                retn.append((self.size, item))
-                self.size = 0
+                item = self.unpk.unpack()
+                retn.append((self.unpk.tell() - self.size, item))
+                self.size = self.unpk.tell()
 
             except msgpack.exceptions.OutOfData:
                 break

--- a/synapse/lib/persist.py
+++ b/synapse/lib/persist.py
@@ -260,11 +260,6 @@ class Dir(s_eventbus.EventBus):
         if self.files[0].opts.get('baseoff') > off:
             raise Exception('Too Far Back') # FIXME
 
-        # a bit of a hack to get lengths from msgpack Unpacker
-        data = {'next': 0}
-        def calcsize(b):
-            data['next'] += len(b)
-
         logger.debug('Entering items with offset %s', off)
 
         for pers in self.files:
@@ -314,9 +309,9 @@ class Dir(s_eventbus.EventBus):
                 try:
 
                     while True:
-                        item = unpk.unpack(write_bytes=calcsize)
+                        item = unpk.unpack()
                         # explicit is better than implicit
-                        reloff = data['next']
+                        reloff = unpk.tell()
                         aboff = reloff + off
                         yield aboff, item
 

--- a/synapse/tests/test_lib_msgpack.py
+++ b/synapse/tests/test_lib_msgpack.py
@@ -47,6 +47,22 @@ class MsgPackTest(SynTest):
 
             fd.close()
 
+    def test_msgpack_types(self):
+        # This is a future-proofing test for msgpack to ensure that
+        buf = b'\x92\xa4hehe\x85\xa3str\xa41234\xa3int\xcd\x04\xd2\xa5float\xcb@(\xae\x14z\xe1G\xae\xa3bin\xc4\x041234\xa9realworld\xac\xc7\x8b\xef\xbf\xbd\xed\xa1\x82\xef\xbf\xbd\x12'
+        node = (
+            'hehe',
+            {
+                'str': '1234',
+                'int': 1234,
+                'float': 12.34,
+                'bin': b'1234',
+                'realworld': '\u01cb\ufffd\ud842\ufffd\u0012'
+            }
+        )
+        unode = s_msgpack.un(buf)
+        self.eq(unode, node)
+
     def test_msgpack_bad_types(self):
         self.raises(TypeError, s_msgpack.en, {1, 2})
         self.raises(TypeError, s_msgpack.en, Exception())


### PR DESCRIPTION
The write_bytes method is slated for deprecation and should no longer be used.