### PR TITLE
010 bug pivot

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -677,6 +677,18 @@ def err(e):
     name = e.__class__.__name__
     info = {}
 
+    tb = sys.exc_info()[2]
+    tbinfo = traceback.extract_tb(tb)
+    if tbinfo:
+        path, line, tbname, src = tbinfo[-1]
+        path = os.path.basename(path)
+        info = {
+            'efile': path,
+            'eline': line,
+            'esrc': src,
+            'ename': tbname,
+        }
+
     if isinstance(e, s_exc.SynErr):
         info.update(e.items())
     else:

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -751,7 +751,7 @@ class TagValuCond(Cond):
 
         cmprctor = ival.getCmprCtor(cmpr)
         if cmprctor is None:
-            raise s_exc.NoSuchCmpr(name=cmpr, type=prop.type.name)
+            raise s_exc.NoSuchCmpr(name=cmpr, type=ival.name)
 
         if isinstance(self.kids[2], Const):
 

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -714,7 +714,7 @@ class AbsPropCond(Cond):
 
         ctor = prop.type.getCmprCtor(cmpr)
         if ctor is None:
-            raise s_exc.NoSuchCmpr(name=cmpr, type=prop.type.name)
+            raise s_exc.NoSuchCmpr(cmpr=cmpr, name=prop.type.name)
 
         if prop.isform:
 
@@ -751,7 +751,7 @@ class TagValuCond(Cond):
 
         cmprctor = ival.getCmprCtor(cmpr)
         if cmprctor is None:
-            raise s_exc.NoSuchCmpr(name=cmpr, type=ival.name)
+            raise s_exc.NoSuchCmpr(cmpr=cmpr, name=ival.name)
 
         if isinstance(self.kids[2], Const):
 

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -1200,6 +1200,10 @@ class Parser:
             if self.nextchar() not in cmprstart:
                 return s_ast.TagCond(kids=(tag,))
 
+            # Special case of pivot operations which ALSO start with cmprstart chars
+            if self.nextstrs('<-', '<+-'):
+                return s_ast.TagCond(kids=(tag,))
+
             cmpr = self.cmpr()
             self.ignore(whitespace)
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -108,7 +108,7 @@ class Type:
         '''
         ctor = self.getCmprCtor(name)
         if ctor is None:
-            raise s_exc.NoSuchCmpr(name=name)
+            raise s_exc.NoSuchCmpr(cmpr=name, name=self.name)
 
         norm1 = self.norm(val1)[0]
         norm2 = self.norm(val2)[0]
@@ -326,7 +326,7 @@ class Type:
         func = self.indxcmpr.get(cmpr)
 
         if func is None:
-            raise s_exc.NoSuchCmpr(type=self.name, cmpr=cmpr)
+            raise s_exc.NoSuchCmpr(name=self.name, cmpr=cmpr)
 
         return func(valu)
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1022,6 +1022,25 @@ class CortexTest(s_test.SynTest):
             nodes = getPackNodes(core, q)
             self.len(3, nodes)
 
+            # tag conditional filters followed by * pivot operators
+            # These are all going to yield zero nodes but should
+            # parse cleanly.
+            q = '#test.bar -#test <- *'
+            nodes = getPackNodes(core, q)
+            self.len(0, nodes)
+
+            q = '#test.bar -#test <+- *'
+            nodes = getPackNodes(core, q)
+            self.len(0, nodes)
+
+            q = '#test.bar -#test -> *'
+            nodes = getPackNodes(core, q)
+            self.len(0, nodes)
+
+            q = '#test.bar -#test -+> *'
+            nodes = getPackNodes(core, q)
+            self.len(0, nodes)
+
             # Setup a propvalu pivot where the secondary prop may fail to norm
             # to the destination prop for some of the inbound nodes.
             list(core.eval('[ testcomp=(127,newp) ] [testcomp=(127,127)]'))

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -670,6 +670,10 @@ class CortexTest(s_test.SynTest):
 
             self.genraises(s_exc.NoSuchOpt, core.eval, '%foo=asdf')
             self.genraises(s_exc.BadOptValu, core.eval, '%limit=asdf')
+            self.genraises(s_exc.NoSuchCmpr, core.eval, 'teststr*near=newp')
+            self.genraises(s_exc.NoSuchCmpr, core.eval, 'teststr +teststr@=2018')
+            self.genraises(s_exc.NoSuchCmpr, core.eval, 'teststr +#test*near=newp')
+            self.genraises(s_exc.NoSuchCmpr, core.eval, 'teststr +teststr:tick*near=newp')
             self.genraises(s_exc.BadStormSyntax, core.eval, ' | | ')
 
             self.len(2, list(core.eval(('[ teststr=foo teststr=bar ]'))))

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -689,7 +689,7 @@ class CortexTest(s_test.SynTest):
                     mesgs = list(core.storm('help ask'))
                     self.true(stream.wait(6))
                 # Bad syntax
-                self.genraises(s_exc.BadStormSyntax, list, core.storm(' | | | '))
+                self.genraises(s_exc.BadStormSyntax, core.storm, ' | | | ')
 
     def test_feed_splice(self):
 

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -9,7 +9,9 @@ import synapse.datamodel as s_datamodel
 class TypesTest(s_test.SynTest):
 
     def test_type(self):
-        self.skip('Implement base type test')
+        model = s_datamodel.Model()
+        t = model.type('bool')
+        self.raises(s_exc.NoSuchCmpr, t.cmpr, val1=1, name='newp', val2=0)
 
     def test_bool(self):
         model = s_datamodel.Model()


### PR DESCRIPTION
- Allow pivot operators after tag conditional filters
- Ensure NoSuchCmpr arguments are consistent
- Pack additional data into marshalled exceptions so they are more useful for debugging purposes