### PR TITLE
Adds maximum values for dependency version ranges

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ setup(
     include_package_data=True,
 
     install_requires=[
-        'tornado>=3.2.2',
-        'pyOpenSSL>=16.2.0',
-        'msgpack>=0.5.1',
-        'xxhash>=1.0.1',
-        'lmdb>=0.92',
+        'tornado>=3.2.2,<5.0.0',
+        'pyOpenSSL>=16.2.0,<18.0.0',
+        'msgpack>=0.5.1,<0.6.0',
+        'xxhash>=1.0.1,<2.0.0',
+        'lmdb>=0.92,<1.0.0',
         'regex>=2017.9.23'
     ],
 


### PR DESCRIPTION
More 3rd party version fun this week!

The "latest" version of `tornado` on PyPI is currently `5.0a1` which is not compatible with synapse. In this PR, I add maximum versions to the modules listed in `install_requires` to avoid this in the future.

I did not change anything for the `regex` module as their version scheme is just the current date...