### PR TITLE
Cleans up Core FIFO API

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -273,10 +273,10 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         self.onConfOptSet('axon:url', self._onSetAxonUrl)
 
     def _initCortexConfSetPost(self):
+        self._initCoreFifos()
         # It is not safe to load modules during SetConfOpts() since the path
         # value may not be set due to dictionary ordering, and there may be
         # modules which rely on it being present
-        self._initCoreFifos()
         self.onConfOptSet('modules', self._onSetMods)
         # Load any existing modules which may have been configured
         valu = self.getConfOpt('modules')

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -89,6 +89,7 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
 
         # BusRef for handling named Fifo objects
         self._core_fifos = s_eventbus.BusRef(ctor=self._initCoreFifo)
+        self.onfini(self._core_fifos.fini)
 
         # we keep an in-ram set of "ephemeral" nodes which are runtime-only ( non-persistent )
         self.runt_forms = set()

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -167,11 +167,6 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         logger.debug('Setting the syn:core:synapse:version value.')
         self.setBlobValu('syn:core:synapse:version', s_version.version)
 
-        # Pre-load all FIFOs
-        for node in self.getTufosByProp('syn:fifo'):
-            name = node[1].get('syn:fifo:name')
-            self.getCoreFifo(name)
-
         # The iden of self.myfo is persistent
         logger.debug('Done starting up cortex %s', self.myfo[0])
 
@@ -262,6 +257,11 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         self.on('fifo:ack', self._onFifoAck)
         self.on('fifo:sub', self._onFifoSub)
 
+    def _initCoreFifos(self):
+        for node in self.getTufosByProp('syn:fifo'):
+            name = node[1].get('syn:fifo:name')
+            self._core_fifos.gen(name)
+
     def _initCoreStormOpers(self):
         self.setOperFunc('stat', self._stormOperStat)
         self.setOperFunc('dset', self._stormOperDset)
@@ -275,6 +275,7 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         # It is not safe to load modules during SetConfOpts() since the path
         # value may not be set due to dictionary ordering, and there may be
         # modules which rely on it being present
+        self._initCoreFifos()
         self.onConfOptSet('modules', self._onSetMods)
         # Load any existing modules which may have been configured
         valu = self.getConfOpt('modules')

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -167,6 +167,11 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         logger.debug('Setting the syn:core:synapse:version value.')
         self.setBlobValu('syn:core:synapse:version', s_version.version)
 
+        # Pre-load all FIFOs
+        for node in self.getTufosByProp('syn:fifo'):
+            name = node[1].get('syn:fifo:name')
+            self.getCoreFifo(name)
+
         # The iden of self.myfo is persistent
         logger.debug('Done starting up cortex %s', self.myfo[0])
 

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -371,8 +371,15 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
         Args:
             name (str): The :name of the syn:fifo node.
 
+        Notes:
+            This requires a syn:fifo node to have been created which has a
+            syn:fifo:name property equal to the called name.
+
         Returns:
             s_fifo.Fifo: The Fifo object.
+
+        Raises:
+            NoSuchFifo: If there is no corresponding syn:fifo node in the Cortex.
         '''
         name = name.lower()
         return self._core_fifos.gen(name)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2879,6 +2879,9 @@ class CortexTest(SynTest):
             # refs are not automatically closed on core exit
             # the core fifo busref will not fini if refs are left open
             self.false(fiforef_0.isfini)
+            fiforef_1.fini()
+            self.true(fiforef_0.isfini)
+            self.eq(0, fiforef_0._syn_refs)
 
     def test_cortex_fifos(self):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2876,6 +2876,8 @@ class CortexTest(SynTest):
                 fiforef_1.fini()
                 self.eq(2, fiforef_0._syn_refs)
 
+            self.true(fiforef_0.isfini)  # should automatically fini this
+
     def test_cortex_fifos(self):
 
         with self.getTestDir() as dirn:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2876,7 +2876,9 @@ class CortexTest(SynTest):
                 fiforef_1.fini()
                 self.eq(2, fiforef_0._syn_refs)
 
-            self.true(fiforef_0.isfini)  # should automatically fini this
+            # refs are not automatically closed on core exit
+            # the core fifo busref will not fini if refs are left open
+            self.false(fiforef_0.isfini)
 
     def test_cortex_fifos(self):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2876,7 +2876,7 @@ class CortexTest(SynTest):
                 fiforef_1.fini()
                 self.eq(2, fiforef_0._syn_refs)
 
-            # refs are not automatically closed on core exit
+            # refs are finied, but the fifo is not finid because not all of the refs were closed yet
             # the core fifo busref will not fini if refs are left open
             self.false(fiforef_0.isfini)
             fiforef_1.fini()

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2877,7 +2877,6 @@ class CortexTest(SynTest):
                 self.eq(2, fiforef_0._syn_refs)
 
             # refs are finied, but the fifo is not finid because not all of the refs were closed yet
-            # the core fifo busref will not fini if refs are left open
             self.false(fiforef_0.isfini)
             fiforef_1.fini()
             self.true(fiforef_0.isfini)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2849,6 +2849,25 @@ class CortexTest(SynTest):
             self.none(t1[1].get('strform:baz'))
             self.none(t1[1].get('strform:haha'))
 
+    def test_cortex_fifos_busref(self):
+        with self.getTestDir() as dirn:
+
+            url = 'dir:///' + dirn
+            with s_cortex.openurl(url) as core:
+                node = core.formTufoByProp('syn:fifo', '(haHA)', desc='test fifo')
+                name = node[1].get('syn:fifo:name')
+
+                fifo = core.getCoreFifo(name)
+                self.eq(1, fifo._syn_refs)
+
+                fifo = core.getCoreFifo(name)
+                self.eq(2, fifo._syn_refs)
+
+                fifo = core.getCoreFifo(name)
+                self.eq(3, fifo._syn_refs)
+
+                # NOTE: fifo._syn_refs just keeps increasing?
+
     def test_cortex_fifos(self):
 
         with self.getTestDir() as dirn:

--- a/synapse/tests/test_eventbus.py
+++ b/synapse/tests/test_eventbus.py
@@ -282,17 +282,23 @@ class EventBusTest(SynTest):
             self.none(refs.get('woot'))
 
             woot = refs.gen('woot')
+            self.eq(1, woot._syn_refs)
 
             self.nn(woot)
             self.true(refs.gen('woot') is woot)
+            self.eq(2, woot._syn_refs)
 
             woot.fini()
             self.false(woot.isfini)
             self.true(refs.get('woot') is woot)
+            self.eq(1, woot._syn_refs)
 
             woot.fini()
+            self.eq(0, woot._syn_refs)
+
             self.true(woot.isfini)
             self.false(refs.get('woot') is woot)
+            self.eq(0, woot._syn_refs)
 
     def test_eventbus_main_sigterm(self):
         self.thisHostMustNot(platform='windows')


### PR DESCRIPTION
- No longer incrs refcount for each API call
- Loads all syn:fifos at cortex startup