### PR TITLE
010 ctx stats

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -236,7 +236,11 @@ class CoreApi(s_cell.CellApi):
             return snap.addFeedData(name, items, seqn=seqn)
 
     def getFeedOffs(self, iden):
-        return self.cell.layer.getOffset(iden)
+        return self.cell.getFeedOffs(iden)
+
+    @s_cell.adminapi
+    def setFeedOffs(self, iden, offs):
+        return self.cell.setFeedOffs(iden, offs)
 
     def count(self, text, opts=None):
         '''
@@ -1045,6 +1049,15 @@ class Cortex(s_cell.Cell):
 
     def getFeedOffs(self, iden):
         return self.layer.getOffset(iden)
+
+    def setFeedOffs(self, iden, offs):
+        if offs < 0:
+            raise s_exc.BadConfValu(mesg='Offset must be greater than or equal to zero.', offs=offs,
+                                    iden=iden)
+        oldoffs = self.getFeedOffs(iden)
+        logger.info('Setting Feed offset for [%s] from [%s] to [%s]',
+                    iden, oldoffs, offs)
+        return self.layer.setOffset(iden, offs)
 
     def snap(self, user=None):
         '''

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -91,7 +91,7 @@ class CoreApi(s_cell.CellApi):
 
     @s_cell.adminapi
     def stat(self):
-        return self.layer.stat()
+        return self.cell.stat()
 
     def getNodesBy(self, full, valu, cmpr='='):
         '''
@@ -1122,3 +1122,9 @@ class Cortex(s_cell.Cell):
         except Exception as e:
             logger.exception('mod load fail: %s' % (ctor,))
             return None
+
+    def stat(self):
+        stats = {
+            'layer': self.layer.stat()
+        }
+        return stats

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1138,6 +1138,7 @@ class Cortex(s_cell.Cell):
 
     def stat(self):
         stats = {
+            'iden': self.iden,
             'layer': self.layer.stat()
         }
         return stats

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -89,6 +89,10 @@ class CoreApi(s_cell.CellApi):
     def getCoreMods(self):
         return self.cell.getCoreMods()
 
+    @s_cell.adminapi
+    def stat(self):
+        return self.layer.stat()
+
     def getNodesBy(self, full, valu, cmpr='='):
         '''
         Yield Node.pack() tuples which match the query.

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -224,6 +224,9 @@ class Layer(s_cell.Cell):
     def setOffset(self, iden, offs):  # pragma: no cover
         raise NotImplementedError
 
+    def stat(self):
+        raise NotImplementedError
+
     def splices(self, offs, size):  # pragma: no cover
         raise NotImplementedError
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -64,7 +64,6 @@ class Xact(s_eventbus.EventBus):
 
             yield from func(oper)
 
-
     @contextlib.contextmanager
     def incxref(self):
         '''
@@ -219,16 +218,16 @@ class Layer(s_cell.Cell):
         self.onfini(self.spliced.set)
 
     def getOffset(self, iden):  # pragma: no cover
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def setOffset(self, iden, offs):  # pragma: no cover
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def stat(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def splices(self, offs, size):  # pragma: no cover
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def xact(self, write=False):  # pragma: no cover
         '''

--- a/synapse/lib/lmdb.py
+++ b/synapse/lib/lmdb.py
@@ -71,6 +71,12 @@ class Seqn:
 
         self.indx = indx
 
+    def index(self):
+        '''
+        Return the current index to be used
+        '''
+        return self.indx
+
     def nextindx(self, xact):
         '''
         Determine the next insert offset according to storage.

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -393,6 +393,11 @@ class LmdbLayer(s_layer.Layer):
             for i, mesg in self.splicelog.slice(xact, offs, size):
                 yield mesg
 
+    def stat(self):
+        return {
+            'splicelog_indx': self.splicelog.index(),
+        }
+
     def db(self, name):
         return self.dbs.get(name)
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1469,9 +1469,11 @@ class CortexTest(s_test.SynTest):
     def test_stat(self):
 
         with self.getTestDmon(mirror='dmoncoreauth') as dmon:
+            coreiden = dmon.shared['core'].iden
             pconf = {'user': 'root', 'passwd': 'root'}
             with dmon._getTestProxy('core', **pconf) as core:
                 ostat = core.stat()
+                self.eq(ostat.get('iden'), coreiden)
                 self.isin('layer', ostat)
                 self.len(1, (core.eval('sudo | [teststr=123 :tick=2018]')))
                 nstat = core.stat()

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1476,3 +1476,15 @@ class CortexTest(s_test.SynTest):
                 self.len(1, (core.eval('sudo | [teststr=123 :tick=2018]')))
                 nstat = core.stat()
                 self.gt(nstat.get('layer').get('splicelog_indx'), ostat.get('layer').get('splicelog_indx'))
+
+    def test_offset(self):
+        with self.getTestDmon(mirror='dmoncoreauth') as dmon:
+            pconf = {'user': 'root', 'passwd': 'root'}
+            with dmon._getTestProxy('core', **pconf) as core:
+                iden = s_common.guid()
+                self.eq(core.getFeedOffs(iden), 0)
+                self.none(core.setFeedOffs(iden, 10))
+                self.eq(core.getFeedOffs(iden), 10)
+                self.none(core.setFeedOffs(iden, 0))
+                self.eq(core.getFeedOffs(iden), 0)
+                self.raises(s_exc.BadConfValu, core.setFeedOffs, iden, -1)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1465,3 +1465,14 @@ class CortexTest(s_test.SynTest):
         with self.getTestCore() as core1:
             retn = core1.addFeedData('syn.nodes', podes)
             self.len(3, core1.eval('testint'))
+
+    def test_stat(self):
+
+        with self.getTestDmon(mirror='dmoncoreauth') as dmon:
+            pconf = {'user': 'root', 'passwd': 'root'}
+            with dmon._getTestProxy('core', **pconf) as core:
+                ostat = core.stat()
+                self.isin('layer', ostat)
+                self.len(1, (core.eval('sudo | [teststr=123 :tick=2018]')))
+                nstat = core.stat()
+                self.gt(nstat.get('layer').get('splicelog_indx'), ostat.get('layer').get('splicelog_indx'))

--- a/synapse/tests/test_lib_lmdb.py
+++ b/synapse/tests/test_lib_lmdb.py
@@ -33,6 +33,7 @@ class LmdbTest(SynTest):
             # Reopen the seqn and continue where we left off
             lenv = lmdb.open(dirn, writemap=True, max_dbs=128)
             seqn = s_lmdb.Seqn(lenv, b'seqn:test')
+            self.eq(seqn.index(), 3)
 
             with lenv.begin(write=True) as xact:
                 self.eq(seqn.nextindx(xact), 3)


### PR DESCRIPTION
- Add a `stat()` function to a cortex.  Currently this just returns the splice offset for the cortexes top most layer.
- Add a `setFeedOFfs()` function to the Cortex (and CoreApi) that allows for setting the splice feed offset to a arbitrary non-negative value.

kudos to @whippit for starting this