### PR TITLE
Deconflict at the axon layer

### DIFF
--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -139,6 +139,8 @@ class AxonBadChunk(AxonErr): pass
 class AxonNoBlobStors(AxonErr): pass
 class AxonBlobStorBsidChanged(AxonErr): pass
 class AxonUnknownBsid(AxonErr): pass
+class AxonUploaderFinished(AxonErr): pass
+class AxonBlobStorDisagree(AxonErr): pass
 
 class FileExists(SynErr): pass
 class NoCertKey(SynErr):

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -261,12 +261,10 @@ class AxonTest(s_test.SynTest):
                 self.eq([], await axon.wants([abhash, cdhash]))
                 foo = await axon.get(cdhash)
                 bar = [x async for x in foo]
-                print(bar)
                 self.eq(b'cd', b''.join([x async for x in await axon.get(cdhash)]))
                 self.eq(b'ab', b''.join([x async for x in await axon.get(abhash)]))
 
                 # Test deconfliction, Upload a big boy
-                print('************************')
                 async with await axon.startput() as uploader:
                     await uploader.write(b'cd')
                     await uploader.finishFile()


### PR DESCRIPTION
In the axon redesign recently committed, automatic deconfliction (i.e. not putting the same blob in twice) only happened at the blobstor layer. Now it also happens at the axon layer.

This PR also includes better handling for failures connecting to blobstors.

This PR also includes a workaround for a Python bug.