### PR TITLE
Add --jsonl to option to cryocat

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -99,7 +99,7 @@ The following items should be considered when contributing to Synapse:
             Summary line goes first.
 
             Longer description lives here. It can be a bunch of stuff across
-            multiple blocks if neccesary.
+            multiple blocks if necessary.
 
             Example:
                 Examples should be given using either the ``Example`` section.
@@ -255,7 +255,7 @@ The following items should be considered when contributing to Synapse:
 
      # -*- coding: utf-8 -*-
 
-* Convenience methods are availible for unit tests, primarily through the
+* Convenience methods are available for unit tests, primarily through the
   SynTest class. This is a subclass of unittest.TestCase and provides many
   short aliases for the assert* functions that TestCase provides.
 
@@ -268,7 +268,7 @@ The following items should be considered when contributing to Synapse:
   module. Additionally, ``regex`` does provide some performance benefits over
   ``re``, especially when using pre-compiled regular expression statements.
 
-* Whenever possible, regular expressions should be pre-compiled. String 
+* Whenever possible, regular expressions should be pre-compiled. String
   matches/comparisons should be performed against the pre-compiled regex instance.
 
   ::
@@ -290,7 +290,7 @@ The following items should be considered when contributing to Synapse:
   error.  The logic behind this is that it is much easier, cleaner, faster to
   check a return value than to handle an exception.
 
-  Raising exceptions is reserved for "exceptional circumstances" and should 
+  Raising exceptions is reserved for "exceptional circumstances" and should
   NEVER be used for normal program flow.
 
   ::

--- a/synapse/tests/test_tools_cryo_cat.py
+++ b/synapse/tests/test_tools_cryo_cat.py
@@ -44,7 +44,7 @@ class CryoCatTest(SynTest):
                 self.isin('Currently requires --authfile', log_msgs)
 
                 outp = self.getTestOutp()
-                argv = ['--list', '--authfile', authfp, addr]
+                argv = ['-v', '--list', '--authfile', authfp, addr]
                 self.eq(s_cryocat.main(argv, outp), 0)
                 self.true(outp.expect('test:hehe'))
                 self.true(outp.expect('test:haha'))

--- a/synapse/tests/test_tools_cryo_cat.py
+++ b/synapse/tests/test_tools_cryo_cat.py
@@ -37,8 +37,9 @@ class CryoCatTest(SynTest):
 
                 outp = self.getTestOutp()
                 argv = ['--list', addr]
-                self.eq(s_cryocat.main(argv, outp), 1)
-                self.true(outp.expect('Currently requires --authfile'))
+                with self.assertLogs(logger='synapse.tools.cryo.cat', level='ERROR') as logs:
+                    self.eq(s_cryocat.main(argv, outp), 1)
+                self.true(logs[0][0].message.startswith('Currently requires --authfile'))
 
                 outp = self.getTestOutp()
                 argv = ['--list', '--authfile', authfp, addr]
@@ -50,6 +51,11 @@ class CryoCatTest(SynTest):
                 argv = ['--offset', '0', '--size', '1', '--authfile', authfp, addr]
                 self.eq(s_cryocat.main(argv, outp), 0)
                 self.true(outp.expect("(0, (None, {'key': 0}))"))
+
+                outp = self.getTestOutp()
+                argv = ['--offset', '0', '--jsonl', '--size', '2', '--authfile', authfp, addr]
+                self.eq(s_cryocat.main(argv, outp), 0)
+                self.true(outp.expect('[0, [null, {"key": 0}]]\n[1, [null, {"key": 1}]]\n'))
 
                 outp = self.getTestOutp()
                 argv = ['--offset', '0', '--size', '20', '--authfile', authfp, addr]

--- a/synapse/tests/test_tools_cryo_cat.py
+++ b/synapse/tests/test_tools_cryo_cat.py
@@ -37,9 +37,11 @@ class CryoCatTest(SynTest):
 
                 outp = self.getTestOutp()
                 argv = ['--list', addr]
-                with self.assertLogs(logger='synapse.tools.cryo.cat', level='ERROR') as logs:
+                with self.getLoggerStream('synapse.tools.cryo.cat') as stream:
                     self.eq(s_cryocat.main(argv, outp), 1)
-                self.true(logs[0][0].message.startswith('Currently requires --authfile'))
+                stream.seek(0)
+                log_msgs = stream.read()
+                self.isin('Currently requires --authfile', log_msgs)
 
                 outp = self.getTestOutp()
                 argv = ['--list', '--authfile', authfp, addr]
@@ -55,7 +57,7 @@ class CryoCatTest(SynTest):
                 outp = self.getTestOutp()
                 argv = ['--offset', '0', '--jsonl', '--size', '2', '--authfile', authfp, addr]
                 self.eq(s_cryocat.main(argv, outp), 0)
-                self.true(outp.expect('[0, [null, {"key": 0}]]\n[1, [null, {"key": 1}]]\n'))
+                self.true(outp.expect('[null, {"key": 0}]\n[null, {"key": 1}]\n'))
 
                 outp = self.getTestOutp()
                 argv = ['--offset', '0', '--size', '20', '--authfile', authfp, addr]

--- a/synapse/tools/cryo/cat.py
+++ b/synapse/tools/cryo/cat.py
@@ -12,7 +12,7 @@ import synapse.lib.msgpack as s_msgpack
 
 logger = logging.getLogger(__name__)
 
-def main(argv, outp=s_output.stdout, errfd=sys.stderr):
+def main(argv, outp=s_output.stdout):
 
     pars = argparse.ArgumentParser(prog='cryo.cat', description='display data items from a cryo cell')
     pars.add_argument('cryocell', help='The cell descriptor and cryo tank path (cell://<host:port>/<name>).')
@@ -22,12 +22,17 @@ def main(argv, outp=s_output.stdout, errfd=sys.stderr):
     pars.add_argument('--timeout', default=10, type=int, help='The network timeout setting')
     pars.add_argument('--authfile', help='Path to your auth file for the remote cell')
     pars.add_argument('--jsonl', default=False, action='store_true', help='Output items in jsonl format')
+    pars.add_argument('--verbose', '-v', default=False, action='store_true', help='Verbose output')
 
     # TODO: make input mode using stdin...
     # TODO: make --jsonl output form for writing to file
     # TODO: make --no-index option that prints just the item
 
     opts = pars.parse_args(argv)
+
+    if opts.verbose:
+        logger.addHandler(logging.StreamHandler())
+        logger.setLevel(logging.INFO)
 
     if not opts.authfile:
         logger.error('Currently requires --authfile until neuron protocol is supported')
@@ -53,7 +58,7 @@ def main(argv, outp=s_output.stdout, errfd=sys.stderr):
 
     for item in cryo.slice(path, opts.offset, opts.size, opts.timeout):
         if opts.jsonl:
-            outp.printf(json.dumps(item, sort_keys=True))
+            outp.printf(json.dumps(item[1], sort_keys=True))
         else:
             outp.printf(pprint.pformat(item))
 

--- a/synapse/tools/cryo/cat.py
+++ b/synapse/tools/cryo/cat.py
@@ -31,7 +31,6 @@ def main(argv, outp=s_output.stdout):
     opts = pars.parse_args(argv)
 
     if opts.verbose:
-        logger.addHandler(logging.StreamHandler())
         logger.setLevel(logging.INFO)
 
     if not opts.authfile:
@@ -65,4 +64,5 @@ def main(argv, outp=s_output.stdout):
     return 0
 
 if __name__ == '__main__':  # pragma: no cover
+    logging.basicConfig()
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
synapse.tools.cryo.cat now accepts a --jsonl option that causes items to be output in jsonl, a newline delimited json format.

Also change status output to go to stderr to enable piping the output.