### PR TITLE
Feature storm status

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -26,6 +26,22 @@ class AskCmd(s_cli.Cmd):
         ('query', {'type': 'glob'}),
     )
 
+    def show_mesgs(self, mesgs):
+        '''
+        Show messages to a user.
+
+        Args:
+            mesgs (tuple): A tuple of messages to display to the user.
+
+        Returns:
+            None
+        '''
+        if not mesgs:
+            return
+        self.printf('Storm Status Messages:')
+        for i, mesg in enumerate(mesgs):
+            self.printf('[%s] %s' % (i, mesg))
+
     def runCmdOpts(self, opts):
 
         ques = opts.get('query')
@@ -90,6 +106,7 @@ class AskCmd(s_cli.Cmd):
 
         show = resp.get('show', {})
         cols = show.get('columns')
+        mesgs = resp.get('mesgs', ())
 
         if cols is not None:
 
@@ -149,5 +166,7 @@ class AskCmd(s_cli.Cmd):
                         self.printf('    %s = %s' % (prop, disp))
 
         self.printf('(%d results)' % (len(nodes),))
+
+        self.show_mesgs(mesgs)
 
         return resp

--- a/synapse/lib/iq.py
+++ b/synapse/lib/iq.py
@@ -679,6 +679,7 @@ class SynTest(unittest.TestCase):
 
         s_scope.set('syn:test:link', link)
         s_scope.set('syn:cmd:core', prox)
+        s_scope.set('syn:core', core)
 
         try:
             yield prox

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -219,6 +219,7 @@ class Query:
 
             'data': list(data),
             'show': {},
+            'mesgs': [],
         }
 
     def __len__(self):
@@ -293,6 +294,18 @@ class Query:
         Log execution metadata for the current oper.
         '''
         self.results['oplog'][-1].update(info)
+
+    def mesg(self, mesg):
+        '''
+        Add a message to the Storm messages list.
+
+        Args:
+            mesg (str): Message to append to the messages list.
+
+        Returns:
+            None
+        '''
+        self.results['mesgs'].append(mesg)
 
     def result(self):
         return self.results

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -60,6 +60,20 @@ def checkLock(fd, timeout, wait=0.5):
         if wtime >= timeout:
             return False
 
+def mesg_cmd(query, oper):
+    '''
+    Test command which adds messages to the storm message queue.
+
+    Args:
+        query (s_storm.Query): Query object.
+        oper ((str, dict)): Oper tuple
+
+    Returns:
+        None
+    '''
+    query.mesg('Log test messages')
+    query.mesg('Query has [%s] nodes' % len(query.data()))
+
 class ModelSeenMixin:
 
     def check_seen(self, core, node):

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -65,6 +65,23 @@ class SynCmdCoreTest(SynTest):
             for term in terms:
                 self.nn(regex.search(term, outp))
 
+    def test_cmds_ask_mesgs(self):
+        with self.getDmonCore() as core:
+            real_core = s_scope.get('syn:core')
+            real_core.setOperFunc('test:mesg', mesg_cmd)
+
+            outp = self.getTestOutp()
+            cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+            resp = cmdr.runCmdLine('ask [inet:ipv4=1.2.3.4] test:mesg()')
+            self.len(1, resp['data'])
+            self.len(2, resp['mesgs'])
+
+            outp.expect('Storm Status Messages:')
+            outp.expect('Log test messages')
+            outp.expect('Query has [1] nodes')
+            print('cli> ask [inet:ipv4=1.2.3.4] test:mesg()')
+            print(outp)
+
     def test_cmds_ask_tagtime(self):
 
         with self.getDmonCore() as core:

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1547,6 +1547,13 @@ class StormTest(SynTest):
             self.eq(nodes[0][1].get('inet:dns:a'), 'example.com/4.3.2.1')
             self.eq(nodes[1][1].get('inet:dns:a'), 'vertex.link/1.2.3.4')
 
+    def test_storm_messages(self):
+        with self.getRamCore() as core:  # type: s_cores_common.Cortex
+            core.setOperFunc('test:mesg', mesg_cmd)
+            results = core.ask('[inet:ipv4=1.2.3.4] test:mesg()')
+            mesgs = results.get('mesgs')
+            self.sorteq(mesgs, ['Log test messages', 'Query has [1] nodes'])
+
 class LimitTest(SynTest):
     def test_limit_default(self):
         # LimitHelper would normally be used with the kwlist arg limit,


### PR DESCRIPTION
Allow a storm operator to add an arbitrary number of messages to a general message list instead of relying on use of operlog.  Example:

```
cli> ask [inet:ipv4=1.2.3.4] test:mesg()
inet:ipv4 = 1.2.3.4
(1 results)
Storm Status Messages:
[0] Log test messages
[1] Query has [1] nodes
```