### PR TITLE
Bug axon zerobytes

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -261,6 +261,9 @@ class AxonMixin:
         sess = self.alloc(props.get('size'))
 
         byts = fd.read(10000000)
+        retn = self.chunk(sess, byts)
+
+        byts = fd.read(10000000)
         while byts:
             retn = self.chunk(sess, byts)
             byts = fd.read(10000000)

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -296,6 +296,17 @@ def errinfo(name, mesg):
 def chunks(item, size):
     '''
     Divide an iterable into chunks.
+
+    Args:
+        item: Item to slice
+        size (int): Maximum chunk size.
+
+    Notes:
+        This supports Generator objects and objects which support calling
+        the __getitem__() method with a slice object.
+
+    Yields:
+        Slices of the item containing up to "size" number of items.
     '''
     # use islice if it's a generator
     if isinstance(item, types.GeneratorType):
@@ -308,8 +319,15 @@ def chunks(item, size):
 
             yield chunk
 
-    # otherwise, use normal slicing
+    # The sequence item is empty, yield a empty slice from it.
+    # This will also catch mapping objects since a slice should
+    # be an unhashable type for a mapping and the __getitem__
+    # method would not be present on a set object
+    if not item:
+        yield item[0:0]
+        return
 
+    # otherwise, use normal slicing
     off = 0
 
     while True:

--- a/synapse/cores/postgres.py
+++ b/synapse/cores/postgres.py
@@ -167,6 +167,8 @@ class PsqlStorage(s_cores_sqlite.SqliteStorage):
         return self._foldTypeCols(rows)
 
     def getRowsByIdens(self, idens):
+        if len(idens) == 0:
+            return []
         rows = self.select(self._q_getrows_by_idens, valu=tuple(idens))
         return self._foldTypeCols(rows)
 

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -124,10 +124,23 @@ class AxonTest(SynTest):
                     with io.BytesIO(b'durr') as fd:
                         blob3 = prox.eatfd(fd)
 
+                blob4 = axon.eatbytes(b'')
+
         self.eq(blob0[1].get('axon:blob'), '442f602ecf8230b2a59a44b4f845be27')
         self.eq(blob1[1].get('axon:blob'), 'd4552906c1f6966b96d27e6fc79441b5')
         self.eq(blob2[1].get('axon:blob'), '0d60960570ef6da0a15f68c24b420334')
         self.eq(blob3[1].get('axon:blob'), '97c11d1057f75c9c0b79090131709f62')
+        self.eq(blob4[1].get('axon:blob'), '370c1098a47904ea9caeb9f5f71459ba')
+
+    def test_axon_eatfd_empty(self):
+        self.thisHostMustNot(platform='windows')
+
+        with self.getTestDir() as dirname:
+            with s_axon.Axon(dirname) as axon:
+                with io.BytesIO(b'') as fd:
+                    blob0 = axon.eatfd(fd)
+
+        self.eq(blob0[1].get('axon:blob'), '370c1098a47904ea9caeb9f5f71459ba')
 
 class AxonHostTest(SynTest):
     def test_axon_host(self):

--- a/synapse/tests/test_common.py
+++ b/synapse/tests/test_common.py
@@ -79,25 +79,13 @@ class CommonTest(SynTest):
         self.eq(parts, [[1, 2], [3, 4], [5]])
 
         # set is unslicable
-        tpass = False
-        try:
+        with self.assertRaises(TypeError) as cm:
             parts = [chunk for chunk in chunks({1, 2, 3}, 10000)]
-        except TypeError as e:
-            tpass = True
-        self.true(tpass)
 
         # dict is unslicable
-        tpass = False
-        try:
+        with self.assertRaises(TypeError) as cm:
             parts = [chunk for chunk in chunks({1: 2}, 10000)]
-        except TypeError as e:
-            tpass = True
-        self.true(tpass)
 
         # empty dict is caught during the [0:0] slice
-        tpass = False
-        try:
+        with self.assertRaises(TypeError) as cm:
             parts = [chunk for chunk in chunks({}, 10000)]
-        except TypeError as e:
-            tpass = True
-        self.true(tpass)

--- a/synapse/tests/test_common.py
+++ b/synapse/tests/test_common.py
@@ -57,3 +57,47 @@ class CommonTest(SynTest):
 
             retn = tuple(listdir(dirn, glob='*.txt'))
             self.eq(retn, ((path,)))
+
+    def test_common_chunks(self):
+        s = '123456789'
+        parts = [chunk for chunk in chunks(s, 2)]
+        self.eq(parts, ['12', '34', '56', '78', '9'])
+
+        parts = [chunk for chunk in chunks(s, 100000)]
+        self.eq(parts, [s])
+
+        parts = [chunk for chunk in chunks(b'', 10000)]
+        self.eq(parts, [b''])
+
+        parts = [chunk for chunk in chunks([], 10000)]
+        self.eq(parts, [[]])
+
+        parts = [chunk for chunk in chunks('', 10000)]
+        self.eq(parts, [''])
+
+        parts = [chunk for chunk in chunks([1, 2, 3, 4, 5], 2)]
+        self.eq(parts, [[1, 2], [3, 4], [5]])
+
+        # set is unslicable
+        tpass = False
+        try:
+            parts = [chunk for chunk in chunks({1, 2, 3}, 10000)]
+        except TypeError as e:
+            tpass = True
+        self.true(tpass)
+
+        # dict is unslicable
+        tpass = False
+        try:
+            parts = [chunk for chunk in chunks({1: 2}, 10000)]
+        except TypeError as e:
+            tpass = True
+        self.true(tpass)
+
+        # empty dict is caught during the [0:0] slice
+        tpass = False
+        try:
+            parts = [chunk for chunk in chunks({}, 10000)]
+        except TypeError as e:
+            tpass = True
+        self.true(tpass)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -332,6 +332,8 @@ class CortexBaseTest(SynTest):
 
         idens = [t0[0], t1[0], t2[0]]
         self.sorteq(core.getTufosByIdens(idens), [t0, t1, t2])
+        # Expect an empty list of idens to return an empty list.
+        self.eq(core.getTufosByIdens([]), [])
 
     def runcore(self, core):
 


### PR DESCRIPTION
Add tests for eatfd / eatbytes which have zero bytes objects
Fix eatfd by ensuring that we chunk the first blob of bytes we consume and then pull in a second read prior to entering the while loop.
Fix eatbytes by changing s_common.chunks() to handle empty sequences.
Add a cortex test to ensure that getRowsByIdens() returns an empty list when presented with a empty iterable of idens.  
