### PR TITLE
Do not propagate events from the Cortex to the CoreModule class.

### DIFF
--- a/synapse/lib/module.py
+++ b/synapse/lib/module.py
@@ -87,12 +87,6 @@ class CoreModule(s_eventbus.EventBus, s_config.Configable):
         s_telepath.reqNotProxy(core)
 
         self.core = core  # type: s_cores_common.Cortex
-        core.link(self.dist)
-
-        def fini():
-            core.unlink(self.dist)
-
-        self.onfini(fini)
 
         # check for decorated functions for model rev
         self._syn_mrevs = []

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -413,7 +413,10 @@ class InetMod(s_module.CoreModule):
         self.onFormNode('inet:fqdn', self.onTufoFormFqdn)
         self.onFormNode('inet:passwd', self.onTufoFormPasswd)
 
-        self.on('node:prop:set', self.onSetFqdnSfx, prop='inet:fqdn:sfx')
+        self.core.on('node:prop:set', self.onSetFqdnSfx, prop='inet:fqdn:sfx')
+
+    def finiCoreModule(self):
+        self.core.off('node:prop:set', self.onSetFqdnSfx)
 
     def onTufoFormFqdn(self, form, valu, props, mesg):
         parts = valu.split('.', 1)


### PR DESCRIPTION
This is very expensive and typically doesn't do anything. Use explicit references to self.core when implementing a event handler in a CoreModule.

Running `python -m unittest synapse.tests.test_cortex.CortexBaseTest.test_cortex_ram -f -v` has a runtime range of 0.3-0.5 seconds with this.  On current master, this test runs in a range of 0.5-0.8 seconds.