### PR TITLE
010 bug pivot

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -491,6 +491,10 @@ class PivotInFrom(PivotOper):
             full = self.form.name + ':n2'
 
             for node, path in genr:
+
+                if self.isjoin:
+                    yield node, path
+
                 for pivo in self.snap.getNodesBy(full, node.ndef):
                     yield pivo, path.fork(pivo)
 
@@ -498,6 +502,9 @@ class PivotInFrom(PivotOper):
 
         # edge <- form
         for node, path in genr:
+
+            if self.isjoin:
+                yield node, path
 
             if not isinstance(node.form.type, s_types.Edge):
                 continue

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -555,6 +555,10 @@ class FormPivot(PivotOper):
             full = self.prop.name + ':n1'
 
             for node, path in genr:
+
+                if self.isjoin:
+                    yield node, path
+
                 for pivo in self.snap.getNodesBy(full, node.ndef):
                     yield pivo, path.fork(pivo)
 

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -1035,6 +1035,9 @@ class Parser:
             if self.nextstr('-+>'):
                 return self.propjoin(prop)
 
+            if self.nextstrs('<-', '<+-'):
+                self._raiseSyntaxError('Pivot in syntax does not currently support relative properties.')
+
         name = self.noms(varset)
         if not name:
             self._raiseSyntaxError('unknown query syntax')

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -958,13 +958,13 @@ class Parser:
 
     def propjoin(self, prop):
         '''
-        :foo:bar <- baz:faz
+        :foo:bar -+> baz:faz
         '''
         pval = s_ast.RelPropValue(kids=(prop,))
 
         self.ignore(whitespace)
 
-        self.nextmust('<-')
+        self.nextmust('-+>')
 
         self.ignore(whitespace)
 
@@ -1032,7 +1032,7 @@ class Parser:
             if self.nextstr('->'):
                 return self.proppivot(prop)
 
-            if self.nextstr('<-'):
+            if self.nextstr('-+>'):
                 return self.propjoin(prop)
 
         name = self.noms(varset)

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -874,7 +874,7 @@ class Parser:
 
     def formpivotin(self):
         '''
-        <- *
+        <- * / <- prop
         '''
 
         self.ignore(whitespace)
@@ -892,7 +892,7 @@ class Parser:
 
     def formjoinin(self):
         '''
-        <+- *
+        <+- * / <+- prop
         '''
 
         self.ignore(whitespace)
@@ -901,9 +901,12 @@ class Parser:
 
         self.ignore(whitespace)
 
-        self.nextmust('*')
+        if self.nextchar() == '*':
+            self.offs += 1
+            return s_ast.PivotIn(isjoin=True)
 
-        return s_ast.PivotIn(isjoin=True)
+        prop = self.absprop()
+        return s_ast.PivotInFrom(kids=(prop,), isjoin=True)
 
     def formpivot(self):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1058,7 +1058,7 @@ class CortexTest(s_test.SynTest):
                       'pivcomp :lulz <- teststr',
                       'pivcomp :lulz <+- teststr',
                       ]:
-                self.raises(s_exc.BadStormSyntax)
+                self.genraises(s_exc.BadStormSyntax, core.eval, q)
 
     def test_node_repr(self):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1009,6 +1009,14 @@ class CortexTest(s_test.SynTest):
             self.len(1, nodes)
             self.eq(nodes[0][1][0], ('testint', 127))
 
+            # Bad pivots go here
+            for q in ['pivcomp :lulz <- *',
+                      'pivcomp :lulz <+- *',
+                      'pivcomp :lulz <- teststr',
+                      'pivcomp :lulz <+- teststr',
+                      ]:
+                self.raises(s_exc.BadStormSyntax)
+
     def test_node_repr(self):
 
         with self.getTestCore() as core:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -944,6 +944,17 @@ class CortexTest(s_test.SynTest):
             self.len(1, nodes)
             self.eq(nodes[0][0], ('pivtarg', 'foo'))
 
+            q = 'teststr=bar -> pivcomp:lulz'
+            nodes = getPackNodes(core, q)
+            self.len(1, nodes)
+            self.eq(nodes[0][0], ('pivcomp', ('foo', 'bar')))
+
+            q = 'teststr=bar -+> pivcomp:lulz'
+            nodes = getPackNodes(core, q)
+            self.len(2, nodes)
+            self.eq(nodes[0][0], ('pivcomp', ('foo', 'bar')))
+            self.eq(nodes[1][0], ('teststr', 'bar'))
+
             q = 'pivcomp=(foo,bar) -+> pivtarg'
             nodes = getPackNodes(core, q)
             self.len(2, nodes)
@@ -987,6 +998,12 @@ class CortexTest(s_test.SynTest):
 
             # A simple edge for testing pivotinfrom with a edge to n2
             nodes = list(core.eval('[has=((teststr, foobar), (teststr, foo))]'))
+
+            q = 'teststr=foobar -+> has'
+            nodes = getPackNodes(core, q)
+            self.len(2, nodes)
+            self.eq(nodes[0][0], ('has', (('teststr', 'foobar'), ('teststr', 'foo'))))
+            self.eq(nodes[1][0], ('teststr', 'foobar'))
 
             # traverse from node to edge:n1
             q = 'teststr=foo <- has'


### PR DESCRIPTION
* Change propjoin <- syntax to -+>
* Make PivotInFrom use self.isjoin
* add missing support for self.isjoin to opers which may be used with `-+>` and `<+-` syntax