### PR TITLE
010 node queue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    #'sphinx.ext.napoleon',  # TODO - Uncomment this line when we are ready to cut over style types.
+    'sphinx.ext.napoleon',
 ]
 
 # # Napoleon settings # TODO - Uncomment these napoleon settings when we are ready to cover over style types.
@@ -353,6 +353,8 @@ def run_apidoc(_):
     main(['-M', '-o', 'synapse/api', '../'])
 
 def run_autodoc(_):
+    # FIXME - Make Autodoc work with 010
+    return
     import synapse.tools.autodoc as s_autodoc
     s_autodoc.main(['--doc-model', '--savefile', 'synapse/datamodel.rst'])
 

--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -15,6 +15,8 @@ import synapse.glob as s_glob  # setup glob here to avoid import loops...
 import synapse.lib.plex as s_plex
 import synapse.lib.threads as s_threads
 
+from synapse.lib.version import version, verstring
+
 tmax = multiprocessing.cpu_count() * 8
 
 s_glob.plex = s_plex.Plex()

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -184,10 +184,6 @@ class CoreApi(s_cell.CellApi):
         return self.cell.setQueueKey(name, key, valu)
 
     @s_cell.adminapi
-    def popQueueKey(self, name, key):
-        return self.cell.popQueueKey(name, key)
-
-    @s_cell.adminapi
     def getQueues(self):
         return self.cell.getQueues()
 
@@ -230,9 +226,6 @@ class Cortex(s_cell.Cell):
 
         ('feeds', {'type': 'list', 'defval': (),
             'doc': 'A list of feed dictionaries.'}),
-
-        ('queue:endpoints', {'type': 'list', 'defval': (),
-            'doc': 'A list of queue endpoint dictionaries the cortex can send nodes to.'})
 
         #('storm:save', {'type': 'bool', 'defval': False,
             #'doc': 'Archive storm queries for audit trail.'}),

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -6,6 +6,7 @@ import synapse.dyndeps as s_dyndeps
 import synapse.telepath as s_telepath
 import synapse.datamodel as s_datamodel
 
+import synapse.lib.kv as s_kv
 import synapse.lib.cell as s_cell
 import synapse.lib.snap as s_snap
 import synapse.lib.const as s_const
@@ -171,6 +172,33 @@ class CoreApi(s_cell.CellApi):
         '''
         yield from self.cell.layer.splices(offs, size)
 
+    def getQueueDescs(self):
+        return self.cell.getQueueDescs()
+
+    @s_cell.adminapi
+    def addQueue(self, conf):
+        return self.cell.addQueue(conf)
+
+    @s_cell.adminapi
+    def setQueueKey(self, name, key, valu):
+        return self.cell.setQueueKey(name, key, valu)
+
+    @s_cell.adminapi
+    def popQueueKey(self, name, key):
+        return self.cell.popQueueKey(name, key)
+
+    @s_cell.adminapi
+    def getQueues(self):
+        return self.cell.getQueues()
+
+    @s_cell.adminapi
+    def getQueue(self, name):
+        return self.cell.getQueue(name)
+
+    @s_cell.adminapi
+    def delQueue(self, name):
+        return self.cell.delQueue(name)
+
 class Cortex(s_cell.Cell):
     '''
     A Cortex implements the synapse hypergraph.
@@ -203,6 +231,9 @@ class Cortex(s_cell.Cell):
         ('feeds', {'type': 'list', 'defval': (),
             'doc': 'A list of feed dictionaries.'}),
 
+        ('queue:endpoints', {'type': 'list', 'defval': (),
+            'doc': 'A list of queue endpoint dictionaries the cortex can send nodes to.'})
+
         #('storm:save', {'type': 'bool', 'defval': False,
             #'doc': 'Archive storm queries for audit trail.'}),
 
@@ -220,12 +251,11 @@ class Cortex(s_cell.Cell):
         self.feedfuncs = {}
 
         self.stormcmds = {}
-        self.tqueue = None  # type: s_queue.Queue
 
         self.addStormCmd(s_storm.HelpCmd)
         self.addStormCmd(s_storm.SudoCmd)
-        self.addStormCmd(s_storm.TaskCmd)
         self.addStormCmd(s_storm.LimitCmd)
+        self.addStormCmd(s_storm.QueueCmd)
         self.addStormCmd(s_storm.DelNodeCmd)
 
         self.splicers = {
@@ -238,6 +268,12 @@ class Cortex(s_cell.Cell):
         }
 
         self.setFeedFunc('syn.splice', self._addSynSplice)
+
+        # Create our cortex local KVStore
+        self.kvstor = s_kv.KvStor(s_common.genpath(self.dirn, 'cortex.lmdb'))
+        self.onfini(self.kvstor.fini)
+        # Initialize our queue kvdict
+        self.queueConfs = self.kvstor.getKvLook('cortex:queues')
 
         # load any configured external layers
         for path in self.conf.get('layers'):
@@ -259,7 +295,6 @@ class Cortex(s_cell.Cell):
         self._initCryoLoop()
         self._initPushLoop()
         self._initFeedLoops()
-        self._initTaskLoop()
 
     def addStormCmd(self, ctor):
         '''
@@ -272,27 +307,6 @@ class Cortex(s_cell.Cell):
 
     def getStormCmds(self):
         return list(self.stormcmds.items())
-
-    def _initTaskLoop(self):
-        if self.conf.get('task:queue') is None:
-            return
-
-        self.tqueue = s_queue.Queue()
-        self.onfini(self.tqueue.done)
-        thrd = self._runTaskLoop()
-        def fini():
-            return thrd.join(timeout=8)
-        self.onfini(fini)
-
-    @s_common.firethread
-    def _runTaskLoop(self):
-        while not self.isfini:
-            try:
-                tconf = self.conf.get('task:queue')
-                s_persist.run(self, tconf)
-            except Exception as e:
-                logger.exception('task sync error')
-                self.cellfini.wait(timeout=1)
 
     def _initPushLoop(self):
 
@@ -793,3 +807,112 @@ class Cortex(s_cell.Cell):
         except Exception as e:
             logger.exception('mod load fail: %s' % (ctor,))
             return None
+
+    # Get all queue descriptions (safe for storm users)
+    def getQueueDescs(self):
+        '''
+        Get tufos containing only metadata for queues configured by the Cortex.
+
+        Returns:
+            list: A list of tufos.
+        '''
+        ret = []
+        desckeys = ['type', 'desc']
+        for name, conf in self.queueConfs.items():
+            v = conf[1]
+            [v.pop(_key) for _key in list(v.keys()) if _key not in desckeys]
+            ret.append((name, v))
+        return ret
+
+    # Add a specific queue with a whole conf tufo
+    def addQueue(self, conf):
+        '''
+        Add a queue endpoint to the Cortex.
+
+        Args:
+            conf ((str, dict)): A tufo with the name of the queue as the iden, and
+
+        Returns:
+            True: After adding the queue.
+
+        Examples:
+            Add a queue config:
+
+                name = 'qt1'
+                info = {'desc': 'A queue', 'type': 'cryotank', 'url': 'tcp://.../cryo/qt1'}
+                conf = (name, info)
+                core.addQueue(conf)
+
+        Raises:
+            s_exc.BadConfValu: If the queue already exists.
+        '''
+        name = conf[0]
+        s_persist.validate(conf)
+        econf = self.queueConfs.get(name)
+        if econf:
+            raise s_exc.BadConfValu(mesg='Cannot overwrite an exist queue by name with addQueue().',
+                                    name=name)
+        self.queueConfs.set(name, conf)
+        logger.info('Added queue [%s]', conf)
+        return True
+
+    # Update a specific key in a conf
+    def setQueueKey(self, name, key, valu):
+        '''
+        Set a specific key in a queue config.
+
+        Args:
+            name (str): Name of the queue.
+            key (str): Name of the key to set.
+            valu: Value to set in the config tufo.
+
+        Returns:
+            True: True if the configuration is valid.
+
+        Raises:
+            s_exc.BadConfValu: If the configuration is invalid after updating it.
+        '''
+        conf = self.queueConfs.get(name)
+        conf[1][key] = valu
+        s_persist.validate(conf)
+        self.queueConfs.set(name, conf)
+        logger.info('Set key for queue: [%s][%s][%s]', name, key, valu)
+        return True
+
+    def getQueue(self, name):
+        '''
+        Get a single queue configuration.
+
+        Args:
+            name (str): Name of the queue configuration to retrieve.
+
+        Returns:
+            ((str, dict)): A configuration tufo for the queue.
+        '''
+        return self.queueConfs.get(name)
+
+    # Get all queues
+    def getQueues(self):
+        '''
+        Get all queues configured for this Cortex.
+
+        Returns:
+            list: A list of all configured queues for this cortex.
+        '''
+        return [v for k, v in self.queueConfs.items()]
+
+    def delQueue(self, name):
+        '''
+        Remove a queue.
+
+        Args:
+            name (str): Name of the queue to remove.
+
+        Returns:
+            bool: True if the queue was removed.  False if the queue does not exist.
+        '''
+        conf = self.queueConfs.pop(name)
+        logger.info('Deleted queue: [%s]', conf)
+        if conf:
+            return True
+        return False

--- a/synapse/lib/cmdr.py
+++ b/synapse/lib/cmdr.py
@@ -4,6 +4,7 @@ import synapse.cmds.cortex as s_cmds_cortex
 cmdsbycell = {
     'cortex': (
         s_cmds_cortex.StormCmd,
+        s_cmds_cortex.QueueCmd,
     ),
 }
 

--- a/synapse/lib/kv.py
+++ b/synapse/lib/kv.py
@@ -146,6 +146,23 @@ class KvLook:
             valu = s_msgpack.un(lval)
             yield prop, valu
 
+    def pop(self, prop):
+        '''
+        Pop a property from the KvLook.
+
+        Args:
+            prop (str): The property name.
+
+        Returns:
+            object: The object stored in the KvLook, or None if the object was not present.
+        '''
+        valu = self.get(prop, None)
+
+        lkey = self.iden + prop.encode('utf8')
+        self.stor.delKvProp(lkey)
+
+        return valu
+
     def getraw(self, lkey):
         '''
         Retrieve a value directly by bytes.

--- a/synapse/lib/persist.py
+++ b/synapse/lib/persist.py
@@ -1,0 +1,114 @@
+'''
+Helpers for persistent queuing loop functions.
+'''
+import logging
+import collections
+
+import synapse.common as s_common
+import synapse.telepath as s_telepath
+
+logger = logging.getLogger(__name__)
+
+qtypes = {}
+
+def add(name, func):
+    '''
+    Register a task queue constructor function.
+
+    Args:
+        name (str): Name of the task queue alias.
+        func: Function used to run the task queue.
+
+    Notes:
+        Third party modules which implement a task queue consumer class
+        should import ``synapse.lib.persist`` and register their alias
+        and queue function using this function.  This can be done in a module
+        ``__init__.py`` file.  Functions are expected to take a Cortex with
+        ``tqueue`` attribute which is a ``synapse.lib.queue.Queue`` object,
+        and a dictionary of configuration data.
+
+    Returns:
+        None
+    '''
+    qtypes[name] = func
+
+def getQueues():
+    '''
+    Get a list of registered queue names and their fully qualified paths.
+    '''
+    ret = []
+    for alias, ctor in qtypes.items():
+        ret.append((alias, '.'.join([ctor.__module__, ctor.__qualname__])))
+    return ret
+
+def run(core, conf):
+    func = qtypes.get(conf.get('type'))
+    func(core, conf)
+
+def cryoCellQueue(core, conf):
+    '''
+    Consume task events from the Cortex.tqueue, and place them into CryoTanks
+    managed by a CryoCell.
+
+    Args:
+        core: Cortex to consume events from.
+        conf (dict): A config dictionary. The following keys are used:
+          - url: The Cryocell to connect too via Telepath.
+          - size: The number of items to pull from the queue at once. If not
+          provided, the default size of 1000 will be used.
+
+    Notes:
+        Task events consumed by the Queue are bucketed by their task name, and
+        only the task dictionaries are placed into the CryoTank. Tasks are put
+        into the tanks by their name.
+        For Cortex configuration purposes, this is named ``cryo:cell``.
+
+    '''
+    url = conf.get('url')
+    sz = conf.get('size', 1000)
+    with s_telepath.openurl(url) as cryocell:
+        for items in core.tqueue.slices(sz):
+            d = collections.defaultdict(list)
+            for ttype, rec in items:
+                d[ttype].append(rec)
+
+            for ttype, recs in d.items():
+                try:
+                    cryocell.puts(ttype, recs)
+                except Exception as e:
+                    logger.exception('Failed to put items into tank for [%s]', ttype)
+                    raise
+            core.fire('persist:task:cryo:cell', len=len(items))
+
+def cryoTankQueue(core, conf):
+    '''
+        Consume task events from the Cortex.tqueue, and put them directly into
+        a Cryotank.
+
+        Args:
+            core: Cortex to consume events from.
+            conf (dict): A config dictionary. The following keys are used:
+              - url: The CryoTank to connect to via Telepath.
+              - size: The number of items to pull from the queue at once. If not
+              provided, the default size of 1000 will be used.
+
+        Notes:
+            This puts tasks into the CryoTanks as a tufo of
+            ``('someTaskName', {..task data..})``.
+            For Cortex configuration purposes, this is named ``cryo:tank``.
+
+        '''
+    url = conf.get('url')
+    sz = conf.get('size', 1000)
+    with s_telepath.openurl(url) as cryotank:
+        for items in core.tqueue.slices(sz):
+            try:
+                cryotank.puts(items)
+            except Exception as e:
+                logger.exception('Failed to put items into cryotank')
+                raise
+            core.fire('persist:task:cryo:tank', len=len(items))
+
+# Register built-in queue loop functions.
+add('cryo:cell', cryoCellQueue)
+add('cryo:tank', cryoTankQueue)

--- a/synapse/lib/persist.py
+++ b/synapse/lib/persist.py
@@ -1,114 +1,168 @@
 '''
-Helpers for persistent queuing loop functions.
+Helpers for persistent queuing functions.
 '''
 import logging
-import collections
 
-import synapse.common as s_common
+import synapse.exc as s_exc
 import synapse.telepath as s_telepath
+
+import synapse.lib.urlhelp as s_urlhelp
 
 logger = logging.getLogger(__name__)
 
 qtypes = {}
 
-def add(name, func):
+class QueueBase:
     '''
-    Register a task queue constructor function.
+    Base class for implementing queue endpoints for the Storm ``queue``
+    command.
+
+    This class, and its derivatives, are never constructed as standalone
+    objects. Implementors should override the ``validate`` and ``queue``
+    classmethods in order to implement their endpoints.
+    '''
+    @classmethod
+    def validate(cls, conf):
+        '''
+        Validate that a
+
+        Args:
+            conf ((str, dict)): A Configuration tufo.
+
+        Returns:
+            bool: True if the configuration is valid.
+
+        Notes:
+            Implementors may override this method to provide their
+            own configuration validation.
+
+        Raises:
+            s_exc.BadConfValu: If the configuration is invalid.
+        '''
+        name = conf[0]
+        if not isinstance(name, str):
+            raise s_exc.BadConfValu(mesg='name is incorrect or missing.',
+                                    key='name')
+        return True
+
+    @classmethod
+    def queue(cls, conf, items):
+        '''
+        Queue up items to a endpoint with a given configuraiton.
+
+        Args:
+            conf (dict): A configuration dictionary. This should contain the
+            information necessary to connect too and place items into a given
+            queue endpoint.
+            items (list): A list of packed nodes to queue.
+
+        Notes:
+            Implementors must override this method in order to connect to
+            their remote queueing service and place packed nodes into the
+            queue with the given configuration.
+
+        Returns:
+            int: The number of items placed into the queue.
+        '''
+        raise s_exc.NoSuchImpl(mesg='Queue function is not implemented on the base class.',
+                               name='queue')
+
+class CryoQueue(QueueBase):
+    '''
+    A CryoTank backed queue for nodes.
+    '''
+    @classmethod
+    def validate(cls, conf):
+        '''
+        Ensure that the configuration has name and a valid URL managed by a CryoCell.
+        '''
+        QueueBase.validate(conf)
+        name, conf = conf
+        url = conf.get('url')
+        try:
+            parts = s_urlhelp.chopurl(url)
+            path = parts.get('path')
+            cellname, tankname = path.lstrip('/').split('/')
+        except Exception as e:
+            logger.exception('Failed to parse url [%s].', url)
+            raise s_exc.BadConfValu(mesg='Unable to parse tank name from URL.',
+                                    name='url', valu=url) from e
+        if not tankname:
+            raise s_exc.BadConfValu(mesg='No tank name found in url',
+                                    name='url', valu=url)
+        return True
+
+    @classmethod
+    def queue(cls, conf, items):
+        '''
+        Place items into the configured CryoTank.
+        '''
+        name, conf = conf
+        url = conf.get('url')
+        try:
+            with s_telepath.openurl(url) as cryotank:
+                cryotank.puts(items)
+        except Exception as e:
+            logger.exception('Failed to put items into cryotank')
+            raise
+        return len(items)
+
+def add(name, ctor):
+    '''
+    Register a queue constructor class.
 
     Args:
         name (str): Name of the task queue alias.
-        func: Function used to run the task queue.
+        ctor: Class used to run the task queue.
 
     Notes:
-        Third party modules which implement a task queue consumer class
-        should import ``synapse.lib.persist`` and register their alias
-        and queue function using this function.  This can be done in a module
-        ``__init__.py`` file.  Functions are expected to take a Cortex with
-        ``tqueue`` attribute which is a ``synapse.lib.queue.Queue`` object,
-        and a dictionary of configuration data.
+        Third party modules which implement a QueueBase class should import
+        ``synapse.lib.persist`` and register their alias and queue class using
+        this function.  This can be done in a module ``__init__.py`` file.
 
     Returns:
         None
     '''
-    qtypes[name] = func
+    qtypes[name] = ctor
 
 def getQueues():
     '''
-    Get a list of registered queue names and their fully qualified paths.
+    Get a list of registered queue names and their fully qualified class paths.
     '''
     ret = []
     for alias, ctor in qtypes.items():
         ret.append((alias, '.'.join([ctor.__module__, ctor.__qualname__])))
     return ret
 
-def run(core, conf):
-    func = qtypes.get(conf.get('type'))
-    func(core, conf)
-
-def cryoCellQueue(core, conf):
+def validate(conf):
     '''
-    Consume task events from the Cortex.tqueue, and place them into CryoTanks
-    managed by a CryoCell.
+    Validate a configuration is correct.
 
     Args:
-        core: Cortex to consume events from.
-        conf (dict): A config dictionary. The following keys are used:
-          - url: The Cryocell to connect too via Telepath.
-          - size: The number of items to pull from the queue at once. If not
-          provided, the default size of 1000 will be used.
+        conf ((str, dict)): A configuration tufo.
 
-    Notes:
-        Task events consumed by the Queue are bucketed by their task name, and
-        only the task dictionaries are placed into the CryoTank. Tasks are put
-        into the tanks by their name.
-        For Cortex configuration purposes, this is named ``cryo:cell``.
-
+    Returns:
+        bool: True if the configuration is valid.
     '''
-    url = conf.get('url')
-    sz = conf.get('size', 1000)
-    with s_telepath.openurl(url) as cryocell:
-        for items in core.tqueue.slices(sz):
-            d = collections.defaultdict(list)
-            for ttype, rec in items:
-                d[ttype].append(rec)
+    typ = conf[1].get('type')
+    ctor = qtypes.get(typ)  # type: QueueBase
+    if ctor is None:
+        raise s_exc.NoSuchName(name=typ, mesg='No queue ctor by that name')
+    return ctor.validate(conf)
 
-            for ttype, recs in d.items():
-                try:
-                    cryocell.puts(ttype, recs)
-                except Exception as e:
-                    logger.exception('Failed to put items into tank for [%s]', ttype)
-                    raise
-            core.fire('persist:task:cryo:cell', len=len(items))
-
-def cryoTankQueue(core, conf):
+def queue(conf, items):
     '''
-        Consume task events from the Cortex.tqueue, and put them directly into
-        a Cryotank.
+    Place items in the queue for a given configuration.
 
-        Args:
-            core: Cortex to consume events from.
-            conf (dict): A config dictionary. The following keys are used:
-              - url: The CryoTank to connect to via Telepath.
-              - size: The number of items to pull from the queue at once. If not
-              provided, the default size of 1000 will be used.
+    Args:
+        conf ((str, dict)): A configuration tufo.
+        items (list): A list of packed Nodes.
+    '''
+    typ = conf[1].get('type')
+    ctor = qtypes.get(typ)  # type: QueueBase
+    if ctor is None:
+        raise s_exc.NoSuchName(name=typ, mesg='No queue ctor by that name')
+    return ctor.queue(conf, items)
 
-        Notes:
-            This puts tasks into the CryoTanks as a tufo of
-            ``('someTaskName', {..task data..})``.
-            For Cortex configuration purposes, this is named ``cryo:tank``.
-
-        '''
-    url = conf.get('url')
-    sz = conf.get('size', 1000)
-    with s_telepath.openurl(url) as cryotank:
-        for items in core.tqueue.slices(sz):
-            try:
-                cryotank.puts(items)
-            except Exception as e:
-                logger.exception('Failed to put items into cryotank')
-                raise
-            core.fire('persist:task:cryo:tank', len=len(items))
-
-# Register built-in queue loop functions.
-add('cryo:cell', cryoCellQueue)
-add('cryo:tank', cryoTankQueue)
+# Add a CryoTank backed queue implementation.
+add('cryotank', CryoQueue)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -219,6 +219,7 @@ class QueueCmd(Cmd):
                 s_persist.queue(conf, pnodes)
             except Exception as e:
                 logger.exception('Failed to queue %s nodes to [%s].', plen, name)
+                snap.warn(f'queue error: {e}')
             else:
                 cnt += plen
             finally:

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -89,6 +89,67 @@ class CmdCoreTest(s_test.SynTest):
             outp.expect('Traceback')
             outp.expect('BadStormSyntax')
 
+    def test_queue(self):
+        with self.getTestDmon('dmoncoreauth') as dmon:
+            pconf = {'user': 'root', 'passwd': 'root'}
+            with dmon._getTestProxy('core', **pconf) as core:  # type: s_cortex.CortexApi
+
+                outp = self.getTestOutp()
+                cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+                line = 'queue --act add --name qt1 --url tcp://1.2.3.4:80/cryo/qt1 --desc "test tank" --type cryotank'
+                cmdr.runCmdLine(line)
+                outp.expect('Added queue conf')
+                outp.expect('qt1')
+
+                # Get all queues
+                outp = self.getTestOutp()
+                cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+                line = 'queue'
+                cmdr.runCmdLine(line)
+                outp.expect('Configured queues')
+                outp.expect('qt1')
+
+                # Get a single queue
+                outp = self.getTestOutp()
+                cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+                line = 'queue --name qt1'
+                cmdr.runCmdLine(line)
+                outp.expect('Configured queues')
+                outp.expect('qt1')
+
+                # Set a valu
+                outp = self.getTestOutp()
+                cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+                line = 'queue --act set --name qt1 --url tcp://1.2.3.4:443/cryo01/qt1:2'
+                cmdr.runCmdLine(line)
+                outp.expect('Set queue [qt1] key [url] to [tcp://1.2.3.4:443/cryo01/qt1:2]')
+
+                # Delete a queue
+                outp = self.getTestOutp()
+                cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+                line = 'queue --act del --name qt1'
+                cmdr.runCmdLine(line)
+                outp.expect('Deleted queue [qt1]')
+
+                outp = self.getTestOutp()
+                cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+                line = 'queue --act del --name qt1'
+                cmdr.runCmdLine(line)
+                outp.expect('Queue does not exist')
+
+                # Sad path tests
+                outp = self.getTestOutp()
+                cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+                line = 'queue --act add --url tcp://1.2.3.4:80/cryo/qt1'
+                cmdr.runCmdLine(line)
+                outp.expect('--name required to add queue')
+
+                outp = self.getTestOutp()
+                cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+                line = 'queue --act add --name qt2 --url tcp://1.2.3.4:80/cryo/qt1'
+                cmdr.runCmdLine(line)
+                outp.expect('--type required to add queue')
+
 '''
 class SynCmdCoreTest(s_test.SynTest):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1,4 +1,5 @@
 import synapse.exc as s_exc
+import synapse.cortex as s_cortex
 import synapse.common as s_common
 import synapse.tests.common as s_test
 
@@ -641,3 +642,35 @@ class CortexTest(s_test.SynTest):
             list(core.addNodes((node,)))
 
             self.nn(core.getNodeByNdef(('teststr', 'foo')))
+
+    def test_queues(self):
+        # Test for queueing management APIS for a Cortex
+        with self.getTestDmon(mirror='dmoncoreauth') as dmon:
+            pconf = {'user': 'root', 'passwd': 'root'}
+            with dmon._getTestProxy('core', **pconf) as core:  # type: s_cortex.CortexApi
+                conf = ('qt1', {'url': 'tcp://1.2.3.4:8080/cryo/qt1',
+                                'type': 'cryotank',
+                                'desc': 'A test queue'
+                })
+                core.addQueue(conf)
+                self.eq(conf, core.getQueue('qt1'))
+                confs = core.getQueues()
+                self.len(1, confs)
+                self.eq(confs, (conf,))
+                self.true(core.setQueueKey('qt1', 'desc', 'A new desc.'))
+                self.eq('A new desc.', core.getQueue('qt1')[1].get('desc'))
+                descs = core.getQueueDescs()
+                self.len(1, descs)
+                # Only these keys are allowed out
+                keys = {'desc', 'type'}
+                for name, info in descs:
+                    self.eq(keys, set(info.keys()))
+
+                # Cannot smash an existing queue by name
+                self.raises(s_exc.BadConfValu, core.addQueue, conf)
+                # Delete the queue
+                self.true(core.delQueue('qt1'))
+                self.none(core.getQueue('qt1'))
+                confs = core.getQueues()
+                self.len(0, confs)
+                self.false(core.delQueue('qt1'))

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -544,6 +544,16 @@ class CortexTest(s_test.SynTest):
                 nodes = list(core.eval('sudo | [ inet:ipv4=1.2.3.4 ]'))
                 self.len(1, nodes)
 
+                core.addAuthUser('foo')
+                core.setUserPasswd('foo', 'bar')
+
+        # Ensure a non-admin user, using sudo, still fails when they
+        # have elevated themselves
+        pconf = {'user': 'foo', 'passwd': 'bar'}
+        with dmon._getTestProxy('core', **pconf) as core:
+            q = 'sudo | [ inet:ipv4=1.2.3.5 ]'
+            self.genraises(s_exc.AuthDeny, core.eval, q)
+
     def test_cortex_snap_cancel(self):
 
         with self.getTestCore() as core:

--- a/synapse/tests/test_lib_persist.py
+++ b/synapse/tests/test_lib_persist.py
@@ -1,0 +1,195 @@
+import threading
+
+import synapse.exc as s_exc
+import synapse.common as s_common
+import synapse.eventbus as s_eventbus
+
+import synapse.lib.const as s_const
+import synapse.lib.queue as s_queue
+import synapse.lib.scope as s_scope
+import synapse.lib.persist as s_persist
+
+import synapse.tests.common as s_test
+
+class PersistTest(s_test.SynTest):
+
+    def test_add_get(self):
+        self.none(s_persist.add('test', print))
+        ret = s_persist.getQueues()
+        queues = {name: path for name, path in ret}
+        self.isin('cryo:cell', queues)
+        self.isin('cryo:tank', queues)
+        self.isin('test', queues)
+        self.eq(queues.get('test'), 'builtins.print')
+
+    def test_storm_task(self):
+
+        # Test cryo:cell configuration. This automatically splits tasks into their own
+        # cryotanks, which then need dedicated nommers.
+        with self.getTestDmon(mirror='cryodmon') as dmon:
+            host, port = dmon.addr
+            url = f'tcp://{host}:{port}/cryo00'
+            tconf = {'type': 'cryo:cell',
+                     'url': url}
+            conf = {'task:queue': tconf,
+                    'modules': ['synapse.tests.utils.TestModule', ],
+                    }
+            dirn = s_scope.get('dirn')
+            with self.getTestCell(dirn, 'cortex', conf=conf) as core:
+                w = core.waiter(1, 'persist:task:cryo:cell')
+                q = '[teststr=foobar] [teststr=haha] | task knight ni --kwarg ip 1.2.3.4'
+                mesgs = list(core.storm(q))
+                self.true(w.wait(5))
+
+                # Validate the task record stored in the cryotank is shaped like the following
+                # {
+                #   'kwargs': {...},
+                #   'node': (a packed node)
+                #   'tid': '<guid>',
+                #   'tick': 1234..
+                #   'user': None or str
+                # }
+                with dmon._getTestProxy('cryo00') as cryo:
+                    tanks = cryo.list()
+                    self.len(2, tanks)
+                    d = {k: v for k, v in tanks}
+                    self.ge(d.get('knight').get('indx'), 1)
+                    self.ge(d.get('ni').get('indx'), 1)
+                    rec = list(cryo.slice('knight', 0, 1))[0][1]
+                    self.isinstance(rec.get('tid'), str)
+                    self.isnode(rec.get('node'))
+                    self.isinstance(rec.get('tick'), int)
+                    # We are not currently in a auth cortex so user is None
+                    self.none(rec.get('user', s_common.novalu))
+                    # kwargs is a dict
+                    self.eq(rec.get('kwargs'), {'ip': '1.2.3.4'})
+
+                # A task can be fired without inbound nodes
+                w = core.waiter(1, 'persist:task:cryo:cell')
+                q = 'task ipthing --kwarg ip 1.2.3.4'
+                mesgs = list(core.storm(q))
+                self.true(w.wait(5))
+                with dmon._getTestProxy('cryo00') as cryo:
+                    d = {k: v for k, v in cryo.list()}
+                    self.eq(d.get('ipthing').get('indx'), 1)
+                    rec = list(cryo.slice('ipthing', 0, 1))[0][1]
+                    # The 'node' field is None if there was no inbound node
+                    self.none(rec.get('user', s_common.novalu))
+
+        # Test cryo:tank configuration. This automatically puts all task events
+        # into a single tank which is connected to directly.
+        with self.getTestDmon(mirror='cryodmon') as dmon:
+            host, port = dmon.addr
+            url = f'tcp://{host}:{port}/cryo00/tasks'
+            tconf = {'type': 'cryo:tank',
+                     'url': url}
+            conf = {'task:queue': tconf,
+                    'modules': ['synapse.tests.utils.TestModule', ],
+                    }
+            dirn = s_scope.get('dirn')
+            with self.getTestCell(dirn, 'cortex', conf=conf) as core:
+                w = core.waiter(1, 'persist:task:cryo:tank')
+                q = '[teststr=foobar] [teststr=haha] | task knight ni --kwarg ip 1.2.3.4'
+                mesgs = list(core.storm(q))
+                self.true(w.wait(5))
+
+                # Validate the task record stored in the cryotank is shaped like the following
+                # (name,
+                #  {
+                #    'kwargs': {...},
+                #    'node': (a packed node)
+                #    'tid': '<guid>',
+                #    'tick': 1234..
+                #    'user': None or str
+                #  })
+                with dmon._getTestProxy('cryo00') as cryo:
+                    d = {k: v for k, v in cryo.list()}
+                    self.eq(d.get('tasks').get('indx'), 4)
+                    recs = [rec for offset, rec in cryo.slice('tasks', 0, 10)]
+                    rec = recs[0]
+                    rectype, rec = rec
+                    self.isin(rectype, ['knight', 'ni'])
+                    self.isinstance(rec.get('tid'), str)
+                    self.isnode(rec.get('node'))
+                    self.isinstance(rec.get('tick'), int)
+                    # We are not currently in a auth cortex so user is None
+                    self.none(rec.get('user', s_common.novalu))
+                    # kwargs is a dict
+                    self.eq(rec.get('kwargs'), {'ip': '1.2.3.4'})
+
+                    # all the rectypes are accounted for
+                    self.eq({rectype for rectype, _ in recs}, {'knight', 'ni'})
+
+        # Null configuration throws an error
+        with self.getTestCore() as core:
+            q = 'task knight --kwarg ip 1.2.3.4'
+            mesgs = list(core.storm(q))
+            self.len(3, mesgs)
+            err = ('err', ('NoSuchConf', {'mesg': 'Cortex is not configured for tasking.'}))
+            self.eq(mesgs[1], err)
+
+    def test_cryo_sadpath(self):
+        class PsuedoCortex(s_eventbus.EventBus):
+            # Minimial implementation for the built in queue functions to operate.
+            def __init__(self):
+                s_eventbus.EventBus.__init__(self)
+                self.tqueue = s_queue.Queue()
+                self.onfini(self.tqueue.fini)
+
+        rec0 = {
+            'tick': s_common.now(),
+            'user': None,
+            'tid': s_common.guid(),
+            'node': None,
+            'kwargs': {
+                'buf': '0' * (s_const.mebibyte - (s_const.kibibyte * 45)),
+            }
+        },
+        rec1 = {
+            'tick': s_common.now(),
+            'user': None,
+            'tid': s_common.guid(),
+            'node': None,
+            'kwargs': {
+                'buf': '0' * 2,
+            }
+        }
+        core = PsuedoCortex()
+
+        with PsuedoCortex() as core:
+            with self.getTestDmon(mirror='cryodmon') as dmon:
+                host, port = dmon.addr
+                url = f'tcp://{host}:{port}/cryo00'
+                tconf = {'url': url}
+                with dmon._getTestProxy('cryo00') as cryo:
+                    cryo.init('test:1', {'mapsize': s_const.mebibyte * 1,
+                                         'noindex': True})
+                    core.tqueue.put(('test:1', rec0))
+                    evt = threading.Event()
+                    def boom(mesg):
+                        if evt.is_set():
+                            return
+                        evt.set()
+                        core.tqueue.put(('test:1', rec1))
+
+                    core.on('persist:task:cryo:cell', boom)
+                    self.raises(s_exc.SynErr, s_persist.cryoCellQueue, core, tconf)
+
+        with PsuedoCortex() as core:
+            with self.getTestDmon(mirror='cryodmon') as dmon:
+                host, port = dmon.addr
+                url = f'tcp://{host}:{port}/cryo00/test:1'
+                tconf = {'url': url}
+                with dmon._getTestProxy('cryo00') as cryo:
+                    cryo.init('test:1', {'mapsize': s_const.mebibyte * 1,
+                                         'noindex': True})
+                    core.tqueue.put(('test:1', rec0))
+                    evt = threading.Event()
+                    def boom(mesg):
+                        if evt.is_set():
+                            return
+                        evt.set()
+                        core.tqueue.put(('test:1', rec1))
+
+                    core.on('persist:task:cryo:tank', boom)
+                    self.raises(s_exc.SynErr, s_persist.cryoTankQueue, core, tconf)

--- a/synapse/tests/test_lib_persist.py
+++ b/synapse/tests/test_lib_persist.py
@@ -6,190 +6,112 @@ import synapse.eventbus as s_eventbus
 
 import synapse.lib.const as s_const
 import synapse.lib.queue as s_queue
-import synapse.lib.scope as s_scope
 import synapse.lib.persist as s_persist
 
 import synapse.tests.common as s_test
 
+class TstQ(s_persist.QueueBase):
+    pass
+
 class PersistTest(s_test.SynTest):
 
+    def test_validate(self):
+        conf = ('clownQueue', {'type': 'cryotank',
+                               'desc': 'A queue for clowns.',
+                               'url': 'tcp://pennywise:floaties@1.2.3.4:8080/cryo/clown:v1',
+                               })
+        self.true(s_persist.validate(conf))
+        # No type - so None.validate() fails
+        self.raises(s_exc.NoSuchName, s_persist.validate, (None, {}))
+        # Bad name in conf
+        self.raises(s_exc.BadConfValu, s_persist.validate, (None, {'type': 'cryotank'}))
+        # cryotank checks default implementation first which requires a name.
+        self.raises(s_exc.BadConfValu, s_persist.validate, ('newp', {'type': 'cryotank'}))
+
     def test_add_get(self):
-        self.none(s_persist.add('test', print))
+        s_persist.add('test', TstQ)
         ret = s_persist.getQueues()
         queues = {name: path for name, path in ret}
-        self.isin('cryo:cell', queues)
-        self.isin('cryo:tank', queues)
+        self.isin('cryotank', queues)
         self.isin('test', queues)
-        self.eq(queues.get('test'), 'builtins.print')
+        self.eq(queues.get('test'), 'synapse.tests.test_lib_persist.TstQ')
+        self.raises(s_exc.NoSuchImpl, s_persist.queue, ('tst', {'type': 'test'}), [])
 
-    def test_storm_task(self):
-
-        # Test cryo:cell configuration. This automatically splits tasks into their own
-        # cryotanks, which then need dedicated nommers.
+    def test_queue_cryotank(self):
         with self.getTestDmon(mirror='cryodmon') as dmon:
             host, port = dmon.addr
-            url = f'tcp://{host}:{port}/cryo00'
-            tconf = {'type': 'cryo:cell',
-                     'url': url}
-            conf = {'task:queue': tconf,
-                    'modules': ['synapse.tests.utils.TestModule', ],
-                    }
-            dirn = s_scope.get('dirn')
-            with self.getTestCell(dirn, 'cortex', conf=conf) as core:
-                w = core.waiter(1, 'persist:task:cryo:cell')
-                q = '[teststr=foobar] [teststr=haha] | task knight ni --kwarg ip 1.2.3.4'
-                mesgs = list(core.storm(q))
-                self.true(w.wait(5))
+            url = f'tcp://{host}:{port}/cryo00/queue:t1'
+            conf = ('qt1', {'url': url,
+                            'type': 'cryotank',
+                            'desc': 'A test queue backed by a CryoTank.'})
+            rec = {'hehe': 1}
+            self.true(s_persist.validate(conf))
+            s_persist.queue(conf, [rec])
+            with dmon._getTestProxy('cryo00') as prox:
+                d = {k: v for k, v in prox.list()}
+                self.eq(d.get('queue:t1').get('indx'), 1)
+                self.eq(list(prox.slice('queue:t1', 0, 10)), [(0, rec)])
 
-                # Validate the task record stored in the cryotank is shaped like the following
-                # {
-                #   'kwargs': {...},
-                #   'node': (a packed node)
-                #   'tid': '<guid>',
-                #   'tick': 1234..
-                #   'user': None or str
-                # }
+            # Sad path test - fail on a telepath error.
+            # That is easier to setup than breaking on a cryotank error.
+            conf[1]['url'] = f'tcp://{host}:{port}/cryo01'
+            self.raises(s_exc.NoSuchName, s_persist.queue, conf, [rec])
+            conf[1]['type'] = 'newp'
+            self.raises(s_exc.NoSuchName, s_persist.queue, conf, [rec])
+
+        burl = 'tcp://1.2.3.4:8000/someCryo'
+        self.raises(s_exc.BadConfValu, s_persist.validate, ('qt2,', {'type': 'cryotank',
+                                                                     'name': 'qt2',
+                                                                     'url': burl}))
+        burl = 'tcp://1.2.3.4:8000/someCryo/'
+        self.raises(s_exc.BadConfValu, s_persist.validate, ('qt2,', {'type': 'cryotank',
+                                                                     'name': 'qt2',
+                                                                     'url': burl}))
+        burl = 'tcp://1.2.3.4:8000/someCryo/tank1/wut'
+        self.raises(s_exc.BadConfValu, s_persist.validate, ('qt2,', {'type': 'cryotank',
+                                                                     'name': 'qt2',
+                                                                     'url': burl}))
+
+    def test_storm_queue_cryotank(self):
+        with self.getTestDmon(mirror='cryodmon') as dmon:
+            host, port = dmon.addr
+            url = f'tcp://{host}:{port}/cryo00/qt1'
+            conf = ('qt1', {'type': 'cryotank',
+                            'desc': 'A test tank.',
+                            'url': url})
+
+            with self.getTestCore() as core:
+                q = 'queue -l'
+                mesgs = list(core.storm(q))
+                self.eq(mesgs[1][1].get('mesg'), 'No queues are configured for the current Cortex.')
+
+                # Add a queue and show that it is present.
+                core.addQueue(conf)
+                self.eq(core.getQueueDescs(), [('qt1', {'type': 'cryotank', 'desc': 'A test tank.'})])
+
+                q = 'queue -l'
+                mesgs = list(core.storm(q))
+                mesg = mesgs[2][1].get('mesg')
+                self.isin('qt1', mesg)
+
+                q = '[teststr=foobar teststr=haha] | queue qt1'
+                mesgs = list(core.storm(q))
                 with dmon._getTestProxy('cryo00') as cryo:
                     tanks = cryo.list()
-                    self.len(2, tanks)
-                    d = {k: v for k, v in tanks}
-                    self.ge(d.get('knight').get('indx'), 1)
-                    self.ge(d.get('ni').get('indx'), 1)
-                    rec = list(cryo.slice('knight', 0, 1))[0][1]
-                    self.isinstance(rec.get('tid'), str)
-                    self.isnode(rec.get('node'))
-                    self.isinstance(rec.get('tick'), int)
-                    # We are not currently in a auth cortex so user is None
-                    self.none(rec.get('user', s_common.novalu))
-                    # kwargs is a dict
-                    self.eq(rec.get('kwargs'), {'ip': '1.2.3.4'})
+                    tanks = {k: v for k, v in tanks}
+                    self.len(1, tanks)
+                    self.eq(tanks.get('qt1').get('indx'), 2)
+                    recs = list(cryo.slice('qt1', 0, 10))
+                    self.len(2, recs)
+                    for rec in recs:
+                        offset, data = rec
+                        self.isnode(data)
 
-                # A task can be fired without inbound nodes
-                w = core.waiter(1, 'persist:task:cryo:cell')
-                q = 'task ipthing --kwarg ip 1.2.3.4'
+                # A non-configured queue throws an error
+                q = 'tststr | queue qt2'
                 mesgs = list(core.storm(q))
-                self.true(w.wait(5))
-                with dmon._getTestProxy('cryo00') as cryo:
-                    d = {k: v for k, v in cryo.list()}
-                    self.eq(d.get('ipthing').get('indx'), 1)
-                    rec = list(cryo.slice('ipthing', 0, 1))[0][1]
-                    # The 'node' field is None if there was no inbound node
-                    self.none(rec.get('user', s_common.novalu))
-
-        # Test cryo:tank configuration. This automatically puts all task events
-        # into a single tank which is connected to directly.
-        with self.getTestDmon(mirror='cryodmon') as dmon:
-            host, port = dmon.addr
-            url = f'tcp://{host}:{port}/cryo00/tasks'
-            tconf = {'type': 'cryo:tank',
-                     'url': url}
-            conf = {'task:queue': tconf,
-                    'modules': ['synapse.tests.utils.TestModule', ],
-                    }
-            dirn = s_scope.get('dirn')
-            with self.getTestCell(dirn, 'cortex', conf=conf) as core:
-                w = core.waiter(1, 'persist:task:cryo:tank')
-                q = '[teststr=foobar] [teststr=haha] | task knight ni --kwarg ip 1.2.3.4'
-                mesgs = list(core.storm(q))
-                self.true(w.wait(5))
-
-                # Validate the task record stored in the cryotank is shaped like the following
-                # (name,
-                #  {
-                #    'kwargs': {...},
-                #    'node': (a packed node)
-                #    'tid': '<guid>',
-                #    'tick': 1234..
-                #    'user': None or str
-                #  })
-                with dmon._getTestProxy('cryo00') as cryo:
-                    d = {k: v for k, v in cryo.list()}
-                    self.eq(d.get('tasks').get('indx'), 4)
-                    recs = [rec for offset, rec in cryo.slice('tasks', 0, 10)]
-                    rec = recs[0]
-                    rectype, rec = rec
-                    self.isin(rectype, ['knight', 'ni'])
-                    self.isinstance(rec.get('tid'), str)
-                    self.isnode(rec.get('node'))
-                    self.isinstance(rec.get('tick'), int)
-                    # We are not currently in a auth cortex so user is None
-                    self.none(rec.get('user', s_common.novalu))
-                    # kwargs is a dict
-                    self.eq(rec.get('kwargs'), {'ip': '1.2.3.4'})
-
-                    # all the rectypes are accounted for
-                    self.eq({rectype for rectype, _ in recs}, {'knight', 'ni'})
-
-        # Null configuration throws an error
-        with self.getTestCore() as core:
-            q = 'task knight --kwarg ip 1.2.3.4'
-            mesgs = list(core.storm(q))
-            self.len(3, mesgs)
-            err = ('err', ('NoSuchConf', {'mesg': 'Cortex is not configured for tasking.'}))
-            self.eq(mesgs[1], err)
-
-    def test_cryo_sadpath(self):
-        class PsuedoCortex(s_eventbus.EventBus):
-            # Minimial implementation for the built in queue functions to operate.
-            def __init__(self):
-                s_eventbus.EventBus.__init__(self)
-                self.tqueue = s_queue.Queue()
-                self.onfini(self.tqueue.fini)
-
-        rec0 = {
-            'tick': s_common.now(),
-            'user': None,
-            'tid': s_common.guid(),
-            'node': None,
-            'kwargs': {
-                'buf': '0' * (s_const.mebibyte - (s_const.kibibyte * 45)),
-            }
-        },
-        rec1 = {
-            'tick': s_common.now(),
-            'user': None,
-            'tid': s_common.guid(),
-            'node': None,
-            'kwargs': {
-                'buf': '0' * 2,
-            }
-        }
-        core = PsuedoCortex()
-
-        with PsuedoCortex() as core:
-            with self.getTestDmon(mirror='cryodmon') as dmon:
-                host, port = dmon.addr
-                url = f'tcp://{host}:{port}/cryo00'
-                tconf = {'url': url}
-                with dmon._getTestProxy('cryo00') as cryo:
-                    cryo.init('test:1', {'mapsize': s_const.mebibyte * 1,
-                                         'noindex': True})
-                    core.tqueue.put(('test:1', rec0))
-                    evt = threading.Event()
-                    def boom(mesg):
-                        if evt.is_set():
-                            return
-                        evt.set()
-                        core.tqueue.put(('test:1', rec1))
-
-                    core.on('persist:task:cryo:cell', boom)
-                    self.raises(s_exc.SynErr, s_persist.cryoCellQueue, core, tconf)
-
-        with PsuedoCortex() as core:
-            with self.getTestDmon(mirror='cryodmon') as dmon:
-                host, port = dmon.addr
-                url = f'tcp://{host}:{port}/cryo00/test:1'
-                tconf = {'url': url}
-                with dmon._getTestProxy('cryo00') as cryo:
-                    cryo.init('test:1', {'mapsize': s_const.mebibyte * 1,
-                                         'noindex': True})
-                    core.tqueue.put(('test:1', rec0))
-                    evt = threading.Event()
-                    def boom(mesg):
-                        if evt.is_set():
-                            return
-                        evt.set()
-                        core.tqueue.put(('test:1', rec1))
-
-                    core.on('persist:task:cryo:tank', boom)
-                    self.raises(s_exc.SynErr, s_persist.cryoTankQueue, core, tconf)
+                self.len(3, mesgs)
+                err = ('err', ('NoSuchConf', {
+                    'mesg': 'Cortex is not configured for queuing to the specified endpoint.',
+                    'name': 'qt2'}))
+                self.eq(mesgs[1], err)

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1092,6 +1092,20 @@ class SynTest(unittest.TestCase):
         '''
         self.eq(x, len(obj), msg=msg)
 
+    def isnode(self, obj):
+        '''
+        Check to see if an object is a packed Node.
+        '''
+        self.isinstance(obj, tuple)
+        self.len(2, obj)
+        # ndef - we can't validate the second half of the ndef though
+        self.isinstance(obj[0], tuple)
+        self.len(2, obj[0])
+        self.isinstance(obj[0][0], str)
+        # props / tags bag
+        self.isinstance(obj[1].get('props'), dict)
+        self.isinstance(obj[1].get('tags'), dict)
+
     def istufo(self, obj):
         '''
         Check to see if an object is a tufo.


### PR DESCRIPTION
Adds a persistent node queuing capability to the Cortex. 
This allows for admins to dynamically create named queue endpoints that users can use to send nodes too.
Currently the only supported queue endpoint is backed directly by a CryoTank managed by a CryoCell.
The registration of additional endpoint types is easy to hook, so third parties and additional task queue consumers should be easy to add.