### PR TITLE
Add `seen:min` and `seen:max` to `ps:has*`

### DIFF
--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -140,26 +140,36 @@ class PsMod(CoreModule):
                 ('ps:hasuser', {'ptype': 'ps:hasuser'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('user', {'ptype': 'inet:user'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
                 )),
 
                 ('ps:hasalias', {'ptype': 'ps:hasalias'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('alias', {'ptype': 'ps:name'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
                 )),
 
                 ('ps:hasphone', {'ptype': 'ps:hasphone'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('phone', {'ptype': 'tel:phone'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
                 )),
 
                 ('ps:hasemail', {'ptype': 'ps:hasemail'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('email', {'ptype': 'inet:email'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
                 )),
 
                 ('ps:haswebacct', {'ptype': 'ps:haswebacct'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('web:acct', {'ptype': 'inet:web:acct'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
                 )),
             ),
         }

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -151,6 +151,13 @@ class PsMod(CoreModule):
                     ('seen:max', {'ptype': 'time:max'}),
                 )),
 
+                ('ps:hashost', {'ptype': 'ps:hashost'}, (
+                    ('person', {'ptype': 'ps:person'}),
+                    ('host', {'ptype': 'it:host'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
+                )),
+
                 ('ps:hasphone', {'ptype': 'ps:hasphone'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('phone', {'ptype': 'tel:phone'}),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -61,7 +61,7 @@ class PsMod(CoreModule):
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
                 ('ps:hasuser', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|user,inet:user'}),
-                ('ps:hashost', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|host,it:host'}),
+                ('ps:hashost', {'subof': 'comp', 'fields': 'person=ps:person,host=it:host'}),
                 ('ps:hasalias', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|alias,ps:name'}),
                 ('ps:hasphone', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|phone,tel:phone'}),
                 ('ps:hasemail', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|email,inet:email'}),

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -74,3 +74,25 @@ def checkLock(fd, timeout, wait=0.5):
         wtime += wait
         if wtime >= timeout:
             return False
+
+class ModelSeenMixin:
+
+    def check_seen(self, core, node):
+        form = node[1]['tufo:form']
+        minp = form + ':seen:min'
+        maxp = form + ':seen:max'
+
+        self.none(node[1].get(minp))
+        self.none(node[1].get(maxp))
+
+        core.setTufoProps(node, **{'seen:min': 100, 'seen:max': 100})
+        self.eq(node[1].get(minp), 100)
+        self.eq(node[1].get(maxp), 100)
+
+        core.setTufoProps(node, **{'seen:min': 0, 'seen:max': 0})
+        self.eq(node[1].get(minp), 0)
+        self.eq(node[1].get(maxp), 100)
+
+        core.setTufoProps(node, **{'seen:min': 1000, 'seen:max': 1000})
+        self.eq(node[1].get(minp), 0)
+        self.eq(node[1].get(maxp), 1000)

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -1,26 +1,6 @@
 from synapse.tests.common import *
 
-class PersonTest(SynTest):
-
-    def _check_seen(self, core, node):
-        form = node[1]['tufo:form']
-        minp = form + ':seen:min'
-        maxp = form + ':seen:max'
-
-        self.none(node[1].get(minp))
-        self.none(node[1].get(maxp))
-
-        core.setTufoProps(node, **{'seen:min': 100, 'seen:max': 100})
-        self.eq(node[1].get(minp), 100)
-        self.eq(node[1].get(maxp), 100)
-
-        core.setTufoProps(node, **{'seen:min': 0, 'seen:max': 0})
-        self.eq(node[1].get(minp), 0)
-        self.eq(node[1].get(maxp), 100)
-
-        core.setTufoProps(node, **{'seen:min': 1000, 'seen:max': 1000})
-        self.eq(node[1].get(minp), 0)
-        self.eq(node[1].get(maxp), 1000)
+class PersonTest(SynTest, ModelSeenMixin):
 
     def test_model_person(self):
 
@@ -98,7 +78,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('inet:user', 'visi'))
 
-            self._check_seen(core, node)
+            self.check_seen(core, node)
 
     def test_model_person_has_alias(self):
         with self.getRamCore() as core:
@@ -111,7 +91,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('ps:name', 'kenshoto,invisigoth'))
 
-            self._check_seen(core, node)
+            self.check_seen(core, node)
 
     def test_model_person_has_phone(self):
         with self.getRamCore() as core:
@@ -124,7 +104,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('tel:phone', 17035551212))
 
-            self._check_seen(core, node)
+            self.check_seen(core, node)
 
     def test_model_person_has_email(self):
         with self.getRamCore() as core:
@@ -137,7 +117,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('inet:email', 'visi@vertex.link'))
 
-            self._check_seen(core, node)
+            self.check_seen(core, node)
 
     def test_model_person_has_webacct(self):
         with self.getRamCore() as core:
@@ -151,7 +131,7 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('inet:user', 'visi'))
             self.nn(core.getTufoByProp('inet:web:acct', 'rootkit.com/visi'))
 
-            self._check_seen(core, node)
+            self.check_seen(core, node)
 
     def test_model_person_guidname(self):
 

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -68,18 +68,6 @@ class PersonTest(SynTest, ModelSeenMixin):
             self.nn(core.getTufoByProp('ps:tokn', 'kenshoto'))
             self.nn(core.getTufoByProp('ps:tokn', 'invisigoth'))
 
-    def test_model_person_has_user(self):
-        with self.getRamCore() as core:
-            iden = guid()
-            node = core.formTufoByProp('ps:hasuser', '%s/visi' % iden)
-
-            self.eq(node[1].get('ps:hasuser:user'), 'visi')
-            self.eq(node[1].get('ps:hasuser:person'), iden)
-            self.nn(core.getTufoByProp('ps:person', iden))
-            self.nn(core.getTufoByProp('inet:user', 'visi'))
-
-            self.check_seen(core, node)
-
     def test_model_person_has_alias(self):
         with self.getRamCore() as core:
             iden = guid()
@@ -90,6 +78,35 @@ class PersonTest(SynTest, ModelSeenMixin):
 
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('ps:name', 'kenshoto,invisigoth'))
+
+            self.check_seen(core, node)
+
+    def test_model_person_has_host(self):
+        with self.getRamCore() as core:
+            pval = 32 * 'a'
+            hval = 32 * 'b'
+
+            node = core.formTufoByProp('ps:hashost', (pval, hval))
+
+            self.eq(node[1]['ps:hashost'], '%s/%s' % (pval, hval))
+            self.eq(node[1].get('ps:hashost:host'), hval)
+            self.eq(node[1].get('ps:hashost:person'), pval)
+
+            self.nn(core.getTufoByProp('ps:person', pval))
+            self.nn(core.getTufoByProp('it:host', hval))
+
+            self.check_seen(core, node)
+
+    def test_model_person_has_email(self):
+        with self.getRamCore() as core:
+            iden = guid()
+            node = core.formTufoByProp('ps:hasemail', '%s/visi@VERTEX.link' % iden)
+
+            self.eq(node[1].get('ps:hasemail:email'), 'visi@vertex.link')
+            self.eq(node[1].get('ps:hasemail:person'), iden)
+
+            self.nn(core.getTufoByProp('ps:person', iden))
+            self.nn(core.getTufoByProp('inet:email', 'visi@vertex.link'))
 
             self.check_seen(core, node)
 
@@ -106,16 +123,15 @@ class PersonTest(SynTest, ModelSeenMixin):
 
             self.check_seen(core, node)
 
-    def test_model_person_has_email(self):
+    def test_model_person_has_user(self):
         with self.getRamCore() as core:
             iden = guid()
-            node = core.formTufoByProp('ps:hasemail', '%s/visi@VERTEX.link' % iden)
+            node = core.formTufoByProp('ps:hasuser', '%s/visi' % iden)
 
-            self.eq(node[1].get('ps:hasemail:email'), 'visi@vertex.link')
-            self.eq(node[1].get('ps:hasemail:person'), iden)
-
+            self.eq(node[1].get('ps:hasuser:user'), 'visi')
+            self.eq(node[1].get('ps:hasuser:person'), iden)
             self.nn(core.getTufoByProp('ps:person', iden))
-            self.nn(core.getTufoByProp('inet:email', 'visi@vertex.link'))
+            self.nn(core.getTufoByProp('inet:user', 'visi'))
 
             self.check_seen(core, node)
 

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -88,7 +88,7 @@ class PersonTest(SynTest, ModelSeenMixin):
 
             node = core.formTufoByProp('ps:hashost', (pval, hval))
 
-            self.eq(node[1]['ps:hashost'], '%s/%s' % (pval, hval))
+            self.eq(node[1]['ps:hashost'], '20ffcd864aeb7f4f6e23d95680eeed47')
             self.eq(node[1].get('ps:hashost:host'), hval)
             self.eq(node[1].get('ps:hashost:person'), pval)
 

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -1,7 +1,26 @@
-
 from synapse.tests.common import *
 
 class PersonTest(SynTest):
+
+    def _check_seen(self, core, node):
+        form = node[1]['tufo:form']
+        minp = form + ':seen:min'
+        maxp = form + ':seen:max'
+
+        self.none(node[1].get(minp))
+        self.none(node[1].get(maxp))
+
+        core.setTufoProps(node, **{'seen:min': 100, 'seen:max': 100})
+        self.eq(node[1].get(minp), 100)
+        self.eq(node[1].get(maxp), 100)
+
+        core.setTufoProps(node, **{'seen:min': 0, 'seen:max': 0})
+        self.eq(node[1].get(minp), 0)
+        self.eq(node[1].get(maxp), 100)
+
+        core.setTufoProps(node, **{'seen:min': 1000, 'seen:max': 1000})
+        self.eq(node[1].get(minp), 0)
+        self.eq(node[1].get(maxp), 1000)
 
     def test_model_person(self):
 
@@ -76,9 +95,10 @@ class PersonTest(SynTest):
 
             self.eq(node[1].get('ps:hasuser:user'), 'visi')
             self.eq(node[1].get('ps:hasuser:person'), iden)
-
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('inet:user', 'visi'))
+
+            self._check_seen(core, node)
 
     def test_model_person_has_alias(self):
         with self.getRamCore() as core:
@@ -91,6 +111,8 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('ps:name', 'kenshoto,invisigoth'))
 
+            self._check_seen(core, node)
+
     def test_model_person_has_phone(self):
         with self.getRamCore() as core:
             iden = guid()
@@ -101,6 +123,8 @@ class PersonTest(SynTest):
 
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('tel:phone', 17035551212))
+
+            self._check_seen(core, node)
 
     def test_model_person_has_email(self):
         with self.getRamCore() as core:
@@ -113,6 +137,8 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('inet:email', 'visi@vertex.link'))
 
+            self._check_seen(core, node)
+
     def test_model_person_has_webacct(self):
         with self.getRamCore() as core:
             iden = guid()
@@ -124,6 +150,8 @@ class PersonTest(SynTest):
             self.nn(core.getTufoByProp('ps:person', iden))
             self.nn(core.getTufoByProp('inet:user', 'visi'))
             self.nn(core.getTufoByProp('inet:web:acct', 'rootkit.com/visi'))
+
+            self._check_seen(core, node)
 
     def test_model_person_guidname(self):
 


### PR DESCRIPTION
- Should this also be added to `ou:has*`?
    - Yes, and I just added it
- `ps:hashost` only has a type definition and seems to be unused. Should we remove it? Make it a form?
    - Yes, make it a form
    - Done
- Should _check_seen(...) be moved to synapse/lib/iq.py?
    - No, we can add it as a mixin though
    - Done