### PR TITLE
Storm limits

### DIFF
--- a/docs/synapse/userguides/ug013_storm_ref_lift.rst
+++ b/docs/synapse/userguides/ug013_storm_ref_lift.rst
@@ -187,8 +187,8 @@ Optional parameters:
 **Operator Syntax:**
 
 .. parsed-literal::
-  
-  **alltag(** *<tag>* [ **,** ...] **, limit=** *<limit>* **)**
+
+  **alltag(** *<tag>* [ **,** *<tag>* **,** ... **, limit=** *<limit>* ] **)**
   
 **Macro Syntax:**
 

--- a/docs/synapse/userguides/ug013_storm_ref_lift.rst
+++ b/docs/synapse/userguides/ug013_storm_ref_lift.rst
@@ -208,11 +208,16 @@ Optional parameters:
 ::
   alltag( foo.bar , limit=3)
 
+  #foo.bar limit(3)
+
 
 **Usage Notes:**
 
 * ``alltag()`` retrieves all nodes that have **any** of the specified tags.
 
+* The macro syntax for ``alltag()`` does not support the use of a limit parameter with the operator itself. The
+  ``limit()`` operator_ can be used to with the alltags macro syntax to limit the number of nodes returned, as shown
+  above.
 
 .. _storm.py: https://github.com/vertexproject/synapse/blob/master/synapse/lib/storm.py
 

--- a/docs/synapse/userguides/ug013_storm_ref_lift.rst
+++ b/docs/synapse/userguides/ug013_storm_ref_lift.rst
@@ -178,11 +178,17 @@ alltag()
 
 Lifts a set of nodes based on one or more tags.
 
+Optional parameters:
+
+* **Return limit:** specify the maximum number of nodes to be returned by the alltag query.
+
+  * ``limit=`` (operator syntax)
+
 **Operator Syntax:**
 
 .. parsed-literal::
   
-  **alltag(** *<tag>* [ **,** ...] **)**
+  **alltag(** *<tag>* [ **,** ...] **, limit=** *<limit>* **)**
   
 **Macro Syntax:**
 
@@ -191,11 +197,17 @@ Lifts a set of nodes based on one or more tags.
   **#** *<tag>* ...
   
 **Examples:**
+
 *Lifts all nodes that have the tag foo.bar or the tag baz.faz.*
 ::
   alltag( foo.bar , baz.faz )
   
   #foo.bar #baz.faz
+
+*Lifts up to three nodes that have the tag foo.bar*
+::
+  alltag( foo.bar , limit=3)
+
 
 **Usage Notes:**
 

--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -100,7 +100,6 @@ Optional parameters:
 
 **Usage notes:**
 
-v
 * If the source property for the pivot is the primary property of the working set of nodes, *<srcprop>* can be omitted from both Operator and Macro syntax.
 * If the source property for the pivot is a secondary property of the working set of nodes, relative property syntax can be used to specify *<srcprop>* as the source properties are, by definition, properties from the working set of nodes.
 * The ``limit=`` parameter can be provided as input to the ``pivot()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``pivot()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.

--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -215,6 +215,7 @@ N/A
 
 **Usage notes:**
 
+* ``refs()`` does not consume nodes, so the results of a ``refs()`` operation will include both the original working set as well as the resulting set of nodes.
 * ``refs()`` / ``refs(in)`` / ``refs(out)`` can be useful in an "exploratory" manner to identify what other nodes / forms are "reachable from" (can be pivoted to or from) the working set of nodes. However, because ``refs()`` essentially carries out all possible pivots, the set of nodes returned may be quite large. In such cases a more focused ``pivot()`` or ``join()`` operation may be more useful.
 * ``refs()`` does not consume nodes, so the results of a ``refs()`` operation will include both the original working set as well as the resulting set of nodes.
 * The ``limit=`` parameter can be provided as input to the ``refs()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``refs()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
@@ -449,6 +450,7 @@ N/A
 
 **Usage Notes:**
 
+* ``tree()`` does not consume nodes, so the results of a ``tree()`` operation will include both the original working set as well as the resulting set of nodes.
 * If the source property for the ``tree()`` operation is the primary property of the working set of nodes, *<srcprop>* can be omitted.
 * If the source property for the ``tree()`` operation is a secondary property of the working set of nodes, relative property syntax can be used to specify *<srcprop>* as the source properties are, by definition, properties from of the working set of nodes.
 * ``tree()`` does not consume nodes by design, so the results of a ``tree()`` operation will include both the original working set as well as the resulting (recursive) set of nodes.

--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -100,7 +100,7 @@ Optional parameters:
 
 **Usage notes:**
 
-* ``pivot()`` does consume nodes by design.
+v
 * If the source property for the pivot is the primary property of the working set of nodes, *<srcprop>* can be omitted from both Operator and Macro syntax.
 * If the source property for the pivot is a secondary property of the working set of nodes, relative property syntax can be used to specify *<srcprop>* as the source properties are, by definition, properties from the working set of nodes.
 * The ``limit=`` parameter can be provided as input to the ``pivot()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``pivot()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.

--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -100,6 +100,7 @@ Optional parameters:
 
 **Usage notes:**
 
+* ``pivot()`` does consume nodes by design.
 * If the source property for the pivot is the primary property of the working set of nodes, *<srcprop>* can be omitted from both Operator and Macro syntax.
 * If the source property for the pivot is a secondary property of the working set of nodes, relative property syntax can be used to specify *<srcprop>* as the source properties are, by definition, properties from the working set of nodes.
 * The ``limit=`` parameter can be provided as input to the ``pivot()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``pivot()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
@@ -112,7 +113,7 @@ Returns the current (working) set of nodes **and** the set of nodes that share a
 
 Optional parameters:
 
-* **Return limit**: specify the maximum number of nodes returned by the ``join()`` query.
+* **Return limit**: specify the maximum number of nodes added to the current working set by the ``join()`` query.
   
   * ``limit=`` (operator syntax)
 
@@ -162,13 +163,13 @@ Optional parameters:
 
 **Usage notes:**
 
-* ``join()`` does not consume nodes by design.
+* ``join()`` does not consume nodes, so the results of a ``join()`` operation will include both the original working set as well as the resulting set of nodes.
 * If the source property for the join is the primary property of the working set of nodes, *<srcprop>* can be omitted from both Operator and Macro syntax.
 * If the source property for the join is a secondary property of the working set of nodes, relative property syntax can be used to specify *<srcprop>* as the source properties are, by definition, properties from the working set of nodes.
 * The ``limit=`` parameter can be provided as input to the ``join()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``join()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 * Because ``join()`` does not consume nodes, this impacts the results returned by either the ``limit=`` parameter or the ``limit()`` operator.
   
-  * The ``limit=`` parameter will return **all** of the original nodes, **plus** the specified number of results (if ``limit=10`` and the number of working nodes was eight, this will return 18 nodes).
+  * The ``limit=`` parameter will return **all** of the original nodes, **plus** the specified number of results (if ``limit=10`` and the number of working nodes was eight, this will return up to 18 total nodes).
   * The ``limit()`` operator will return a **total** number of nodes equal to the specified limit, first including the original working nodes and then including resulting nodes (if ``limit=10`` and the number of working nodes was eight, this will return 10 nodes: the original eight, plus two results).
 
 refs()
@@ -180,7 +181,7 @@ Optional parameters:
 * **in:** return all nodes that have a secondary property *<type> (<ptype>) = <valu>* that is the same as (**references**) any primary *<prop> = <valu>* in the working set of nodes.
 * **out:** return all the nodes whose primary *<prop> = <valu>* is the same as (is **referenced by**) any secondary property *<type> (<ptype>) = <valu>* in the working set of nodes.
 * If no parameters are specified, ``refs()`` will return the combined results of both ``refs(in)`` and ``refs(out)`` (e.g., execute all pivots to / from the working set of nodes).
-* **Return limit:** specify the maximum number of nodes returned by the ``refs()`` query.
+* **Return limit:** specify the maximum number of nodes added to the current working set by the ``refs()`` query.
   
   * ``limit=`` (operator syntax)
 
@@ -220,7 +221,7 @@ N/A
 * The ``limit=`` parameter can be provided as input to the ``refs()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``refs()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 * Because ``refs()`` does not consume nodes, this impacts the results returned by either the ``limit=`` parameter or the ``limit()`` operator.
   
-  * The ``limit=`` parameter will return **all** of the original nodes, **plus** the specified number of results (if ``limit=10`` and the number of working nodes was eight, this will return 18 nodes).
+  * The ``limit=`` parameter will return **all** of the original nodes, **plus** the specified number of results (if ``limit=10`` and the number of working nodes was eight, this will return up to 18 nodes).
   * The ``limit()`` operator will return a **total** number of nodes equal to the specified limit, first including the original working nodes and then including resulting nodes (if ``limit=10`` and the number of working nodes was eight, this will return 10 nodes: the original eight, plus two results).
 
 fromtags()
@@ -265,6 +266,7 @@ N/A
 
 **Usage notes:**
 
+* ``fromtags()`` does consume nodes by design.
 * ``fromtags()`` pivots from leaf tags only. For example, if the working set contains ``syn:tag=foo.bar.baz``, ``fromtags()`` will return nodes with ``#foo.bar.baz`` but **not** nodes with ``#foo.bar`` or ``#foo`` alone.
 * The ``limit=`` parameter can be provided as input to the ``fromtags()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``fromtags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 * In some cases, pivoting with ``fromtags()`` is equivalent to lifting by tag; for example, ``ask #foo.mytag`` is equivalent to ``ask syn:tag=foo.mytag fromtags()``. However, ``fromtags()`` can also take more complex queries as input.
@@ -320,6 +322,8 @@ N/A
     totags( leaf = 0, limit = 10 )
 
 **Usage notes:**
+
+* ``totags()`` does consume nodes by design.
 
 * ``totags()`` and ``totags(leaf=1)`` return the set of leaf tags only. For example, if nodes in the working set have the tag ``#foo.bar.baz``, ``totags()`` will return ``syn:tag=foo.bar.baz``, but not ``syn:tag=foo.bar`` or ``syn:tag=foo``.
 
@@ -393,7 +397,7 @@ Optional parameters:
   * To disable limits on recursion (e.g., continue executing pivots until no more results are returned), ``recurnlim`` should be set to 0 (``recurnlim=0``).
   * **Note:** due to a known bug, ``tree()`` currently ignores any ``recurnlim`` parameter.
 
-* **Return limit:** specify the maximum number of nodes returned by the ``tree()`` query.
+* **Return limit:** specify the maximum number of nodes added to the current working set by the ``tree()`` query.
   
   * ``limit=`` (operator syntax)
 

--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -265,7 +265,6 @@ N/A
 
 **Usage notes:**
 
-* ``fromtags()`` does consume nodes by design.
 * ``fromtags()`` pivots from leaf tags only. For example, if the working set contains ``syn:tag=foo.bar.baz``, ``fromtags()`` will return nodes with ``#foo.bar.baz`` but **not** nodes with ``#foo.bar`` or ``#foo`` alone.
 * The ``limit=`` parameter can be provided as input to the ``fromtags()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``fromtags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 * In some cases, pivoting with ``fromtags()`` is equivalent to lifting by tag; for example, ``ask #foo.mytag`` is equivalent to ``ask syn:tag=foo.mytag fromtags()``. However, ``fromtags()`` can also take more complex queries as input.
@@ -321,8 +320,6 @@ N/A
     totags( leaf = 0, limit = 10 )
 
 **Usage notes:**
-
-* ``totags()`` does consume nodes by design.
 
 * ``totags()`` and ``totags(leaf=1)`` return the set of leaf tags only. For example, if nodes in the working set have the tag ``#foo.bar.baz``, ``totags()`` will return ``syn:tag=foo.bar.baz``, but not ``syn:tag=foo.bar`` or ``syn:tag=foo``.
 

--- a/docs/synapse/userguides/ug018_storm_ref_misc.rst
+++ b/docs/synapse/userguides/ug018_storm_ref_misc.rst
@@ -17,12 +17,6 @@ Provides a hard limit on the number of nodes which are emitted by the ``limit()`
 This also back-propagates a ``limit=`` argument to the previous query operator.
 
 
-Optional parameters:
-
-* **Return limit:** specify the maximum number of nodes returned by the ``pivot()`` query.
-
-  * ``limit=`` (operator syntax)
-
 **Operator syntax:**
 
 .. parsed-literal::

--- a/docs/synapse/userguides/ug018_storm_ref_misc.rst
+++ b/docs/synapse/userguides/ug018_storm_ref_misc.rst
@@ -37,13 +37,13 @@ N/A
 
 * Limit the total number of nodes of a lift to 10 nodes:
   ::
-    inet:ipv4*tag=hehe.haha limit(10)
+    inet:ipv4 limit(10)
 
-* Limit the number of nodes which were emitted by a ``refs()`` command to 10 nodes:
+* Limit the number of nodes which were returned by a ``refs()`` command to 10 total nodes:
   ::
     inet:ipv4=8.8.8.8 refs() limit(10)
 
-* Limit the numbers of nodes which were emitted by a pivot macro operator to 10 nodes:
+* Limit the nodes returned by a pivot operation to 10:
   ::
      inet:ipv4=8.8.8.8 inet:ipv4->inet:dns:a:ipv4 limit(10)
 
@@ -51,15 +51,18 @@ N/A
   ::
      inet:ipv4=8.8.8.8 inet:ipv4->inet:dns:a:ipv4 limit(10) totags()
 
-* ``limit()`` will push its own limit into the preceeding query operator, so the following example would behave as if the ``pivot()`` had ``limit=10``:
-  ::
-     inet:ipv4=8.8.8.8 pivot(inet:dns:a:ipv4, limit=1) limit(10)
 
 **Usage notes:**
 
 * ``limit()`` does consume nodes by design.  It will readd the consume nodes back into the working set of nodes until the limit value is met.
 * Since the ``limit()`` operator acts as a hard limit for the number of nodes it emits, care must be taken when using ``limit()`` in conjunction with multiple storm operations which do not consume nodes. It is possible that the use of ``limit()`` may discard all nodes from subsequent lifts or join type of operations.  In that case, it is typically better to just specify a ``limit=<value>`` argument to those operators directly, rather than using the ``limit()`` operator.
-* The ``limit()`` operator causes the Storm query planner to insert the limit value into the previous storm operator as a ``limit=<value>`` argument. This will override any value already provided to an operator.
+* The ``limit()`` operator causes the Storm query planner to insert the limit value into the previous storm operator as a ``limit=<value>`` argument. This will override any value already provided to an operator. The following example would behave as if the ``pivot()`` had ``limit=10``,
+instead of ``limit=1``:
+
+  ::
+
+     inet:ipv4=8.8.8.8 pivot(inet:dns:a:ipv4, limit=1) limit(10)
+
 * The ``limit()`` oeprator may produce an artificial limit on the number of nodes produced by a query. It may be a good tool for sampling data but its use may impair the user from being able to perform effective analysis on the system.
 
 opts()

--- a/docs/synapse/userguides/ug018_storm_ref_misc.rst
+++ b/docs/synapse/userguides/ug018_storm_ref_misc.rst
@@ -13,7 +13,54 @@ Todo
 
 limit()
 -------
-Todo
+Provides a hard limit on the number of nodes which are emitted by the ``limit()`` operator.
+This also back-propagates a ``limit=`` argument to the previous query operator.
+
+
+Optional parameters:
+
+* **Return limit:** specify the maximum number of nodes returned by the ``pivot()`` query.
+
+  * ``limit=`` (operator syntax)
+
+**Operator syntax:**
+
+.. parsed-literal::
+
+  **limit( *<limit>* )**
+
+**Macro syntax:**
+
+N/A
+
+**Examples:**
+
+* Limit the total number of nodes of a lift to 10 nodes:
+  ::
+    inet:ipv4*tag=hehe.haha limit(10)
+
+* Limit the number of nodes which were emitted by a ``refs()`` command to 10 nodes:
+  ::
+    inet:ipv4=8.8.8.8 refs() limit(10)
+
+* Limit the numbers of nodes which were emitted by a pivot macro operator to 10 nodes:
+  ::
+     inet:ipv4=8.8.8.8 inet:ipv4->inet:dns:a:ipv4 limit(10)
+
+* Perform a pivot, limiting the output with ``limit()``, then find all the tags which are on the output nodes:
+  ::
+     inet:ipv4=8.8.8.8 inet:ipv4->inet:dns:a:ipv4 limit(10) totags()
+
+* ``limit()`` will push its own limit into the preceeding query operator, so the following example would behave as if the ``pivot()`` had ``limit=10``:
+  ::
+     inet:ipv4=8.8.8.8 pivot(inet:dns:a:ipv4, limit=1) limit(10)
+
+**Usage notes:**
+
+* ``limit()`` does consume nodes by design.  It will readd the consume nodes back into the working set of nodes until the limit value is met.
+* Since the ``limit()`` operator acts as a hard limit for the number of nodes it emits, care must be taken when using ``limit()`` in conjunction with multiple storm operations which do not consume nodes. It is possible that the use of ``limit()`` may discard all nodes from subsequent lifts or join type of operations.  In that case, it is typically better to just specify a ``limit=<value>`` argument to those operators directly, rather than using the ``limit()`` operator.
+* The ``limit()`` operator causes the Storm query planner to insert the limit value into the previous storm operator as a ``limit=<value>`` argument. This will override any value already provided to an operator.
+* The ``limit()`` oeprator may produce an artificial limit on the number of nodes produced by a query. It may be a good tool for sampling data but its use may impair the user from being able to perform effective analysis on the system.
 
 opts()
 ------
@@ -39,7 +86,9 @@ dset()
 ------
 Todo
 
-
+get:tasks()
+-----------
+Todo
 
 .. _conventions: ../userguides/ug011_storm_basics.html#syntax-conventions
 __ conventions_

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -668,12 +668,7 @@ class Runtime(Configable):
 
         query = Query(data=data, maxtime=maxtime)
 
-        try:
-
-            self._runOperFuncs(query, opers)
-
-        except Exception as e:
-            logger.exception(e)
+        self._runOperFuncs(query, opers)
 
         return query.result()
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1435,10 +1435,9 @@ class Runtime(Configable):
 
                 nodes = core.getTufosByTag(tag, limit=limt.get())
 
-                limt.dec(len(nodes))
                 [query.add(n) for n in nodes]
 
-                if limt.reached():
+                if limt.dec(len(nodes)):
                     break
 
             return
@@ -1452,10 +1451,9 @@ class Runtime(Configable):
 
                 nodes = core.getTufosByTag(tag, form=form, limit=limt.get())
 
-                limt.dec(len(nodes))
                 [query.add(n) for n in nodes]
 
-                if limt.reached():
+                if limt.dec(len(nodes)):
                     break
 
     def _stormOperToTags(self, query, oper):

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1020,21 +1020,63 @@ class Runtime(Configable):
         if limit is not None and limit < 0:
             raise s_common.BadOperArg(oper='pivot', name='limit', mesg='must be >= 0')
 
+        self._runPivotOper(query, srcp, dstp, limit)
+
+    def _stormOperJoin(self, query, oper):
+
+        args = oper[1].get('args')
+        opts = dict(oper[1].get('kwlist'))
+
+        if len(args) is 1:
+            srcp, dstp = None, args[0]
+
+        elif len(args) is 2:
+            srcp, dstp = args[0], args[1]
+
+        else:
+            raise s_common.BadSyntaxError(mesg='join(<srcprop>,<dstprop>)')
+
+        limit = opts.get('limit')
+        if limit is not None and limit < 0:
+            raise s_common.BadOperArg(oper='join', name='limit', mesg='must be >= 0')
+
+        self._runPivotOper(query, srcp, dstp, limit, take=False)
+
+    def _runPivotOper(self, query, srcp, dstp, limit, take=True):
+        '''
+        Run the pivot/join operator.
+
+        Args:
+            query (Query): Current query execution.
+            srcp (str): Source property. May be relative or absolute. May also be None.
+            dstp (str): Destination property.
+            limit (int): Limit on the number of nodes lifted.
+            take (bool): Remove nodes from the Query working set if True.
+
+        Returns:
+            None
+        '''
+
+        limt = self.getLiftLimitHelp(limit)
+
         # do we have a relative source property?
         relsrc = srcp is not None and srcp.startswith(':')
 
         vals = set()
-        tufs = query.take()
+
+        # pivot() is called with take=True, join() uses take=False
+        if take:
+            tufs = query.take()
+        else:
+            tufs = query.data()
 
         if srcp is not None and not relsrc:
-
             for tufo in tufs:
                 valu = tufo[1].get(srcp)
                 if valu is not None:
                     vals.add(valu)
 
         elif not relsrc:
-
             for tufo in tufs:
                 form = tufo[1].get('tufo:form')
                 valu = tufo[1].get(form)
@@ -1042,32 +1084,24 @@ class Runtime(Configable):
                     vals.add(valu)
 
         else:
-
             for tufo in tufs:
                 form = tufo[1].get('tufo:form')
                 valu = tufo[1].get(form + srcp)
                 if valu is not None:
                     vals.add(valu)
 
-        # do not use fancy by handlers for runt nodes...
+        # do not use the 'in' handler for runt nodes
         core = self.getStormCore()
         if core.isRuntProp(dstp):
-
-            limt = self.getLiftLimitHelp(limit)
             for valu in vals:
-
                 # the base "eq" handler is aware of runts...
                 news = self.stormTufosBy('eq', dstp, valu, limit=limt.get())
-                limt.dec(len(news))
-
                 [query.add(n) for n in news]
-
-                if limt.reached():
+                if limt.dec(len(news)):
                     break
-
             return
 
-        [query.add(t)for t in self.stormTufosBy('in', dstp, list(vals), limit=limit)]
+        [query.add(t) for t in self.stormTufosBy('in', dstp, list(vals), limit=limt.get())]
 
     def _stormOperNextTag(self, query, oper):
         name = None
@@ -1089,73 +1123,6 @@ class Runtime(Configable):
         node = core.formTufoByProp('syn:tag', valu, doc=doc)
 
         query.add(node)
-
-    def _stormOperJoin(self, query, oper):
-
-        args = oper[1].get('args')
-        opts = dict(oper[1].get('kwlist'))
-
-        if len(args) is 1:
-            srcp, dstp = None, args[0]
-
-        elif len(args) is 2:
-            srcp, dstp = args[0], args[1]
-
-        else:
-            raise s_common.BadSyntaxError(mesg='join(<srcprop>,<dstprop>)')
-
-        limit = opts.get('limit')
-        if limit is not None and limit < 0:
-            raise s_common.BadOperArg(oper='join', name='limit', mesg='must be >= 0')
-
-        # do we have a relative source property?
-        relsrc = srcp is not None and srcp.startswith(':')
-
-        vals = set()
-        tufs = query.data()
-
-        if srcp is not None and not relsrc:
-
-            for tufo in tufs:
-                valu = tufo[1].get(srcp)
-                if valu is not None:
-                    vals.add(valu)
-
-        elif not relsrc:
-
-            for tufo in tufs:
-                form = tufo[1].get('tufo:form')
-                valu = tufo[1].get(form)
-                if valu is not None:
-                    vals.add(valu)
-
-        else:
-
-            for tufo in tufs:
-                form = tufo[1].get('tufo:form')
-                valu = tufo[1].get(form + srcp)
-                if valu is not None:
-                    vals.add(valu)
-
-        # do not use fancy by handlers for runt nodes...
-        core = self.getStormCore()
-        if core.isRuntProp(dstp):
-
-            limt = self.getLiftLimitHelp(limit)
-            for valu in vals:
-
-                # the base "eq" handler is aware of runts...
-                news = self.stormTufosBy('eq', dstp, valu, limit=limt.get())
-                limt.dec(len(news))
-
-                [query.add(n) for n in news]
-
-                if limt.reached():
-                    break
-
-            return
-
-        [query.add(t) for t in self.stormTufosBy('in', dstp, list(vals), limit=limit)]
 
     def _stormOperAddXref(self, query, oper):
 
@@ -1379,18 +1346,16 @@ class Runtime(Configable):
 
         core = self.getStormCore()
 
-        limit = self.getLiftLimit(opts.get('limit'))
+        limt = self.getLiftLimitHelp(opts.get('limit'))
 
         for tag in tags:
 
-            nodes = core.getTufosByTag(tag, limit=limit)
+            nodes = core.getTufosByTag(tag, limit=limt.get())
 
             [query.add(node) for node in nodes]
 
-            if limit is not None:
-                limit -= len(nodes)
-                if limit <= 0:
-                    break
+            if limt.dec(len(nodes)):
+                break
 
     def _stormOperAddTag(self, query, oper):
         tags = oper[1].get('args')

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1464,15 +1464,15 @@ class Runtime(Configable):
         core = self.getStormCore()
 
         leaf = opts.get('leaf', True)
-        limt = opts.get('limit', 0)
-        if limt < 0:
+        limt = self.getLiftLimitHelp(opts.get('limit'))
+        limtv = limt.get()
+
+        if limtv and limtv < 0:
             raise s_common.BadOperArg(oper='totags', name='limit', mesg='limit must be >= 0')
 
         tags = list({tag for node in nodes for tag in s_tufo.tags(node, leaf=leaf)})
-        if limt > 0:
-            tags = tags[0:limt]
 
-        [query.add(tufo) for tufo in core.getTufosBy('in', 'syn:tag', tags)]
+        [query.add(tufo) for tufo in core.getTufosBy('in', 'syn:tag', tags, limit=limtv)]
 
     def getLiftLimitHelp(self, *limits):
         '''

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1571,6 +1571,8 @@ class Runtime(Configable):
         if not args:
             raise s_common.BadSyntaxError(mesg='tree([<srcprop>], <destprop>, [recurlim=<limit>])')
 
+        limt = self.getLiftLimitHelp(opts.get('limit'))
+
         core = self.getStormCore()
 
         # Prevent infinite pivots
@@ -1625,7 +1627,12 @@ class Runtime(Configable):
             if not qvals:
                 break
 
-            [query.add(t) for t in self.stormTufosBy('in', dstp, qvals, limit=opts.get('limit'))]
+            nodes = core.stormTufosBy('in', dstp, qvals, limit=limt.get())
+
+            [query.add(n) for n in nodes]
+
+            if limt.dec(len(nodes)):
+                break
 
             queried_vals = queried_vals.union(vals)
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -704,6 +704,20 @@ class Runtime(Configable):
 
         return answ.get('data')
 
+    def getLiftLimitHelp(self, *limits):
+        '''
+        Return a LimitHelp object for the specified limits or defaults.
+
+        Args:
+            limits (list):  A list of int/None limits
+
+        Returns:
+            LimitHelp: A LimitHelp object.
+
+        '''
+        limit = self.getLiftLimit(*limits)
+        return LimitHelp(limit)
+
     def _reqOperArg(self, oper, name):
         valu = oper[1].get(name)
         if valu is None:
@@ -1437,20 +1451,6 @@ class Runtime(Configable):
 
         [query.add(tufo) for tufo in core.getTufosBy('in', 'syn:tag', tags, limit=limtv)]
 
-    def getLiftLimitHelp(self, *limits):
-        '''
-        Return a LimitHelp object for the specified limits or defaults.
-
-        Args:
-            limits (list):  A list of int/None limits
-
-        Returns:
-            LimitHelp: A LimitHelp object.
-
-        '''
-        limit = self.getLiftLimit(*limits)
-        return LimitHelp(limit)
-
     def _stormOperFromTags(self, query, oper):
         args = oper[1].get('args')
         opts = dict(oper[1].get('kwlist'))
@@ -1610,8 +1610,6 @@ class Runtime(Configable):
         args = oper[1].get('args')
         opts = dict(oper[1].get('kwlist'))
 
-        core = self.getStormCore()
-
         if not args:
             raise s_common.BadSyntaxError(mesg='delprop(<prop>, [force=1]>')
 
@@ -1624,6 +1622,7 @@ class Runtime(Configable):
         if not prop:
             raise s_common.BadSyntaxError(mesg='delprop(<prop>, [force=1]>')
 
+        core = self.getStormCore()
         force, _ = core.getTypeNorm('bool', opts.get('force', 0))
 
         if not force:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1482,7 +1482,7 @@ class Runtime(Configable):
             limits (list):  A list of int/None limits
 
         Returns:
-            (LimitHelp)
+            LimitHelp: A LimitHelp object.
 
         '''
         limit = self.getLiftLimit(*limits)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1448,7 +1448,7 @@ class CortexTest(SynTest):
         self.eq(len(core.eval('inet:fqdn=w00t.com totags(leaf=0, limit=3)')), 2)
         self.eq(len(core.eval('inet:fqdn=w00t.com totags(leaf=0, limit=2)')), 2)
         self.eq(len(core.eval('inet:fqdn=w00t.com totags(leaf=0, limit=1)')), 1)
-        self.eq(len(core.eval('inet:fqdn=w00t.com totags(leaf=0, limit=0)')), 2)
+        self.eq(len(core.eval('inet:fqdn=w00t.com totags(leaf=0, limit=0)')), 0)
         self.raises(BadOperArg, core.eval, 'inet:fqdn=w00t.com totags(leaf=0, limit=-1)')
         self.eq(len(core.eval('syn:tag=some')), 1)
         self.eq(len(core.eval('syn:tag=some.tag')), 1)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -527,6 +527,12 @@ class StormTest(SynTest):
             nodes = core.eval('#aka.duck totags()')
             self.eq(len(nodes), 10)
 
+            nodes = core.eval('#aka.duck totags(limit=3)')
+            self.eq(len(nodes), 3)
+
+            nodes = core.eval('#aka.duck totags(limit=0)')
+            self.eq(len(nodes), 0)
+
             nodes = core.eval('ps:tokn totags()')
             self.eq(len(nodes), 0)
 
@@ -537,6 +543,8 @@ class StormTest(SynTest):
             # Tagless node input
             nodes = core.eval('geo:loc=derry totags()')
             self.eq(len(nodes), 0)
+
+            self.raises(BadOperArg, core.eval, '#aka.duck totags(limit=-1)')
 
     def test_storm_tag_fromtag(self):
         with self.getRamCore() as core:  # type: s_cores_common.Cortex

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1051,6 +1051,9 @@ class StormTest(SynTest):
             nodes = core.eval('syn:tag=foo tree(syn:tag, syn:tag:up, recurlim=3)')
             self.len(6, nodes)
 
+            nodes = core.eval('syn:tag=foo tree(syn:tag, syn:tag:up, limit=4)')
+            self.len(5, nodes)  # 1 src node + 4 additional nodes lifted
+
             nodes = core.eval('syn:tag=foo tree(syn:tag, syn:tag:up, recurlim=12345)')
             self.len(6, nodes)
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1245,6 +1245,8 @@ class StormTest(SynTest):
             # Ensure that pivot and join operations work
             self.true(len(core.eval('syn:prop:ptype=it:host :form->syn:form')) > 1)
             self.true(len(core.eval('syn:prop:ptype=it:host :form<-syn:form')) > 1)
+            # Ensure limits are covered
+            self.len(3, core.eval('syn:prop:ptype=it:host :form->syn:form limit(3)'))
 
     def test_storm_prop_gtor(self):
         with self.getRamCore() as core:


### PR DESCRIPTION
Storm operators which do not lifts now use a LimitHelper and decrement that helper upon iterative lifts.  This now limits the number of new nodes added or lifted to the current set by a storm operator.

For operators which use ``query.take()`` , the limit will be the total number of nodes output by the operator.  For operators which use ``query.data()``, the limit will be a limit on the number of nodes which are added to the current working set.