### PR TITLE
Bug cortex init

### DIFF
--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -20,7 +20,9 @@ class SynMod(CoreModule):
 
                 ('syn:alias', {'subof': 'str', 'regex': r'^\$[a-z_]+$',
                     'doc': 'A synapse guid alias', 'ex': '$visi'}),
-                ('syn:fifo', {'subof': 'comp', 'fields': 'name=str:lwr'})
+                ('syn:fifo', {'subof': 'comp', 'fields': 'name=str:lwr'}),
+                ('syn:ingest', {'subof': 'str:lwr'}),
+                ('syn:log', {'subof': 'guid'}),
 
             ),
 
@@ -120,7 +122,19 @@ class SynMod(CoreModule):
                 ('syn:seq', {'ptype': 'str:lwr', 'doc': 'A sequential id generation tracker'}, (
                     ('width', {'ptype': 'int', 'defval': 0, 'doc': 'How many digits to use to represent the number'}),
                     ('nextvalu', {'ptype': 'int', 'defval': 0, 'doc': 'The next sequential value'}),
-                ))
+                )),
+                ('syn:ingest', {'ptype': 'syn:ingest', 'local': 1}, (
+                    ('time', {'ptype': 'time'}),
+                    ('text', {'ptype': 'json'})
+                )),
+                ('syn:log', {'ptype': 'guid', 'local': 1}, (
+                    ('subsys', {'ptype': 'str', 'defval': '??',
+                                'doc': 'Named subsystem which originaed teh log event'}),
+                    ('level', {'ptype': 'int', 'defval': logging.WARNING, }),
+                    ('time', {'ptype': 'time', 'doc': 'When the log event occured'}),
+                    ('exc', {'ptype': 'str', 'doc': 'Exception class name if caused by an exception'}),
+                    ('info:*', {'glob': 1})
+                )),
             )
         }
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -3080,6 +3080,43 @@ class CortexTest(SynTest):
             self.isin('hehe:haha', tasks)
             self.isin('wow', tasks)
 
+    def test_cortex_dynalias(self):
+        conf = {
+            'ctors': [
+                [
+                    'core',
+                    'syn:cortex',
+                    {
+                        'url': 'ram:///',
+                        'storm:query:log:en': 1,
+                        'modules': [
+                            [
+                                'synapse.tests.test_cortex.CoreTestModule',
+                                {'foobar': True}
+                            ]
+                        ]
+                    }
+                ]
+            ],
+            'share': [
+                [
+                    'core',
+                    {}
+                ]
+            ],
+            'listen': [
+                'tcp://0.0.0.0:0/'
+            ]
+        }
+
+        with s_daemon.Daemon() as dmon:
+            dmon.loadDmonConf(conf)
+            link = dmon.links()[0]
+            port = link[1].get('port')
+            with s_cortex.openurl('tcp://0.0.0.0/core', port=port) as prox:
+                self.isin('synapse.tests.test_cortex.CoreTestModule', prox.getCoreMods())
+                self.eq(prox.getConfOpt('storm:query:log:en'), 1)
+
 class StorageTest(SynTest):
 
     def test_nonexist_ctor(self):


### PR DESCRIPTION
Allow using the ``syn:cortex`` dynamic alias in dmon configurations by rewriting the ``Cortex.__init__``