### PR TITLE
fix node:del events

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -2873,8 +2873,8 @@ class Cortex(EventBus, DataModel, Runtime, s_ingest.IngestApi):
             self.delTufoDset(tufo, name)
 
         if self.caching:
-            for prop, valu in list(tufo[1].items()):
-                self._bumpTufoCache(tufo, prop, valu, None)
+            for prop, pvalu in list(tufo[1].items()):
+                self._bumpTufoCache(tufo, prop, pvalu, None)
 
         iden = tufo[0]
         with self.getCoreXact() as xact:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1359,6 +1359,7 @@ class CortexTest(SynTest):
 
     def test_cortex_tags(self):
         core = s_cortex.openurl('ram://')
+        core.setConfOpt('caching', 1)
 
         core.addTufoForm('foo', ptype='str')
 


### PR DESCRIPTION
The ``delTufo()`` API was smashing the primary property of nodes during a for loop. This causes `node:del` events to have incorrect `valu`s being passed to them.  This can cause things like `syn:tag` deletion to not behave properly.