### PR TITLE
Split jointags into jointags and pivottags

### DIFF
--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -335,8 +335,7 @@ N/A
 
 jointags()
 ----------
-Returns all specified nodes that have **any** of the tags applied to **any** of the working set of nodes,
-while retaining results from previous query steps.
+Returns the current working set **plus** all nodes that have **any** of the tags applied to **any** node in the working set.
 
 ``jointags()`` can be thought of as executing a ``totags()`` operation followed by a ``fromtags()`` operation.
 
@@ -376,18 +375,17 @@ N/A
 
 **Usage notes:**
 
+* ``jointags()`` does **not** consume nodes by design and so includes (retains) the original working set as part of the resulting set.
 * ``jointags()`` joins using the set of leaf tags only. For example if nodes in the working set have the tag ``#foo.bar.baz``, ``jointags()`` will return other nodes with ``#foo.bar.baz``, but not nodes with ``#foo.bar`` or ``#foo`` alone.
 * ``jointags()``, like ``refs()``, can be useful to "explore" other nodes that share some analytical assessment (tag) with the working set of nodes, but may return a large number of nodes.
 It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
-* The ``limit=`` parameter can be provided as input to the ``jointags()`` operator itself when using Operator syntax.
+* The ``limit=`` parameter represents the maximum number of nodes **added** to the results.
+It can be provided as input to the ``jointags()`` operator itself when using Operator syntax.
 Alternately the ``limit()`` operator_ can be used after the ``jointags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 
 pivottags()
 ----------
-Returns all specified nodes that have **any** of the tags applied to **any** of the working set of nodes,
-removing all other data from the query results.
-
-``pivottags()`` can be thought of as executing a ``totags()`` operation followed by a ``fromtags()`` operation.
+Returns all nodes that have **any** of the tags applied to **any** node in the original working set; excludes the original working set from the results.
 
 Optional parameters:
 
@@ -425,10 +423,12 @@ N/A
 
 **Usage notes:**
 
+* ``pivottags()`` consumes nodes input into the function, so the resulting set of nodes will **not** include nodes from the original working set.
 * ``pivottags()`` pivots using the set of leaf tags only. For example if nodes in the working set have the tag ``#foo.bar.baz``, ``pivottags()`` will return other nodes with ``#foo.bar.baz``, but not nodes with ``#foo.bar`` or ``#foo`` alone.
 * ``pivottags()``, like ``refs()``, can be useful to "explore" other nodes that share some analytical assessment (tag) with the working set of nodes, but may return a large number of nodes.
 It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
-* The ``limit=`` parameter can be provided as input to the ``pivottags()`` operator itself when using Operator syntax.
+* The ``limit=`` parameter represents the **total** number of nodes returned, as the original working set is consumed.
+It can be provided as input to the ``pivottags()`` operator itself when using Operator syntax.
 Alternately the ``limit()`` operator_ can be used after the ``pivottags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 
 tree()

--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -333,19 +333,19 @@ N/A
   * pivot from a set of nodes, to the tags applied to those nodes, to other nodes that have the same tags; or
   * from a set of tags, to nodes those tags are applied to, to other tags applied to those same nodes.
 
-jointags()
+pivottags()
 ----------
 Returns all specified nodes that have **any** of the tags applied to **any** of the working set of nodes.
 
-``jointags()`` can be thought of as executing a ``totags()`` operation followed by a ``fromtags()`` operation.
+``pivottags()`` can be thought of as executing a ``totags()`` operation followed by a ``fromtags()`` operation.
 
 Optional parameters:
 
 * **<form>:** return only nodes of the specified form(s).
   
-  * If no forms are specified, ``jointags()`` returns all nodes for all forms to which the tags are applied.
+  * If no forms are specified, ``pivottags()`` returns all nodes for all forms to which the tags are applied.
 
-* **Return limit:** specify the maximum number of nodes returned by the ``jointags()`` query.
+* **Return limit:** specify the maximum number of nodes returned by the ``pivottags()`` query.
   
   * ``limit=`` (operator syntax)
 
@@ -353,7 +353,7 @@ Optional parameters:
 
 .. parsed-literal::
   
-  **jointags(** [ *<form_1>* **,** *<form_2>* **,** *...<form_n>* **, limit=** *<num>* ] **)**
+  **pivottags(** [ *<form_1>* **,** *<form_2>* **,** *...<form_n>* **, limit=** *<num>* ] **)**
 
 **Macro syntax:**
 
@@ -363,21 +363,23 @@ N/A
 
 * Return the set of nodes that share any of the tags applied to the working set of nodes:
   ::
-    jointags()
+    pivottags()
 
 * Return the set of ``inet:fqdn`` and ``inet:email`` nodes that share any of the tags applied to the working set of nodes:
   ::
-    jointags( inet:fqdn, inet:email )
+    pivottags( inet:fqdn, inet:email )
 
 * Return the set of ``inet:fqdn`` and ``inet:email`` nodes that share any of the tags applied to the working set of nodes, limiting the number of results to 10:
   ::
-    jointags( inet:fqdn, inet:email, limit=10 )
+    pivottags( inet:fqdn, inet:email, limit=10 )
 
 **Usage notes:**
 
-* ``jointags()`` pivots using the set of leaf tags only. For example if nodes in the working set have the tag ``#foo.bar.baz``, ``jointags()`` will return other nodes with ``#foo.bar.baz``, but not nodes with ``#foo.bar`` or ``#foo`` alone.
-* ``jointags()``, like ``refs()``, can be useful to "explore" other nodes that share some analytical assessment (tag) with the working set of nodes, but may return a large number of nodes. It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
-* The ``limit=`` parameter can be provided as input to the ``jointags()`` operator itself when using Operator syntax. Alternately the ``limit()`` operator_ can be used after the ``jointags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
+* ``pivottags()`` pivots using the set of leaf tags only. For example if nodes in the working set have the tag ``#foo.bar.baz``, ``pivottags()`` will return other nodes with ``#foo.bar.baz``, but not nodes with ``#foo.bar`` or ``#foo`` alone.
+* ``pivottags()``, like ``refs()``, can be useful to "explore" other nodes that share some analytical assessment (tag) with the working set of nodes, but may return a large number of nodes.
+It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
+* The ``limit=`` parameter can be provided as input to the ``pivottags()`` operator itself when using Operator syntax.
+Alternately the ``limit()`` operator_ can be used after the ``pivottags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 
 tree()
 ------

--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -333,9 +333,59 @@ N/A
   * pivot from a set of nodes, to the tags applied to those nodes, to other nodes that have the same tags; or
   * from a set of tags, to nodes those tags are applied to, to other tags applied to those same nodes.
 
+jointags()
+----------
+Returns all specified nodes that have **any** of the tags applied to **any** of the working set of nodes,
+while retaining results from previous query steps.
+
+``jointags()`` can be thought of as executing a ``totags()`` operation followed by a ``fromtags()`` operation.
+
+Optional parameters:
+
+* **<form>:** return only nodes of the specified form(s).
+  
+  * If no forms are specified, ``jointags()`` returns all nodes for all forms to which the tags are applied.
+
+* **Return limit:** specify the maximum number of nodes returned by the ``jointags()`` query.
+  
+  * ``limit=`` (operator syntax)
+
+**Operator syntax:**
+
+.. parsed-literal::
+  
+  **jointags(** [ *<form_1>* **,** *<form_2>* **,** *...<form_n>* **, limit=** *<num>* ] **)**
+
+**Macro syntax:**
+
+N/A
+
+**Examples:**
+
+* Return the set of nodes that share any of the tags applied to the working set of nodes:
+  ::
+    jointags()
+
+* Return the set of ``inet:fqdn`` and ``inet:email`` nodes that share any of the tags applied to the working set of nodes:
+  ::
+    jointags( inet:fqdn, inet:email )
+
+* Return the set of ``inet:fqdn`` and ``inet:email`` nodes that share any of the tags applied to the working set of nodes, limiting the number of results to 10:
+  ::
+    jointags( inet:fqdn, inet:email, limit=10 )
+
+**Usage notes:**
+
+* ``jointags()`` joins using the set of leaf tags only. For example if nodes in the working set have the tag ``#foo.bar.baz``, ``jointags()`` will return other nodes with ``#foo.bar.baz``, but not nodes with ``#foo.bar`` or ``#foo`` alone.
+* ``jointags()``, like ``refs()``, can be useful to "explore" other nodes that share some analytical assessment (tag) with the working set of nodes, but may return a large number of nodes.
+It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
+* The ``limit=`` parameter can be provided as input to the ``jointags()`` operator itself when using Operator syntax.
+Alternately the ``limit()`` operator_ can be used after the ``jointags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
+
 pivottags()
 ----------
-Returns all specified nodes that have **any** of the tags applied to **any** of the working set of nodes.
+Returns all specified nodes that have **any** of the tags applied to **any** of the working set of nodes,
+removing all other data from the query results.
 
 ``pivottags()`` can be thought of as executing a ``totags()`` operation followed by a ``fromtags()`` operation.
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1464,7 +1464,7 @@ class Runtime(Configable):
 
         limt = self.getLiftLimitHelp(opts.get('limit'))
         if isinstance(limt.limit, int) and limt.limit < 0:
-                raise s_common.BadOperArg(oper='pivottags', name='limit', mesg='limit must be >= 0')
+                raise s_common.BadOperArg(oper=oper[0], name='limit', mesg='limit must be >= 0')
 
         if take:
             nodes = query.take()

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1467,14 +1467,9 @@ class Runtime(Configable):
         core = self.getStormCore()
 
         forms = set(args)
-        keep_nodes = opts.get('keep_nodes', False)
-
         limt = self.getLiftLimitHelp(opts.get('limit'))
 
         nodes = query.data()
-        if not keep_nodes:
-            query.clear()
-
         tags = {tag for node in nodes for tag in s_tufo.tags(node, leaf=True)}
 
         if not forms:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1466,11 +1466,11 @@ class Runtime(Configable):
         opts = dict(oper[1].get('kwlist'))
         core = self.getStormCore()
 
-        forms = set(args)
-        limt = self.getLiftLimitHelp(opts.get('limit'))
-
         nodes = query.data()
-        tags = {tag for node in nodes for tag in s_tufo.tags(node, leaf=True)}
+        forms = sorted(set(args))
+
+        limt = self.getLiftLimitHelp(opts.get('limit'))
+        tags = sorted({tag for node in nodes for tag in s_tufo.tags(node, leaf=True)})
 
         if not forms:
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -439,6 +439,7 @@ class Runtime(Configable):
         self.setOperFunc('addxref', self._stormOperAddXref)
         self.setOperFunc('fromtags', self._stormOperFromTags)
         self.setOperFunc('jointags', self._stormOperJoinTags)
+        self.setOperFunc('pivottags', self._stormOperPivotTags)
 
         self.setOperFunc('get:tasks', self._stormOperGetTasks)
 
@@ -1455,6 +1456,9 @@ class Runtime(Configable):
 
         for tag in tags:
             [core.delTufoTag(node, tag) for node in nodes]
+
+    def _stormOperPivotTags(self, query, oper):
+        pass  # FIXME
 
     def _stormOperJoinTags(self, query, oper):
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -530,24 +530,31 @@ class StormTest(SynTest):
             self.eq(len(nodes), 2)
 
             nodes = core.eval('inet:dns:a jointags(inet:fqdn, limit=2)')
-            self.eq(len(nodes), 1)
-            self.eq(nodes[0][1].get('tufo:form'), 'inet:fqdn')
+            self.eq(len(nodes), 2)
+            self.eq(nodes[0][1].get('tufo:form'), 'inet:dns:a')
+            self.eq(nodes[1][1].get('tufo:form'), 'inet:fqdn')
 
             nodes = core.eval('inet:dns:a jointags(ps:tokn,inet:fqdn)')
-            self.eq(len(nodes), 1)
-            self.eq(nodes[0][1].get('tufo:form'), 'inet:fqdn')
+            self.eq(len(nodes), 2)
+            self.eq(nodes[0][1].get('tufo:form'), 'inet:dns:a')
+            self.eq(nodes[1][1].get('tufo:form'), 'inet:fqdn')
 
             nodes = core.eval('inet:dns:a jointags(ps:tokn)')
-            self.eq(len(nodes), 0)
-
-            nodes = core.eval('inet:dns:a jointags(ps:tokn, keep_nodes=1)')
             self.eq(len(nodes), 1)
 
-            nodes = core.eval('inet:dns:a jointags(inet:fqdn, keep_nodes=1)')
+            nodes = core.eval('inet:dns:a jointags(ps:tokn, keep_nodes=1)')  # NOTE: keep_nodes doesn't do anything anymore
+            self.eq(len(nodes), 1)
+            nodes = core.eval('inet:dns:a jointags(ps:tokn)')
+            self.eq(len(nodes), 1)
+
+            nodes = core.eval('inet:dns:a jointags(inet:fqdn, keep_nodes=1)')  # NOTE: keep_nodes doesn't do anything anymore
+            self.eq(len(nodes), 2)
+            nodes = core.eval('inet:dns:a jointags(inet:fqdn)')
             self.eq(len(nodes), 2)
 
-            nodes = core.eval('inet:dns:a jointags(limit=1)')
+            nodes = core.eval('inet:dns:a jointags(limit=1)')  # FIXME: this sometimes fails and gets 2 nodes instead. the second node is the inet:fqdn
             self.eq(len(nodes), 1)
+            self.eq(nodes[0][1].get('tufo:form'), 'inet:dns:a')
 
     def test_storm_tag_totag(self):
         with self.getRamCore() as core:  # type: s_cores_common.Cortex

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -73,9 +73,9 @@ class StormTest(SynTest):
     def test_storm_cmpr_norm(self):
         with self.getRamCore() as core:
             core.formTufoByProp('inet:dns:a', 'woot.com/1.2.3.4')
-            self.eq(len(core.eval('inet:dns:a:ipv4="1.2.3.4"')), 1)
-            self.eq(len(core.eval('inet:dns:a:ipv4="1.2.3.4" -:ipv4="1.2.3.4"')), 0)
-            self.eq(len(core.eval('inet:dns:a:ipv4="1.2.3.4" +:ipv4="1.2.3.4"')), 1)
+            self.len(1, core.eval('inet:dns:a:ipv4="1.2.3.4"'))
+            self.len(0, core.eval('inet:dns:a:ipv4="1.2.3.4" -:ipv4="1.2.3.4"'))
+            self.len(1, core.eval('inet:dns:a:ipv4="1.2.3.4" +:ipv4="1.2.3.4"'))
 
     def test_storm_pivot(self):
         with self.getRamCore() as core:
@@ -113,13 +113,13 @@ class StormTest(SynTest):
             self.nn(node)
             self.eq(node[1].get('inet:dns:a'), 'woot.com/1.2.3.4')
 
-            self.eq(len(core.eval('inet:dns:a:ipv4="5.6.7.8" :fqdn->inet:fqdn')), 2)
-            self.eq(len(core.eval('inet:ipv4="5.6.7.8" -> inet:dns:a:ipv4')), 2)
-            self.eq(len(core.eval('inet:ipv4="5.6.7.8" inet:ipv4->inet:dns:a:ipv4')), 2)
+            self.len(2, core.eval('inet:dns:a:ipv4="5.6.7.8" :fqdn->inet:fqdn'))
+            self.len(2, core.eval('inet:ipv4="5.6.7.8" -> inet:dns:a:ipv4'))
+            self.len(2, core.eval('inet:ipv4="5.6.7.8" inet:ipv4->inet:dns:a:ipv4'))
 
-            self.eq(len(core.eval('inet:dns:a:ipv4="5.6.7.8" pivot(:fqdn,inet:fqdn)')), 2)
-            self.eq(len(core.eval('inet:ipv4="5.6.7.8" pivot(inet:dns:a:ipv4)')), 2)
-            self.eq(len(core.eval('inet:ipv4="5.6.7.8" pivot(inet:ipv4, inet:dns:a:ipv4)')), 2)
+            self.len(2, core.eval('inet:dns:a:ipv4="5.6.7.8" pivot(:fqdn,inet:fqdn)'))
+            self.len(2, core.eval('inet:ipv4="5.6.7.8" pivot(inet:dns:a:ipv4)'))
+            self.len(2, core.eval('inet:ipv4="5.6.7.8" pivot(inet:ipv4, inet:dns:a:ipv4)'))
 
             self.raises(BadSyntaxError, core.eval, 'inet:ipv4="5.6.7.8" pivot()')
             self.raises(BadSyntaxError, core.eval, 'inet:ipv4="5.6.7.8" pivot(:fqdn, inet:fqdn, hehe:haha)')
@@ -213,7 +213,7 @@ class StormTest(SynTest):
             node2 = core.formTufoByProp('file:bytes', iden2, name='toow.exe')
 
             nodes = core.eval('file:bytes +:name~=exe')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
     def test_storm_alltag(self):
         with self.getRamCore() as core:
@@ -233,14 +233,14 @@ class StormTest(SynTest):
 
             # test alltag macro syntax with limit
             core.eval('[ inet:fqdn=hehe.com inet:fqdn=haha.com #lol ]')
-            self.eq(len(core.eval('#lol limit(1)')), 1)
+            self.len(1, core.eval('#lol limit(1)'))
 
     def test_storm_limit(self):
         with self.getRamCore() as core:
             # test that the limit operator correctly handles being first (no opers[-1])
             # and will subsequently filter down to the correct number of nodes
             nodes = core.eval('[ inet:ipv4=1.2.3.4 inet:ipv4=3.4.5.6 ]')
-            self.eq(len(core.eval(' limit(1) ', data=nodes)), 1)
+            self.len(1, core.eval(' limit(1) ', data=nodes))
 
             # test that the limit() operator reaches backward to limit a previous oper
             # during the planning pass...
@@ -342,18 +342,18 @@ class StormTest(SynTest):
             core.formTufoByProp('inet:dns:a', 'foo.com/1.2.3.4')
             core.formTufoByProp('inet:dns:a', 'bar.com/1.2.3.4')
 
-            self.eq(len(core.eval('inet:ipv4=1.2.3.4 refs(in)')), 3)
-            self.eq(len(core.eval('inet:ipv4=1.2.3.4 refs(in,limit=1)')), 2)
+            self.len(3, core.eval('inet:ipv4=1.2.3.4 refs(in)'))
+            self.len(2, core.eval('inet:ipv4=1.2.3.4 refs(in,limit=1)'))
 
-            self.eq(len(core.eval('inet:dns:a=foo.com/1.2.3.4 refs(out)')), 3)
-            self.eq(len(core.eval('inet:dns:a=foo.com/1.2.3.4 refs(out,limit=1)')), 2)
+            self.len(3, core.eval('inet:dns:a=foo.com/1.2.3.4 refs(out)'))
+            self.len(2, core.eval('inet:dns:a=foo.com/1.2.3.4 refs(out,limit=1)'))
 
             # Try refs() with a file:txtref node.  This uses propvalu to do the pivoting
             fnode = core.formTufoByProp('file:bytes:md5', 'd41d8cd98f00b204e9800998ecf8427e')
             form, pprop = s_tufo.ndef(fnode)
             node = core.formTufoByProp('file:txtref', '({},inet:ipv4=1.2.3.4)'.format(pprop))
             nodes = core.eval('file:txtref refs()')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
             forms = {s_tufo.ndef(node)[0] for node in nodes}
             self.eq(forms, {'inet:ipv4', 'file:bytes', 'file:txtref'})
 
@@ -363,7 +363,7 @@ class StormTest(SynTest):
             node = core.formTufoByProp('file:txtref', '({},"inet:passwd=oh=my=graph!")'.format(pprop))
             form, pprop = s_tufo.ndef(node)
             nodes = core.eval('file:txtref={} refs()'.format(pprop))
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
             forms = {s_tufo.ndef(node)[0] for node in nodes}
             self.eq(forms, {'file:bytes', 'file:txtref', 'inet:passwd'})
 
@@ -371,7 +371,7 @@ class StormTest(SynTest):
             f1 = core.formTufoByProp('pvsub', 'hai', xref='inet:ipv4=1.2.3.4')
             self.nn(f1)
             nodes = core.eval('pvsub refs()')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             # Try refs() on a node which points to a ref node
             t0 = core.formTufoByProp('inet:ipv4', '1.2.3.5')
@@ -409,22 +409,22 @@ class StormTest(SynTest):
             core.addTufoTags(node3, ['aka.foo.bar.knight', 'aka.duck.sound.loud', 'src.clowntown'])
 
             nodes = core.eval('inet:dns:a +#src.clowntown')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('inet:dns:a +#src')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.duck.quack')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.foo.bar.knight')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('inet:dns:a +#src.internet')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('inet:dns:a -#aka.foo.bar')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
     def test_storm_tag_glob(self):
         # Ensure that glob operators with tag filters operate properly.
@@ -452,58 +452,58 @@ class StormTest(SynTest):
                                      'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
 
             nodes = core.eval('inet:dns:a +#aka.*.baz')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.duck.*.loud')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.*.sound.loud')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a -#aka.*.baz')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.*.loud')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.*.*.loud')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.*.*.*.loud')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.*.knight')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('inet:dns:a +#aka.**.loud')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('inet:dns:a +#loc.**.perfection')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a +#loc.**.sol.*.us')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('inet:dns:a +#loc.*.galactic_arm_a.**.us.*.perfection')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a +#**.baz')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a +#**.mars')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('inet:dns:a -#**.mars.*.tx')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('inet:dns:a +#loc.milkyway.*arm*.**.tx')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('inet:dns:a +#loc.**.u*')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('inet:dns:a +#loc.milkyway.galactic**.tx')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
     def test_storm_tag_jointag(self):
         with self.getRamCore() as core:  # type: s_cores_common.Cortex
@@ -527,30 +527,30 @@ class StormTest(SynTest):
                                      'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
 
             nodes = core.eval('inet:dns:a jointags()')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a jointags(inet:fqdn, limit=2)')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
             self.eq(nodes[0][1].get('tufo:form'), 'inet:dns:a')
             self.eq(nodes[1][1].get('tufo:form'), 'inet:fqdn')
 
             nodes = core.eval('inet:dns:a jointags(ps:tokn,inet:fqdn)')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
             self.eq(nodes[0][1].get('tufo:form'), 'inet:dns:a')
             self.eq(nodes[1][1].get('tufo:form'), 'inet:fqdn')
 
             nodes = core.eval('inet:dns:a jointags(ps:tokn)')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('inet:dns:a jointags(ps:tokn, keep_nodes=1)')  # NOTE: keep_nodes doesn't do anything anymore
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
             nodes = core.eval('inet:dns:a jointags(ps:tokn)')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('inet:dns:a jointags(inet:fqdn, keep_nodes=1)')  # NOTE: keep_nodes doesn't do anything anymore
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
             nodes = core.eval('inet:dns:a jointags(inet:fqdn)')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:dns:a jointags(limit=1)')
             self.eq(len(nodes), 1)
@@ -577,33 +577,33 @@ class StormTest(SynTest):
                                      'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
 
             nodes = core.eval('inet:dns:a totags()')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('inet:dns:a totags(leaf=0)')
-            self.eq(len(nodes), 14)
+            self.len(14, nodes)
 
             nodes = core.eval('#aka.duck.quack.loud totags()')
-            self.eq(len(nodes), 5)
+            self.len(5, nodes)
 
             nodes = core.eval('#aka.duck totags()')
-            self.eq(len(nodes), 10)
+            self.len(10, nodes)
 
             nodes = core.eval('#aka.duck totags(limit=3)')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('#aka.duck totags(limit=0)')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('ps:tokn totags()')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             # Tag input
             nodes = core.eval('syn:tag=aktoa.bar.baz totags()')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             # Tagless node input
             nodes = core.eval('geo:loc=derry totags()')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             self.raises(BadOperArg, core.eval, '#aka.duck totags(limit=-1)')
 
@@ -627,35 +627,35 @@ class StormTest(SynTest):
                                      'loc.milkyway.galactic_arm_a.sol.mars.us.tx.perfection'])
 
             nodes = core.eval('syn:tag=aka.bar.baz fromtags()')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('syn:tag=aka.bar fromtags()')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             nodes = core.eval('syn:tag=aka.duck fromtags()')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('syn:tag=aka.bar.baz fromtags(inet:dns:a)')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('syn:tag=aka.bar.baz fromtags(inet:dns:a, ps:tokn)')
-            self.eq(len(nodes), 1)
+            self.len(1, nodes)
 
             nodes = core.eval('syn:tag=aka.bar.baz fromtags(ps:tokn)')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('syn:tag=spam.and.eggs fromtags()')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('syn:tag=aka.duck fromtags(limit=2)')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             # Non-tag input
             nodes = core.eval('inet:dns:a fromtags()')
-            self.eq(len(nodes), 0)
+            self.len(0, nodes)
 
             nodes = core.eval('syn:tag:base=bar fromtags()')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
     def test_storm_lift(self):
         with self.getRamCore() as core:
@@ -1168,15 +1168,15 @@ class StormTest(SynTest):
             self.len(4, nodes)
 
             nodes = core.eval('ou:org:alias=s4 -> ou:suborg:org tree(ou:suborg:sub, ou:suborg:org) :sub-> ou:org')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('ou:org:alias=master -> ou:suborg:org tree(ou:suborg:sub, ou:suborg:org, recurlim=1) '
                               ':sub-> ou:org')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             # Tree up instead of down
             nodes = core.eval('ou:org:alias=s6 -> ou:suborg:sub tree(ou:suborg:org, ou:suborg:sub) :org-> ou:org')
-            self.eq(len(nodes), 3)
+            self.len(3, nodes)
 
             # fqdn tests
             f0 = core.formTufoByProp('inet:fqdn', 'woohoo.wow.vertex.link')
@@ -1184,26 +1184,26 @@ class StormTest(SynTest):
             f2 = core.formTufoByProp('inet:fqdn', 'wow.ohmy.clowntown.vertex.link')
 
             nodes = core.eval('inet:fqdn=vertex.link tree(inet:fqdn, inet:fqdn:domain)')
-            self.eq(len(nodes), 8)
+            self.len(8, nodes)
 
             nodes = core.eval('inet:fqdn=vertex.link tree(inet:fqdn:domain)')
-            self.eq(len(nodes), 8)
+            self.len(8, nodes)
 
             nodes = core.eval('inet:fqdn=vertex.link tree(inet:fqdn:domain, recurlim=1)')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('inet:fqdn=vertex.link tree(inet:fqdn:domain, recurlim=2)')
-            self.eq(len(nodes), 7)
+            self.len(7, nodes)
 
             # tree up
             nodes = core.eval('inet:fqdn=vertex.link tree(inet:fqdn:domain, inet:fqdn)')
-            self.eq(len(nodes), 2)
+            self.len(2, nodes)
 
             nodes = core.eval('inet:fqdn=woot.woot.vertex.link tree(inet:fqdn:domain, inet:fqdn)')
-            self.eq(len(nodes), 4)
+            self.len(4, nodes)
 
             nodes = core.eval('inet:fqdn=wow.ohmy.clowntown.vertex.link tree(inet:fqdn:domain, inet:fqdn)')
-            self.eq(len(nodes), 5)
+            self.len(5, nodes)
 
     def test_storm_delprop(self):
         with self.getRamCore() as core:

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -552,7 +552,7 @@ class StormTest(SynTest):
             nodes = core.eval('inet:dns:a jointags(inet:fqdn)')
             self.eq(len(nodes), 2)
 
-            nodes = core.eval('inet:dns:a jointags(limit=1)')  # FIXME: this sometimes fails and gets 2 nodes instead. the second node is the inet:fqdn
+            nodes = core.eval('inet:dns:a jointags(limit=1)')
             self.eq(len(nodes), 1)
             self.eq(nodes[0][1].get('tufo:form'), 'inet:dns:a')
 


### PR DESCRIPTION
- (breaking change) jointags loses the `keep_nodes` kwarg
- (breaking change) jointags no longer acts as a pivot by default
- adds pivottags operator