### PR TITLE
010 bug comp repr

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -363,7 +363,7 @@ class Comp(Type):
         for valu, (name, typename) in zip(valu, fields):
 
             # if any of our comp fields need repr we do too...
-            rval = self.modl.types[typename].repr(valu)
+            rval = self.tcache[name].repr(valu)
 
             if rval is not None:
                 hit = True

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -38,7 +38,14 @@ class TypesTest(s_test.SynTest):
         self.eq(t.repr(0), 'False')
 
     def test_comp(self):
-        self.skip('Implement base comp test')
+        with self.getTestCore() as core:
+            t = 'testcomplexcomp'
+            valu = ('123', 'HAHA')
+            with core.snap() as snap:
+                node = snap.addNode(t, valu)
+            pnode = node.pack(dorepr=True)
+            self.eq(pnode[0], (t, (123, 'haha')))
+            self.eq(pnode[1].get('repr'), ('123', 'haha'))
 
     def test_fieldhelper(self):
         self.skip('Implement base fieldhelper test')

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -46,6 +46,8 @@ class TypesTest(s_test.SynTest):
             pnode = node.pack(dorepr=True)
             self.eq(pnode[0], (t, (123, 'haha')))
             self.eq(pnode[1].get('repr'), ('123', 'haha'))
+            self.eq(pnode[1].get('reprs').get('foo'), '123')
+            self.notin('bar', pnode[1].get('reprs'))
             self.eq(node.get('foo'), 123)
             self.eq(node.get('bar'), 'haha')
 

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -46,6 +46,8 @@ class TypesTest(s_test.SynTest):
             pnode = node.pack(dorepr=True)
             self.eq(pnode[0], (t, (123, 'haha')))
             self.eq(pnode[1].get('repr'), ('123', 'haha'))
+            self.eq(node.get('foo'), 123)
+            self.eq(node.get('bar'), 'haha')
 
     def test_fieldhelper(self):
         self.skip('Implement base fieldhelper test')

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -133,6 +133,10 @@ testmodel = {
             ('hehe', 'testint'),
             ('haha', 'testlower'))
         }), {'doc': 'A fake comp type.'}),
+        ('testcomplexcomp', ('comp', {'fields': (
+            ('foo', 'testint'),
+            ('bar', ('str', {'lower': True}),),
+        )}), {'doc': 'A complex comp type.'}),
         ('testhexa', ('hex', {}), {'doc': 'anysize test hex type'}),
         ('testhex4', ('hex', {'size': 4}), {'doc': 'size 4 test hex type'}),
 
@@ -171,6 +175,11 @@ testmodel = {
         ('testcomp', {}, (
             ('hehe', ('testint', {}), {'ro': 1}),
             ('haha', ('testlower', {}), {'ro': 1}),
+        )),
+
+        ('testcomplexcomp', {}, (
+            ('foo', ('testint', {}), {'ro': 1}),
+            ('bar', ('str', {'lower': 1}), {'ro': 1})
         )),
 
         ('testint', {}, {}),


### PR DESCRIPTION
Comp types with non-model forms failed to repr() properly. This is fixed.