### PR TITLE
neuron/cell leaks

### DIFF
--- a/synapse/tests/test_neuron.py
+++ b/synapse/tests/test_neuron.py
@@ -452,3 +452,5 @@ class NeuronTest(SynTest):
 
                     mesg = ('cell:ping', {'data': 'w00t!'})
                     self.eq(pool.get('woot@localhost').call(mesg), 'w00t!')
+
+                pool.fini()


### PR DESCRIPTION
This should address cell00 and woot connections which appear to leak from ``test_neuron_neuron``