### PR TITLE
010 - Change the way nodes are printed to be more copy-paste friendly

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -62,7 +62,7 @@ class StormCmd(s_cli.Cmd):
             self.printf(repr(node))
             return
 
-        self.printf('%.20s = %s' % (formname, formvalu))
+        self.printf('%s=%s' % (formname, formvalu))
 
         if not opts.get('hide-props'):
 

--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -62,7 +62,7 @@ class StormCmd(s_cli.Cmd):
             self.printf(repr(node))
             return
 
-        self.printf('%s=%s' % (formname, formvalu))
+        self.printf(f'{formname}={formvalu}')
 
         if not opts.get('hide-props'):
 

--- a/synapse/tests/test_tools_feed.py
+++ b/synapse/tests/test_tools_feed.py
@@ -25,8 +25,8 @@ class FeedTest(s_test.SynTest):
             cmdg = s_test.CmdGenerator(['storm pivcomp -> *'], on_end=EOFError)
             with mock.patch('synapse.lib.cli.get_input', cmdg) as p:
                 self.eq(s_feed.main(argv, outp=outp), 0)
-            self.true(outp.expect('teststr = haha', throw=False))
-            self.true(outp.expect('pivtarg = hehe', throw=False))
+            self.true(outp.expect('teststr=haha', throw=False))
+            self.true(outp.expect('pivtarg=hehe', throw=False))
 
     def test_syningest_fail(self):
         with self.getTestDir() as dirn:
@@ -74,8 +74,8 @@ class FeedTest(s_test.SynTest):
             cmdg = s_test.CmdGenerator(['storm pivcomp -> *'], on_end=EOFError)
             with mock.patch('synapse.lib.cli.get_input', cmdg) as p:
                 self.eq(s_feed.main(argv, outp=outp), 0)
-            self.true(outp.expect('teststr = haha', throw=False))
-            self.true(outp.expect('pivtarg = hehe', throw=False))
+            self.true(outp.expect('teststr=haha', throw=False))
+            self.true(outp.expect('pivtarg=hehe', throw=False))
 
     def test_synsplice_remote(self):
         with self.getTestDmon(mirror='dmoncoreauth') as dmon:


### PR DESCRIPTION
Do not truncate formname or add spaces between formname/formvalu when printing nodes.