### PR TITLE
Return raw data for inet:fqdn repr where domain starts with xn-- but isn't a valid internationalized domain name

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -88,9 +88,6 @@ class FqdnType(DataType):
         except UnicodeError as e:
             self._raiseBadValu(valu)
 
-        if not fqdnre.match(valu):
-            self._raiseBadValu(valu)
-
         parts = valu.split('.', 1)
         subs = {'host': parts[0]}
         if len(parts) == 2:

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -105,6 +105,7 @@ class FqdnType(DataType):
             return valu.encode('utf8').decode('idna')
         except UnicodeError as e:
             if len(valu) >= 4 and valu[0:4] == 'xn--':
+                logger.exception(msg='Failed to IDNA decode ACE prefixed inet:fqdn')
                 return valu
             raise  # pragma: no cover
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -101,7 +101,12 @@ class FqdnType(DataType):
         return valu, subs
 
     def repr(self, valu):
-        return valu.encode('utf8').decode('idna')
+        try:
+            return valu.encode('utf8').decode('idna')
+        except UnicodeError as e:
+            if len(valu) >= 4 and valu[0:4] == 'xn--':
+                return valu
+            raise  # pragma: no cover
 
 class Rfc2822Addr(DataType):
     '''

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -178,6 +178,8 @@ class InetModelTest(SynTest):
             self.eq(t0[1].get('inet:ipv4'), 0x01020304)
             self.eq(t0[1].get('inet:ipv4:asn'), -1)
 
+            self.raises(BadTypeValu, core.formTufoByProp, 'inet:ipv4', [])
+
     def test_model_inet_ipv6(self):
 
         with self.getRamCore() as core:

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -380,10 +380,9 @@ class InetModelTest(SynTest):
             tufo = core.getTufoByProp(prop, valu)
             self.eq(tufo[1][prop], valu)
 
-            # FIXME
-            # I think we should either not allow this data in or catch the exception
-            # and return it in its raw form during repr.
-            core.getTypeRepr(prop, tufo[1][prop])
+            # Catch invalid IDNA error and just return the raw data
+            self.eq(core.getTypeRepr(prop, tufo[1][prop]), valu)
+            self.eq(core.getPropRepr(prop, tufo[1][prop]), valu)
 
     def test_model_inet_fqdn_set_sfx(self):
         with self.getRamCore() as core:

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -330,6 +330,7 @@ class InetModelTest(SynTest):
             prop = 'inet:fqdn'
             idna_valu = 'xn--tst-6la.xn--xampl-3raf.link'
             unicode_valu = 'tèst.èxamplè.link'
+            unicode_cap_valu = 'tèst.èxaMplè.link'
             parents = (
                     ('xn--xampl-3raf.link', {'inet:fqdn:host': 'xn--xampl-3raf', 'inet:fqdn:domain': 'link', 'inet:fqdn:zone': 1, 'inet:fqdn:sfx': 0}),
                     ('link', {'inet:fqdn:host': 'link', 'inet:fqdn:domain': None, 'inet:fqdn:zone': 0, 'inet:fqdn:sfx': 1}),
@@ -347,7 +348,9 @@ class InetModelTest(SynTest):
 
             idna_tufo = core.formTufoByProp(prop, idna_valu)
             unicode_tufo = core.formTufoByProp(prop, unicode_valu)
+            unicode_cap_tufo = core.formTufoByProp(prop, unicode_cap_valu)
             self.eq(unicode_tufo, idna_tufo)
+            self.eq(unicode_tufo, unicode_cap_tufo)
 
         with self.getRamCore() as core:
             prop = 'inet:web:acct'

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -368,6 +368,23 @@ class InetModelTest(SynTest):
             tufo = core.formTufoByProp(prop, valu)
             self.eq(tufo[1].get('inet:url'), 'https://xn--tst-6la.xn--xampl-3raf.link/things') # hostpart is not normed in inet:url
 
+    def test_model_inet_fqdn_idna(self):
+
+        with self.getRamCore() as core:
+            prop = 'inet:fqdn'
+            valu = 'xn--lskfjaslkdfjaslfj.link'
+
+            tufo = core.formTufoByProp(prop, valu)
+            self.eq(tufo[1][prop], valu)
+
+            tufo = core.getTufoByProp(prop, valu)
+            self.eq(tufo[1][prop], valu)
+
+            # FIXME
+            # I think we should either not allow this data in or catch the exception
+            # and return it in its raw form during repr.
+            core.getTypeRepr(prop, tufo[1][prop])
+
     def test_model_inet_fqdn_set_sfx(self):
         with self.getRamCore() as core:
             tufo = core.formTufoByProp('inet:fqdn', 'abc.dyndns.com') # abc.dyndns.com - zone=0 sfx=0, dyndns.com - zone=1 sfx=0, com - zone=0 sfx=1


### PR DESCRIPTION
Return raw data for inet:fqdn repr where domain starts with xn-- but isn't a valid internationalized domain name