### PR TITLE
010 - better telepath aliases.yaml support

### DIFF
--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -398,12 +398,15 @@ def alias(name):
         name (str): Name of the alias to resolve.
 
     Notes:
-        If this string contains a '/' in it, only the value before the slash
-        is looked up and the remainder of the path is joined to any result.
-        This is done to support dynamic Telepath share names.
+        An exact match against the aliases will always be returned first.
+        If no exact match is found and the name contains a '/' in it, the
+        value before the slash is looked up and the remainder of the path
+        is joined to any result. This is done to support dynamic Telepath
+        share names.
 
     Returns:
-        str: The url string, if present in the alias.
+        str: The url string, if present in the alias.  None will be returned
+        if there are no matches.
     '''
     path = s_common.getSynPath('aliases.yaml')
     if not os.path.isfile(path):

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -411,6 +411,11 @@ def alias(name):
 
     conf = s_common.yamlload(path)
 
+    # Is there an exact match - if so, return it.
+    url = conf.get(name)
+    if url:
+        return url
+
     # Since telepath supports dynamic shared object access,
     # slice a name at the first '/', look up using that value
     # and then append the second value to it.

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -393,13 +393,35 @@ class Proxy(s_coro.Fini):
 def alias(name):
     '''
     Resolve a telepath alias via ~/.syn/aliases.yaml
+
+    Args:
+        name (str): Name of the alias to resolve.
+
+    Notes:
+        If this string contains a '/' in it, only the value before the slash
+        is looked up and the remainder of the path is joined to any result.
+        This is done to support dynamic Telepath share names.
+
+    Returns:
+        str: The url string, if present in the alias.
     '''
     path = s_common.getSynPath('aliases.yaml')
     if not os.path.isfile(path):
         return None
 
     conf = s_common.yamlload(path)
-    return conf.get(name)
+
+    # Since telepath supports dynamic shared object access,
+    # slice a name at the first '/', look up using that value
+    # and then append the second value to it.
+    dynname = None
+    if '/' in name:
+        name, dynname = name.split('/', 1)
+    url = conf.get(name)
+    if url and dynname:
+        url = '/'.join([url, dynname])
+
+    return url
 
 @s_glob.synchelp
 async def openurl(url, **opts):

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -319,15 +319,24 @@ class TeleTest(s_test.SynTest):
             dmon.share(name, item)
             dirn = s_scope.get('dirn')
 
-            alias = f'tcp://{addr[0]}:{addr[1]}/{name}'
+            url = f'tcp://{addr[0]}:{addr[1]}/{name}'
+            beepbeep_alias = url + '/beepbeep'
+            aliases = {name: url,
+                       f'{name}/borp': beepbeep_alias}
 
             with self.setSynDir(dirn):
                 fp = s_common.getSynPath('aliases.yaml')
-                s_common.yamlsave({name: alias}, fp)
+                s_common.yamlsave(aliases, fp)
 
                 # None existent aliases return None
                 self.none(s_telepath.alias('newp'))
                 self.none(s_telepath.alias('newp/path'))
+
+                # An exact match wins
+                self.eq(s_telepath.alias(name), url)
+                self.eq(s_telepath.alias(f'{name}/borp'), beepbeep_alias)
+                # Dynamic aliases are valid.
+                self.eq(s_telepath.alias(f'{name}/beepbeep'), beepbeep_alias)
 
                 with s_telepath.openurl(name) as prox:
                     self.eq(10, prox.getFooBar(20, 10))

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -6,9 +6,11 @@ logger = logging.getLogger(__name__)
 
 import synapse.exc as s_exc
 import synapse.glob as s_glob
+import synapse.common as s_common
 import synapse.telepath as s_telepath
 
 import synapse.lib.share as s_share
+import synapse.lib.scope as s_scope
 import synapse.tests.common as s_test
 
 from synapse.tests.utils import SyncToAsyncCMgr
@@ -24,6 +26,13 @@ class CustomShare(s_share.Share):
 
     def boo(self, x):
         return x
+
+class Beep:
+    def __init__(self, path):
+        self.path = path
+
+    def beep(self):
+        return f'{self.path}: beep'
 
 class Foo:
 
@@ -99,6 +108,20 @@ class TeleApi:
         return CustomShare(self.link, 42)
 
 class TeleAware(s_telepath.Aware):
+    def __init__(self):
+        s_telepath.Aware.__init__(self)
+        self.beeps = {}
+
+    def _initBeep(self, path):
+        beep = self.beeps.get(path)
+        if beep:
+            return beep
+        beep = Beep(path)
+        self.beeps[path] = beep
+        return beep
+
+    def onTeleOpen(self, link, path):
+        return self._initBeep(path[1])
 
     def getTeleApi(self, link, mesg):
         return TeleApi(self, link)
@@ -249,12 +272,16 @@ class TeleTest(s_test.SynTest):
 
         with self.getTestDmon() as dmon:
             dmon.share('woke', item)
-            proxy = dmon._getTestProxy('woke')
-            self.eq(10, proxy.getFooBar(20, 10))
+            with dmon._getTestProxy('woke') as proxy:
+                self.eq(10, proxy.getFooBar(20, 10))
 
-            # check a custom share works
-            obj = proxy.customshare()
-            self.eq(999, obj.boo(999))
+                # check a custom share works
+                obj = proxy.customshare()
+                self.eq(999, obj.boo(999))
+
+            # check that a dynamic share works
+            with dmon._getTestProxy('woke/up') as proxy:
+                self.eq('up: beep', proxy.beep())
 
     def test_telepath_auth(self):
 
@@ -282,3 +309,30 @@ class TeleTest(s_test.SynTest):
             host, port = dmon.listen('tcp://127.0.0.1:0/')
 
             self.raises(s_exc.BadMesgVers, s_telepath.openurl, 'tcp://127.0.0.1/', port=port)
+
+    def test_alias(self):
+        item = TeleAware()
+        name = 'item'
+
+        with self.getTestDmon() as dmon:
+            addr = dmon.listen('tcp://127.0.0.1:0')
+            dmon.share(name, item)
+            dirn = s_scope.get('dirn')
+
+            alias = f'tcp://{addr[0]}:{addr[1]}/{name}'
+
+            with self.setSynDir(dirn):
+                fp = s_common.getSynPath('aliases.yaml')
+                s_common.yamlsave({name: alias}, fp)
+
+                # None existent aliases return None
+                self.none(s_telepath.alias('newp'))
+                self.none(s_telepath.alias('newp/path'))
+
+                with s_telepath.openurl(name) as prox:
+                    self.eq(10, prox.getFooBar(20, 10))
+
+                # Check to see that we can connect to an aliased name
+                # with a dynamic share attached to it.
+                with s_telepath.openurl(f'{name}/bar') as prox:
+                    self.eq('bar: beep', prox.beep())

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -798,6 +798,24 @@ class SynTest(unittest.TestCase):
 
         self.raises(exc, testfunc)
 
+    @contextlib.contextmanager
+    def setSynDir(self, dirn):
+        '''
+        Sets s_common.syndir to a specific directory and then unsets it afterwards.
+
+        Args:
+            dirn (str): Directory to set syndir to.
+
+        Notes:
+            This is to be used as a context manager.
+        '''
+        olddir = s_common.syndir
+        try:
+            s_common.syndir = dirn
+            yield None
+        finally:
+            s_common.syndir = olddir
+
     def eq(self, x, y, msg=None):
         '''
         Assert X is equal to Y


### PR DESCRIPTION
- Fixes #938
- Add explicit tests for Telepath dynamic share paths. 
- Add explicit tests for Telepath aliases.yaml.
- Add support to Telepath aliases.yaml file to support dynamic share paths.
