### PR TITLE
Add precomputed datapaths

### DIFF
--- a/synapse/tests/test_lib_datapath.py
+++ b/synapse/tests/test_lib_datapath.py
@@ -19,10 +19,15 @@ class DataPathTest(SynTest):
         data = s_datapath.initelem(item0)
         self.eq(data.valu('results/0/foo'), 10)
         self.eq(data.valu('results/1/foo'), 20)
+        dp = s_datapath.DataPath('results/1/foo')
+        self.eq(data.valu(dp), 20)
 
     def test_datapath_iter(self):
         data = s_datapath.initelem(item0)
         vals = tuple(data.vals('results/*/foo'))
+        self.eq(vals, (10, 20))
+        dp = s_datapath.DataPath('results/*/foo')
+        vals = tuple(data.vals(dp))
         self.eq(vals, (10, 20))
 
     def test_datapath_parent(self):
@@ -33,11 +38,6 @@ class DataPathTest(SynTest):
         data = s_datapath.initelem(item0)
         self.eq(data.valu('".."'), 'hurr')
         self.eq(data.valu('"20"'), 'durr')
-
-    #def test_datapath_abs(self):
-        #data = s_datapath.initelem(item0)
-        #woot = data.open('woot')
-        #self.eq( woot.open('/results/0/foo').valu(), 10 )
 
     def test_datapath_self(self):
         data = s_datapath.initelem(item0)


### PR DESCRIPTION
For instances where the same datapath is used over and over, we used to reparse the datapath string every time. We now allow the valu and iter methods of DataItem to accept a DataPath object instead and only parse the datapath once.