### PR TITLE
Autodoc configable

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = python -m sphinx
 SPHINXAPIDOC  = sphinx-apidoc
 PAPER         =
 BUILDDIR      = _build

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -86,7 +86,7 @@ The following items should be considered when contributing to Synapse:
   - Google Style typically has the summary line after the opening ''' marker.
     Place this summary value on the new line following the opening ''' marker.
   - More information about Google Style docstrings (and examples) can be found
-    `here <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`_.
+    at the `examples here <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`_.
   - We use Napoleon for parsing these doc strings. More info `here <https://sphinxcontrib-napoleon.readthedocs.io>`_.
   - Synapse as a project is not written using the Napoleon format currently
     but all new modules should audhere to that format.
@@ -468,8 +468,6 @@ This does require docker and docker-compose to be installed and working.
       Ran 1 test in 12.006s
 
       OK
-
-   ::
 
 #. Tear down the PSQL container when done with it.
 

--- a/docs/synapse/devopsguides/cortex_storage_details.rst
+++ b/docs/synapse/devopsguides/cortex_storage_details.rst
@@ -186,6 +186,7 @@ of rows which the Cortex can turn into tufos as needed.
 
 The default implementations of these functions are just wrappers for
 joinsByLe / joinsByGt, respectively.
+
   - joinsByLt(self, prop, valu, limit=None):
   - joinsByGt(self, prop, valu, limit=None):
 

--- a/docs/synapse/devopsguides/cortex_storage_types.rst
+++ b/docs/synapse/devopsguides/cortex_storage_types.rst
@@ -45,7 +45,7 @@ inverse is also true; a Cortex created in 3.x may not work in Python2.7 as expec
 This is known to affect the LMDB Cortex implementation, which heavily relies on using msgpack
 for doing key/value serialization, which has issues across python 2/3 with string handling.
 The Blob store APIs may also be affected by this, since the stored data is stored as a
- sgpack'd object.
+msgpack'd object.
 
 If there is a need for doing a data migration in order to ensure that your able to access a
 Cortex created on 2.7 with python 3.x, we have plans to provide a row level dump/backup tool

--- a/docs/synapse/devopsguides/deployment.rst
+++ b/docs/synapse/devopsguides/deployment.rst
@@ -17,6 +17,7 @@ Install
 -------
 Ubuntu 16.04 LTS is the recommended platform for installation. Installation via Docker is also
 supported. Synapse is available at the following places:
+
     #. PyPi https://pypi.python.org/pypi/synapse
     #. Github https://github.com/vertexproject/synapse
     #. DockerHub https://hub.docker.com/r/vertexproject/synapse/

--- a/docs/synapse/userguides/ug012_storm_ref_datamod.rst
+++ b/docs/synapse/userguides/ug012_storm_ref_datamod.rst
@@ -44,18 +44,21 @@ Adds the specified node(s) to a Cortex.
 
 *Simple Node:*
 ::
+
   addnode( inet:fqdn , woot.com )
   
   [ inet:fqdn = woot.com ]
 
 *Separator (sepr) Node:*
 ::
+
   addnode( inet:dns:a , ( woot.com , 1.2.3.4 ) )
   
   [ inet:dns:a = ( woot.com , 1.2.3.4 ) ]
 
 *Composite (comp) Node:*
 ::
+
   addnode( inet:follows , (twitter.com/ernie , twitter.com/bert ) )
   
   [ inet:follows = ( twitter.com/ernie , twitter.com/bert ) ]
@@ -66,12 +69,14 @@ Todo
 
 *Cross-reference (xref) Node:*
 ::
+
   addnode( file:txtref , ( d41d8cd98f00b204e9800998ecf8427e , inet:fqdn , woot.com ) )
   
   [ file:txtref = ( d41d8cd98f00b204e9800998ecf8427e , inet:fqdn , woot.com ) ]
 
 *Node with Properties:*
 ::
+
   addnode( inet:dns:a , ( woot.com , 1.2.3.4 ) , :seen:min = "2017-08-01 01:23" , 
       :seen:max = "2017-08-10 04:56" )
   
@@ -113,6 +118,7 @@ None.
 
 **Examples:**
 ::
+
   file:bytes = d41d8cd98f00b204e9800998ecf8427e addxref( file:txtref , inet:fqdn , woot.com )
 
 **Usage Notes:**
@@ -140,6 +146,7 @@ Sets one or more property values on the specified node(s).
 
 **Examples:**
 ::
+
   inet:dns:a = woot.com/1.2.3.4 setprop( :seen:min = "2017-08-01 01:23" , 
       :seen:max = "2017-08-10 04:56" )
   
@@ -182,18 +189,21 @@ Adds one or more tags to the specified node(s).
 
 *Add Tags*
 ::
+
   inet:fqdn = woot.com addtag( foo.bar , baz.faz )
   
   inet:fqdn = woot.com [ #foo.bar #baz.faz ]
 
 *Add Tag with Single Timestamp*
 ::
+
   inet:fqdn = woot.com addtag( baz.faz@201708151330 )
   
   inet:fqdn = woot.com [ #baz.faz@201708151330 ]
 
 *Add Tag with Time Boundaries*
 ::
+
   inet:fqdn = woot.com addtag( baz.faz@20160101-20160131 )
   
   inet:fqdn = woot.com [ #baz.faz@20160101-20160131 ]
@@ -238,6 +248,7 @@ None.
 
 **Examples:**
 ::
+
   inet:fqdn = woot.com delnode()
   
   inet:fqdn = woot.com delnode(force=1)
@@ -268,6 +279,7 @@ Delete a property from the specified node(s).
 
 **Examples:**
 ::
+
   # Operator examples
 
   inet:fqdn = vertex.link delprop(:created)
@@ -320,6 +332,7 @@ Deletes one or more tags from the specified node(s).
 
 **Examples:**
 ::
+
   inet:fqdn = woot.com deltag( baz.faz )
   
   inet:fqdn = woot.com [ -#baz.faz ]

--- a/docs/synapse/userguides/ug013_storm_ref_lift.rst
+++ b/docs/synapse/userguides/ug013_storm_ref_lift.rst
@@ -50,6 +50,7 @@ Lift operations are highly flexible. Only basic examples of ``lift()`` usage are
 
 * Lift all domain nodes:
   ::
+
     lift( inet:fqdn )
     
     inet:fqdn
@@ -58,6 +59,7 @@ Lift operations are highly flexible. Only basic examples of ``lift()`` usage are
 
 * Lift all ``inet:fqdn`` nodes that have an ``:updated`` secondary property:
   ::
+
     lift( inet:fqdn:updated )
     
     inet:fqdn:updated
@@ -66,6 +68,7 @@ Lift operations are highly flexible. Only basic examples of ``lift()`` usage are
 
 * Lift the node for domain ``woot.com``:
   ::
+
     lift( inet:fqdn , woot.com )
     
     inet:fqdn = woot.com
@@ -74,6 +77,7 @@ Lift operations are highly flexible. Only basic examples of ``lift()`` usage are
 
 * Lift all DNS A record nodes where the domain is ``woot.com``:
   ::
+
     lift( inet:dns:a:fqdn , woot.com )
     
     inet:dns:a:fqdn = woot.com
@@ -82,12 +86,14 @@ Lift operations are highly flexible. Only basic examples of ``lift()`` usage are
 
 * Lift 10 domain nodes:
   ::
+
     lift( inet:fqdn , limit=10 )
     
     inet:fqdn^10
   
 * Lift 25 DNS A record nodes where the IP is ``127.0.0.1``:
   ::
+
     lift( inet:dns:a:ipv4 , 127.0.0.1 , limit=25)
     
     inet:dns:a:ipv4^25=127.0.0.1
@@ -98,12 +104,14 @@ A single example using a "by" handler is provided for illustrative purposes. Ind
 
 * Lift by tag: lift all ``inet:fqdn`` nodes that have the tag ``my.tag``:
   ::
+
     lift( inet:fqdn , by=tag , my.tag)
     
     inet:fqdn*tag=my.tag
   
 * Lift 10 ``inet:fqdn`` nodes with the tag ``my.tag``:
   ::
+
     lift(inet:fqdn,limit=10,by=tag,my.tag)
     
     inet:fqdn^10*tag=my.tag
@@ -139,12 +147,14 @@ A single example using a "by" handler is provided for illustrative purposes. Ind
 
 * The number of nodes returned by any query can also be restricted by using the ``limit()`` operator_. The first set of examples below uses the *limit* parameter to the ``lift()`` operator (in both operator and macro syntax). The second set of examples uses the ``limit()`` operator (in both operator and macro syntax - note that the macro syntax is equivalent in each case).
   ::
+
     lift ( inet:fqdn , limit=10 )
     
     inet:fqdn^10
 
   vs.
   ::
+
     lift ( inet:fqdn ) limit( 10 )
     
     inet:fqdn^10
@@ -166,6 +176,7 @@ N/A
 
 **Examples:**
 ::
+
   guid( a4d82cf025323796617ff57e884a4738 )
   
   guid( 6472c5f038b0a4e5b1853c49e688fc74 , 5413b2ae7632a0909d63d31a33ec0807 )
@@ -175,6 +186,7 @@ N/A
 * The GUID is a unique identifier assigned to every node. (This identifier is **not** the GUID value used as a primary property by some forms). This GUID is frequently referred to as the ``iden`` in API documentation.
 * The GUID for a node or set of nodes can be displayed at the Synapse CLI by using the ``ask --raw`` option preceding a Storm query. For example, in the query output below, ``b19fe2a26bbe4a6c74b051142d0e5316`` is the GUID for the requested node:
   ::
+
     ask --raw inet:ipv4=1.2.3.4
     [
       [
@@ -217,12 +229,14 @@ Optional parameters:
 
 *Lifts all nodes that have the tag foo.bar or the tag baz.faz.*
 ::
+
   alltag( foo.bar , baz.faz )
   
   #foo.bar #baz.faz
 
 *Lifts up to three nodes that have the tag foo.bar*
 ::
+
   alltag( foo.bar , limit=3)
 
   #foo.bar limit(3)

--- a/docs/synapse/userguides/ug014_storm_ref_filter.rst
+++ b/docs/synapse/userguides/ug014_storm_ref_filter.rst
@@ -35,30 +35,35 @@ These basic examples all use the "equals" comparator. See below for additional e
 
 * Downselect to include only domains:
   ::
+
     +inet:fqdn
 
 *Filter by primary <prop> / <valu>:*
 
 * Downselect to exclude the domain google.com:
   ::
+
     -inet:fqdn = google.com
     
 *Filter by secondary property:*
 
 * Downselect to exclude domains with an "expires" property:
   ::
+
     -inet:fqdn:expires
     
 *Filter by secondary <prop> / <valu>:*
 
 * Downselect to include only those domains that are also logical zones:
   ::
+
     +inet:fqdn:zone = 1
  
 *Filter by tag:*
 
 * Downselect to exclude nodes tagged as associated with Tor:
   ::
+
     -#anon.tor
     
 **Usage Notes:**
@@ -89,30 +94,35 @@ Filter operations can be performed using any of the standard mathematical / logi
 
 * Downselect to include only domains created before January 1, 2017:
   ::
+
     +inet:fqdn:created < "20170101"
 
 *Greater than:*
 
 * Downselect to exclude files larger than 4096 bytes:
   ::
+
     -file:bytes:size > 4096
     
 *Less than or equal to:*
 
 * Downselect to include only DNS A records whose most recent observed time was on or before March 15, 2014 at 12:00 UTC:
   ::
+
     +inet:dns:a:seen:max <= "201403151200"
     
 *Greater than or equal to:*
 
 * Downselect to include only people born on or after January 1, 1980:
   ::
+
     +ps:person:dob >= "19800101"
     
 *Regular expression:*
 
 * Downselect to include only domains that start with the string "serve":
   ::
+
     +inet:fqdn ~= "serve*"
     
 **Usage Notes:**

--- a/docs/synapse/userguides/ug015_storm_ref_pivot.rst
+++ b/docs/synapse/userguides/ug015_storm_ref_pivot.rst
@@ -39,6 +39,7 @@ Optional parameters:
 
 * Pivot from a set of domains (``inet:fqdn`` nodes) in the working set to the DNS A records for those domains:
   ::
+
     pivot( inet:fqdn, inet:dns:a:fqdn )
     
     pivot( inet:dns:a:fqdn )
@@ -49,12 +50,14 @@ Optional parameters:
 
 * Pivot from a set of domains in the working set to the DNS A records for those domains, but limit the results to 10 nodes:
   ::
+
     pivot( inet:fqdn, inet:dns:a:fqdn, limit=10 )
     
     pivot( inet:dns:a:fqdn, limit=10 )
 
 * Pivot from a set of domains in the working set to the DNS A records for those domains, and from the IP addresses in the DNS A records to the associated set of IPv4 nodes (e.g., pivot from a set of domains to the set of IP addresses the domains resolved to).
   ::
+
     pivot( inet:fqdn, inet:dns:a:fqdn ) pivot( inet:dns:a:ipv4, inet:ipv4 )
       
     pivot( inet:dns:a:fqdn ) pivot( :ipv4, inet:ipv4 )
@@ -66,6 +69,7 @@ Optional parameters:
 
 * Pivot from a set of domains in the working set to the set of immediate subdomains for those domains:
   ::
+
     pivot( inet:fqdn, inet:fqdn:domain )
     
     pivot( inet:fqdn:domain )
@@ -76,6 +80,7 @@ Optional parameters:
 
 * Pivot from a set of email addresses in the working set to the set of domains registered to those email addresses.
   ::
+
     pivot( inet:email, inet:whois:regmail:email )
       pivot( inet:whois:regmail:fqdn, inet:fqdn )
     
@@ -88,6 +93,7 @@ Optional parameters:
 
 * Pivot from a set of email addresses in the working set to the set of whois records associated with those email addresses.
   ::
+
     pivot( inet:email, inet:whois:contact:email )
       pivot( inet:whois:contact:rec, inet:whois:rec )
     
@@ -132,6 +138,7 @@ Optional parameters:
 
 * Given a set of domains (``inet:fqdn``) in the working set, return the domains and their set of immediate subdomains:
   ::
+
     join( inet:fqdn, inet:fqdn:domain )
     
     join( inet:fqdn:domain )
@@ -142,6 +149,7 @@ Optional parameters:
 
 * Given a set of email addresses (``inet:email``) in the working set, return the email addresses and the set of domain / registrant email (``inet:whois:regmail``) records associated with those email addresses:
   ::
+
     join( inet:email, inet:whois:regmail:email )
     
     join( inet:whois:regmail:email )
@@ -152,6 +160,7 @@ Optional parameters:
 
 * Given a set of DNS SOA records (``inet:dns:soa``) in the working set, return the SOA records and the email addresses (``inet:email``) associated with them:
   ::
+
     join( inet:dns:soa:email, inet:email )
     
     join( :email, inet:email )
@@ -197,18 +206,21 @@ N/A
 
 * Return all of the nodes that **reference** a set of nodes:
   ::
+
     refs( in )
 
   Assume a set of ``inet:fqdn`` nodes in the working set. ``refs(in)`` will return any node with a secondary property type *<ptype> = <valu>* that matches the *<type> = <valu>* of those ``inet:fqdn`` nodes. For example, this may include ``inet:dns:a`` nodes (``inet:dns:a:fqdn``), ``inet:whois:rec`` nodes (``inet:whois:rec:fqdn``), additional ``inet:fqdn`` nodes (``inet:fqdn:domain``), etc.
 
 * Return all the nodes **referenced by** a set of nodes:
   ::
+
     refs( out )
 
   Assume a set of ``inet:dns:a`` nodes in the working set. ``refs(out)`` will return any node with a primary *<type> = <valu>* that matches any secondary property type *<ptype> = <valu>* in the working set. As an ``inet:dns:a`` record includes secondary properties of type ``inet:fqdn`` (``inet:dns:a:fqdn``) and ``inet:ipv4`` (``inet:dns:a:ipv4``), the query may return those node types.
 
 * Return all of the nodes that **reference** or are **referenced by** a set of nodes:
   ::
+
     refs()
 
   Assume a set of ``inet:email`` nodes in the working set. An ``inet:email`` *<type> = <valu>* may be referenced by *<ptype> = <valu>* from a variety of forms, including ``inet:whois:contact`` (``inet:whois:contact:email``), ``inet:dns:soa`` (``inet:dns:soa:email``) or ``inet:web:acct`` (``inet:web:acct:email``). Based on its secondary properties, a *<ptype> = <valu>* from an ``inet:email`` node may reference *<type> = <valu>* forms such as ``inet:fqdn`` (``inet:email:fqdn``) or ``inet:user`` (``inet:email:user``).
@@ -254,14 +266,17 @@ N/A
 
 * Return the set of all nodes to which a given set of tags have been applied:
   ::
+
     fromtags()
 
 * Return the set of ``inet:fqdn`` and ``inet:email`` nodes to which a given set of tags have been applied:
   ::
+
     fromtags( inet:fqdn, inet:email )
 
 * Return the set of ``inet:fqdn`` and ``inet:email`` nodes to which a given set of tags have been applied, limiting the number of results to 10:
   ::
+
     fromtags( inet:fqdn, inet:email, limit=10 )
 
 **Usage notes:**
@@ -308,16 +323,19 @@ N/A
 
 * Return the set of leaf tags applied to a given set of nodes:
   ::
+
     totags( leaf = 1 )
     
     totags()
 
 * Return all tags applied to a given set of nodes:
   ::
+
     totags( leaf = 0 )
 
 * Return 10 tags applied to a given set of nodes:
   ::
+
     totags( leaf = 0, limit = 10 )
 
 **Usage notes:**
@@ -326,6 +344,7 @@ N/A
 
 * As tags represent analytical observations or assessments, ``totags()`` can be useful for "summarizing" the set of assessments associated with a given set of nodes. For example, with respect to cyber threat data, assume you are using tags to track malicious activity associated with a particular threat cluster (threat group), such as "Threat Cluster 5". After retrieving all nodes tagged as part of that threat cluster, you can use ``totags()`` to list all other tags (analytical observations) that are associated with the nodes in that threat cluster. Depending on the analytical model (tag structure) you are using, those tags could represent the names of malware families, sets of tactics, techniques, and procedures (TTPs) used by the threat cluster, and so on:
   ::
+
     ask #cno.threat.t5.tc totags()
 
 * ``totags()`` and ``fromtags()`` are often used together to:
@@ -363,14 +382,17 @@ N/A
 
 * Return the set of nodes that share any of the tags applied to the working set of nodes:
   ::
+
     jointags()
 
 * Return the set of ``inet:fqdn`` and ``inet:email`` nodes that share any of the tags applied to the working set of nodes:
   ::
+
     jointags( inet:fqdn, inet:email )
 
 * Return the set of ``inet:fqdn`` and ``inet:email`` nodes that share any of the tags applied to the working set of nodes, limiting the number of results to 10:
   ::
+
     jointags( inet:fqdn, inet:email, limit=10 )
 
 **Usage notes:**
@@ -378,13 +400,13 @@ N/A
 * ``jointags()`` does **not** consume nodes by design and so includes (retains) the original working set as part of the resulting set.
 * ``jointags()`` joins using the set of leaf tags only. For example if nodes in the working set have the tag ``#foo.bar.baz``, ``jointags()`` will return other nodes with ``#foo.bar.baz``, but not nodes with ``#foo.bar`` or ``#foo`` alone.
 * ``jointags()``, like ``refs()``, can be useful to "explore" other nodes that share some analytical assessment (tag) with the working set of nodes, but may return a large number of nodes.
-It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
+  It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
 * The ``limit=`` parameter represents the maximum number of nodes **added** to the results.
-It can be provided as input to the ``jointags()`` operator itself when using Operator syntax.
-Alternately the ``limit()`` operator_ can be used after the ``jointags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
+  It can be provided as input to the ``jointags()`` operator itself when using Operator syntax.
+  Alternately the ``limit()`` operator_ can be used after the ``jointags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 
 pivottags()
-----------
+-----------
 Returns all nodes that have **any** of the tags applied to **any** node in the original working set; excludes the original working set from the results.
 
 Optional parameters:
@@ -411,14 +433,17 @@ N/A
 
 * Return the set of nodes that share any of the tags applied to the working set of nodes:
   ::
+
     pivottags()
 
 * Return the set of ``inet:fqdn`` and ``inet:email`` nodes that share any of the tags applied to the working set of nodes:
   ::
+
     pivottags( inet:fqdn, inet:email )
 
 * Return the set of ``inet:fqdn`` and ``inet:email`` nodes that share any of the tags applied to the working set of nodes, limiting the number of results to 10:
   ::
+
     pivottags( inet:fqdn, inet:email, limit=10 )
 
 **Usage notes:**
@@ -426,10 +451,10 @@ N/A
 * ``pivottags()`` consumes nodes input into the function, so the resulting set of nodes will **not** include nodes from the original working set.
 * ``pivottags()`` pivots using the set of leaf tags only. For example if nodes in the working set have the tag ``#foo.bar.baz``, ``pivottags()`` will return other nodes with ``#foo.bar.baz``, but not nodes with ``#foo.bar`` or ``#foo`` alone.
 * ``pivottags()``, like ``refs()``, can be useful to "explore" other nodes that share some analytical assessment (tag) with the working set of nodes, but may return a large number of nodes.
-It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
+  It may be more efficient to narrow the scope of the query using ``totags()`` in combination with a filter operator (e.g., to limit the specific tags selected) followed by ``fromtags()``.
 * The ``limit=`` parameter represents the **total** number of nodes returned, as the original working set is consumed.
-It can be provided as input to the ``pivottags()`` operator itself when using Operator syntax.
-Alternately the ``limit()`` operator_ can be used after the ``pivottags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
+  It can be provided as input to the ``pivottags()`` operator itself when using Operator syntax.
+  Alternately the ``limit()`` operator_ can be used after the ``pivottags()`` operator (in either Operator or Macro syntax) to specify a limit on the number of nodes returned.
 
 tree()
 ------
@@ -466,24 +491,28 @@ N/A
 
 * Given a set of domains (``inet:fqdn``) in the working set, return the domain(s) and all of their child domains (subdomains):
   ::
+
     tree( inet:fqdn, inet:fqdn:domain )
     
     tree( inet:fqdn:domain )
 
 * Given a set of base tags (``syn:tag``) in the working set, return all tags in the tag hierarchy for those tags:
   ::
+
     tree( syn:tag, syn:tag:up )
     
     tree( syn:tag:up )
 
 * Given a set of base tags (``syn:tag``) in the working set, return all the tags in the tag hierarchy for those tags, limiting the number of results to 10:
   ::
+
     tree( syn:tag, syn:tag:up, limit=10 )
     
     tree( syn:tag:up, limit=10 )
 
 * Given a parent organization (``ou:org``), pivot to the organization / sub-organization nodes (``ou:suborg``) where that org is a parent, and return all of the sub-organizations under that parent (full Storm query provided for clarity):
   ::
+
      ask --props ou:org=<org_guid> -> ou:suborg:org tree( ou:suborg:sub,
        ou:suborg:org ) :sub -> ou:org
 
@@ -491,12 +520,14 @@ N/A
 
 * Given a set of domains (``inet:fqdn``) in the working set, return the domain(s) and all of their parent domains:
   ::
+
     tree( inet:fqdn:domain, inet:fqdn )
     
     tree( :domain, inet:fqdn)
 
 * Given a child organization (``ou:org``), pivot to the organization / sub-organization nodes (``ou:suborg``) where that org is a child, and return all of the parent organizations above that child (full Storm query provided for clarity):
   ::
+
     ask --props ou:org=<org_guid> -> ou:suborg:sub tree( ou:suborg:org,
       ou:suborg:sub ) :org -> ou:org
 

--- a/docs/synapse/userguides/ug017_storm_ref_stats.rst
+++ b/docs/synapse/userguides/ug017_storm_ref_stats.rst
@@ -19,12 +19,14 @@ The following examples show how the output of ``stat()`` varies based on the ``a
 
 *No parameters:*
 ::
+
   ask stat(count,inet:fqdn)
   stat:count = inet:fqdn
   (1 results)
 
 *"props" parameter:*
 ::
+
   ask --props stat(count,inet:fqdn)
   stat:count = inet:fqdn
       :valu = 239886
@@ -32,6 +34,7 @@ The following examples show how the output of ``stat()`` varies based on the ``a
 
 *"raw" parameter:*
 ::
+
   ask --raw stat(count,inet:fqdn)
   [
     [
@@ -72,6 +75,7 @@ N/A
 
 *Determine the number of domains in the Cortex:*
 ::
+
   ask --props stat(count,inet:fqdn)
   stat:count = inet:fqdn
       :valu = 239887
@@ -79,6 +83,7 @@ N/A
 
 *Determine the number of .net domains in the Cortex:*
 ::
+
   ask --props stat(count,inet:fqdn:domain,valu=net)
   stat:count = inet:fqdn:domain
       :valu = 11438
@@ -86,6 +91,7 @@ N/A
 
 *Determine the total number of nodes (forms) in the Cortex:*
 ::
+
   ask --props stat(count,tufo:form)
   stat:count = tufo:form
       :valu = 100461644
@@ -95,6 +101,7 @@ N/A
 
 *Determine the minimum (earliest) date of birth for any person in the Cortex:*
 ::
+
   ask --props stat(min,ps:person:dob)
   stat:min - ps:person:dob
       :valu = 345772800000
@@ -102,6 +109,7 @@ N/A
 
 *Determine the minimum (earliest) observed date for any DNS A record in the Cortex:*
 ::
+
   ask --props stat(min,inet:dns:a:seen:min)
   stat:min = inet:dns:a:seen:min
       :valu = 1251770027000
@@ -113,6 +121,7 @@ N/A
 
 *Determine the maximum (largest) IPv6 address stored in the Cortex:*
 ::
+
   ask --props stat(max,inet:ipv6)
   stat:max = inet:ipv6
       :valu = 2a06:1700:0:14::207
@@ -122,6 +131,7 @@ N/A
 
 *Determine the total size of all files in the Cortex:*
 ::
+
   ask --props stat(sum,file:bytes:size)
   stat:sum = file:bytes:size
       :valu = 1088807999
@@ -132,6 +142,7 @@ N/A
 
 *Determine the average size of a file in the Cortex:*
 ::
+
   ask --props stat(mean,file:bytes:size)
   stat:mean - file:bytes:size
       :valu = 1382.3535373669456
@@ -144,6 +155,7 @@ N/A
 
 *Determine the distribution by country for organizations in the Cortex:*
 ::
+
   ask --props stat(histo,ou:org:cc)
   stat:histo - ou:org:cc
       :valu = {'fi': 1, 'ua': 2, 'ca': 1, 'ie': 2, 'ch': 2, 'pl': 1, 'ro': 1, 'cz': 1, 
@@ -153,6 +165,7 @@ N/A
 
 *Determine the distribution of registration dates for domains in the Cortex:*
 ::
+
   ask --props stat(histo,inet:whois:rec:created)
   stat:histo = inet:whois:rec:created
       :valu = {0: 2, 756604800000: 1, 1504310400000: 1, 1481932800000: 2, 
@@ -169,6 +182,7 @@ N/A
 
 *Determine whether the inet:web:acct:avatar property is present (exists and is non-zero) on any nodes in the Cortex:*
 ::
+
   ask --props stat(any,inet:web:acct:avatar)
   stat:any = inet:web:acct:avatar
       :valu = True
@@ -178,6 +192,7 @@ N/A
 
 *Determine whether all syn:tag:title properties in the Cortex have non-zero values:*
 ::
+
   ask --props stat(all,syn:tag:title)
   stat:all = syn:tag:title
       :valu = False

--- a/docs/synapse/userguides/ug018_storm_ref_misc.rst
+++ b/docs/synapse/userguides/ug018_storm_ref_misc.rst
@@ -31,18 +31,22 @@ N/A
 
 * Limit the total number of nodes of a lift to 10 nodes:
   ::
+
     inet:ipv4 limit(10)
 
 * Limit the number of nodes which were returned by a ``refs()`` command to 10 total nodes:
   ::
+
     inet:ipv4=8.8.8.8 refs() limit(10)
 
 * Limit the nodes returned by a pivot operation to 10:
   ::
+
      inet:ipv4=8.8.8.8 inet:ipv4->inet:dns:a:ipv4 limit(10)
 
 * Perform a pivot, limiting the output with ``limit()``, then find all the tags which are on the output nodes:
   ::
+
      inet:ipv4=8.8.8.8 inet:ipv4->inet:dns:a:ipv4 limit(10) totags()
 
 
@@ -50,14 +54,14 @@ N/A
 
 * ``limit()`` does consume nodes by design.  It will readd the consume nodes back into the working set of nodes until the limit value is met.
 * Since the ``limit()`` operator acts as a hard limit for the number of nodes it emits, care must be taken when using ``limit()`` in conjunction with multiple storm operations which do not consume nodes. It is possible that the use of ``limit()`` may discard all nodes from subsequent lifts or join type of operations.  In that case, it is typically better to just specify a ``limit=<value>`` argument to those operators directly, rather than using the ``limit()`` operator.
+* The ``limit()`` oeprator may produce an artificial limit on the number of nodes produced by a query. It may be a good tool for sampling data but its use may impair the user from being able to perform effective analysis on the system.
 * The ``limit()`` operator causes the Storm query planner to insert the limit value into the previous storm operator as a ``limit=<value>`` argument. This will override any value already provided to an operator. The following example would behave as if the ``pivot()`` had ``limit=10``,
-instead of ``limit=1``:
+  instead of ``limit=1``:
 
   ::
 
      inet:ipv4=8.8.8.8 pivot(inet:dns:a:ipv4, limit=1) limit(10)
 
-* The ``limit()`` oeprator may produce an artificial limit on the number of nodes produced by a query. It may be a good tool for sampling data but its use may impair the user from being able to perform effective analysis on the system.
 
 opts()
 ------

--- a/synapse/models/biology.py
+++ b/synapse/models/biology.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule
+import synapse.lib.module as s_module
 
-class BioMod(CoreModule):
+class BioMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/chemistry.py
+++ b/synapse/models/chemistry.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule
+import synapse.lib.module as s_module
 
-class ChemMod(CoreModule):
+class ChemMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/crypto.py
+++ b/synapse/models/crypto.py
@@ -2,7 +2,7 @@ import logging
 
 import synapse.common as s_common
 
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
 logger = logging.getLogger(__name__)
 
@@ -12,9 +12,9 @@ ex_sha256 = 'ad9f4fe922b61e674a09530831759843b1880381de686a43460a76864ca0340c'
 ex_sha384 = 'd425f1394e418ce01ed1579069a8bfaa1da8f32cf823982113ccbef531fa36bda9987f389c5af05b5e28035242efab6c'
 ex_sha512 = 'ca74fe2ff2d03b29339ad7d08ba21d192077fece1715291c7b43c20c9136cd132788239189f3441a87eb23ce2660aa243f334295902c904b5520f6e80ab91f11'
 
-class CryptoMod(CoreModule):
+class CryptoMod(s_module.CoreModule):
 
-    @modelrev('crypto', 201708231712)
+    @s_module.modelrev('crypto', 201708231712)
     def _revModl201708231712(self):
         pass # here from legacy for backward compat
 

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class DnsMod(CoreModule):
+class DnsMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -2,7 +2,7 @@ import synapse.common as s_common
 
 from synapse.lib.types import DataType
 from synapse.common import addpref, guid
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
 class FileBaseType(DataType):
     def norm(self, valu, oldval=None):
@@ -71,7 +71,7 @@ class FileRawPathType(DataType):
 
         return valu, subs
 
-class FileMod(CoreModule):
+class FileMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.core.addSeedCtor('file:bytes:md5', self.seedFileMd5)

--- a/synapse/models/finance.py
+++ b/synapse/models/finance.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule
+import synapse.lib.module as s_module
 
-class FinMod(CoreModule):
+class FinMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/geopol.py
+++ b/synapse/models/geopol.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class PolMod(CoreModule):
+class PolMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/geospace.py
+++ b/synapse/models/geospace.py
@@ -2,7 +2,7 @@ import synapse.lib.gis as s_gis
 import synapse.lib.types as s_types
 import synapse.lib.syntax as s_syntax
 
-from synapse.lib.module import CoreModule
+import synapse.lib.module as s_module
 
 class LatLongType(s_types.DataType):
 
@@ -62,7 +62,7 @@ class DistType(s_types.DataType):
 
         return valu * mult, {}
 
-class GeoMod(CoreModule):
+class GeoMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/gov/cn.py
+++ b/synapse/models/gov/cn.py
@@ -1,7 +1,7 @@
 from synapse.common import guid
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class GovCnMod(CoreModule):
+class GovCnMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/gov/intl.py
+++ b/synapse/models/gov/intl.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class GovIntlMod(CoreModule):
+class GovIntlMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/gov/us.py
+++ b/synapse/models/gov/us.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class GovUsMod(CoreModule):
+class GovUsMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -15,7 +15,7 @@ import synapse.lookup.iana as s_l_iana
 
 from synapse.exc import BadTypeValu
 from synapse.lib.types import DataType
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
 logger = logging.getLogger(__name__)
 
@@ -404,7 +404,7 @@ class AddrType(DataType):
         addr, _ = self.tlib.getTypeNorm('inet:ipv6', valu)
         return addr, subs
 
-class InetMod(CoreModule):
+class InetMod(s_module.CoreModule):
 
     def initCoreModule(self):
         # add an inet:defang cast to swap [.] to .
@@ -434,7 +434,7 @@ class InetMod(CoreModule):
         for tufo in self.core.getTufosByProp('inet:fqdn:domain', fqdn):
             self.core.setTufoProp(tufo, 'zone', sfx)
 
-    @modelrev('inet', 201706201837)
+    @s_module.modelrev('inet', 201706201837)
     def _revModl201706201837(self):
         '''
         Add :port and :ipv4 to inet:tcp4 and inet:udp4 nodes.
@@ -462,7 +462,7 @@ class InetMod(CoreModule):
             if adds:
                 self.core.addRows(adds)
 
-    @modelrev('inet', 201706121318)
+    @s_module.modelrev('inet', 201706121318)
     def _revModl201706121318(self):
 
         # account for the updated sub-property extraction for inet:url nodes
@@ -483,11 +483,11 @@ class InetMod(CoreModule):
         if adds:
             self.core.addRows(adds)
 
-    @modelrev('inet', 201708231646)
+    @s_module.modelrev('inet', 201708231646)
     def _revModl201708231646(self):
         pass # for legacy/backward compat
 
-    @modelrev('inet', 201709181501)
+    @s_module.modelrev('inet', 201709181501)
     def _revModl201709181501(self):
         '''
         Replace inet:whois:rec:ns<int> rows with inet:whos:recns nodes.
@@ -528,7 +528,7 @@ class InetMod(CoreModule):
         for prop in delprops:
             self.core.delRowsByProp(prop)
 
-    @modelrev('inet', 201709271521)
+    @s_module.modelrev('inet', 201709271521)
     def _revModl201709271521(self):
         '''
         Rename inet:net* to inet:web*
@@ -747,7 +747,7 @@ class InetMod(CoreModule):
                     continue
                 self.core.store.updateProperty(old, new)
 
-    @modelrev('inet', 201710111553)
+    @s_module.modelrev('inet', 201710111553)
     def _revModl201710111553(self):
 
         adds, dels = [], []
@@ -764,7 +764,7 @@ class InetMod(CoreModule):
             for i, p, v in dels:
                 self.core.delRowsByIdProp(i, p, v)
 
-    @modelrev('inet', 201802131725)
+    @s_module.modelrev('inet', 201802131725)
     def _revModel201802131725(self):
         # mark changed nodes with a dark row...
         dvalu = 'inet:201802131725'

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -5,7 +5,7 @@ import synapse.datamodel as s_datamodel
 
 import synapse.lib.version as s_version
 
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 from synapse.lib.types import DataType
 
 logger = logging.getLogger(__name__)
@@ -134,7 +134,7 @@ def bruteStr(valu):
                                          subs.get('patch', 0))
             return valu, subs
 
-class ItMod(CoreModule):
+class ItMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.onFormNode('it:dev:str', self._onFormItDevStr)
@@ -144,7 +144,7 @@ class ItMod(CoreModule):
     def _onFormItDevStr(self, form, valu, props, mesg):
         props['it:dev:str:norm'] = valu.lower()
 
-    @modelrev('it', 201801041154)
+    @s_module.modelrev('it', 201801041154)
     def _revModl201801041154(self):
 
         now = s_common.now()

--- a/synapse/models/language.py
+++ b/synapse/models/language.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class LangMod(CoreModule):
+class LangMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/material.py
+++ b/synapse/models/material.py
@@ -1,9 +1,9 @@
 '''
 A data model focused on material objects.
 '''
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class MatMod(CoreModule):
+class MatMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/media.py
+++ b/synapse/models/media.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class MediaMod(CoreModule):
+class MediaMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/mime.py
+++ b/synapse/models/mime.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule
+import synapse.lib.module as s_module
 
-class MimeMod(CoreModule):
+class MimeMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/money.py
+++ b/synapse/models/money.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule
+import synapse.lib.module as s_module
 
-class MoneyMod(CoreModule):
+class MoneyMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -1,7 +1,7 @@
 from synapse.common import guid
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
-class OuMod(CoreModule):
+class OuMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.core.addSeedCtor('ou:org:name', self.seedOrgName)

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -1,6 +1,6 @@
 from synapse.lib.types import DataType
 
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
 # FIXME identify/handle possibly as seeds
 # tony stark
@@ -34,7 +34,7 @@ class Name(DataType):
         valu = ','.join(parts)
         return valu, subs
 
-class PsMod(CoreModule):
+class PsMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.core.addSeedCtor('ps:person:guidname', self.seedPersonGuidName)

--- a/synapse/models/science.py
+++ b/synapse/models/science.py
@@ -1,6 +1,6 @@
-from synapse.lib.module import CoreModule
+import synapse.lib.module as s_module
 
-class SciMod(CoreModule):
+class SciMod(s_module.CoreModule):
 
     @staticmethod
     def getBaseModels():

--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -2,11 +2,11 @@ import logging
 
 import synapse.common as s_common
 import synapse.lib.tufo as s_tufo
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
 logger = logging.getLogger(__name__)
 
-class SynMod(CoreModule):
+class SynMod(s_module.CoreModule):
     @staticmethod
     def getBaseModels():
         modl = {
@@ -141,7 +141,7 @@ class SynMod(CoreModule):
         name = 'syn'
         return ((name, modl),)
 
-    @modelrev('syn', 201709051630)
+    @s_module.modelrev('syn', 201709051630)
     def _delOldModelNodes(self):
         types = self.core.getRowsByProp('syn:type')
         forms = self.core.getRowsByProp('syn:form')
@@ -154,7 +154,7 @@ class SynMod(CoreModule):
             [self.core.delRowsById(r[0]) for r in props]
             [self.core.delRowsById(r[0]) for r in syncore]
 
-    @modelrev('syn', 201709191412)
+    @s_module.modelrev('syn', 201709191412)
     def _revModl201709191412(self):
         '''
         Migrate the XREF types to use the propvalu syntax.
@@ -208,7 +208,7 @@ class SynMod(CoreModule):
             for prop in dels:
                 self.core.delRowsByProp(prop)
 
-    @modelrev('syn', 201710191144)
+    @s_module.modelrev('syn', 201710191144)
     def _revModl201710191144(self):
         with self.core.getCoreXact():
             now = s_common.now()
@@ -229,7 +229,7 @@ class SynMod(CoreModule):
                     logger.debug('Loading {:,d} [{}%] rows into transaction'.format(i, int((i / tot) * 100)))
         logger.debug('Finished adding node:created rows to the Cortex')
 
-    @modelrev('syn', 201711012123)
+    @s_module.modelrev('syn', 201711012123)
     def _revModl201711012123(self):
         now = s_common.now()
         forms = sorted(self.core.getTufoForms())

--- a/synapse/models/telco.py
+++ b/synapse/models/telco.py
@@ -4,7 +4,7 @@ import synapse.common as s_common
 
 import synapse.lookup.phonenum as s_l_phone
 from synapse.lib.types import DataType
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +170,7 @@ class ImsiType(DataType):
         # TODO full imsi analysis tree
         return valu, {'mcc': mcc}
 
-class TelMod(CoreModule):
+class TelMod(s_module.CoreModule):
 
     def initCoreModule(self):
         # TODO

--- a/synapse/models/temporal.py
+++ b/synapse/models/temporal.py
@@ -3,7 +3,7 @@ import datetime
 import synapse.common as s_common
 
 from synapse.lib.types import DataType
-from synapse.lib.module import CoreModule, modelrev
+import synapse.lib.module as s_module
 
 def fromUnixEpoch(valu):
     if isinstance(valu, str):
@@ -77,7 +77,7 @@ class EpochType(DataType):
         dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=int(valu))
         return '%d/%.2d/%.2d %.2d:%.2d:%.2d' % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
 
-class TimeMod(CoreModule):
+class TimeMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.core.addTypeCast('from:unix:epoch', fromUnixEpoch)

--- a/synapse/neuron.py
+++ b/synapse/neuron.py
@@ -342,10 +342,10 @@ class Cell(s_config.Configable, s_net.Link, SessBoss):
 
             ('host', {'defval': socket.gethostname(),
                 'ex': 'cell.vertex.link',
-                'doc': 'The host name used to connect to this cell (should resolve over DNS).'}),
+                'doc': 'The host name used to connect to this cell. This should resolve over DNS. Defaults to the result of socket.gethostname().'}),
 
             ('port', {'defval': 0,
-                'doc': 'The TCP port to bind (defaults to dynamic)'}),
+                'doc': 'The TCP port the Cell binds to (defaults to dynamic)'}),
         ))
 
 class Neuron(Cell):
@@ -442,7 +442,7 @@ class Neuron(Cell):
         Cell.initConfDefs(self)
         self.addConfDefs((
             ('port', {'defval': defport, 'req': 1,
-                'doc': 'The TCP port to bind (defaults to %d)' % defport}),
+                'doc': 'The TCP port the Neuron binds to (defaults to %d)' % defport}),
         ))
 
 

--- a/synapse/tests/test_tools_autodoc.py
+++ b/synapse/tests/test_tools_autodoc.py
@@ -31,3 +31,7 @@ class TestAutoDoc(SynTest):
                 rst = fd.read().decode()
 
             self.true('Synapse Configable Classes' in rst)
+            # Some cell configs which are comming in from @staticmethod and initConfDefs()
+            self.true('axon:mapsize' in rst)
+            self.true('The TCP port the Cell binds to (defaults to dynamic)' in rst)
+            self.true('The TCP port the Neuron binds to' in rst)

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -63,6 +63,243 @@ def inspect_mod(mod, cls):
                 continue
             yield modname, valu, name, meth()
 
+def docConfigables(outp, fd):
+    rst = RstHelp()
+    rst.addHead('Synapse Configable Classes', lvl=0)
+    rst.addLines('The following objects are Configable objects. They have'
+                 ' settings which may be provided at runtime or during object'
+                 ' initialization which may change their behavior.')
+    basename = 'synapse'
+    confdetails = collections.defaultdict(list)
+
+    for root, dirs, files in os.walk(base_synaspe_dir):
+
+        if any([v for v in dir_skips if v in root]):
+            continue
+
+        for fn in files:
+            if fn in fn_skips:
+                continue
+            if not fn.endswith('.py'):
+                continue
+
+            modname = fn.rsplit('.', 1)[0]
+            _modpath = root[len(base_synaspe_dir) + 1:].replace(os.sep, '.')
+            modpath = '.'.join([v for v in [basename, _modpath, modname] if v])
+
+            mod = importlib.import_module(modpath)
+            for modattr, valu, name, results in inspect_mod(mod, cls=s_config.Configable):
+                confdetails[modpath].append((modattr, name, results))
+
+    # Collapse details into a modpath -> Details struct
+    detaildict = collections.defaultdict(list)
+
+    for modpath, details in confdetails.items():
+        for detail in details:
+            modattr, name, results = detail
+            obj_path = '.'.join([modpath, modattr])
+            if obj_path in obj_path_skips:
+                continue
+            for rslt in results:
+                if not rslt:
+                    continue
+                detaildict[obj_path].append(rslt)
+
+    # Now make the RST proper like
+    keys = list(detaildict.keys())
+    keys.sort()
+    for obj_path in keys:
+        details = detaildict.get(obj_path, [])
+        details.sort(key=lambda x: x[0])
+        rst.addHead(name=obj_path, lvl=1)
+        for detail in details:
+            confvalu, confdict = detail[0], detail[1]
+            rst.addHead(confvalu, lvl=2)
+            _keys = list(confdict.keys())
+            _keys.sort()
+            for _key in _keys:
+                v = confdict.get(_key)
+                line = '  - {}: {}'.format(_key, v)
+                rst.addLines(line)
+
+    outp.printf(rst.getRstText())
+    if fd:
+        fd.close()
+    return 0
+
+def docModel(outp, fd, core):
+    forms = []
+    types = []
+
+    props = collections.defaultdict(list)
+
+    for tufo in core.getTufosByProp('syn:type'):
+        name = tufo[1].get('syn:type')
+        info = s_tufo.props(tufo)
+        types.append((name, info))
+
+    for tufo in core.getTufosByProp('syn:form'):
+        name = tufo[1].get('syn:form')
+        info = s_tufo.props(tufo)
+        forms.append((name, info))
+
+    for tufo in core.getTufosByProp('syn:prop'):
+        prop = tufo[1].get('syn:prop')
+        form = tufo[1].get('syn:prop:form')
+        info = s_tufo.props(tufo)
+        props[form].append((prop, info))
+
+    types.sort()
+    forms.sort()
+
+    [v.sort() for v in props.values()]
+
+    rst = RstHelp()
+    rst.addHead('Synapse Data Model', lvl=0)
+
+    rst.addHead('Types', lvl=1)
+
+    for name, info in types:
+
+        rst.addHead(name, lvl=2)
+        inst = core.getTypeInst(name)
+
+        ex = inst.get('ex')
+        doc = inst.get('doc')
+
+        if doc is not None:
+            rst.addLines(doc)
+
+        bases = core.getTypeBases(name)
+        rst.addLines('', 'Type Hierarchy: %s' % (' -> '.join(bases),), '')
+
+        if ex is not None:
+
+            #valu = core.getTypeParse(name,ex)
+            #vrep = reprvalu(valu)
+
+            rst.addLines('', 'Examples:', '')
+            rst.addLines('- repr mode: %s' % (repr(ex),))
+            #rst.addLines('- system mode: %s' % (vrep,))
+            rst.addLines('')
+
+        cons = []
+        xforms = []
+
+        if core.isSubType(name, 'str'):
+
+            regex = inst.get('regex')
+            if regex is not None:
+                cons.append('- regex: %s' % (regex,))
+
+            lower = inst.get('lower')
+            if lower:
+                xforms.append('- case: lower')
+
+            restrip = inst.get('restrip')
+            if restrip is not None:
+                xforms.append('- regex strip: %s' % (restrip,))
+
+            nullval = inst.get('nullval')
+            if nullval is not None:
+                cons.append('- null value: %s' % (nullval,))
+
+        if core.isSubType(name, 'int'):
+
+            minval = inst.get('min')
+            if minval is not None:
+                cons.append('- min value: %d (0x%x)' % (minval, minval))
+
+            maxval = inst.get('max')
+            if maxval is not None:
+                cons.append('- max value: %d (0x%x)' % (maxval, maxval))
+
+            ismin = inst.get('ismin')
+            if ismin is not None:
+                xforms.append('- is minimum: True')
+
+            ismax = inst.get('ismax')
+            if ismax is not None:
+                xforms.append('- is maximum: True')
+
+        if core.isSubType(name, 'sepr'):
+
+            sep = inst.get('sep')
+            fields = inst.get('fields')
+
+            parts = []
+            for part in fields.split('|'):
+                name, stype = part.split(',')
+                parts.append(stype)
+
+            seprs = sep.join(['<%s>' % p for p in parts])
+            rst.addLines('', 'Sepr Fields: %s' % (seprs,))
+
+        if cons:
+            cons.append('')
+            rst.addLines('', 'Type Constraints:', '', *cons)
+
+        if xforms:
+            xforms.append('')
+            rst.addLines('', 'Type Transforms:', '', *xforms)
+
+    rst.addHead('Forms', lvl=1)
+
+    for name, info in forms:
+        ftype = info.get('ptype', 'str')
+        rst.addHead('%s = <%s>' % (name, ftype), lvl=2)
+
+        doc = core.getPropInfo(name, 'doc')
+        if doc is not None:
+            rst.addLines(doc)
+
+        rst.addLines('', 'Properties:', '')
+
+        for prop, pnfo in props.get(name, ()):
+
+            # use the resolver funcs that will recurse upward
+            pex = core.getPropInfo(prop, 'ex')
+            pdoc = core.getPropInfo(prop, 'doc')
+
+            ptype = pnfo.get('ptype')
+
+            pline = '\t- %s = <%s>' % (prop, ptype)
+
+            defval = pnfo.get('defval')
+            if defval is not None:
+                pline += ' (default: %r)' % (defval,)
+
+            rst.addLines(pline)
+
+            if pdoc:
+                rst.addLines('\t\t- %s' % (pdoc,))
+
+    # Add universal props last - they are not associated with a form.
+    uniprops = props.get(None)
+    if uniprops:
+        rst.addHead('Universal Props', lvl=1)
+
+        rst.addLines('', 'Universal props are system level properties which are generally present on every node.',
+                     '', 'These properties are not specific to a particular form and exist outside of a particular'
+                         ' namespace.', '')
+        plist = sorted(uniprops, key=lambda x: x[0])
+        for prop, pnfo in plist:
+            rst.addHead(prop, lvl=2)
+
+            pdoc = core.getPropInfo(prop, 'doc')
+
+            ptype = pnfo.get('ptype')
+
+            pline = '\t- %s = <%s>' % (prop, ptype)
+            rst.addLines(pline)
+
+            if pdoc:
+                rst.addLines('\t\t- %s' % (pdoc,))
+
+    outp.printf(rst.getRstText())
+    if fd:
+        fd.close()
+    return 0
 
 class RstHelp:
 
@@ -108,244 +345,12 @@ def main(argv, outp=None):
         fd = open(opts.savefile, 'wb')
         outp = s_output.OutPutFd(fd)
 
-    core = s_cortex.openurl(opts.cortex)
-
     if opts.doc_model:
-
-        forms = []
-        types = []
-
-        props = collections.defaultdict(list)
-
-        for tufo in core.getTufosByProp('syn:type'):
-            name = tufo[1].get('syn:type')
-            info = s_tufo.props(tufo)
-            types.append((name, info))
-
-        for tufo in core.getTufosByProp('syn:form'):
-            name = tufo[1].get('syn:form')
-            info = s_tufo.props(tufo)
-            forms.append((name, info))
-
-        for tufo in core.getTufosByProp('syn:prop'):
-            prop = tufo[1].get('syn:prop')
-            form = tufo[1].get('syn:prop:form')
-            info = s_tufo.props(tufo)
-            props[form].append((prop, info))
-
-        types.sort()
-        forms.sort()
-
-        [v.sort() for v in props.values()]
-
-        rst = RstHelp()
-        rst.addHead('Synapse Data Model', lvl=0)
-
-        rst.addHead('Types', lvl=1)
-
-        for name, info in types:
-
-            rst.addHead(name, lvl=2)
-            inst = core.getTypeInst(name)
-
-            ex = inst.get('ex')
-            doc = inst.get('doc')
-
-            if doc is not None:
-                rst.addLines(doc)
-
-            bases = core.getTypeBases(name)
-            rst.addLines('', 'Type Hierarchy: %s' % (' -> '.join(bases),), '')
-
-            if ex is not None:
-
-                #valu = core.getTypeParse(name,ex)
-                #vrep = reprvalu(valu)
-
-                rst.addLines('', 'Examples:', '')
-                rst.addLines('- repr mode: %s' % (repr(ex),))
-                #rst.addLines('- system mode: %s' % (vrep,))
-                rst.addLines('')
-
-            cons = []
-            xforms = []
-
-            if core.isSubType(name, 'str'):
-
-                regex = inst.get('regex')
-                if regex is not None:
-                    cons.append('- regex: %s' % (regex,))
-
-                lower = inst.get('lower')
-                if lower:
-                    xforms.append('- case: lower')
-
-                restrip = inst.get('restrip')
-                if restrip is not None:
-                    xforms.append('- regex strip: %s' % (restrip,))
-
-                nullval = inst.get('nullval')
-                if nullval is not None:
-                    cons.append('- null value: %s' % (nullval,))
-
-            if core.isSubType(name, 'int'):
-
-                minval = inst.get('min')
-                if minval is not None:
-                    cons.append('- min value: %d (0x%x)' % (minval, minval))
-
-                maxval = inst.get('max')
-                if maxval is not None:
-                    cons.append('- max value: %d (0x%x)' % (maxval, maxval))
-
-                ismin = inst.get('ismin')
-                if ismin is not None:
-                    xforms.append('- is minimum: True')
-
-                ismax = inst.get('ismax')
-                if ismax is not None:
-                    xforms.append('- is maximum: True')
-
-            if core.isSubType(name, 'sepr'):
-
-                sep = inst.get('sep')
-                fields = inst.get('fields')
-
-                parts = []
-                for part in fields.split('|'):
-                    name, stype = part.split(',')
-                    parts.append(stype)
-
-                seprs = sep.join(['<%s>' % p for p in parts])
-                rst.addLines('', 'Sepr Fields: %s' % (seprs,))
-
-            if cons:
-                cons.append('')
-                rst.addLines('', 'Type Constraints:', '', *cons)
-
-            if xforms:
-                xforms.append('')
-                rst.addLines('', 'Type Transforms:', '', *xforms)
-
-        rst.addHead('Forms', lvl=1)
-
-        for name, info in forms:
-            ftype = info.get('ptype', 'str')
-            rst.addHead('%s = <%s>' % (name, ftype), lvl=2)
-
-            doc = core.getPropInfo(name, 'doc')
-            if doc is not None:
-                rst.addLines(doc)
-
-            rst.addLines('', 'Properties:', '')
-
-            for prop, pnfo in props.get(name, ()):
-
-                # use the resolver funcs that will recurse upward
-                pex = core.getPropInfo(prop, 'ex')
-                pdoc = core.getPropInfo(prop, 'doc')
-
-                ptype = pnfo.get('ptype')
-
-                pline = '\t- %s = <%s>' % (prop, ptype)
-
-                defval = pnfo.get('defval')
-                if defval is not None:
-                    pline += ' (default: %r)' % (defval,)
-
-                rst.addLines(pline)
-
-                if pdoc:
-                    rst.addLines('\t\t- %s' % (pdoc,))
-
-        # Add universal props last - they are not associated with a form.
-        uniprops = props.get(None)
-        if uniprops:
-            rst.addHead('Universal Props', lvl=1)
-
-            rst.addLines('', 'Universal props are system level properties which are generally present on every node.',
-                         '', 'These properties are not specific to a particular form and exist outside of a particular'
-                             ' namespace.', '')
-            plist = sorted(uniprops, key=lambda x: x[0])
-            for prop, pnfo in plist:
-                rst.addHead(prop, lvl=2)
-
-                pdoc = core.getPropInfo(prop, 'doc')
-
-                ptype = pnfo.get('ptype')
-
-                pline = '\t- %s = <%s>' % (prop, ptype)
-                rst.addLines(pline)
-
-                if pdoc:
-                    rst.addLines('\t\t- %s' % (pdoc,))
-
-        outp.printf(rst.getRstText())
-        return 0
+        with s_cortex.openurl(opts.cortex) as core:
+            return docModel(outp, fd, core)
 
     if opts.configable_opts:
-        rst = RstHelp()
-        rst.addHead('Synapse Configable Classes', lvl=0)
-        rst.addLines('The following objects are Configable objects. They have'
-                     ' settings which may be provided at runtime or during object'
-                     ' initialization which may change their behavior.')
-        basename = 'synapse'
-        confdetails = collections.defaultdict(list)
-
-        for root, dirs, files in os.walk(base_synaspe_dir):
-
-            if any([v for v in dir_skips if v in root]):
-                continue
-
-            for fn in files:
-                if fn in fn_skips:
-                    continue
-                if not fn.endswith('.py'):
-                    continue
-
-                modname = fn.rsplit('.', 1)[0]
-                _modpath = root[len(base_synaspe_dir) + 1:].replace(os.sep, '.')
-                modpath = '.'.join([v for v in [basename, _modpath, modname] if v])
-
-                mod = importlib.import_module(modpath)
-                for modattr, valu, name, results in inspect_mod(mod, cls=s_config.Configable):
-                    confdetails[modpath].append((modattr, name, results))
-
-        # Collapse details into a modpath -> Details struct
-        detaildict = collections.defaultdict(list)
-
-        for modpath, details in confdetails.items():
-            for detail in details:
-                modattr, name, results = detail
-                obj_path = '.'.join([modpath, modattr])
-                if obj_path in obj_path_skips:
-                    continue
-                for rslt in results:
-                    if not rslt:
-                        continue
-                    detaildict[obj_path].append(rslt)
-
-        # Now make the RST proper like
-        keys = list(detaildict.keys())
-        keys.sort()
-        for obj_path in keys:
-            details = detaildict.get(obj_path, [])
-            details.sort(key=lambda x: x[0])
-            rst.addHead(name=obj_path, lvl=1)
-            for detail in details:
-                confvalu, confdict = detail[0], detail[1]
-                rst.addHead(confvalu, lvl=2)
-                _keys = list(confdict.keys())
-                _keys.sort()
-                for _key in _keys:
-                    v = confdict.get(_key)
-                    line = '  - {}: {}'.format(_key, v)
-                    rst.addLines(line)
-
-        outp.printf(rst.getRstText())
-        if fd:
-            fd.close()
-        return 0
+        docConfigables(outp, fd)
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -225,7 +225,7 @@ def docModel(outp, fd, core):
 
             regex = inst.get('regex')
             if regex is not None:
-                cons.append('- regex: %s' % (regex,))
+                cons.append('- regex: ``%s``' % (regex,))
 
             lower = inst.get('lower')
             if lower:

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -350,7 +350,7 @@ def main(argv, outp=None):
             return docModel(outp, fd, core)
 
     if opts.configable_opts:
-        docConfigables(outp, fd)
+        return docConfigables(outp, fd)
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -147,6 +147,8 @@ def docConfigables(outp, fd):
         rst.addHead(name=obj_path, lvl=1)
         for detail in details:
             confvalu, confdict = detail[0], detail[1]
+            if confvalu == 'port':
+                print(obj_path, confvalu, confdict)
             rst.addHead(confvalu, lvl=2)
             _keys = list(confdict.keys())
             _keys.sort()

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -147,8 +147,6 @@ def docConfigables(outp, fd):
         rst.addHead(name=obj_path, lvl=1)
         for detail in details:
             confvalu, confdict = detail[0], detail[1]
-            if confvalu == 'port':
-                print(obj_path, confvalu, confdict)
             rst.addHead(confvalu, lvl=2)
             _keys = list(confdict.keys())
             _keys.sort()


### PR DESCRIPTION
Refactor autodoc to be easier to edit/update
Update autodoc to allow us to extract configable options from live objects
Replace explicit CoreModule imports in models with ``s_module` imports.
Update user/devops docs to address RST warnings.
Update docs makefile to run ``python -m sphinx`` instead of ``sphinx-build``