### PR TITLE
010 telco

### DIFF
--- a/synapse/lib/modules.py
+++ b/synapse/lib/modules.py
@@ -12,6 +12,7 @@ coremods = (
     'synapse.models.base.BaseModule',
     'synapse.models.files.FileModule',
     'synapse.models.geopol.PolModule',
+    'synapse.models.telco.TelcoModule',
     'synapse.models.inet.InetModule',
     'synapse.models.material.MatModule',
     'synapse.models.language.LangModule',

--- a/synapse/models/telco.py
+++ b/synapse/models/telco.py
@@ -86,7 +86,7 @@ class Phone(s_types.Type):
                                     mesg='Failed to get phone info')
         cc = info.get('cc')
         if cc is not None:
-            subs['cc'] = cc
+            subs['loc'] = cc
         # TODO prefix based validation?
         return digs, {'subs': subs}
 
@@ -239,7 +239,7 @@ class TelcoModule(s_module.CoreModule):
                     'ex': '310150123456789',
                 }),
                 ('tel:phone', 'synapse.models.telco.Phone', {}, {
-                    'doc': 'A phone number',
+                    'doc': 'A phone number.',
                     'ex': '+15558675309',
                 }),
 
@@ -261,8 +261,8 @@ class TelcoModule(s_module.CoreModule):
             ),
             'forms': (
                 ('tel:phone', {}, (
-                    ('cc', ('pol:iso2', {}), {
-                        'doc': 'The countrycode associated with the number.',
+                    ('loc', ('loc', {}), {
+                        'doc': 'The location associated with the number.',
                         'defval': '??',
                     }),
                 )),

--- a/synapse/models/telco.py
+++ b/synapse/models/telco.py
@@ -81,7 +81,7 @@ class Phone(s_types.Type):
         subs = {}
         try:
             info = s_l_phone.getPhoneInfo(int(digs))
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             raise s_exc.BadTypeValu(valu=valu,
                                     mesg='Failed to get phone info')
         cc = info.get('cc')

--- a/synapse/models/telco.py
+++ b/synapse/models/telco.py
@@ -107,6 +107,14 @@ class Phone(s_types.Type):
         '''
         return valu.encode('utf8')
 
+    def liftPropEq(self, xact, fenc, penc, valu):
+        if isinstance(valu, str) and valu.endswith('*'):
+            norm, _ = self._normPyStr(valu)
+            indx = self.indx(norm)
+            return self._liftByPref(xact, fenc, penc, indx)
+
+        return s_types.Type.liftPropEq(self, xact, fenc, penc, valu)
+
     def repr(self, valu):
         # FIXME implement more geo aware reprs
         # XXX geo-aware reprs are practically a function of cc which

--- a/synapse/tests/test_model_telco.py
+++ b/synapse/tests/test_model_telco.py
@@ -66,15 +66,15 @@ class TelcoModelTest(s_test.SynTest):
             t = core.model.type('tel:phone')
             norm, subs = t.norm('123 456 7890')
             self.eq(norm, '1234567890')
-            self.eq(subs, {'subs': {'cc': 'us'}})
+            self.eq(subs, {'subs': {'loc': 'us'}})
 
             norm, subs = t.norm(1234567890)
             self.eq(norm, '1234567890')
-            self.eq(subs, {'subs': {'cc': 'us'}})
+            self.eq(subs, {'subs': {'loc': 'us'}})
 
             norm, subs = t.norm('+1911')
             self.eq(norm, '1911')
-            self.eq(subs, {'subs': {'cc': 'us'}})
+            self.eq(subs, {'subs': {'loc': 'us'}})
 
             self.eq(t.repr('12345678901'), '+1 (234) 567-8901')
             self.eq(t.repr('9999999999'), '+9999999999')
@@ -85,7 +85,7 @@ class TelcoModelTest(s_test.SynTest):
             with core.xact(write=True) as xact:
                 node = xact.addNode('tel:phone', '+1 (703) 555-1212')
                 self.eq(node.ndef[1], '17035551212')
-                self.eq(node.get('cc'), 'us')
+                self.eq(node.get('loc'), 'us')
                 node = xact.addNode('tel:phone', '+1 (703) 555-2424')
                 # Exact search
                 nodes = list(xact.getNodesBy('tel:phone', 17035552424))

--- a/synapse/tests/test_model_telco.py
+++ b/synapse/tests/test_model_telco.py
@@ -86,6 +86,14 @@ class TelcoModelTest(s_test.SynTest):
                 node = xact.addNode('tel:phone', '+1 (703) 555-1212')
                 self.eq(node.ndef[1], '17035551212')
                 self.eq(node.get('cc'), 'us')
+                node = xact.addNode('tel:phone', '+1 (703) 555-2424')
+                # Exact search
+                nodes = list(xact.getNodesBy('tel:phone', 17035552424))
+                self.len(1, nodes)
+                self.eq(nodes[0].ndef[1], '17035552424')
+                # Prefix search
+                nodes = list(xact.getNodesBy('tel:phone', '1703555*'))
+                self.len(2, nodes)
 
 class Fixme:
 

--- a/synapse/tests/test_model_telco.py
+++ b/synapse/tests/test_model_telco.py
@@ -79,6 +79,9 @@ class TelcoModelTest(s_test.SynTest):
             self.eq(t.repr('12345678901'), '+1 (234) 567-8901')
             self.eq(t.repr('9999999999'), '+9999999999')
 
+            self.raises(s_exc.BadTypeValu, t.norm, -1)
+            self.raises(s_exc.BadTypeValu, t.norm, '+()*')
+
             with core.xact(write=True) as xact:
                 node = xact.addNode('tel:phone', '+1 (703) 555-1212')
                 self.eq(node.ndef[1], '17035551212')


### PR DESCRIPTION
Initial port of the 010 telco model.

Fixmes that need to be addressed:

-  ou:org is still outstanding.
- we had a set of typecasting rules in place - what do we want to do with them? 
- ``tel:prefix`` isn't ported over; its use is unclear