### PR TITLE
010 - finish files.py migration

### DIFF
--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -62,9 +62,8 @@ class FilePath(s_types.Type):
             return ''
 
         path = []
-
-        for part in valu.split('/'):
-
+        vals = [v for v in valu.split('/') if v]
+        for part in vals:
             if part == '.':
                 continue
 

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -165,16 +165,6 @@ class FileBytes(s_types.Type):
 
 class FileModule(s_module.CoreModule):
 
-    _mod_name = 'syn:files'
-
-    def initCoreModule(self):
-        pass
-        #self.core.addSeedCtor('file:bytes:md5', self.seedFileMd5)
-        #self.core.addSeedCtor('file:bytes:sha1', self.seedFileSha1)
-        # sha256 / sha512 are good enough for now
-        #self.core.addSeedCtor('file:bytes:sha256', self.seedFileGoodHash)
-        #self.core.addSeedCtor('file:bytes:sha512', self.seedFileGoodHash)
-
     def getModelDefs(self):
         return (
 
@@ -199,6 +189,10 @@ class FileModule(s_module.CoreModule):
 
                     ('file:ref', ('comp', {'fields': (('file', 'file:bytes'), ('node', 'ndef'))}), {
                         'doc': 'A file that contains an image of the specififed node.'}),
+
+                    ('file:subfile', ('comp', {'fields': (('parent', 'file:bytes'), ('child', 'file:bytes'))}), {
+                        'doc': 'A parent file that fully contains the specified child file.',
+                    }),
 
                 ),
 
@@ -263,6 +257,22 @@ class FileModule(s_module.CoreModule):
                             'doc': 'A convention based name for the type of reference.'}),
                     )),
 
+                    ('file:subfile', {}, (
+                        ('parent', ('file:bytes', {}), {
+                            'ro': True,
+                            'doc': 'The parent file containing the child file.',
+                        }),
+                        ('child', ('file:bytes', {}), {
+                            'ro': True,
+                            'doc': 'The child file contained in the parent file.',
+                        }),
+                        ('name', ('file:base', {}), {
+                            'doc': 'The name of the child file. Because a given set of bytes '
+                                   'can have any number of arbitrary names, this field is '
+                                   'used for display purposes only.'
+                        })
+                    )),
+
                     ('file:path', {}, (
                         ('dir', ('file:path', {}), {'ro': 1,
                             'doc': 'The parent directory.'}),
@@ -278,128 +288,18 @@ class FileModule(s_module.CoreModule):
             }),
         )
 
-
-###############################################################################
-
-    def seedFileGoodHash(self, prop, valu, **props):
-        '''
-        Hashes that we consider "cardinal enough" to pivot.
-        '''
-        name = prop.rsplit(':', 1)[-1]
-        # Normalize the valu before we go any further
-        valu, _ = self.core.getPropNorm(prop, valu)
-        props[name] = valu
-
-        # FIXME could we update additional hashes here and
-        # maybe (gasp) update the primary property if we
-        # finally have enough, then update all other known
-        # records that reference this file guid?
-
-        tufo = self.core.getTufoByProp(prop, valu)
-        if tufo is not None:
-            # add more hashes if we know them...
-            tufo = self.core.setTufoProps(tufo, **props)
-            return tufo
-
-        iden = self.core.getTypeCast('make:guid', valu)
-        tufo = self.core.formTufoByProp('file:bytes', iden, **props)
-        # update with any additional hashes we have...
-        tufo = self.core.setTufoProps(tufo, **props)
-        return tufo
-
-    def seedFileMd5(self, prop, valu, **props):
-        valu, _ = self.core.getPropNorm('file:bytes:md5', valu)
-        props['md5'] = valu
-        return self.core.formTufoByProp('file:bytes', valu, **props)
-
-    def seedFileSha1(self, prop, valu, **props):
-        valu, _ = self.core.getPropNorm('file:bytes:sha1', valu)
-        props['sha1'] = valu
-        valu = guid(valu)
-        return self.core.formTufoByProp('file:bytes', valu, **props)
-
     @staticmethod
     def getBaseModels():
         modl = {
             'types': (
-                ('file:bytes', {
-                    'subof': 'guid',
-                    'doc': 'A unique file identifier'}),
-
-                ('file:sub', {
-                    'subof': 'sepr',
-                    'sep': '/',
-                    'fields': 'parent,file:bytes|child,file:bytes',
-                    'doc': 'A parent file that fully contains the specified child file.'}),
 
                 ('file:rawpath', {
                     'ctor': 'synapse.models.files.FileRawPathType',
                     'doc': 'A raw file path in its default (non-normalized) form. Can consist of a directory '
                         'path, a path and file name, or a file name.'}),
 
-                ('file:base', {
-                    'ctor': 'synapse.models.files.FileBaseType',
-                    'doc': 'A file or directory name (without a full path), such as system32 or foo.exe.'}),
-
-                ('file:path', {
-                    'ctor': 'synapse.models.files.FilePathType',
-                    'doc': 'A file path that has been normalized by Synapse. Can consist of a directory path, '
-                        'a path and file name, or a file name.'}),
-
-                ('file:imgof', {
-                    'subof': 'xref',
-                    'source': 'file,file:bytes',
-                    'doc': 'A file that contains an image of the specified node.'}),
-
-                ('file:txtref', {
-                    'subof': 'xref',
-                    'source': 'file,file:bytes',
-                    'doc': 'A file that contains a reference to the specified node.'}),
             ),
 
-            'forms': (
-
-                ('file:imgof', {}, [
-                    ('file', {'ptype': 'file:bytes', 'doc': 'The guid of the file containing the image.', 'ro': 1}),
-                    ('xref', {'ptype': 'propvalu', 'ro': 1,
-                         'doc': 'The form=valu of the object referenced in the image, e.g., geo:place=<guid_of_place>.'}),
-                    ('xref:prop', {'ptype': 'str', 'ro': 1,
-                         'doc': 'The property (form) of the referenced object, as specified by the propvalu.'}),
-                    ('xref:intval', {'ptype': 'int', 'ro': 1,
-                         'doc': 'The value of the property of the referenced object, as specified by the propvalu, if '
-                             'the value is an integer.'}),
-                    ('xref:strval', {'ptype': 'str', 'ro': 1,
-                          'doc': 'The value of the property of the referenced object, as specified by the propvalu, if '
-                              'the value is a string.'}),
-                ]),
-
-                ('file:txtref', {}, [
-                    ('file', {'ptype': 'file:bytes', 'ro': 1,
-                        'doc': 'The guid of the file containing the reference.'}),
-                    ('xref', {'ptype': 'propvalu', 'ro': 1,
-                         'doc': 'The form=valu of the object referenced in the file, e.g., inet:fqdn=foo.com.'}),
-                    ('xref:prop', {'ptype': 'str', 'ro': 1,
-                         'doc': 'The property (form) of the referenced object, as specified by the propvalu.'}),
-                    ('xref:intval', {'ptype': 'int', 'ro': 1,
-                         'doc': 'The value of the property of the referenced object, as specified by the propvalu, if '
-                             'the value is an integer.'}),
-                    ('xref:strval', {'ptype': 'str', 'ro': 1,
-                         'doc': 'The value of the property of the referenced object, as specified by the propvalu, '
-                             'if the value is a string.'}),
-                ]),
-
-
-                ('file:subfile', {'ptype': 'file:sub'}, (
-                    ('parent', {'ptype': 'file:bytes', 'ro': 1,
-                        'doc': 'The guid of the parent file.'}),
-                    ('child', {'ptype': 'file:bytes', 'ro': 1,
-                        'doc': 'The guid of the child file.'}),
-                    ('name', {'ptype': 'file:base',
-                          'doc': 'The name of the child file. Because a given set of bytes can have any '
-                              'number of arbitrary names, this field is used for display purposes only.'}),
-                    # TODO others....
-                )),
-            ),
         }
         name = 'file'
         return ((name, modl), )

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -42,7 +42,7 @@ class FilePath(s_types.Type):
         self.indxcmpr['^='] = self.indxByPref
 
     def indxByPref(self, valu):
-        valu = value.strip().lower().replace('\\', '/')
+        valu = valu.strip().lower().replace('\\', '/')
         indx = valu.encode('utf8')
         return (
             ('pref', indx),

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -166,140 +166,123 @@ class FileBytes(s_types.Type):
 class FileModule(s_module.CoreModule):
 
     def getModelDefs(self):
-        return (
-
-            ('files', {
-
-                'ctors': (
-
-                    ('file:bytes', 'synapse.models.files.FileBytes', {}, {
-                        'doc': 'The file bytes type with SHA256 based primary property.'}),
-
-                    ('file:base', 'synapse.models.files.FileBase', {}, {
-                        'doc': 'A file name with no path.',
-                        'ex': 'woot.exe'}),
-
-                    ('file:path', 'synapse.models.files.FilePath', {}, {
-                        'doc': 'A normalized file path.',
-                        'ex': 'c:/windows/system32/calc.exe'}),
-
-                ),
-
-                'types': (
-
-                    ('file:ref', ('comp', {'fields': (('file', 'file:bytes'), ('node', 'ndef'))}), {
-                        'doc': 'A file that contains an image of the specififed node.'}),
-
-                    ('file:subfile', ('comp', {'fields': (('parent', 'file:bytes'), ('child', 'file:bytes'))}), {
-                        'doc': 'A parent file that fully contains the specified child file.',
-                    }),
-
-                ),
-
-                'forms': (
-
-                    ('file:bytes', {}, (
-
-                        ('size', ('int', {}), {
-                            'doc': 'The file size in bytes.'}),
-
-                        ('md5', ('hash:md5', {}), {'ro': 1,
-                            'doc': 'The md5 hash of the file.'}),
-
-                        ('sha1', ('hash:sha1', {}), {'ro': 1,
-                            'doc': 'The sha1 hash of the file.'}),
-
-                        ('sha256', ('hash:sha256', {}), {'ro': 1,
-                            'doc': 'The sha256 hash of the file.'}),
-
-                        ('sha512', ('hash:sha512', {}), {'ro': 1,
-                            'doc': 'The sha512 hash of the file.'}),
-
-                        ('name', ('file:base', {}), {
-                              'doc': 'The best known base name for the file.'}),
-
-                        ('mime', ('str', {'lower': 1}), {'defval': '??',
-                              'doc': 'The MIME type of the file.'}),
-
-                        ('mime:x509:cn', ('str', {}), {
-                            'doc': 'The Common Name (CN) attribute of the x509 Subject.'}),
-
-                        ('mime:pe:size', ('int', {}), {
-                            'doc': 'The size of the executable file according to the PE file header.'}),
-
-                        ('mime:pe:imphash', ('guid', {}), {
-                            'doc': 'The PE import hash of the file as calculated by Vivisect; this method excludes '
-                                'imports referenced as ordinals and may fail to calculate an import hash for files '
-                                'that use ordinals.'}),
-
-                        ('mime:pe:compiled', ('time', {}), {
-                            'doc': 'The compile time of the file according to the PE header.'}),
-
-                    )),
-
-                    ('file:base', {}, (
-                        ('ext', ('str', {}), {'ro': 1,
-                            'doc': 'The file extension (if any).'}),
-                    )),
-
-                    ('file:ref', {}, (
-
-                        ('file', ('file:bytes', {}), {'ro': 1,
-                            'doc': 'The file that refers to a node.'}),
-
-                        ('node', ('ndef', {}), {'ro': 1,
-                            'doc': 'The node referenced by the file.'}),
-
-                        ('node:form', ('str', {}), {'ro': 1,
-                            'doc': 'The form of node which is referenced.'}),
-
-                        ('type', ('str', {'lower': 1}), {
-                            'doc': 'A convention based name for the type of reference.'}),
-                    )),
-
-                    ('file:subfile', {}, (
-                        ('parent', ('file:bytes', {}), {
-                            'ro': True,
-                            'doc': 'The parent file containing the child file.',
-                        }),
-                        ('child', ('file:bytes', {}), {
-                            'ro': True,
-                            'doc': 'The child file contained in the parent file.',
-                        }),
-                        ('name', ('file:base', {}), {
-                            'doc': 'The name of the child file. Because a given set of bytes '
-                                   'can have any number of arbitrary names, this field is '
-                                   'used for display purposes only.'
-                        })
-                    )),
-
-                    ('file:path', {}, (
-                        ('dir', ('file:path', {}), {'ro': 1,
-                            'doc': 'The parent directory.'}),
-
-                        ('base', ('file:base', {}), {'ro': 1,
-                            'doc': 'The file base name.'}),
-
-                        ('base:ext', ('str', {}), {'ro': 1,
-                            'doc': 'The file extension.'}),
-                    )),
-                ),
-
-            }),
-        )
-
-    @staticmethod
-    def getBaseModels():
         modl = {
-            'types': (
+            'ctors': (
 
-                ('file:rawpath', {
-                    'ctor': 'synapse.models.files.FileRawPathType',
-                    'doc': 'A raw file path in its default (non-normalized) form. Can consist of a directory '
-                        'path, a path and file name, or a file name.'}),
+                ('file:bytes', 'synapse.models.files.FileBytes', {}, {
+                    'doc': 'The file bytes type with SHA256 based primary property.'}),
+
+                ('file:base', 'synapse.models.files.FileBase', {}, {
+                    'doc': 'A file name with no path.',
+                    'ex': 'woot.exe'}),
+
+                ('file:path', 'synapse.models.files.FilePath', {}, {
+                    'doc': 'A normalized file path.',
+                    'ex': 'c:/windows/system32/calc.exe'}),
 
             ),
 
+            'types': (
+
+                ('file:ref', ('comp', {'fields': (('file', 'file:bytes'), ('node', 'ndef'))}), {
+                    'doc': 'A file that contains an image of the specififed node.'}),
+
+                ('file:subfile', ('comp', {'fields': (('parent', 'file:bytes'), ('child', 'file:bytes'))}), {
+                    'doc': 'A parent file that fully contains the specified child file.',
+                }),
+
+            ),
+
+            'forms': (
+
+                ('file:bytes', {}, (
+
+                    ('size', ('int', {}), {
+                        'doc': 'The file size in bytes.'}),
+
+                    ('md5', ('hash:md5', {}), {'ro': 1,
+                                               'doc': 'The md5 hash of the file.'}),
+
+                    ('sha1', ('hash:sha1', {}), {'ro': 1,
+                                                 'doc': 'The sha1 hash of the file.'}),
+
+                    ('sha256', ('hash:sha256', {}), {'ro': 1,
+                                                     'doc': 'The sha256 hash of the file.'}),
+
+                    ('sha512', ('hash:sha512', {}), {'ro': 1,
+                                                     'doc': 'The sha512 hash of the file.'}),
+
+                    ('name', ('file:base', {}), {
+                        'doc': 'The best known base name for the file.'}),
+
+                    ('mime', ('str', {'lower': 1}), {'defval': '??',
+                                                     'doc': 'The MIME type of the file.'}),
+
+                    ('mime:x509:cn', ('str', {}), {
+                        'doc': 'The Common Name (CN) attribute of the x509 Subject.'}),
+
+                    ('mime:pe:size', ('int', {}), {
+                        'doc': 'The size of the executable file according to the PE file header.'}),
+
+                    ('mime:pe:imphash', ('guid', {}), {
+                        'doc': 'The PE import hash of the file as calculated by Vivisect; this method excludes '
+                               'imports referenced as ordinals and may fail to calculate an import hash for files '
+                               'that use ordinals.'}),
+
+                    ('mime:pe:compiled', ('time', {}), {
+                        'doc': 'The compile time of the file according to the PE header.'}),
+
+                )),
+
+                ('file:base', {}, (
+                    ('ext', ('str', {}), {'ro': 1,
+                                          'doc': 'The file extension (if any).'}),
+                )),
+
+                ('file:ref', {}, (
+
+                    ('file', ('file:bytes', {}), {'ro': 1,
+                                                  'doc': 'The file that refers to a node.'}),
+
+                    ('node', ('ndef', {}), {'ro': 1,
+                                            'doc': 'The node referenced by the file.'}),
+
+                    ('node:form', ('str', {}), {'ro': 1,
+                                                'doc': 'The form of node which is referenced.'}),
+
+                    ('type', ('str', {'lower': 1}), {
+                        'doc': 'A convention based name for the type of reference.'}),
+                )),
+
+                ('file:subfile', {}, (
+                    ('parent', ('file:bytes', {}), {
+                        'ro': True,
+                        'doc': 'The parent file containing the child file.',
+                    }),
+                    ('child', ('file:bytes', {}), {
+                        'ro': True,
+                        'doc': 'The child file contained in the parent file.',
+                    }),
+                    ('name', ('file:base', {}), {
+                        'doc': 'The name of the child file. Because a given set of bytes '
+                               'can have any number of arbitrary names, this field is '
+                               'used for display purposes only.'
+                    })
+                )),
+
+                ('file:path', {}, (
+                    ('dir', ('file:path', {}), {'ro': 1,
+                                                'doc': 'The parent directory.'}),
+
+                    ('base', ('file:base', {}), {'ro': 1,
+                                                 'doc': 'The file base name.'}),
+
+                    ('base:ext', ('str', {}), {'ro': 1,
+                                               'doc': 'The file extension.'}),
+                )),
+            ),
+
         }
+
         name = 'file'
-        return ((name, modl), )
+        return ((name, modl),)

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -60,55 +60,13 @@ class FileTest(s_test.SynTest):
                 fake = snap.addNode('file:bytes', '*')
                 self.true(fake.ndef[1].startswith('guid:'))
 
+                node = snap.addNode('file:subfile', (node1.ndef[1], node2.ndef[1]), {'name': 'embed.BIN'})
+                self.eq(node.ndef[1], (node1.ndef[1], node2.ndef[1]))
+                self.eq(node.get('parent'), node1.ndef[1])
+                self.eq(node.get('child'), node2.ndef[1])
+                self.eq(node.get('name'), 'embed.bin')
+
 class Newp:
-
-    def test_model_file_bytes(self):
-        with self.getRamCore() as core:
-
-            hset = s_hashset.HashSet()
-            hset.update(b'visi')
-
-            valu, props = hset.guid()
-            t0 = core.formTufoByProp('file:bytes', valu, **props)
-
-            self.eq(t0[1].get('file:bytes:size'), 4)
-
-            self.eq(t0[1].get('file:bytes'), '442f602ecf8230b2a59a44b4f845be27')
-            self.eq(t0[1].get('file:bytes:md5'), '1b2e93225959e3722efed95e1731b764')
-            self.eq(t0[1].get('file:bytes:sha1'), '93de0c7d579384feb3561aa504acd8f23f388040')
-            self.eq(t0[1].get('file:bytes:sha256'), 'e45bbb7e03acacf4d1cca4c16af1ec0c51d777d10e53ed3155bd3d8deb398f3f')
-            self.eq(t0[1].get('file:bytes:sha512'), '8238be12bcc3c10da7e07dbea528e9970dc809c07c5aef545a14e5e8d2038563b29c2e818d167b06e6a33412e6beb8347fcc44520691347aea9ee21fcf804e39')
-
-    def test_model_file_seeds(self):
-        with self.getRamCore() as core:
-
-            hset = s_hashset.HashSet()
-            hset.update(b'visi')
-
-            valu, props = hset.guid()
-            t0 = core.formTufoByProp('file:bytes', valu, **props)
-
-            self.eq(t0[0], core.formTufoByProp('file:bytes:sha256', props.get('sha256'))[0])
-            self.eq(t0[0], core.formTufoByProp('file:bytes:sha512', props.get('sha512'))[0])
-
-            self.ne(t0[0], core.formTufoByProp('file:bytes:sha1', props.get('sha1'))[0])
-            self.ne(t0[0], core.formTufoByProp('file:bytes:md5', props.get('md5'))[0])
-
-    def test_model_file_seeds_capitalization(self):
-        fhash = '6ACC29BFC5F8F772FA7AAF4A705F91CB68DC88CB22F4EF5101281DC42109A104'
-        fhash_lower = fhash.lower()
-        stable_guid = 'ed73917b1dc4011627f7a101ace491c8'
-
-        with self.getRamCore() as core:
-
-            n1 = core.formTufoByProp('file:bytes:sha256', fhash)
-            n2 = core.formTufoByProp('file:bytes:sha256', fhash_lower)
-            # Sha256 should be lowercase since the prop type is lowercased
-            n1def = s_tufo.ndef(n1)
-            n2def = s_tufo.ndef(n2)
-            self.eq(n1def[1], stable_guid)
-            self.eq(n2def[1], stable_guid)
-            self.eq(n1[0], n2[0])
 
     def test_model_filepath_complex(self):
         with self.getRamCore() as core:
@@ -171,64 +129,3 @@ class Newp:
             self.nn(core.getTufoByProp('file:base', 'baz.quux'))
 
             self.raises(BadTypeValu, core.formTufoByProp, 'file:base', '/haha')
-
-    def test_model_files_imgof(self):
-        with self.getRamCore() as core:
-
-            pnod = core.formTufoByProp('ps:person', None)
-            fnod = core.formTufoByProp('file:bytes', None)
-
-            piden = pnod[1].get('ps:person')
-            fiden = fnod[1].get('file:bytes')
-
-            img0 = core.formTufoByProp('file:imgof', (fiden, ('ps:person', piden)))
-            img1 = core.formTufoByProp('file:imgof', '(%s,ps:person=%s)' % (fiden, piden))
-
-            self.eq(img0[0], img1[0])
-            self.eq(img0[1].get('file:imgof:file'), fiden)
-            self.eq(img0[1].get('file:imgof:xref'), 'ps:person=' + piden)
-            self.eq(img0[1].get('file:imgof:xref:prop'), 'ps:person')
-            self.eq(img0[1].get('file:imgof:xref:strval'), piden)
-            self.eq(img0[1].get('file:imgof:xref:intval'), None)
-
-    def test_model_files_txtref(self):
-        with self.getRamCore() as core:
-
-            iden = guid()
-
-            img0 = core.formTufoByProp('file:txtref', (iden, ('inet:email', 'visi@vertex.link')))
-            img1 = core.formTufoByProp('file:txtref', '(%s,inet:email=visi@VERTEX.LINK)' % iden)
-
-            self.eq(img0[0], img1[0])
-            self.eq(img0[1].get('file:txtref:file'), iden)
-            self.eq(img0[1].get('file:txtref:xref'), 'inet:email=visi@vertex.link')
-            self.eq(img0[1].get('file:txtref:xref:prop'), 'inet:email')
-            self.eq(img0[1].get('file:txtref:xref:strval'), 'visi@vertex.link')
-            self.eq(img0[1].get('file:txtref:xref:intval'), None)
-
-    def test_model_file_bytes_axon(self):
-        self.skipLongTest()
-        with self.getAxonCore() as env:
-            with s_daemon.Daemon() as dmon:
-
-                dmonlink = dmon.listen('tcp://127.0.0.1:0/')
-                dmonport = dmonlink[1].get('port')
-                dmon.share('core', env.core)
-
-                coreurl = 'tcp://127.0.0.1:%d/core' % dmonport
-                core = s_telepath.openurl(coreurl)
-
-                node = core.formNodeByBytes(b'visi', name='visi.bin')
-                self.eq(node[1].get('file:bytes:size'), 4)
-                self.eq(node[1].get('file:bytes:name'), 'visi.bin')
-                self.eq(node[1].get('file:bytes'), '442f602ecf8230b2a59a44b4f845be27')
-                self.eq(node[1].get('file:bytes:md5'), '1b2e93225959e3722efed95e1731b764')
-                self.eq(node[1].get('file:bytes:sha1'), '93de0c7d579384feb3561aa504acd8f23f388040')
-                self.eq(node[1].get('file:bytes:sha256'), 'e45bbb7e03acacf4d1cca4c16af1ec0c51d777d10e53ed3155bd3d8deb398f3f')
-                self.eq(node[1].get('file:bytes:sha512'), '8238be12bcc3c10da7e07dbea528e9970dc809c07c5aef545a14e5e8d2038563b'
-                                                            '29c2e818d167b06e6a33412e6beb8347fcc44520691347aea9ee21fcf804e39')
-
-                fd = io.BytesIO(b'foobar')
-                node = core.formNodeByFd(fd, name='foobar.exe')
-                self.eq(node[1].get('file:bytes:size'), 6)
-                self.eq(node[1].get('file:bytes:name'), 'foobar.exe')

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -36,9 +36,9 @@ class FileTest(s_test.SynTest):
             self.eq(norm, 'c:/windows/system32/calc.exe')
             self.eq(info['subs']['dir'], 'c:/windows/system32')
             self.eq(info['subs']['base'], 'calc.exe')
-            # XXX This behavior changed!?
-            # norm, info = path.norm(r'/foo////bar/.././baz.json')
-            # self.eq(norm, '/foo/baz.json')
+
+            norm, info = path.norm(r'/foo////bar/.././baz.json')
+            self.eq(norm, '/foo/baz.json')
 
             norm, info = path.norm('c:')
             self.eq(norm, 'c:')

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -1,4 +1,5 @@
 import synapse.exc as s_exc
+import synapse.common as s_common
 
 import synapse.tests.common as s_test
 
@@ -9,11 +10,17 @@ class FileTest(s_test.SynTest):
         # test that sha256: form kicks out a sha256 sub.
         with self.getTestCore() as core:
             valu = 'sha256:' + ('a' * 64)
-            norm, info = core.model.type('file:bytes').norm(valu)
+            fbyts = core.model.type('file:bytes')
+            norm, info = fbyts.norm(valu)
             self.eq(info['subs']['sha256'], 'a' * 64)
 
-            norm, info = core.model.type('file:bytes').norm('b' * 64)
+            norm, info = fbyts.norm('b' * 64)
             self.eq(info['subs']['sha256'], 'b' * 64)
+
+            self.raises(s_exc.BadTypeValu, fbyts.norm, s_common.guid())
+            self.raises(s_exc.BadTypeValu, fbyts.norm, 'guid:0101')
+            self.raises(s_exc.BadTypeValu, fbyts.norm, 'helo:moto')
+            self.raises(s_exc.BadTypeValu, fbyts.norm, f'sha256:{s_common.guid()}')
 
     def test_model_file_types(self):
 

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -29,6 +29,7 @@ class FileTest(s_test.SynTest):
             self.eq('exe', subs.get('ext'))
 
             self.raises(s_exc.BadTypeValu, base.norm, 'foo/bar.exe')
+            self.raises(s_exc.BadTypeValu, base.norm, '/haha')
 
             norm, info = path.norm('c:\\Windows\\System32\\calc.exe')
 
@@ -45,6 +46,13 @@ class FileTest(s_test.SynTest):
             self.none(subs.get('ext'))
             self.none(subs.get('dir'))
             self.eq(subs.get('base'), 'c:')
+
+            norm, info = path.norm('/foo')
+            self.eq(norm, '/foo')
+            subs = info.get('subs')
+            self.none(subs.get('ext'))
+            self.none(subs.get('dir'))
+            self.eq(subs.get('base'), 'foo')
 
             with core.snap() as snap:
 
@@ -75,55 +83,3 @@ class FileTest(s_test.SynTest):
                 self.eq(node.get('parent'), node1.ndef[1])
                 self.eq(node.get('child'), node2.ndef[1])
                 self.eq(node.get('name'), 'embed.bin')
-
-class Newp:
-
-    def test_model_filepath_complex(self):
-        with self.getRamCore() as core:
-
-            node = core.formTufoByProp('file:path', '/Foo/Bar/Baz.exe')
-
-            self.nn(node)
-            self.eq(node[1].get('file:path:dir'), '/foo/bar')
-            self.eq(node[1].get('file:path:ext'), 'exe')
-            self.eq(node[1].get('file:path:base'), 'baz.exe')
-
-            node = core.getTufoByProp('file:path', '/foo')
-
-            self.nn(node)
-            self.none(node[1].get('file:path:ext'))
-
-            self.eq(node[1].get('file:path:dir'), '')
-            self.eq(node[1].get('file:path:base'), 'foo')
-
-            node = core.formTufoByProp('file:path', r'c:\Windows\system32\Kernel32.dll')
-
-            self.nn(node)
-            self.eq(node[1].get('file:path:dir'), 'c:/windows/system32')
-            self.eq(node[1].get('file:path:ext'), 'dll')
-            self.eq(node[1].get('file:path:base'), 'kernel32.dll')
-
-            self.nn(core.getTufoByProp('file:base', 'kernel32.dll'))
-
-    def test_filepath(self):
-        with self.getRamCore() as core:
-
-            core.formTufoByProp('file:path', '/foo/bar/baz/faz/')
-
-            self.nn(core.getTufoByProp('file:path', '/foo/bar/baz/faz'))
-            self.nn(core.getTufoByProp('file:base', 'faz'))
-            self.nn(core.getTufoByProp('file:path', '/foo/bar/baz'))
-            self.nn(core.getTufoByProp('file:base', 'baz'))
-            self.nn(core.getTufoByProp('file:path', '/foo/bar'))
-            self.nn(core.getTufoByProp('file:base', 'bar'))
-            self.nn(core.getTufoByProp('file:path', '/foo'))
-            self.nn(core.getTufoByProp('file:base', 'foo'))
-            self.none(core.getTufoByProp('file:base', ''))
-
-    def test_filebase(self):
-        with self.getRamCore() as core:
-
-            core.formTufoByProp('file:base', 'baz.quux')
-            self.nn(core.getTufoByProp('file:base', 'baz.quux'))
-
-            self.raises(BadTypeValu, core.formTufoByProp, 'file:base', '/haha')

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -35,6 +35,16 @@ class FileTest(s_test.SynTest):
             self.eq(norm, 'c:/windows/system32/calc.exe')
             self.eq(info['subs']['dir'], 'c:/windows/system32')
             self.eq(info['subs']['base'], 'calc.exe')
+            # XXX This behavior changed!?
+            # norm, info = path.norm(r'/foo////bar/.././baz.json')
+            # self.eq(norm, '/foo/baz.json')
+
+            norm, info = path.norm('c:')
+            self.eq(norm, 'c:')
+            subs = info.get('subs')
+            self.none(subs.get('ext'))
+            self.none(subs.get('dir'))
+            self.eq(subs.get('base'), 'c:')
 
             with core.snap() as snap:
 
@@ -94,18 +104,6 @@ class Newp:
             self.eq(node[1].get('file:path:base'), 'kernel32.dll')
 
             self.nn(core.getTufoByProp('file:base', 'kernel32.dll'))
-
-            node = core.getTufoByProp('file:path', 'c:')
-
-            self.nn(node)
-            self.none(node[1].get('file:path:ext'))
-            self.eq(node[1].get('file:path:dir'), '')
-            self.eq(node[1].get('file:path:base'), 'c:')
-
-            node = core.formTufoByProp('file:path', r'/foo////bar/.././baz.json')
-
-            self.nn(node)
-            self.eq(node[1].get('file:path'), '/foo/baz.json')
 
     def test_filepath(self):
         with self.getRamCore() as core:

--- a/synapse/tests/test_model_files.py
+++ b/synapse/tests/test_model_files.py
@@ -70,6 +70,13 @@ class FileTest(s_test.SynTest):
                 self.eq(node.get('dir'), '/foo/bar')
                 self.nn(snap.getNodeByNdef(('file:path', '/foo/bar')))
 
+                nodes = list(snap.getNodesBy('file:path', '/foo/bar/b', cmpr='^='))
+                self.len(1, nodes)
+                self.eq(node.ndef, nodes[0].ndef)
+                nodes = list(snap.getNodesBy('file:base', 'baz', cmpr='^='))
+                self.len(1, nodes)
+                self.eq(node.get('base'), nodes[0].ndef[1])
+
                 node0 = snap.addNode('file:bytes', 'hex:56565656')
                 node1 = snap.addNode('file:bytes', 'base64:VlZWVg==')
                 node2 = snap.addNode('file:bytes', b'VVVV')


### PR DESCRIPTION
- Add file:subfile
- Migrate some file:path tests
- Fix a file:path behavior regarding `..` values in a path-
- Add tests for prefix lifts
- Add sad paths for file:bytes norming

Untested files.py code is tested in #834 