### PR TITLE
Bug - divide

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -8,6 +8,7 @@ import types
 import base64
 import fnmatch
 import hashlib
+import logging
 import builtins
 import functools
 import itertools
@@ -24,6 +25,7 @@ import synapse.exc as s_exc
 
 from synapse.exc import *
 
+import synapse.lib.const as s_const
 import synapse.lib.msgpack as s_msgpack
 
 major = sys.version_info.major
@@ -487,3 +489,26 @@ def makedirs(path, mode=0o777):
 
 def iterzip(*args):
     return itertools.zip_longest(*args)
+
+def setlogging(mlogger, defval=None):
+    '''
+    Configure synapse logging.
+
+    Args:
+        mlogger (logging.Logger): Reference to a logging.Logger()
+        defval (str): Default log level
+
+    Notes:
+        This calls logging.basicConfig and should only be called once per process.
+
+    Returns:
+        None
+    '''
+    log_level = os.getenv('SYN_DMON_LOG_LEVEL',
+                          defval)
+    if log_level:  # pragma: no cover
+        log_level = log_level.upper()
+        if log_level not in s_const.LOG_LEVEL_CHOICES:
+            raise ValueError('Invalid log level provided: {}'.format(log_level))
+        logging.basicConfig(level=log_level, format=s_const.LOG_FORMAT)
+        mlogger.info('log level set to %s', log_level)

--- a/synapse/lib/const.py
+++ b/synapse/lib/const.py
@@ -1,3 +1,9 @@
+### Logging related constants
+LOG_FORMAT = '%(asctime)s [%(levelname)s] %(message)s ' \
+             '[%(filename)s:%(funcName)s:%(threadName)s:%(processName)s]'
+LOG_LEVEL_CHOICES = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+
+### Math related constants
 kilobyte = 1000
 megabyte = 1000 * kilobyte
 gigabyte = 1000 * megabyte

--- a/synapse/lib/net.py
+++ b/synapse/lib/net.py
@@ -5,14 +5,12 @@ import logging
 import threading
 import collections
 
-import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.eventbus as s_eventbus
 
 import synapse.lib.queue as s_queue
 import synapse.lib.config as s_config
 import synapse.lib.msgpack as s_msgpack
-import synapse.lib.reflect as s_reflect
 import synapse.lib.threads as s_threads
 
 logger = logging.getLogger(__file__)

--- a/synapse/neuron.py
+++ b/synapse/neuron.py
@@ -547,6 +547,11 @@ def main(dirn, conf=None):
     '''
     try:
 
+        # Configure logging since we may have come in via
+        # multiprocessing.Process as part of a Daemon config.
+        s_common.setlogging(logger,
+                            os.getenv('SYN_TEST_LOG_LEVEL', 'WARNING'))
+
         dirn = s_common.genpath(dirn)
         ctor, func = getCellCtor(dirn, conf=conf)
 

--- a/synapse/neuron.py
+++ b/synapse/neuron.py
@@ -1,20 +1,13 @@
 import os
-import sys
-import time
-import errno
 import fcntl
-import socket
 import logging
 import threading
-import collections
 import multiprocessing
 
 import synapse.exc as s_exc
 import synapse.glob as s_glob
-import synapse.link as s_link
 import synapse.common as s_common
 import synapse.dyndeps as s_dyndeps
-import synapse.eventbus as s_eventbus
 
 import synapse.lib.kv as s_kv
 import synapse.lib.net as s_net

--- a/synapse/neuron.py
+++ b/synapse/neuron.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import fcntl
 import logging
 import threading
@@ -521,7 +522,8 @@ def divide(dirn, conf=None):
     Returns:
         multiprocessing.Process: The Process object which was created to run the Cell
     '''
-    proc = multiprocessing.Process(target=main, args=(dirn, conf))
+    ctx = multiprocessing.get_context('spawn')
+    proc = ctx.Process(target=main, args=(dirn, conf))
     proc.start()
 
     return proc

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -12,7 +12,7 @@ import contextlib
 import unittest.mock as mock
 
 
-loglevel = int(os.getenv('SYN_TEST_LOG_LEVEL', logging.WARNING))
+loglevel = os.getenv('SYN_TEST_LOG_LEVEL', 'WARNING')
 logging.basicConfig(level=loglevel,
                     format='%(asctime)s [%(levelname)s] %(message)s [%(filename)s:%(funcName)s:%(threadName)s:%(processName)s]')
 

--- a/synapse/tests/test_cryotank.py
+++ b/synapse/tests/test_cryotank.py
@@ -1,4 +1,3 @@
-import synapse.neuron as s_neuron
 import synapse.cryotank as s_cryotank
 
 from synapse.tests.common import *

--- a/synapse/tests/test_lib_net.py
+++ b/synapse/tests/test_lib_net.py
@@ -1,4 +1,3 @@
-
 import synapse.lib.net as s_net
 
 from synapse.tests.common import *

--- a/synapse/tools/dmon.py
+++ b/synapse/tools/dmon.py
@@ -146,13 +146,8 @@ def main(argv, outp=None):
     p = getArgParser()
     opts = p.parse_args(argv)
 
-    log_level = os.getenv('SYN_DMON_LOG_LEVEL', opts.log_level)
-    if log_level:  # pragma: no cover
-        log_level = log_level.upper()
-        if log_level not in LOG_LEVEL_CHOICES:
-            raise ValueError('Invalid log level provided: {}'.format(log_level))
-        logging.basicConfig(level=log_level, format=log_format)
-        logger.info('log level set to ' + log_level)
+    s_common.setlogging(logger,
+                        opts.log_level)
 
     if opts.lsboot:
         for path in lsboot():


### PR DESCRIPTION
Divide needs to spawn new processes instead of using the default fork when making new Cell instances.
Also streamlined logging configuration.
 - ``SYN_TEST_LOG_LEVEL`` is now treated like a string, just like ``SYN_DMON_LOG_LEVEL``.
 -  ``synapse.neuron.divide()`` prefers to pull log level for processes it creates in the following order: `SYN_DMON_LOG_LEVEL``, `SYN_TEST_LOG_LEVEL``, then defaults to ``logging.WARNING`` level.
 - The behavior of ``synapse.tools.dmon`` is unchanged.