### PR TITLE
Bug: Axon clone rows limit

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -260,7 +260,7 @@ class BlobCell(s_cell.Cell):
         with chan:
             offs = mesg[1].get('offs')
             genr = self.blobs.clone(offs)
-            rows = list(itertools.islice(genr, 1000))
+            rows = list(itertools.islice(genr, 63))
             chan.txok(rows)
 
     @s_glob.inpool


### PR DESCRIPTION
Drop the number of rows we can clone at once to 63 (the minimal amount we can safely encrypt at a given point in time).

See https://github.com/pyca/cryptography/issues/4303