### PR TITLE
010 - Make PropPivot resilient to BadLiftValu

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -569,11 +569,11 @@ class PropPivot(PivotOper):
             try:
                 for pivo in self.snap.getNodesBy(self.prop.full, valu):
                     yield pivo, path.fork(pivo)
-            except s_exc.BadTypeValu as e:
+            except (s_exc.BadTypeValu, s_exc.BadLiftValu) as e:
                 logger.warning('Caught error during pivot', exc_info=e)
                 items = e.items()
                 mesg = items.pop('mesg', '')
-                mesg = ': '.join((f'BadTypeValu [{repr(valu)}] during pivot', mesg))
+                mesg = ': '.join((f'{e.__class__.__qualname__} [{repr(valu)}] during pivot', mesg))
                 self.snap.warn(mesg, **items)
 
 class Cond(AstNode):

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -218,6 +218,10 @@ class Fqdn(s_types.Type):
 
     def indxByEq(self, valu):
 
+        if valu == '':
+            raise s_exc.BadLiftValu(valu=valu, name=self.name,
+                                    mesg='Cannot generate fqdn index bytes for a empty string.')
+
         if valu[0] == '*':
             indx = valu[1:][::-1].encode('utf8')
             return (
@@ -225,7 +229,8 @@ class Fqdn(s_types.Type):
             )
 
         if valu.find('*') != -1:
-            raise s_exc.BadLiftValu(valu=valu, mesg='Wild card may only appear at the beginning.')
+            raise s_exc.BadLiftValu(valu=valu, name=self.name,
+                                    mesg='Wild card may only appear at the beginning.')
 
         return s_types.Type.indxByEq(self, valu)
 

--- a/synapse/tests/test_model_dns.py
+++ b/synapse/tests/test_model_dns.py
@@ -37,6 +37,25 @@ class DnsModelTest(s_test.SynTest):
                 answ = snap.addNode('inet:dns:answer', '*', props)
                 self.nn(snap.getNodeByNdef(('inet:dns:a', ('vertex.link', 0x02030405))))
 
+            # DNS queries can be quite complex or awkward since the protocol
+            # allows for nearly anything to be asked about. This can lead to
+            # pivots with non-normable data.
+            q = '[inet:dns:query=(tcp://1.2.3.4, "", 1)]'
+            self.len(1, core.eval(q))
+            q = '[inet:dns:query=(tcp://1.2.3.4, "foo*.haha.com", 1)]'
+            self.len(1, core.eval(q))
+            q = 'inet:dns:query=(tcp://1.2.3.4, "", 1) :name -> inet:fqdn'
+            with self.getLoggerStream('synapse.lib.ast',
+                                      'Cannot generate fqdn index bytes for a empty string') as stream:
+                self.len(0, core.eval(q))
+                self.true(stream.wait(1))
+
+            q = 'inet:dns:query=(tcp://1.2.3.4, "foo*.haha.com", 1) :name -> inet:fqdn'
+            with self.getLoggerStream('synapse.lib.ast',
+                                      'Wild card may only appear at the beginning') as stream:
+                self.len(0, core.eval(q))
+                self.true(stream.wait(1))
+
     def test_forms_dns_simple(self):
 
         with self.getTestCore() as core:


### PR DESCRIPTION
Since a PropPivot may shovel who-knows-what into a indx function, it shouldn't die on a BadLiftValu exception.