### PR TITLE
Async close fix

### DIFF
--- a/synapse/lib/link.py
+++ b/synapse/lib/link.py
@@ -9,6 +9,7 @@ import synapse.eventbus as s_eventbus
 
 import synapse.lib.queue as s_queue
 import synapse.lib.msgpack as s_msgpack
+import logging
 
 class Link(s_eventbus.EventBus):
     '''
@@ -45,7 +46,6 @@ class Link(s_eventbus.EventBus):
         self.txque = asyncio.Queue(maxsize=1000)
         self.rxfunc = None
 
-        self.onfini(self.writer.close)
 
         def fini():
 

--- a/synapse/lib/link.py
+++ b/synapse/lib/link.py
@@ -1,15 +1,12 @@
 import socket
 import asyncio
-import threading
 
 import synapse.exc as s_exc
-import synapse.glob as s_glob
 import synapse.common as s_common
 import synapse.eventbus as s_eventbus
 
 import synapse.lib.queue as s_queue
 import synapse.lib.msgpack as s_msgpack
-import logging
 
 class Link(s_eventbus.EventBus):
     '''
@@ -45,7 +42,6 @@ class Link(s_eventbus.EventBus):
         self.unpk = s_msgpack.Unpk()
         self.txque = asyncio.Queue(maxsize=1000)
         self.rxfunc = None
-
 
         def fini():
 


### PR DESCRIPTION
The async debug stuff was warning about doing stuff from the wrong thread. This fixes it.

The writer close was actually already handled in `_onAsyncFini`