### PR TITLE
Add printables() to chop to strip non-printables from a string.

### DIFF
--- a/synapse/lib/chop.py
+++ b/synapse/lib/chop.py
@@ -18,6 +18,9 @@ def intrange(text):
 def digits(text):
     return ''.join([c for c in text if c.isdigit()])
 
+def printables(text):
+    return ''.join([c for c in text if c.isprintable()])
+
 def mergeRanges(x, y):
     '''
     Merge two ranges into one.

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -14,6 +14,7 @@ import regex
 # custom code
 import synapse.exc as s_exc
 import synapse.common as s_common
+import synapse.lib.chop as s_chop
 import synapse.lib.types as s_types
 import synapse.lib.module as s_module
 import synapse.lookup.iana as s_l_iana
@@ -234,6 +235,7 @@ class IPv4(s_types.Type):
     def _normPyStr(self, valu):
 
         valu = valu.replace('[.]', '.')
+        valu = s_chop.printables(valu)
 
         try:
             byts = socket.inet_aton(valu)
@@ -281,8 +283,10 @@ class IPv6(s_types.Type):
 
         try:
 
-            if type(valu) == str and valu.find(':') == -1:
-                valu = '::ffff:' + valu
+            if type(valu) == str:
+                valu = s_chop.printables(valu)
+                if valu.find(':') == -1:
+                    valu = '::ffff:' + valu
 
             v6 = ipaddress.IPv6Address(valu)
             v4 = v6.ipv4_mapped

--- a/synapse/tests/test_lib_chop.py
+++ b/synapse/tests/test_lib_chop.py
@@ -11,9 +11,6 @@ class ChopTest(s_test.SynTest):
         tags = s_chop.tags('foo.bar.baz')
         self.eq(tags, ('foo', 'foo.bar', 'foo.bar.baz'))
 
-    def test_chop_onespace(self):
-        self.eq('foo bar baz', s_chop.onespace('foo   bar baz'))
-
     def test_chop_tag(self):
         self.eq('foo.bar.ba z', s_chop.tag('#foo  .bar.  BA Z'))
 
@@ -41,19 +38,24 @@ class ChopTest(s_test.SynTest):
                 self.raises(e, s_chop.hexstr, v)
 
     def test_chop_onespace(self):
-        ivs = ['asdfasdf  asdfasdf ',
-               'asdfasdf ',
-               'asdf',
-               '  asdfasdf  ',
-               ' asdf  asdf    asdf \t \t asdf asdf   ',
-               ' '
-               ]
-        evs = ['asdfasdf asdfasdf',
-               'asdfasdf',
-               'asdf',
-               'asdfasdf',
-               'asdf asdf asdf asdf asdf',
-               '']
-        for iv, ev in zip(ivs, evs):
+        tvs = [
+            ('asdfasdf  asdfasdf ', 'asdfasdf asdfasdf'),
+            ('asdfasdf ', 'asdfasdf'),
+            ('asdf', 'asdf'),
+            ('  asdfasdf  ', 'asdfasdf'),
+            (' asdf  asdf    asdf \t \t asdf asdf   ', 'asdf asdf asdf asdf asdf'),
+            (' ', ''),
+            ('foo   bar baz', 'foo bar baz'),
+        ]
+        for iv, ev in tvs:
             rv = s_chop.onespace(iv)
+            self.eq(rv, ev)
+
+    def test_chop_printables(self):
+        tvs = [
+            ('hehe haha', 'hehe haha'),
+            ('hehe\u200bhaha\u200b ', 'hehehaha ')
+        ]
+        for iv, ev in tvs:
+            rv = s_chop.printables(iv)
             self.eq(rv, ev)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -910,7 +910,7 @@ class InetModelTest(s_t_common.SynTest):
 
     def _test_types_url_behavior(self, t, htype, host, norm_host, repr_host):
 
-            # Handle IPv6 Port Brackets
+        # Handle IPv6 Port Brackets
         host_port = host
         repr_host_port = repr_host
 


### PR DESCRIPTION
Use that when norming a IPV4/IPv6 address.
fix indentation of a test function.