### PR TITLE
Adds `ps:persona` and `ps:persona:has` forms

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1293,7 +1293,19 @@ class Runtime(Configable):
                 if limt.reached():
                     break
 
+                # node:ndef optimization
                 form = node[1].get('tufo:form')
+                ndef = node[1].get(form + ':xref:node')
+                if ndef is not None:
+                    skipprop = form + ':xref'
+                    done.add((skipprop, node[1].get(skipprop)))
+
+                    newfo = core.getTufoByProp('node:ndef', ndef)
+                    if newfo:
+                        query.add(newfo)
+                        if limt.dec(1):
+                            break
+
                 for prop, info in core.getSubProps(form):
 
                     valu = node[1].get(prop)

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -631,10 +631,12 @@ class XrefType(DataType):
         valu, vsub = self.tlib.getTypeNorm(self._sorc_type, valu)
         tval, tsub = self.tlib.getTypeNorm(tstr, tval)
 
+        tndef = s_common.guid((tstr, tval))
         iden = s_common.guid((valu, tstr, tval))
 
         subs = {
             self._sorc_name: valu,
+            'xref:node': tndef,
             'xref': pvval,
         }
 

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -116,7 +116,6 @@ class PsMod(s_module.CoreModule):
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
                 ('ps:hashost', {'subof': 'comp', 'fields': 'person=ps:person,host=it:host'}),
-                ('ps:hasphone', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|phone,tel:phone'}),
                 ('ps:hasemail', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|email,inet:email'}),
                 ('ps:haswebacct', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|web:acct,inet:web:acct'}),
 
@@ -198,13 +197,6 @@ class PsMod(s_module.CoreModule):
                 ('ps:hashost', {'ptype': 'ps:hashost'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('host', {'ptype': 'it:host'}),
-                    ('seen:min', {'ptype': 'time:min'}),
-                    ('seen:max', {'ptype': 'time:max'}),
-                )),
-
-                ('ps:hasphone', {'ptype': 'ps:hasphone'}, (
-                    ('person', {'ptype': 'ps:person'}),
-                    ('phone', {'ptype': 'tel:phone'}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 )),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -38,12 +38,20 @@ class PsMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.core.addSeedCtor('ps:person:guidname', self.seedPersonGuidName)
+        self.core.addSeedCtor('ps:persona:guidname', self.seedPersonGuidName)
 
     def seedPersonGuidName(self, prop, valu, **props):
         node = self.core.getTufoByProp('ps:person:guidname', valu)
         if node is None:
             # trigger GUID auto-creation
             node = self.core.formTufoByProp('ps:person', None, guidname=valu, **props)
+        return node
+
+    def seedPersonaGuidName(self, prop, valu, **props):
+        node = self.core.getTufoByProp('ps:persona:guidname', valu)
+        if node is None:
+            # trigger GUID auto-creation
+            node = self.core.formTufoByProp('ps:persona', None, guidname=valu, **props)
         return node
 
     @s_module.modelrev('ps', 201802281621)
@@ -110,7 +118,9 @@ class PsMod(s_module.CoreModule):
                 ('ps:name',
                  {'ctor': 'synapse.models.person.Name', 'ex': 'smith,bob', 'doc': 'A last,first person full name'}),
                 ('ps:person',
-                 {'subof': 'guid', 'alias': 'ps:person:guidname', 'doc': 'A GUID for a person or suspected person'}),
+                 {'subof': 'guid', 'alias': 'ps:person:guidname', 'doc': 'A GUID for a person'}),
+                ('ps:persona',
+                 {'subof': 'guid', 'alias': 'ps:persona:guidname', 'doc': 'A GUID for a suspected person'}),
 
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
@@ -153,6 +163,23 @@ class PsMod(s_module.CoreModule):
                     ('name:given', {'ptype': 'ps:tokn'}),
                     ('name:en', {'ptype': 'ps:name',
                         'doc': 'The English version of the name for the person'}),
+                    ('name:en:sur', {'ptype': 'ps:tokn'}),
+                    ('name:en:middle', {'ptype': 'ps:tokn'}),
+                    ('name:en:given', {'ptype': 'ps:tokn'}),
+                ]),
+
+                ('ps:persona', {'ptype': 'ps:persona'}, [
+                    ('guidname', {'ptype': 'str:lwr', 'doc': 'The GUID resolver alias for this suspected person'}),
+                    ('dob', {'ptype': 'time', 'doc': 'The Date of Birth (DOB) if known'}),
+                    ('img', {'ptype': 'file:bytes', 'doc': 'The "primary" image of a suspected person'}),
+                    ('nick', {'ptype': 'inet:user'}),
+                    ('name', {'ptype': 'ps:name',
+                        'doc': 'The localized name for the suspected person'}),
+                    ('name:sur', {'ptype': 'ps:tokn', }),
+                    ('name:middle', {'ptype': 'ps:tokn'}),
+                    ('name:given', {'ptype': 'ps:tokn'}),
+                    ('name:en', {'ptype': 'ps:name',
+                        'doc': 'The English version of the name for the suspected person'}),
                     ('name:en:sur', {'ptype': 'ps:tokn'}),
                     ('name:en:middle', {'ptype': 'ps:tokn'}),
                     ('name:en:given', {'ptype': 'ps:tokn'}),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -116,7 +116,6 @@ class PsMod(s_module.CoreModule):
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
                 ('ps:hashost', {'subof': 'comp', 'fields': 'person=ps:person,host=it:host'}),
-                ('ps:haswebacct', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|web:acct,inet:web:acct'}),
 
                 ('ps:has', {
                     'subof': 'xref',
@@ -196,13 +195,6 @@ class PsMod(s_module.CoreModule):
                 ('ps:hashost', {'ptype': 'ps:hashost'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('host', {'ptype': 'it:host'}),
-                    ('seen:min', {'ptype': 'time:min'}),
-                    ('seen:max', {'ptype': 'time:max'}),
-                )),
-
-                ('ps:haswebacct', {'ptype': 'ps:haswebacct'}, (
-                    ('person', {'ptype': 'ps:person'}),
-                    ('web:acct', {'ptype': 'inet:web:acct'}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 )),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -50,8 +50,8 @@ class PsMod(s_module.CoreModule):
     @modelrev('ps', 201802281621)
     def _revModl201802281621(self):
         '''
-        Combine ps:has* into ps:has
-        - Forms a new ps:has node for all of the old ps:has* nodes
+        Combine ps:has* into ps:person:has
+        - Forms a new ps:person:has node for all of the old ps:has* nodes
         - Applies the old node's tags to the new node
         - Deletes the old node
         - Deletes the syn:tagform nodes for the old form
@@ -85,7 +85,7 @@ class PsMod(s_module.CoreModule):
                     if smax is not None:
                         kwargs['seen:max'] = smax
 
-                    newfo = self.core.formTufoByProp('ps:has', (perval, (ptype, newval)), **kwargs)
+                    newfo = self.core.formTufoByProp('ps:person:has', (perval, (ptype, newval)), **kwargs)
 
                     tags = s_tufo.tags(tufo, leaf=True)
                     self.core.addTufoTags(newfo, tags)
@@ -94,11 +94,11 @@ class PsMod(s_module.CoreModule):
 
                 self.core.delTufosByProp('syn:tagform:form', oldform)
 
-            # Add dark rows to the ps:has
-            # It is safe to operate on all ps:has nodes as this point as none should exist
+            # Add dark rows to the ps:person:has
+            # It is safe to operate on all ps:person:has nodes as this point as none should exist
             dvalu = 'ps:201802281621'
             dprop = '_:dark:syn:modl:rev'
-            darks = [(i[::-1], dprop, dvalu, t) for (i, p, v, t) in self.core.getRowsByProp('ps:has')]
+            darks = [(i[::-1], dprop, dvalu, t) for (i, p, v, t) in self.core.getRowsByProp('ps:person:has')]
             self.core.addRows(darks)
 
     @staticmethod
@@ -115,7 +115,7 @@ class PsMod(s_module.CoreModule):
 
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
-                ('ps:has', {
+                ('ps:person:has', {
                     'subof': 'xref',
                     'source': 'person,ps:person',
                     'doc': 'A person owns, controls, or has exclusive use of an object or resource,'
@@ -191,7 +191,7 @@ class PsMod(s_module.CoreModule):
                     # FIXME add an optional bounding box
                 )),
 
-                ('ps:has', {}, [
+                ('ps:person:has', {}, [
                     ('person', {'ptype': 'ps:person', 'ro': 1, 'req': 1,
                         'doc': 'The person who owns or controls the object or resource.'}),
                     ('xref', {'ptype': 'propvalu', 'ro': 1, 'req': 1,

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -115,8 +115,6 @@ class PsMod(s_module.CoreModule):
 
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
-                ('ps:hashost', {'subof': 'comp', 'fields': 'person=ps:person,host=it:host'}),
-
                 ('ps:has', {
                     'subof': 'xref',
                     'source': 'person,ps:person',
@@ -190,13 +188,6 @@ class PsMod(s_module.CoreModule):
                     ('person', {'ptype': 'ps:person'}),
                     ('file', {'ptype': 'file:bytes'}),
                     # FIXME add an optional bounding box
-                )),
-
-                ('ps:hashost', {'ptype': 'ps:hashost'}, (
-                    ('person', {'ptype': 'ps:person'}),
-                    ('host', {'ptype': 'it:host'}),
-                    ('seen:min', {'ptype': 'time:min'}),
-                    ('seen:max', {'ptype': 'time:max'}),
                 )),
 
                 ('ps:has', {}, [

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -225,6 +225,8 @@ class PsMod(s_module.CoreModule):
                         'doc': 'The person that has the given node.'}),
                     ('xref', {'ptype': 'propvalu', 'ro': 1, 'req': 1,
                         'doc': 'The prop=valu that is referenced as part of the FIXME.'}),
+                    ('xref:node', {'ptype': 'ndef', 'ro': 1, 'req': 1,
+                        'doc': 'FIXME.'}),
                     ('xref:prop', {'ptype': 'str', 'ro': 1,
                         'doc': 'The property (form) of the referenced object, as specified by the propvalu.'}),
                     ('xref:intval', {'ptype': 'int', 'ro': 1,

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -60,7 +60,6 @@ class PsMod(s_module.CoreModule):
 
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
-                ('ps:hasuser', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|user,inet:user'}),
                 ('ps:hashost', {'subof': 'comp', 'fields': 'person=ps:person,host=it:host'}),
                 ('ps:hasalias', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|alias,ps:name'}),
                 ('ps:hasphone', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|phone,tel:phone'}),
@@ -140,13 +139,6 @@ class PsMod(s_module.CoreModule):
                     ('person', {'ptype': 'ps:person'}),
                     ('file', {'ptype': 'file:bytes'}),
                     # FIXME add an optional bounding box
-                )),
-
-                ('ps:hasuser', {'ptype': 'ps:hasuser'}, (
-                    ('person', {'ptype': 'ps:person'}),
-                    ('user', {'ptype': 'inet:user'}),
-                    ('seen:min', {'ptype': 'time:min'}),
-                    ('seen:max', {'ptype': 'time:max'}),
                 )),
 
                 ('ps:hasalias', {'ptype': 'ps:hasalias'}, (

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -70,11 +70,22 @@ class PsMod(s_module.CoreModule):
             for oldform, pname, ptype in data:
                 personkey = oldform + ':person'
                 newvalkey = oldform + ':' + pname
+                sminkey = oldform + ':seen:min'
+                smaxkey = oldform + ':seen:max'
 
                 for tufo in self.core.getTufosByProp(oldform):
                     perval = tufo[1].get(personkey)
                     newval = tufo[1].get(newvalkey)
-                    newfo = self.core.formTufoByProp('ps:has', (perval, (ptype, newval)))
+
+                    kwargs = {}
+                    smin = tufo[1].get(sminkey)
+                    if smin is not None:
+                        kwargs['seen:min'] = smin
+                    smax = tufo[1].get(smaxkey)
+                    if smax is not None:
+                        kwargs['seen:max'] = smax
+
+                    newfo = self.core.formTufoByProp('ps:has', (perval, (ptype, newval)), **kwargs)
 
                     tags = s_tufo.tags(tufo, leaf=True)
                     self.core.addTufoTags(newfo, tags)
@@ -229,6 +240,8 @@ class PsMod(s_module.CoreModule):
                         'doc': 'FIXME.'}),
                     ('xref:prop', {'ptype': 'str', 'ro': 1,
                         'doc': 'The property (form) of the referenced object, as specified by the propvalu.'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
                 ]),
 
             ),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -83,6 +83,13 @@ class PsMod(s_module.CoreModule):
 
                 self.core.delTufosByProp('syn:tagform:form', oldform)
 
+            # Add dark rows to the ps:has
+            # It is safe to operate on all ps:has nodes as this point as none should exist
+            dvalu = 'ps:201802281621'
+            dprop = '_:dark:syn:modl:rev'
+            darks = [(i[::-1], dprop, dvalu, t) for (i, p, v, t) in self.core.getRowsByProp('ps:has')]
+            self.core.addRows(darks)
+
     @staticmethod
     def getBaseModels():
         modl = {

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -47,7 +47,7 @@ class PsMod(s_module.CoreModule):
             node = self.core.formTufoByProp('ps:person', None, guidname=valu, **props)
         return node
 
-    @modelrev('ps', 201802281621)
+    @s_module.modelrev('ps', 201802281621)
     def _revModl201802281621(self):
         '''
         Combine ps:has* into ps:person:has

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -118,7 +118,8 @@ class PsMod(s_module.CoreModule):
                 ('ps:has', {
                     'subof': 'xref',
                     'source': 'person,ps:person',
-                    'doc': 'A person that has a thing. FIXME reword'}),
+                    'doc': 'A person owns, controls, or has exclusive use of an object or resource,'
+                        'potentially during a specific period of time.'}),
 
                 ('ps:image', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|file,file:bytes'}),
 
@@ -192,13 +193,13 @@ class PsMod(s_module.CoreModule):
 
                 ('ps:has', {}, [
                     ('person', {'ptype': 'ps:person', 'ro': 1, 'req': 1,
-                        'doc': 'The person that has the given node.'}),
+                        'doc': 'The person who owns or controls the object or resource.'}),
                     ('xref', {'ptype': 'propvalu', 'ro': 1, 'req': 1,
-                        'doc': 'The prop=valu that is referenced as part of the FIXME.'}),
+                        'doc': 'The object or resource (prop=valu) that is owned or controlled by the person.'}),
                     ('xref:node', {'ptype': 'ndef', 'ro': 1, 'req': 1,
-                        'doc': 'FIXME.'}),
+                        'doc': 'The ndef of the node that is owned or controlled by the person.'}),
                     ('xref:prop', {'ptype': 'str', 'ro': 1,
-                        'doc': 'The property (form) of the referenced object, as specified by the propvalu.'}),
+                        'doc': 'The property (form) of the object or resource that is owned or controlled by the person.'}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 ]),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -229,10 +229,6 @@ class PsMod(s_module.CoreModule):
                         'doc': 'FIXME.'}),
                     ('xref:prop', {'ptype': 'str', 'ro': 1,
                         'doc': 'The property (form) of the referenced object, as specified by the propvalu.'}),
-                    ('xref:intval', {'ptype': 'int', 'ro': 1,
-                        'doc': 'The normed value of the form that was referenced, if the value is an integer.'}),
-                    ('xref:strval', {'ptype': 'str', 'ro': 1,
-                        'doc': 'The normed value of the form that was referenced, if the value is a string.'}),
                 ]),
 
             ),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -38,7 +38,7 @@ class PsMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.core.addSeedCtor('ps:person:guidname', self.seedPersonGuidName)
-        self.core.addSeedCtor('ps:persona:guidname', self.seedPersonGuidName)
+        self.core.addSeedCtor('ps:persona:guidname', self.seedPersonaGuidName)
 
     def seedPersonGuidName(self, prop, valu, **props):
         node = self.core.getTufoByProp('ps:person:guidname', valu)

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -116,7 +116,6 @@ class PsMod(s_module.CoreModule):
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
                 ('ps:hashost', {'subof': 'comp', 'fields': 'person=ps:person,host=it:host'}),
-                ('ps:hasemail', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|email,inet:email'}),
                 ('ps:haswebacct', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|web:acct,inet:web:acct'}),
 
                 ('ps:has', {
@@ -197,13 +196,6 @@ class PsMod(s_module.CoreModule):
                 ('ps:hashost', {'ptype': 'ps:hashost'}, (
                     ('person', {'ptype': 'ps:person'}),
                     ('host', {'ptype': 'it:host'}),
-                    ('seen:min', {'ptype': 'time:min'}),
-                    ('seen:max', {'ptype': 'time:max'}),
-                )),
-
-                ('ps:hasemail', {'ptype': 'ps:hasemail'}, (
-                    ('person', {'ptype': 'ps:person'}),
-                    ('email', {'ptype': 'inet:email'}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 )),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -1,7 +1,6 @@
 import synapse.lib.tufo as s_tufo
-from synapse.lib.types import DataType
-
 import synapse.lib.module as s_module
+from synapse.lib.types import DataType
 
 # FIXME identify/handle possibly as seeds
 # tony stark

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -116,7 +116,6 @@ class PsMod(s_module.CoreModule):
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
                 ('ps:hashost', {'subof': 'comp', 'fields': 'person=ps:person,host=it:host'}),
-                ('ps:hasalias', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|alias,ps:name'}),
                 ('ps:hasphone', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|phone,tel:phone'}),
                 ('ps:hasemail', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|email,inet:email'}),
                 ('ps:haswebacct', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|web:acct,inet:web:acct'}),
@@ -194,13 +193,6 @@ class PsMod(s_module.CoreModule):
                     ('person', {'ptype': 'ps:person'}),
                     ('file', {'ptype': 'file:bytes'}),
                     # FIXME add an optional bounding box
-                )),
-
-                ('ps:hasalias', {'ptype': 'ps:hasalias'}, (
-                    ('person', {'ptype': 'ps:person'}),
-                    ('alias', {'ptype': 'ps:name'}),
-                    ('seen:min', {'ptype': 'time:min'}),
-                    ('seen:max', {'ptype': 'time:max'}),
                 )),
 
                 ('ps:hashost', {'ptype': 'ps:hashost'}, (

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -55,7 +55,7 @@ class PsMod(s_module.CoreModule):
         - Applies the old node's tags to the new node
         - Deletes the old node
         - Deletes the syn:tagform nodes for the old form
-        - FIXME do we need to do anything with dark rows?
+        - Adds dark row for each node, signifying that they were added by migration
         '''
         data = (
             ('ps:hasuser', 'user', 'inet:user'),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -215,9 +215,9 @@ class PsMod(s_module.CoreModule):
 
                 ('ps:has', {}, [
                     ('person', {'ptype': 'ps:person', 'ro': 1, 'req': 1,
-                        'doc': 'The action that references the given node.'}),
+                        'doc': 'The person that has the given node.'}),
                     ('xref', {'ptype': 'propvalu', 'ro': 1, 'req': 1,
-                        'doc': 'The prop=valu that is referenced as part of the action.'}),
+                        'doc': 'The prop=valu that is referenced as part of the FIXME.'}),
                     ('xref:prop', {'ptype': 'str', 'ro': 1,
                         'doc': 'The property (form) of the referenced object, as specified by the propvalu.'}),
                     ('xref:intval', {'ptype': 'int', 'ro': 1,

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -120,6 +120,12 @@ class PsMod(s_module.CoreModule):
                     'doc': 'A person owns, controls, or has exclusive use of an object or resource,'
                         'potentially during a specific period of time.'}),
 
+                ('ps:persona:has', {
+                    'subof': 'xref',
+                    'source': 'persona,ps:persona',
+                    'doc': 'A persona owns, controls, or has exclusive use of an object or resource,'
+                        'potentially during a specific period of time.'}),
+
                 ('ps:image', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|file,file:bytes'}),
 
                 # FIXME add wireless elemements like NMEI and IMEI once modeled
@@ -199,6 +205,19 @@ class PsMod(s_module.CoreModule):
                         'doc': 'The ndef of the node that is owned or controlled by the person.'}),
                     ('xref:prop', {'ptype': 'str', 'ro': 1,
                         'doc': 'The property (form) of the object or resource that is owned or controlled by the person.'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
+                ]),
+
+                ('ps:persona:has', {}, [
+                    ('persona', {'ptype': 'ps:persona', 'ro': 1, 'req': 1,
+                        'doc': 'The persona who owns or controls the object or resource.'}),
+                    ('xref', {'ptype': 'propvalu', 'ro': 1, 'req': 1,
+                        'doc': 'The object or resource (prop=valu) that is owned or controlled by the persona.'}),
+                    ('xref:node', {'ptype': 'ndef', 'ro': 1, 'req': 1,
+                        'doc': 'The ndef of the node that is owned or controlled by the persona.'}),
+                    ('xref:prop', {'ptype': 'str', 'ro': 1,
+                        'doc': 'The property (form) of the object or resource that is owned or controlled by the persona.'}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 ]),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -67,6 +67,11 @@ class PsMod(s_module.CoreModule):
                 ('ps:hasemail', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|email,inet:email'}),
                 ('ps:haswebacct', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|web:acct,inet:web:acct'}),
 
+                ('ps:has', {
+                    'subof': 'xref',
+                    'source': 'person,ps:person',
+                    'doc': 'A person that has a thing. FIXME reword'}),
+
                 ('ps:image', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|file,file:bytes'}),
 
                 # FIXME add wireless elemements like NMEI and IMEI once modeled
@@ -178,6 +183,20 @@ class PsMod(s_module.CoreModule):
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 )),
+
+                ('ps:has', {}, [
+                    ('person', {'ptype': 'ps:person', 'ro': 1, 'req': 1,
+                        'doc': 'The action that references the given node.'}),
+                    ('xref', {'ptype': 'propvalu', 'ro': 1, 'req': 1,
+                        'doc': 'The prop=valu that is referenced as part of the action.'}),
+                    ('xref:prop', {'ptype': 'str', 'ro': 1,
+                        'doc': 'The property (form) of the referenced object, as specified by the propvalu.'}),
+                    ('xref:intval', {'ptype': 'int', 'ro': 1,
+                        'doc': 'The normed value of the form that was referenced, if the value is an integer.'}),
+                    ('xref:strval', {'ptype': 'str', 'ro': 1,
+                        'doc': 'The normed value of the form that was referenced, if the value is a string.'}),
+                ]),
+
             ),
         }
         name = 'ps'

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -345,7 +345,6 @@ class StormTest(SynTest):
             phas0 = core.formTufoByProp('ps:has', (pvalu, ('inet:email', 'c00l@vertex.link')))
             core.formTufoByProp('ps:has', (pvalu, ('inet:fqdn', 'vertex.link')))
 
-            # It does not actually make sense to have a file reference a ps:has, this is just for testing
             fnode = core.formTufoByProp('file:bytes:md5', 'd41d8cd98f00b204e9800998ecf8427e')
             _, fvalu = s_tufo.ndef(fnode)
             core.formTufoByProp('file:txtref', (fvalu, ('ps:has', phas0[1].get('ps:has'))))

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1101,8 +1101,16 @@ class StormTest(SynTest):
             self.notin('.new', node1[1])
             self.eq(node0[0], node1[0])
 
-            node2 = core.eval('addnode(ps:haswebacct, ((guidname="bob gray"),vertex.link/pennywise))')[0]
-            self.eq(node2[1].get('ps:haswebacct'), 'faebe657f7a5839ecda3f8af15293893/vertex.link/pennywise')
+            pnode = core.eval('addnode(ps:person, (guidname="bob gray"))')[0]
+            pguid = pnode[1].get('ps:person')
+            self.eq(pguid, 'faebe657f7a5839ecda3f8af15293893')
+
+            node2 = core.eval('addnode(ps:has, (faebe657f7a5839ecda3f8af15293893,(inet:web:acct,vertex.link/pennywise)))')[0]
+            self.eq(node2[1].get('ps:has'), 'e845e52f7bd78385291d3df6c1aeda31')
+            self.eq(node2[1].get('ps:has:person'), 'faebe657f7a5839ecda3f8af15293893')
+            self.eq(node2[1].get('ps:has:xref'), 'inet:web:acct=vertex.link/pennywise')
+            self.eq(node2[1].get('ps:has:xref:prop'), 'inet:web:acct')
+            self.eq(node2[1].get('ps:has:xref:node'), '600ec8667d978eba100b8a412f7154ae')
 
             node3 = core.eval('addnode(ou:haswebacct, ((alias="vertex"),vertex.link/pennywise))')[0]
             self.eq(node3[1].get('ou:haswebacct'), 'e0d1c290732ac433444afe7b5825f94d')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -342,8 +342,13 @@ class StormTest(SynTest):
             pnode = core.formTufoByProp('ps:person', 32 * '0')
             enode = core.formTufoByProp('inet:email', 'c00l@vertex.link')
             pvalu = pnode[1].get('ps:person')
-            core.formTufoByProp('ps:has', (pvalu, ('inet:email', 'c00l@vertex.link')))
+            phas0 = core.formTufoByProp('ps:has', (pvalu, ('inet:email', 'c00l@vertex.link')))
             core.formTufoByProp('ps:has', (pvalu, ('inet:fqdn', 'vertex.link')))
+
+            # It does not actually make sense to have a file reference a ps:has, this is just for testing
+            fnode = core.formTufoByProp('file:bytes:md5', 'd41d8cd98f00b204e9800998ecf8427e')
+            _, fvalu = s_tufo.ndef(fnode)
+            core.formTufoByProp('file:txtref', (fvalu, ('ps:has', phas0[1].get('ps:has'))))
 
             outnodes = core.eval('ps:has refs(out)')  # out
             outforms = sorted({node[1]['tufo:form'] for node in outnodes})
@@ -352,14 +357,14 @@ class StormTest(SynTest):
 
             innodes = core.eval('ps:has refs(in)')  # in
             informs = sorted({node[1]['tufo:form'] for node in innodes})
-            self.len(2, innodes)
-            self.eq(informs, ['ps:has'])  # Nothing refs in to these nodes
+            self.len(3, innodes)
+            self.eq(informs, ['file:txtref', 'ps:has'])  # Nothing refs in to these nodes
 
             expected_bothforms = sorted(set(informs + outforms))
 
             bothnodes = core.eval('ps:has refs()')  # in and out
             bothforms = sorted({node[1]['tufo:form'] for node in bothnodes})
-            self.len(5, bothnodes)
+            self.len(6, bothnodes)
             self.eq(expected_bothforms, bothforms)
 
     def test_storm_refs(self):

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -342,36 +342,36 @@ class StormTest(SynTest):
             pnode = core.formTufoByProp('ps:person', 32 * '0')
             enode = core.formTufoByProp('inet:email', 'c00l@vertex.link')
             pvalu = pnode[1].get('ps:person')
-            phas0 = core.formTufoByProp('ps:has', (pvalu, ('inet:email', 'c00l@vertex.link')))
-            core.formTufoByProp('ps:has', (pvalu, ('inet:fqdn', 'vertex.link')))
+            phas0 = core.formTufoByProp('ps:person:has', (pvalu, ('inet:email', 'c00l@vertex.link')))
+            core.formTufoByProp('ps:person:has', (pvalu, ('inet:fqdn', 'vertex.link')))
 
             fnode = core.formTufoByProp('file:bytes:md5', 'd41d8cd98f00b204e9800998ecf8427e')
             _, fvalu = s_tufo.ndef(fnode)
-            core.formTufoByProp('file:txtref', (fvalu, ('ps:has', phas0[1].get('ps:has'))))
+            core.formTufoByProp('file:txtref', (fvalu, ('ps:person:has', phas0[1].get('ps:person:has'))))
 
-            outnodes = core.eval('ps:has refs(out)')  # out
+            outnodes = core.eval('ps:person:has refs(out)')  # out
             outforms = {node[1]['tufo:form'] for node in outnodes}
             self.len(5, outnodes)
-            self.sorteq(outforms, ['inet:email', 'inet:fqdn', 'ps:has', 'ps:person'])
+            self.sorteq(outforms, ['inet:email', 'inet:fqdn', 'ps:person:has', 'ps:person'])
 
-            outnodes = core.eval('ps:has refs(out, limit=0)')  # out
+            outnodes = core.eval('ps:person:has refs(out, limit=0)')  # out
             limtoutforms = {node[1]['tufo:form'] for node in outnodes}
             self.len(2, outnodes)
-            self.sorteq(limtoutforms, ['ps:has'])
+            self.sorteq(limtoutforms, ['ps:person:has'])
 
-            outnodes = core.eval('ps:has refs(out, limit=1)')  # out
+            outnodes = core.eval('ps:person:has refs(out, limit=1)')  # out
             limtoutforms = {node[1]['tufo:form'] for node in outnodes}
             self.len(3, outnodes)
-            [self.isin(form, ['inet:email', 'inet:fqdn', 'ps:has', 'ps:person']) for form in limtoutforms]
+            [self.isin(form, ['inet:email', 'inet:fqdn', 'ps:person:has', 'ps:person']) for form in limtoutforms]
 
-            innodes = core.eval('ps:has refs(in)')  # in
+            innodes = core.eval('ps:person:has refs(in)')  # in
             informs = {node[1]['tufo:form'] for node in innodes}
             self.len(3, innodes)
-            self.sorteq(informs, ['file:txtref', 'ps:has'])  # Nothing refs in to these nodes
+            self.sorteq(informs, ['file:txtref', 'ps:person:has'])  # Nothing refs in to these nodes
 
             expected_bothforms = informs.union(outforms)
 
-            bothnodes = core.eval('ps:has refs()')  # in and out
+            bothnodes = core.eval('ps:person:has refs()')  # in and out
             bothforms = {node[1]['tufo:form'] for node in bothnodes}
             self.len(6, bothnodes)
             self.sorteq(expected_bothforms, bothforms)
@@ -1114,12 +1114,12 @@ class StormTest(SynTest):
             pguid = pnode[1].get('ps:person')
             self.eq(pguid, 'faebe657f7a5839ecda3f8af15293893')
 
-            node2 = core.eval('addnode(ps:has, (faebe657f7a5839ecda3f8af15293893,(inet:web:acct,vertex.link/pennywise)))')[0]
-            self.eq(node2[1].get('ps:has'), 'e845e52f7bd78385291d3df6c1aeda31')
-            self.eq(node2[1].get('ps:has:person'), 'faebe657f7a5839ecda3f8af15293893')
-            self.eq(node2[1].get('ps:has:xref'), 'inet:web:acct=vertex.link/pennywise')
-            self.eq(node2[1].get('ps:has:xref:prop'), 'inet:web:acct')
-            self.eq(node2[1].get('ps:has:xref:node'), '600ec8667d978eba100b8a412f7154ae')
+            node2 = core.eval('addnode(ps:person:has, (faebe657f7a5839ecda3f8af15293893,(inet:web:acct,vertex.link/pennywise)))')[0]
+            self.eq(node2[1].get('ps:person:has'), 'e845e52f7bd78385291d3df6c1aeda31')
+            self.eq(node2[1].get('ps:person:has:person'), 'faebe657f7a5839ecda3f8af15293893')
+            self.eq(node2[1].get('ps:person:has:xref'), 'inet:web:acct=vertex.link/pennywise')
+            self.eq(node2[1].get('ps:person:has:xref:prop'), 'inet:web:acct')
+            self.eq(node2[1].get('ps:person:has:xref:node'), '600ec8667d978eba100b8a412f7154ae')
 
             node3 = core.eval('addnode(ou:haswebacct, ((alias="vertex"),vertex.link/pennywise))')[0]
             self.eq(node3[1].get('ou:haswebacct'), 'e0d1c290732ac433444afe7b5825f94d')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -355,6 +355,16 @@ class StormTest(SynTest):
             self.len(5, outnodes)
             self.eq(outforms, ['inet:email', 'inet:fqdn', 'ps:has', 'ps:person'])
 
+            outnodes = core.eval('ps:has refs(out, limit=0)')  # out
+            limtoutforms = sorted({node[1]['tufo:form'] for node in outnodes})
+            self.len(2, outnodes)
+            self.eq(limtoutforms, ['ps:has'])
+
+            outnodes = core.eval('ps:has refs(out, limit=1)')  # out
+            limtoutforms = sorted({node[1]['tufo:form'] for node in outnodes})
+            self.len(3, outnodes)
+            [self.isin(form, ['inet:email', 'inet:fqdn', 'ps:has', 'ps:person']) for form in limtoutforms]
+
             innodes = core.eval('ps:has refs(in)')  # in
             informs = sorted({node[1]['tufo:form'] for node in innodes})
             self.len(3, innodes)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -337,6 +337,31 @@ class StormTest(SynTest):
             self.none(node[1].get('#foo.bar'))
             self.none(node[1].get('#baz.faz'))
 
+    def test_storm_refs_ndef(self):
+        with self.getRamCore() as core:
+            pnode = core.formTufoByProp('ps:person', 32 * '0')
+            enode = core.formTufoByProp('inet:email', 'c00l@vertex.link')
+            pvalu = pnode[1].get('ps:person')
+            core.formTufoByProp('ps:has', (pvalu, ('inet:email', 'c00l@vertex.link')))
+            core.formTufoByProp('ps:has', (pvalu, ('inet:fqdn', 'vertex.link')))
+
+            outnodes = core.eval('ps:has refs(out)')  # out
+            outforms = sorted({node[1]['tufo:form'] for node in outnodes})
+            self.len(5, outnodes)
+            self.eq(outforms, ['inet:email', 'inet:fqdn', 'ps:has', 'ps:person'])
+
+            innodes = core.eval('ps:has refs(in)')  # in
+            informs = sorted({node[1]['tufo:form'] for node in innodes})
+            self.len(2, innodes)
+            self.eq(informs, ['ps:has'])  # Nothing refs in to these nodes
+
+            expected_bothforms = sorted(set(informs + outforms))
+
+            bothnodes = core.eval('ps:has refs()')  # in and out
+            bothforms = sorted({node[1]['tufo:form'] for node in bothnodes})
+            self.len(5, bothnodes)
+            self.eq(expected_bothforms, bothforms)
+
     def test_storm_refs(self):
         with self.getRamCore() as core:
             core.formTufoByProp('inet:dns:a', 'foo.com/1.2.3.4')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -350,31 +350,31 @@ class StormTest(SynTest):
             core.formTufoByProp('file:txtref', (fvalu, ('ps:has', phas0[1].get('ps:has'))))
 
             outnodes = core.eval('ps:has refs(out)')  # out
-            outforms = sorted({node[1]['tufo:form'] for node in outnodes})
+            outforms = {node[1]['tufo:form'] for node in outnodes}
             self.len(5, outnodes)
-            self.eq(outforms, ['inet:email', 'inet:fqdn', 'ps:has', 'ps:person'])
+            self.sorteq(outforms, ['inet:email', 'inet:fqdn', 'ps:has', 'ps:person'])
 
             outnodes = core.eval('ps:has refs(out, limit=0)')  # out
-            limtoutforms = sorted({node[1]['tufo:form'] for node in outnodes})
+            limtoutforms = {node[1]['tufo:form'] for node in outnodes}
             self.len(2, outnodes)
-            self.eq(limtoutforms, ['ps:has'])
+            self.sorteq(limtoutforms, ['ps:has'])
 
             outnodes = core.eval('ps:has refs(out, limit=1)')  # out
-            limtoutforms = sorted({node[1]['tufo:form'] for node in outnodes})
+            limtoutforms = {node[1]['tufo:form'] for node in outnodes}
             self.len(3, outnodes)
             [self.isin(form, ['inet:email', 'inet:fqdn', 'ps:has', 'ps:person']) for form in limtoutforms]
 
             innodes = core.eval('ps:has refs(in)')  # in
-            informs = sorted({node[1]['tufo:form'] for node in innodes})
+            informs = {node[1]['tufo:form'] for node in innodes}
             self.len(3, innodes)
-            self.eq(informs, ['file:txtref', 'ps:has'])  # Nothing refs in to these nodes
+            self.sorteq(informs, ['file:txtref', 'ps:has'])  # Nothing refs in to these nodes
 
-            expected_bothforms = sorted(set(informs + outforms))
+            expected_bothforms = informs.union(outforms)
 
             bothnodes = core.eval('ps:has refs()')  # in and out
-            bothforms = sorted({node[1]['tufo:form'] for node in bothnodes})
+            bothforms = {node[1]['tufo:form'] for node in bothnodes}
             self.len(6, bothnodes)
-            self.eq(expected_bothforms, bothforms)
+            self.sorteq(expected_bothforms, bothforms)
 
     def test_storm_refs(self):
         with self.getRamCore() as core:

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -166,7 +166,7 @@ class PersonTest(SynTest, ModelSeenMixin):
 
         def run_assertions(core, oldname, reftype, tufo_check):
             # assert that the correct number of items was migrated
-            tufos = core.getTufosByProp('ps:has:xref:prop', 'inet:user')
+            tufos = core.getTufosByProp('ps:has:xref:prop', reftype)
             self.len(N, tufos)
 
             # check that properties were correctly migrated and tags were not damaged

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -63,6 +63,61 @@ class PersonTest(SynTest, ModelSeenMixin):
             self.eq(node[1].get('ps:person:name:en:given'), 'emmanuel')
             self.eq(node[1].get('ps:person:name:en:middle'), 'brother')
 
+            node = core.formTufoByProp('ps:person:guidname', 'person123', name='cool')
+            person = node[1].get('ps:person')
+
+            node = core.getTufoByProp('ps:person', person)
+            self.eq(node[1].get('ps:person'), person)
+            self.eq(node[1].get('ps:person:guidname'), 'person123')
+            self.eq(node[1].get('ps:person:name'), 'cool')
+
+    def test_model_persona(self):
+
+        with self.getRamCore() as core:
+            dob = core.getTypeParse('time', '19700101000000001')
+            node = core.formTufoByProp('ps:persona', guid(), dob=dob[0],
+                                       name='Kenshoto,Invisigoth')
+            self.eq(node[1].get('ps:persona:dob'), 1)
+            self.eq(node[1].get('ps:persona:name'), 'kenshoto,invisigoth')
+            self.eq(node[1].get('ps:persona:name:sur'), 'kenshoto')
+            self.eq(node[1].get('ps:persona:name:given'), 'invisigoth')
+            self.none(node[1].get('ps:persona:name:middle'))
+
+            node = core.formTufoByProp('ps:persona', guid(), dob=dob[0],
+                                       name='Kenshoto,Invisigoth,Ninja')
+            self.eq(node[1].get('ps:persona:name'), 'kenshoto,invisigoth,ninja')
+            self.eq(node[1].get('ps:persona:name:sur'), 'kenshoto')
+            self.eq(node[1].get('ps:persona:name:given'), 'invisigoth')
+            self.eq(node[1].get('ps:persona:name:middle'), 'ninja')
+
+            node = core.formTufoByProp('ps:persona', guid(), dob=dob[0],
+                                       name='Kenshoto,Invisigoth,Ninja,Gray')
+            self.eq(node[1].get('ps:persona:name'), 'kenshoto,invisigoth,ninja,gray')
+            self.eq(node[1].get('ps:persona:name:sur'), 'kenshoto')
+            self.eq(node[1].get('ps:persona:name:given'), 'invisigoth')
+            self.eq(node[1].get('ps:persona:name:middle'), 'ninja')
+
+            node = core.formTufoByProp('ps:persona', guid(),
+                                       **{'name': 'Гольдштейн, Эммануэль, брат',
+                                          'name:en': 'Goldstein, Emmanuel, Brother',
+                                          })
+            self.eq(node[1].get('ps:persona:name'), 'гольдштейн,эммануэль,брат')
+            self.eq(node[1].get('ps:persona:name:sur'), 'гольдштейн')
+            self.eq(node[1].get('ps:persona:name:given'), 'эммануэль')
+            self.eq(node[1].get('ps:persona:name:middle'), 'брат')
+            self.eq(node[1].get('ps:persona:name:en'), 'goldstein,emmanuel,brother')
+            self.eq(node[1].get('ps:persona:name:en:sur'), 'goldstein')
+            self.eq(node[1].get('ps:persona:name:en:given'), 'emmanuel')
+            self.eq(node[1].get('ps:persona:name:en:middle'), 'brother')
+
+            node = core.formTufoByProp('ps:persona:guidname', 'persona456', name='cool')
+            persona = node[1].get('ps:persona')
+
+            node = core.getTufoByProp('ps:persona', persona)
+            self.eq(node[1].get('ps:persona'), persona)
+            self.eq(node[1].get('ps:persona:guidname'), 'persona456')
+            self.eq(node[1].get('ps:persona:name'), 'cool')
+
     def test_model_person_tokn(self):
         with self.getRamCore() as core:
             node = core.formTufoByProp('ps:tokn', 'Invisigoth')

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -236,10 +236,10 @@ class PersonTest(SynTest, ModelSeenMixin):
         def _check_tags(core, tufo, tags):
             self.eq(sorted(tags), sorted(s_tufo.tags(tufo)))
 
-        def _check_tagforms(core, oldname, newname, count):
+        def _check_tagforms(core, oldname, newname):
             self.len(0, core.getRowsByProp('syn:tagform:form', oldname))
             self.len(0, core.getJoinByProp(oldname))
-            self.len(count, core.getRowsByProp('syn:tagform:form', newname))
+            self.len(len(TAGS), core.getRowsByProp('syn:tagform:form', newname))
 
         def _check_tagdarks(core, oldname, newname, count):
             self.len(0, core.getRowsByProp('_:*' + oldname + '#hehe.hoho'))
@@ -261,7 +261,7 @@ class PersonTest(SynTest, ModelSeenMixin):
 
             # check that tags were correctly migrated
             _check_tags(core, tufo, TAGS)
-            _check_tagforms(core, oldname, 'ps:has', NODECOUNT)
+            _check_tagforms(core, oldname, 'ps:has')
             _check_tagdarks(core, oldname, 'ps:has', NODECOUNT)
             _check_darkmodlrev(core, tufo)
 

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -243,6 +243,10 @@ class PersonTest(SynTest, ModelSeenMixin):
             self.len(count, core.getRowsByProp('_:*' + newname + '#hehe.hoho'))
             self.len(count, core.getRowsByProp('_:*' + newname + '#hehe'))
 
+        def _check_darkmodlrev(core, tufo):
+            dark_rows = core.getRowsById(tufo[0][::-1])
+            self.true(any([p == '_:dark:syn:modl:rev' and v == 'ps:201802281621' for (i, p, v, t) in dark_rows]))
+
         def run_assertions(core, oldname, reftype, tufo_check):
             # assert that the correct number of items was migrated
             tufos = core.getTufosByProp('ps:has:xref:prop', 'inet:user')
@@ -255,6 +259,7 @@ class PersonTest(SynTest, ModelSeenMixin):
             _check_tags(core, tufo, TAGS)
             _check_tagforms(core, oldname, 'ps:has', NODECOUNT)
             _check_tagdarks(core, oldname, 'ps:has', NODECOUNT)
+            _check_darkmodlrev(core, tufo)
 
             # assert that no old data remains
             _check_no_old_data_remains(core, oldname)

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -10,7 +10,6 @@ class PersonTest(SynTest, ModelSeenMixin):
             person_guid = 32 * '0'
             person_tufo = core.formTufoByProp('ps:person', person_guid, name='Kenshoto,Invisigoth')
             personval = person_tufo[1].get('ps:person')
-            fqdn_tufo = core.formTufoByProp('inet:fqdn', 'vertex.link')
 
             node = core.formTufoByProp('ps:has', (personval, ('inet:fqdn', 'vertex.link')))
             self.ge(node[1].get('node:created'), 1519852535218)
@@ -18,7 +17,12 @@ class PersonTest(SynTest, ModelSeenMixin):
             self.eq(node[1].get('ps:has:person'), personval)
             self.eq(node[1].get('ps:has:xref'), 'inet:fqdn=vertex.link')
             self.eq(node[1].get('ps:has:xref:prop'), 'inet:fqdn')
-            self.eq(node[1].get('ps:has:xref:strval'), 'vertex.link')
+            self.eq(node[1].get('ps:has:xref:node'), '42366d896b947b97e7f3b1afeb9433a3')
+
+            self.none(core.getTufoByProp('node:ndef', '42366d896b947b97e7f3b1afeb9433a3'))  # Not automatically formed
+            core.formTufoByProp('inet:fqdn', 'vertex.link')
+            fqdnfo = core.getTufoByProp('node:ndef', '42366d896b947b97e7f3b1afeb9433a3')
+            self.eq(fqdnfo[1].get('inet:fqdn'), 'vertex.link')
 
     def test_model_person(self):
 
@@ -319,7 +323,6 @@ class PersonTest(SynTest, ModelSeenMixin):
                     self.eq(tufo[1]['ps:has'], 'f8cb39f7e4d8f1b82a5263c14655df68')
                     self.eq(tufo[1]['ps:has:xref'], 'inet:user=pennywise0')
                     self.eq(tufo[1]['ps:has:xref:prop'], 'inet:user')
-                    self.eq(tufo[1]['ps:has:xref:strval'], 'pennywise0')
                     self.eq(tufo[1]['ps:has:xref:node'], '707d5a722ceaa4101d19d7ce3b1a60bb')
                     self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -344,14 +344,14 @@ class PersonTest(SynTest, ModelSeenMixin):
                     self.eq(tufo[1]['ps:has:seen:min'], 0)
                     self.eq(tufo[1]['ps:has:seen:max'], 1)
                     self.eq(tufo[1]['ps:has:xref'], 'inet:user=inet:user0')
-                    self.eq(tufo[1]['ps:has:xref:prop'], 'inet:user')
+                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
                     self.eq(tufo[1]['ps:has:xref:node'], 'bec8693bb5b38ffe62b97b0d2b7cdbb5')
                     self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
-                    core.formTufoByProp('inet:user', 'inet:user0')
+                    core.formTufoByProp(reftype, 'inet:user0')
                     userfo = core.getTufoByProp('node:ndef', 'bec8693bb5b38ffe62b97b0d2b7cdbb5')
-                    self.eq(userfo[1].get('inet:user'), 'inet:user0')
+                    self.eq(userfo[1].get(reftype), 'inet:user0')
 
                     return tufo
                 run_assertions(core, oldname, reftype, tufo_check)
@@ -376,14 +376,14 @@ class PersonTest(SynTest, ModelSeenMixin):
                     self.eq(tufo[1]['ps:has:seen:min'], 0)
                     self.eq(tufo[1]['ps:has:seen:max'], 1)
                     self.eq(tufo[1]['ps:has:xref'], 'ps:name=ps:name0')
-                    self.eq(tufo[1]['ps:has:xref:prop'], 'ps:name')
+                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
                     self.eq(tufo[1]['ps:has:xref:node'], '06359585e4d66e7ab081aaafdedabe39')
                     self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
-                    core.formTufoByProp('ps:name', 'ps:name0')
+                    core.formTufoByProp(reftype, 'ps:name0')
                     namefo = core.getTufoByProp('node:ndef', '06359585e4d66e7ab081aaafdedabe39')
-                    self.eq(namefo[1].get('ps:name'), 'ps:name0')
+                    self.eq(namefo[1].get(reftype), 'ps:name0')
 
                     return tufo
                 run_assertions(core, oldname, reftype, tufo_check)
@@ -398,14 +398,14 @@ class PersonTest(SynTest, ModelSeenMixin):
                     self.eq(tufo[1]['ps:has:seen:min'], 0)
                     self.eq(tufo[1]['ps:has:seen:max'], 1)
                     self.eq(tufo[1]['ps:has:xref'], 'tel:phone=+1 (234) 567-890')
-                    self.eq(tufo[1]['ps:has:xref:prop'], 'tel:phone')
+                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
                     self.eq(tufo[1]['ps:has:xref:node'], '0068a540030a8de1d3f3817e52d50b7c')
                     self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
-                    core.formTufoByProp('tel:phone', '1234567890')
+                    core.formTufoByProp(reftype, '1234567890')
                     phonefo = core.getTufoByProp('node:ndef', '0068a540030a8de1d3f3817e52d50b7c')
-                    self.eq(phonefo[1].get('tel:phone'), 1234567890)
+                    self.eq(phonefo[1].get(reftype), 1234567890)
 
                     return tufo
                 run_assertions(core, oldname, reftype, tufo_check)
@@ -420,14 +420,14 @@ class PersonTest(SynTest, ModelSeenMixin):
                     self.eq(tufo[1]['ps:has:seen:min'], 0)
                     self.eq(tufo[1]['ps:has:seen:max'], 1)
                     self.eq(tufo[1]['ps:has:xref'], 'inet:email=email0@vertex.link')
-                    self.eq(tufo[1]['ps:has:xref:prop'], 'inet:email')
+                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
                     self.eq(tufo[1]['ps:has:xref:node'], '79249f2582baef41cbed45f609e2ea89')
                     self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
-                    core.formTufoByProp('inet:email', 'email0@vertex.link')
+                    core.formTufoByProp(reftype, 'email0@vertex.link')
                     namefo = core.getTufoByProp('node:ndef', '79249f2582baef41cbed45f609e2ea89')
-                    self.eq(namefo[1].get('inet:email'), 'email0@vertex.link')
+                    self.eq(namefo[1].get(reftype), 'email0@vertex.link')
 
                     return tufo
                 run_assertions(core, oldname, reftype, tufo_check)

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -320,7 +320,14 @@ class PersonTest(SynTest, ModelSeenMixin):
                     self.eq(tufo[1]['ps:has:xref'], 'inet:user=pennywise0')
                     self.eq(tufo[1]['ps:has:xref:prop'], 'inet:user')
                     self.eq(tufo[1]['ps:has:xref:strval'], 'pennywise0')
+                    self.eq(tufo[1]['ps:has:xref:node'], '707d5a722ceaa4101d19d7ce3b1a60bb')
                     self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
+
+                    # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
+                    core.formTufoByProp('inet:user', 'pennywise0')
+                    userfo = core.getTufoByProp('node:ndef', '707d5a722ceaa4101d19d7ce3b1a60bb')
+                    self.eq(userfo[1].get('inet:user'), 'pennywise0')
+
                     return tufo
                 run_assertions(core, oldname, reftype, tufo_check)
                 return

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -299,6 +299,8 @@ class PersonTest(SynTest, ModelSeenMixin):
                 (iden, 'ps:hasuser:user', user, tick),
                 (iden, 'ps:hasuser:person', '2f6d1248de48f451e1f349cff33f336c', tick),
                 (iden, 'ps:hasuser', '2f6d1248de48f451e1f349cff33f336c/' + user, tick),
+                (iden, 'ps:hasuser:seen:min', 0, tick),
+                (iden, 'ps:hasuser:seen:max', 1, tick),
                 (iden, '#hehe.hoho', tick, tick),
                 (iden, '#hehe', tick, tick),
                 (dark_iden, '_:*ps:hasuser#hehe.hoho', tick, tick),
@@ -313,6 +315,7 @@ class PersonTest(SynTest, ModelSeenMixin):
             stor.on('modl:vers:rev', addrows, name='ps', vers=201802281621)
 
             with s_cortex.fromstore(stor) as core:
+                # FIXME seen/min/max. hashost is a comp
 
                 # ps:hasuser ======================================================================
                 oldname = 'ps:hasuser'
@@ -321,6 +324,8 @@ class PersonTest(SynTest, ModelSeenMixin):
                     tufo = core.getTufoByProp('ps:has:xref', 'inet:user=pennywise0')
                     self.eq(tufo[1]['tufo:form'], 'ps:has')
                     self.eq(tufo[1]['ps:has'], 'f8cb39f7e4d8f1b82a5263c14655df68')
+                    self.eq(tufo[1]['ps:has:seen:min'], 0)
+                    self.eq(tufo[1]['ps:has:seen:max'], 1)
                     self.eq(tufo[1]['ps:has:xref'], 'inet:user=pennywise0')
                     self.eq(tufo[1]['ps:has:xref:prop'], 'inet:user')
                     self.eq(tufo[1]['ps:has:xref:node'], '707d5a722ceaa4101d19d7ce3b1a60bb')

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -138,18 +138,6 @@ class PersonTest(SynTest, ModelSeenMixin):
 
             self.check_seen(core, node)
 
-    def test_model_person_has_user(self):
-        with self.getRamCore() as core:
-            iden = guid()
-            node = core.formTufoByProp('ps:hasuser', '%s/visi' % iden)
-
-            self.eq(node[1].get('ps:hasuser:user'), 'visi')
-            self.eq(node[1].get('ps:hasuser:person'), iden)
-            self.nn(core.getTufoByProp('ps:person', iden))
-            self.nn(core.getTufoByProp('inet:user', 'visi'))
-
-            self.check_seen(core, node)
-
     def test_model_person_has_webacct(self):
         with self.getRamCore() as core:
             iden = guid()

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -2,6 +2,21 @@ from synapse.tests.common import *
 
 class PersonTest(SynTest, ModelSeenMixin):
 
+    def test_model_ps_has(self):
+        with self.getRamCore() as core:
+            person_guid = 32 * '0'
+            person_tufo = core.formTufoByProp('ps:person', person_guid, name='Kenshoto,Invisigoth')
+            personval = person_tufo[1].get('ps:person')
+            fqdn_tufo = core.formTufoByProp('inet:fqdn', 'vertex.link')
+
+            node = core.formTufoByProp('ps:has', (personval, ('inet:fqdn', 'vertex.link')))
+            self.ge(node[1].get('node:created'), 1519852535218)
+            self.eq(node[1].get('ps:has'), '03870dc800bc21c7c594a900ae65f5cb')
+            self.eq(node[1].get('ps:has:person'), personval)
+            self.eq(node[1].get('ps:has:xref'), 'inet:fqdn=vertex.link')
+            self.eq(node[1].get('ps:has:xref:prop'), 'inet:fqdn')
+            self.eq(node[1].get('ps:has:xref:strval'), 'vertex.link')
+
     def test_model_person(self):
 
         with self.getRamCore() as core:

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -147,7 +147,7 @@ class PersonTest(SynTest, ModelSeenMixin):
             self.len(0, rows)
 
         def _check_tags(core, tufo, tags):
-            self.eq(sorted(tags), sorted(s_tufo.tags(tufo)))
+            self.sorteq(tags, s_tufo.tags(tufo))
 
         def _check_tagforms(core, oldname, newname):
             self.len(0, core.getRowsByProp('syn:tagform:form', oldname))

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -11,13 +11,13 @@ class PersonTest(SynTest, ModelSeenMixin):
             person_tufo = core.formTufoByProp('ps:person', person_guid, name='Kenshoto,Invisigoth')
             personval = person_tufo[1].get('ps:person')
 
-            node = core.formTufoByProp('ps:has', (personval, ('inet:fqdn', 'vertex.link')))
+            node = core.formTufoByProp('ps:person:has', (personval, ('inet:fqdn', 'vertex.link')))
             self.ge(node[1].get('node:created'), 1519852535218)
-            self.eq(node[1].get('ps:has'), '03870dc800bc21c7c594a900ae65f5cb')
-            self.eq(node[1].get('ps:has:person'), personval)
-            self.eq(node[1].get('ps:has:xref'), 'inet:fqdn=vertex.link')
-            self.eq(node[1].get('ps:has:xref:prop'), 'inet:fqdn')
-            self.eq(node[1].get('ps:has:xref:node'), '42366d896b947b97e7f3b1afeb9433a3')
+            self.eq(node[1].get('ps:person:has'), '03870dc800bc21c7c594a900ae65f5cb')
+            self.eq(node[1].get('ps:person:has:person'), personval)
+            self.eq(node[1].get('ps:person:has:xref'), 'inet:fqdn=vertex.link')
+            self.eq(node[1].get('ps:person:has:xref:prop'), 'inet:fqdn')
+            self.eq(node[1].get('ps:person:has:xref:node'), '42366d896b947b97e7f3b1afeb9433a3')
 
             self.none(core.getTufoByProp('node:ndef', '42366d896b947b97e7f3b1afeb9433a3'))  # Not automatically formed
             core.formTufoByProp('inet:fqdn', 'vertex.link')
@@ -166,7 +166,7 @@ class PersonTest(SynTest, ModelSeenMixin):
 
         def run_assertions(core, oldname, reftype, tufo_check):
             # assert that the correct number of items was migrated
-            tufos = core.getTufosByProp('ps:has:xref:prop', reftype)
+            tufos = core.getTufosByProp('ps:person:has:xref:prop', reftype)
             self.len(N, tufos)
 
             # check that properties were correctly migrated and tags were not damaged
@@ -174,8 +174,8 @@ class PersonTest(SynTest, ModelSeenMixin):
 
             # check that tags were correctly migrated
             _check_tags(core, tufo, TAGS)
-            _check_tagforms(core, oldname, 'ps:has')
-            _check_tagdarks(core, oldname, 'ps:has', NODECOUNT)
+            _check_tagforms(core, oldname, 'ps:person:has')
+            _check_tagdarks(core, oldname, 'ps:person:has', NODECOUNT)
             _check_darkmodlrev(core, tufo)
 
             # assert that no old data remains
@@ -319,21 +319,20 @@ class PersonTest(SynTest, ModelSeenMixin):
             stor.on('modl:vers:rev', addrows, name='ps', vers=201802281621)
 
             with s_cortex.fromstore(stor) as core:
-                # FIXME hashost is a comp
 
                 # ps:hasuser ======================================================================
                 oldname = 'ps:hasuser'
                 reftype = 'inet:user'
                 def tufo_check(core):
-                    tufo = core.getTufoByProp('ps:has:xref', 'inet:user=inet:user0')
-                    self.eq(tufo[1]['tufo:form'], 'ps:has')
-                    self.eq(tufo[1]['ps:has'], '1d69ccd1948c985d9467fb4d3caab4f1')
-                    self.eq(tufo[1]['ps:has:seen:min'], 0)
-                    self.eq(tufo[1]['ps:has:seen:max'], 1)
-                    self.eq(tufo[1]['ps:has:xref'], 'inet:user=inet:user0')
-                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
-                    self.eq(tufo[1]['ps:has:xref:node'], 'bec8693bb5b38ffe62b97b0d2b7cdbb5')
-                    self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
+                    tufo = core.getTufoByProp('ps:person:has:xref', 'inet:user=inet:user0')
+                    self.eq(tufo[1]['tufo:form'], 'ps:person:has')
+                    self.eq(tufo[1]['ps:person:has'], '1d69ccd1948c985d9467fb4d3caab4f1')
+                    self.eq(tufo[1]['ps:person:has:seen:min'], 0)
+                    self.eq(tufo[1]['ps:person:has:seen:max'], 1)
+                    self.eq(tufo[1]['ps:person:has:xref'], 'inet:user=inet:user0')
+                    self.eq(tufo[1]['ps:person:has:xref:prop'], reftype)
+                    self.eq(tufo[1]['ps:person:has:xref:node'], 'bec8693bb5b38ffe62b97b0d2b7cdbb5')
+                    self.eq(tufo[1]['ps:person:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
                     core.formTufoByProp(reftype, 'inet:user0')
@@ -347,15 +346,15 @@ class PersonTest(SynTest, ModelSeenMixin):
                 oldname = 'ps:hashost'
                 reftype = 'it:host'
                 def tufo_check(core):
-                    tufo = core.getTufoByProp('ps:has:xref', 'it:host=00000000000000000000000000000000')
-                    self.eq(tufo[1]['tufo:form'], 'ps:has')
-                    self.eq(tufo[1]['ps:has'], '4b4e7d417c84e75fbd30332bde6d9614')
-                    self.eq(tufo[1]['ps:has:seen:min'], 0)
-                    self.eq(tufo[1]['ps:has:seen:max'], 1)
-                    self.eq(tufo[1]['ps:has:xref'], 'it:host=00000000000000000000000000000000')
-                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
-                    self.eq(tufo[1]['ps:has:xref:node'], '09cd1fbc8b183f18c38ae034713af5e3')
-                    self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
+                    tufo = core.getTufoByProp('ps:person:has:xref', 'it:host=00000000000000000000000000000000')
+                    self.eq(tufo[1]['tufo:form'], 'ps:person:has')
+                    self.eq(tufo[1]['ps:person:has'], '4b4e7d417c84e75fbd30332bde6d9614')
+                    self.eq(tufo[1]['ps:person:has:seen:min'], 0)
+                    self.eq(tufo[1]['ps:person:has:seen:max'], 1)
+                    self.eq(tufo[1]['ps:person:has:xref'], 'it:host=00000000000000000000000000000000')
+                    self.eq(tufo[1]['ps:person:has:xref:prop'], reftype)
+                    self.eq(tufo[1]['ps:person:has:xref:node'], '09cd1fbc8b183f18c38ae034713af5e3')
+                    self.eq(tufo[1]['ps:person:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
                     core.formTufoByProp(reftype, 32 * '0')
@@ -369,15 +368,15 @@ class PersonTest(SynTest, ModelSeenMixin):
                 oldname = 'ps:hasalias'
                 reftype = 'ps:name'
                 def tufo_check(core):
-                    tufo = core.getTufoByProp('ps:has:xref', 'ps:name=ps:name0')
-                    self.eq(tufo[1]['tufo:form'], 'ps:has')
-                    self.eq(tufo[1]['ps:has'], '5225cebcede28ca91fae6d9dcf0442f0')
-                    self.eq(tufo[1]['ps:has:seen:min'], 0)
-                    self.eq(tufo[1]['ps:has:seen:max'], 1)
-                    self.eq(tufo[1]['ps:has:xref'], 'ps:name=ps:name0')
-                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
-                    self.eq(tufo[1]['ps:has:xref:node'], '06359585e4d66e7ab081aaafdedabe39')
-                    self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
+                    tufo = core.getTufoByProp('ps:person:has:xref', 'ps:name=ps:name0')
+                    self.eq(tufo[1]['tufo:form'], 'ps:person:has')
+                    self.eq(tufo[1]['ps:person:has'], '5225cebcede28ca91fae6d9dcf0442f0')
+                    self.eq(tufo[1]['ps:person:has:seen:min'], 0)
+                    self.eq(tufo[1]['ps:person:has:seen:max'], 1)
+                    self.eq(tufo[1]['ps:person:has:xref'], 'ps:name=ps:name0')
+                    self.eq(tufo[1]['ps:person:has:xref:prop'], reftype)
+                    self.eq(tufo[1]['ps:person:has:xref:node'], '06359585e4d66e7ab081aaafdedabe39')
+                    self.eq(tufo[1]['ps:person:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
                     core.formTufoByProp(reftype, 'ps:name0')
@@ -391,15 +390,15 @@ class PersonTest(SynTest, ModelSeenMixin):
                 oldname = 'ps:hasphone'
                 reftype = 'tel:phone'
                 def tufo_check(core):
-                    tufo = core.getTufoByProp('ps:has:xref', 'tel:phone=+1 (234) 567-890')
-                    self.eq(tufo[1]['tufo:form'], 'ps:has')
-                    self.eq(tufo[1]['ps:has'], 'e7cdfaba2a1cb739bdf5afd56795dbd3')
-                    self.eq(tufo[1]['ps:has:seen:min'], 0)
-                    self.eq(tufo[1]['ps:has:seen:max'], 1)
-                    self.eq(tufo[1]['ps:has:xref'], 'tel:phone=+1 (234) 567-890')
-                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
-                    self.eq(tufo[1]['ps:has:xref:node'], '0068a540030a8de1d3f3817e52d50b7c')
-                    self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
+                    tufo = core.getTufoByProp('ps:person:has:xref', 'tel:phone=+1 (234) 567-890')
+                    self.eq(tufo[1]['tufo:form'], 'ps:person:has')
+                    self.eq(tufo[1]['ps:person:has'], 'e7cdfaba2a1cb739bdf5afd56795dbd3')
+                    self.eq(tufo[1]['ps:person:has:seen:min'], 0)
+                    self.eq(tufo[1]['ps:person:has:seen:max'], 1)
+                    self.eq(tufo[1]['ps:person:has:xref'], 'tel:phone=+1 (234) 567-890')
+                    self.eq(tufo[1]['ps:person:has:xref:prop'], reftype)
+                    self.eq(tufo[1]['ps:person:has:xref:node'], '0068a540030a8de1d3f3817e52d50b7c')
+                    self.eq(tufo[1]['ps:person:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
                     core.formTufoByProp(reftype, '1234567890')
@@ -413,15 +412,15 @@ class PersonTest(SynTest, ModelSeenMixin):
                 oldname = 'ps:hasemail'
                 reftype = 'inet:email'
                 def tufo_check(core):
-                    tufo = core.getTufoByProp('ps:has:xref', 'inet:email=email0@vertex.link')
-                    self.eq(tufo[1]['tufo:form'], 'ps:has')
-                    self.eq(tufo[1]['ps:has'], 'f1459cf885d792f2a98ae89d36ee9227')
-                    self.eq(tufo[1]['ps:has:seen:min'], 0)
-                    self.eq(tufo[1]['ps:has:seen:max'], 1)
-                    self.eq(tufo[1]['ps:has:xref'], 'inet:email=email0@vertex.link')
-                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
-                    self.eq(tufo[1]['ps:has:xref:node'], '79249f2582baef41cbed45f609e2ea89')
-                    self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
+                    tufo = core.getTufoByProp('ps:person:has:xref', 'inet:email=email0@vertex.link')
+                    self.eq(tufo[1]['tufo:form'], 'ps:person:has')
+                    self.eq(tufo[1]['ps:person:has'], 'f1459cf885d792f2a98ae89d36ee9227')
+                    self.eq(tufo[1]['ps:person:has:seen:min'], 0)
+                    self.eq(tufo[1]['ps:person:has:seen:max'], 1)
+                    self.eq(tufo[1]['ps:person:has:xref'], 'inet:email=email0@vertex.link')
+                    self.eq(tufo[1]['ps:person:has:xref:prop'], reftype)
+                    self.eq(tufo[1]['ps:person:has:xref:node'], '79249f2582baef41cbed45f609e2ea89')
+                    self.eq(tufo[1]['ps:person:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
                     core.formTufoByProp(reftype, 'email0@vertex.link')
@@ -435,15 +434,15 @@ class PersonTest(SynTest, ModelSeenMixin):
                 oldname = 'ps:haswebacct'
                 reftype = 'inet:web:acct'
                 def tufo_check(core):
-                    tufo = core.getTufoByProp('ps:has:xref', 'inet:web:acct=vertex.link/user0')
-                    self.eq(tufo[1]['tufo:form'], 'ps:has')
-                    self.eq(tufo[1]['ps:has'], '9f2179b7a428d4ca233b96acd9b0c8fc')
-                    self.eq(tufo[1]['ps:has:seen:min'], 0)
-                    self.eq(tufo[1]['ps:has:seen:max'], 1)
-                    self.eq(tufo[1]['ps:has:xref'], 'inet:web:acct=vertex.link/user0')
-                    self.eq(tufo[1]['ps:has:xref:prop'], reftype)
-                    self.eq(tufo[1]['ps:has:xref:node'], '0cd705305c7f4573a38b7e7c8f4ddef9')
-                    self.eq(tufo[1]['ps:has:person'], '2f6d1248de48f451e1f349cff33f336c')
+                    tufo = core.getTufoByProp('ps:person:has:xref', 'inet:web:acct=vertex.link/user0')
+                    self.eq(tufo[1]['tufo:form'], 'ps:person:has')
+                    self.eq(tufo[1]['ps:person:has'], '9f2179b7a428d4ca233b96acd9b0c8fc')
+                    self.eq(tufo[1]['ps:person:has:seen:min'], 0)
+                    self.eq(tufo[1]['ps:person:has:seen:max'], 1)
+                    self.eq(tufo[1]['ps:person:has:xref'], 'inet:web:acct=vertex.link/user0')
+                    self.eq(tufo[1]['ps:person:has:xref:prop'], reftype)
+                    self.eq(tufo[1]['ps:person:has:xref:node'], '0cd705305c7f4573a38b7e7c8f4ddef9')
+                    self.eq(tufo[1]['ps:person:has:person'], '2f6d1248de48f451e1f349cff33f336c')
 
                     # Demonstrate that node:ndef works (We have to form this node as adding the xref will not)
                     core.formTufoByProp(reftype, 'vertex.link/user0')


### PR DESCRIPTION
PR #683 #685 and #687 all go together. I would review and merge #683 first, as it is the base of the other two PRs and contains the general `xref`/`refs` changes.