### PR TITLE
Add a try/except around readline.read_init_file

### DIFF
--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -277,7 +277,15 @@ class Cli(s_eventbus.EventBus):
         Run commands from a user in an interactive fashion until fini() or EOFError is raised.
         '''
         import readline
-        readline.read_init_file()
+        try:
+            readline.read_init_file()
+        except OSError:
+            # from cpython 3.6 site.py:
+            # An OSError here could have many causes, but the most likely one
+            # is that there's no .inputrc file (or .editrc file in the case of
+            # Mac OS X + libedit) in the expected location.  In that case, we
+            # want to ignore the exception.
+            pass
 
         while not self.isfini:
 


### PR DESCRIPTION
Closes #535 
cc: @MichaelSquires 
@jnwatson can you confirm this works on osx?