### PR TITLE
Tweak some cortex logging.

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -447,7 +447,7 @@ class Cortex(s_cell.Cell):
                             layr.spliced.wait(timeout=1)
                             continue
 
-                        logger.info('tanking splices: {:,}'.format(len(items)))
+                        logger.info('tanking splices: %d', len(items))
 
                         offs = tank.puts(items, seqn=(self.iden, offs))
                         self.fire('core:splice:cryotank:sent')

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -204,7 +204,7 @@ class Cortex(s_cell.Cell):
 
         ('storm:log:level', {
             'type': 'int',
-            'defval': logging.DEBUG,
+            'defval': logging.WARNING,
             'doc': 'Logging log level to emit storm logs at.'
         }),
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -143,10 +143,6 @@ class CoreApi(s_cell.CellApi):
         if opts is not None:
             query.opts.update(opts)
 
-        if self.cell.conf.get('storm:log'):
-            lvl = self.cell.conf.get('storm:log:level')
-            logger.log(lvl, 'Executing storm query [%s] as [%s]', text, self.user)
-
         return query
 
     def storm(self, text, opts=None):
@@ -626,6 +622,14 @@ class Cortex(s_cell.Cell):
 
         for mesg in query.execute():
             yield mesg
+
+    def _logStormQuery(self, text, user):
+        '''
+        Log a storm query.
+        '''
+        if self.conf.get('storm:log'):
+            lvl = self.conf.get('storm:log:level')
+            logger.log(lvl, 'Executing storm query [%s] as [%r]', text, user)
 
     def getNodeByNdef(self, ndef):
         '''

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -102,6 +102,7 @@ class Query(AstNode):
 
         self.user = None
         self.view = view
+        self.text = ''
 
         self.opts = {}
 
@@ -141,6 +142,8 @@ class Query(AstNode):
                 yield node
 
     def _runQueryLoop(self, snap):
+
+        snap.core._logStormQuery(self.text, self.user)
 
         count = 0
 

--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -112,7 +112,7 @@ class Node:
 
         except Exception as e:
             mesg = f'Bad property value: {prop.full}={valu!r}'
-            return self.snap._raiseOnStrict(s_exc.BadPropValu, mesg, valu=valu)
+            return self.snap._raiseOnStrict(s_exc.BadPropValu, mesg, valu=valu, emesg=str(e))
 
         # do we already have the value?
         if curv == norm:

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -636,6 +636,7 @@ class Parser:
         self.ignore(whitespace)
 
         query = s_ast.Query(self.view)
+        query.text = self.text
 
         while True:
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -507,6 +507,13 @@ class CortexTest(s_test.SynTest):
             for node in core.eval('teststr=$foo', opts=opts):
                 self.eq('bar', node.ndef[1])
 
+        conf = {'storm:log': True}
+        with self.getTestDir() as dirn:
+            with self.getTestCell(dirn, 'cortex', conf=conf) as core:
+                with self.getLoggerStream('synapse.cortex', 'Executing storm query [help ask] as [None]') as stream:
+                    mesgs = list(core.storm('help ask'))
+                    self.true(stream.wait(6))
+
     def test_feed_splice(self):
 
         iden = s_common.guid()


### PR DESCRIPTION
- Move alot of the cortex warning logs to be info/exceptions.
- Capture the `str(e)` value when we fail to norm a prop on `Node.set()`.
- Allow storm queries to be logged on local cortexes, not just on remote calls.
- Allow storm query log level to be set via config.