### PR TITLE
convert cmdr "ask" cmd to "storm"

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -2,12 +2,12 @@ import pprint
 
 import synapse.lib.cli as s_cli
 
-class AskCmd(s_cli.Cmd):
+class StormCmd(s_cli.Cmd):
     '''
     Execute a storm query.
 
     Syntax:
-        ask <query>
+        storm <query>
 
     Arguments:
         query: The storm query
@@ -21,11 +21,11 @@ class AskCmd(s_cli.Cmd):
             (overrides --hide-tags, --hide-props and raw)
 
     Examples:
-        ask inet:ipv4=1.2.3.4
-        ask --debug inet:ipv4=1.2.3.4
+        storm inet:ipv4=1.2.3.4
+        storm --debug inet:ipv4=1.2.3.4
     '''
 
-    _cmd_name = 'ask'
+    _cmd_name = 'storm'
     _cmd_syntax = (
         ('--hide-tags', {}),
         ('--hide-props', {}),

--- a/synapse/lib/cmdr.py
+++ b/synapse/lib/cmdr.py
@@ -3,7 +3,7 @@ import synapse.cmds.cortex as s_cmds_cortex
 
 cmdsbycell = {
     'cortex': (
-        s_cmds_cortex.AskCmd,
+        s_cmds_cortex.StormCmd,
     ),
 }
 

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -1,14 +1,11 @@
 
-
-import regex
-
 import synapse.lib.cmdr as s_cmdr
 import synapse.tests.common as s_test
 
 
 class CmdCoreTest(s_test.SynTest):
 
-    def test_ask(self):
+    def test_storm(self):
         help_msg = 'Execute a storm query.'
         with self.getTestCore() as core:
             with core.snap() as snap:
@@ -18,17 +15,17 @@ class CmdCoreTest(s_test.SynTest):
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('help ask')
+            cmdr.runCmdLine('help storm')
             outp.expect(help_msg)
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask')
+            cmdr.runCmdLine('storm')
             outp.expect(help_msg)
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask --debug teststr=abcd')
+            cmdr.runCmdLine('storm --debug teststr=abcd')
             outp.expect("('init',")
             outp.expect("('node',")
             outp.expect("('fini',")
@@ -38,7 +35,7 @@ class CmdCoreTest(s_test.SynTest):
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask --debug teststr=zzz')
+            cmdr.runCmdLine('storm --debug teststr=zzz')
             outp.expect("('init',")
             self.false(outp.expect("('node',", throw=False))
             outp.expect("('fini',")
@@ -48,54 +45,54 @@ class CmdCoreTest(s_test.SynTest):
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask teststr=b')
+            cmdr.runCmdLine('storm teststr=b')
             outp.expect('complete. 0 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask teststr=abcd')
+            cmdr.runCmdLine('storm teststr=abcd')
             outp.expect(':tick = 1970/01/01 00:00:00.123')
             outp.expect('#cool = (None, None)')
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask --hide-tags teststr=abcd')
+            cmdr.runCmdLine('storm --hide-tags teststr=abcd')
             outp.expect(':tick = 1970/01/01 00:00:00.123')
             self.false(outp.expect('#cool = (None, None)', throw=False))
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask --hide-props teststr=abcd')
+            cmdr.runCmdLine('storm --hide-props teststr=abcd')
             self.false(outp.expect(':tick = 1970/01/01 00:00:00.123', throw=False))
             outp.expect('#cool = (None, None)')
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask --hide-tags --hide-props teststr=abcd')
+            cmdr.runCmdLine('storm --hide-tags --hide-props teststr=abcd')
             self.false(outp.expect(':tick = 1970/01/01 00:00:00.123', throw=False))
             self.false(outp.expect('#cool = (None, None)', throw=False))
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask --raw teststr=abcd')
+            cmdr.runCmdLine('storm --raw teststr=abcd')
             outp.expect("'tick': 123")
             outp.expect("{'tags': {'cool': (None, None)}")
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            cmdr.runCmdLine('ask --bad')
+            cmdr.runCmdLine('storm --bad')
             outp.expect('Traceback')
             outp.expect('BadStormSyntax')
 
 '''
 class SynCmdCoreTest(s_test.SynTest):
 
-    def test_cmds_ask_showcols(self):
+    def test_cmds_storm_showcols(self):
         with self.getDmonCore() as core:
             core.formTufoByProp('inet:email', 'visi@vertex.link')
             core.formTufoByProp('inet:email', 'vertexmc@vertex.link')
@@ -104,44 +101,44 @@ class SynCmdCoreTest(s_test.SynTest):
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            line = 'ask inet:email="visi@vertex.link" show:cols(inet:email:fqdn,inet:email:user,node:ndef)'
+            line = 'storm inet:email="visi@vertex.link" show:cols(inet:email:fqdn,inet:email:user,node:ndef)'
             resp = cmdr.runCmdLine(line)
             self.len(1, resp['data'])
             self.true(outp.expect('vertex.link visi a20979f71b90cf2ae1c53933675b5c3c'))
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            line = 'ask inet:email show:cols(inet:email, order=inet:email:fqdn)'
+            line = 'storm inet:email show:cols(inet:email, order=inet:email:fqdn)'
             resp = cmdr.runCmdLine(line)
             self.len(4, resp['data'])
             result = [mesg.strip() for mesg in outp.mesgs]
             self.eq(result, ['z@a.vertex.link', 'a@vertex.link', 'vertexmc@vertex.link', 'visi@vertex.link', '(4 results)'])
 
-    def test_cmds_ask_mesgs(self):
+    def test_cmds_storm_mesgs(self):
         with self.getDmonCore() as core:
             real_core = s_scope.get('syn:core')
             real_core.setOperFunc('test:mesg', mesg_cmd)
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
-            resp = cmdr.runCmdLine('ask [inet:ipv4=1.2.3.4] test:mesg()')
+            resp = cmdr.runCmdLine('storm [inet:ipv4=1.2.3.4] test:mesg()')
             self.len(1, resp['data'])
             self.len(2, resp['mesgs'])
 
             outp.expect('Storm Status Messages:')
             outp.expect('Log test messages')
             outp.expect('Query has [1] nodes')
-            print('cli> ask [inet:ipv4=1.2.3.4] test:mesg()')
+            print('cli> storm [inet:ipv4=1.2.3.4] test:mesg()')
             print(outp)
 
-    def test_cmds_ask_tagtime(self):
+    def test_cmds_storm_tagtime(self):
 
         with self.getDmonCore() as core:
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
 
-            resp = cmdr.runCmdLine('ask [ inet:ipv4=1.2.3.4 #foo.bar@2011-2016 #baz.faz ]')
+            resp = cmdr.runCmdLine('storm [ inet:ipv4=1.2.3.4 #foo.bar@2011-2016 #baz.faz ]')
             self.len(1, resp['data'])
 
             lines = [s.strip() for s in str(outp).split('\n')]
@@ -149,30 +146,30 @@ class SynCmdCoreTest(s_test.SynTest):
             self.true(any([regex.search('^#baz.faz \(added [0-9/: \.]+\)$', l) for l in lines]))
             self.true(any([regex.search('^#foo.bar \(added [0-9/: \.]+\) 2011/01/01 00:00:00.000  -  2016/01/01 00:00:00.000$', l) for l in lines]))
 
-    def test_cmds_ask_mutual_exclusive(self):
+    def test_cmds_storm_mutual_exclusive(self):
         with self.getDmonCore() as core:
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             core.formTufoByProp('inet:email', 'visi@vertex.link')
-            resp = cmdr.runCmdLine('ask --raw --props inet:email="visi@vertex.link"')
+            resp = cmdr.runCmdLine('storm --raw --props inet:email="visi@vertex.link"')
             self.none(resp)
             self.true(outp.expect('Cannot specify --raw and --props together.'))
 
-    def test_cmds_ask_null_response(self):
+    def test_cmds_storm_null_response(self):
         with self.getDmonCore() as core:
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             core.formTufoByProp('inet:email', 'visi@vertex.link')
-            resp = cmdr.runCmdLine('ask inet:email="pennywise@vertex.link"')
+            resp = cmdr.runCmdLine('storm inet:email="pennywise@vertex.link"')
             self.none(resp)
             self.true(outp.expect('(0 results)'))
 
-    def test_cmds_ask_exc_response(self):
+    def test_cmds_storm_exc_response(self):
         with self.getDmonCore() as core:
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             core.formTufoByProp('inet:email', 'visi@vertex.link')
-            resp = cmdr.runCmdLine('ask inet:dns:a:ipv4*inet:cidr=192.168.0.0/100')
+            resp = cmdr.runCmdLine('storm inet:dns:a:ipv4*inet:cidr=192.168.0.0/100')
             self.none(resp)
 
             outp = str(outp)
@@ -183,13 +180,13 @@ class SynCmdCoreTest(s_test.SynTest):
             for term in terms:
                 self.nn(regex.search(term, outp))
 
-    def test_cmds_ask_multilift(self):
+    def test_cmds_storm_multilift(self):
         with self.getDmonCore() as core:
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             core.formTufoByProp('strform', 'hehe')
             core.formTufoByProp('inet:ipv4', 0)
-            resp = cmdr.runCmdLine('ask strform inet:ipv4')
+            resp = cmdr.runCmdLine('storm strform inet:ipv4')
             self.len(2, resp['data'])
 
             outp = str(outp)


### PR DESCRIPTION
This is to *hopefully* alleviate some confusion / make it more intuitive when using cmdr to issue storm queries.