### PR TITLE
010 migration bugfixes and improvements

### DIFF
--- a/synapse/tests/test_tools_migrate_010.py
+++ b/synapse/tests/test_tools_migrate_010.py
@@ -30,7 +30,7 @@ class Migrate010Test(s_iq.SynTest):
             nodes = self.get_formfile('file:ref', fh)
             self.eq(len(nodes), 1)
             node = nodes[0]
-            self.eq(node[0][1][1][0], 'inet:srv4')
+            self.eq(node[0][1][1][0], 'inet:server')
 
     def test_basic(self):
         self.maxDiff = None

--- a/synapse/tests/test_tools_migrate_010.py
+++ b/synapse/tests/test_tools_migrate_010.py
@@ -316,15 +316,15 @@ class Migrate010Test(s_iq.SynTest):
                     'name:en': 'Pompey the Great',
                     'name:en:sur': 'Pompey'
                 }
-                core.formTufoByProp(f'ps:{personx}', s_common.guid(), **props)
+                core.formTufoByProp('ps:%s' % personx, s_common.guid(), **props)
                 fh = tempfile.TemporaryFile(dir=dirn)
                 m = s_migrate.Migrator(core, fh, tmpdir=dirn)
                 m.migrate()
-                nodes = self.get_formfile(f'ps:{personx}', fh)
+                nodes = self.get_formfile('ps:%s' % personx, fh)
                 self.len(1, nodes)
                 self.isin('name:given', nodes[0][1]['props'])
                 self.notin('name:en', nodes[0][1]['props'])
-                nodes = self.get_formfile(f'ps:{personx}:has', fh)
+                nodes = self.get_formfile('ps:%s:has' % personx, fh)
                 self.len(1, nodes)
                 self.eq(nodes[0][0][1][1], ('ps:name', 'pompey the great'))
 
@@ -335,14 +335,14 @@ class Migrate010Test(s_iq.SynTest):
                 'name': 'Senatus Romanum',
                 'name:en': 'The Roman Senate',
             }
-            core.formTufoByProp(f'ou:org', s_common.guid(), **props)
+            core.formTufoByProp('ou:org', s_common.guid(), **props)
             fh = tempfile.TemporaryFile(dir=dirn)
             m = s_migrate.Migrator(core, fh, tmpdir=dirn)
             m.migrate()
-            nodes = self.get_formfile(f'ou:org', fh)
+            nodes = self.get_formfile('ou:org', fh)
             self.len(1, nodes)
             self.notin('name:en', nodes[0][1]['props'])
-            nodes = self.get_formfile(f'ou:org:has', fh)
+            nodes = self.get_formfile('ou:org:has', fh)
             self.len(1, nodes)
             self.eq(nodes[0][0][1][1], ('ou:org:name', 'the roman senate'))
 

--- a/synapse/tests/test_tools_migrate_010.py
+++ b/synapse/tests/test_tools_migrate_010.py
@@ -15,6 +15,23 @@ class Migrate010Test(s_iq.SynTest):
         nodes = list(node for node in s_msgpack.iterfd(fh) if node[0][0] == formname)
         return nodes
 
+    def test_txtref_tcp4(self):
+        with self.getTestDir() as dirn, s_cortex.openurl('sqlite:///:memory:') as core:
+            # with self.getTestDir() as dirn, self.getRamCore() as core:
+
+            dirn = pathlib.Path(dirn)
+
+            iden = s_common.guid()
+            core.formTufoByProp('file:txtref', (iden, ('inet:tcp4', '1.2.3.4:4567')))
+            fh = tempfile.TemporaryFile(dir=str(dirn))
+            m = s_migrate.Migrator(core, fh, tmpdir=str(dirn))
+            m.migrate()
+
+            nodes = self.get_formfile('file:ref', fh)
+            self.eq(len(nodes), 1)
+            node = nodes[0]
+            self.eq(node[0][1][1][0], 'inet:srv4')
+
     def test_basic(self):
         self.maxDiff = None
         with self.getTestDir() as dirn, s_cortex.openurl('sqlite:///:memory:') as core:

--- a/synapse/tools/migrate_010.py
+++ b/synapse/tools/migrate_010.py
@@ -7,7 +7,6 @@ from binascii import unhexlify, hexlify
 
 import lmdb  # type: ignore
 
-
 import synapse.cortex as s_cortex
 import synapse.common as s_common
 import synapse.lib.modules as s_modules
@@ -853,7 +852,8 @@ def main(argv, outp=None):  # pragma: no cover
     p.add_argument('--stage-1', help='Start at stage 2 with stage 1 file')
     p.add_argument('--log-level', choices=s_const.LOG_LEVEL_CHOICES, help='specify the log level', type=str.upper)
     p.add_argument('--extra-module', nargs='+', help='name of an extra module to load')
-    p.add_argument('--only-convert-forms-file', type=argparse.FileType('r'))
+    p.add_argument('--only-convert-forms-file', type=argparse.FileType('r'),
+                   help='Path to newline-delimited file of forms to convert')
     opts = p.parse_args(argv)
 
     s_common.setlogging(logger, opts.log_level)
@@ -869,10 +869,9 @@ def main(argv, outp=None):  # pragma: no cover
     if opts.only_convert_forms_file:
         good_forms = []
         for line in opts.only_convert_forms_file:
-            good_forms.append(line)
+            good_forms.append(line.rstrip())
     else:
         good_forms = None
-
 
     fh = open(opts.outfile, 'wb')
     rejects_fh = open(opts.outfile + '.rejects', 'wb')

--- a/synapse/tools/migrate_010.py
+++ b/synapse/tools/migrate_010.py
@@ -376,11 +376,16 @@ class Migrator:
         t = self.core.getPropType(propname)
         sourceval = props[propname + ':' + t._sorc_name]
         destprop = props[propname + ':xref:prop']
+
         destval = props.get(propname + ':xref:intval', props.get(propname + ':xref:strval'))
         if destval is None:
             destval = props[propname + ':xref'].split('=', 1)[1]
         source_final = self.convert_foreign_key(propname, t._sorc_type, sourceval)
         dest_final = self.convert_foreign_key(propname, destprop, destval)
+
+        if destprop in self.form_renames:
+            destprop = self.form_renames[destprop]
+
         return (source_final, (destprop, dest_final))
 
     def convert_primary(self, props):
@@ -423,6 +428,8 @@ class Migrator:
         '''
         if pivot_formname in self.filebytes:
             return self.convert_filebytes_secondary(pivot_formname, pivot_fk)
+        if pivot_formname in ('inet:tcp4', 'inet:tcp6', 'inet:udp4', 'inet:udp6'):
+            return self.xxp_to_server(pivot_formname, pivot_formname, pivot_formname, pivot_fk, {})[1]
         if self.is_comp(pivot_formname):
             return self.convert_comp_secondary(pivot_formname, pivot_fk)
         if self.is_sepr(pivot_formname):

--- a/synapse/tools/migrate_010.py
+++ b/synapse/tools/migrate_010.py
@@ -337,8 +337,8 @@ class Migrator:
                 props = self._get_props_from_cursor(txn, curs)
                 rv = curs.next()
                 formname = props.get('tufo:form')
-                if not (formname is None or formname in self.first_forms or
-                        (self.good_forms and formname not in self.good_forms)):
+                if not (formname is None or formname in self.first_forms or (self.good_forms and formname not in
+                        self.good_forms)):
                     try:
                         node = self.convert_props(props)
                         if node is not None:


### PR DESCRIPTION
Add a --only-convert-forms-file option to limit which forms are migrated.

Will no longer generate packed node entries without the second tuple entry.

Change how name:en fields are migrated.

Fix incorrect migration of txtrefs that point to inet:tcp4