### PR TITLE
Add encode/decode 64-bit integer funcs, et aliter

### DIFF
--- a/docs/synapse/devopsguides/model_format.rst
+++ b/docs/synapse/devopsguides/model_format.rst
@@ -136,7 +136,7 @@ An example of extending the previous example is shown below (minus migration fun
     class FooBarModule(s_module.CoreModule):
 
         # Override the default initCoreModule function
-        def initCoreModule(self):
+        async def initCoreModule(self):
 
             # Define a function used for helping out during node creation.
             self.onFormNode('foo:knight', self.onTufoFormKnight)

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -965,7 +965,8 @@ class Axon(s_cell.Cell):
                 except Exception:
                     logger.error('At axon startup, failed to connect to stored blobstor path %s', _path_sanitize(path))
 
-        s_glob.plex.addLoopCoro(_connect_to_blobstors())
+        future = s_glob.plex.coroToTask(_connect_to_blobstors())
+        self.onfini(future.cancel)
 
         self._workq = _AsyncQueue(50)
         self.xact = IncrementalTransaction(self.lenv)
@@ -1000,7 +1001,7 @@ class Axon(s_cell.Cell):
         stop_watching_event = asyncio.Event(loop=s_glob.plex.loop)
         self.blobstorwatchers[blobstorpath] = stop_watching_event
 
-        s_glob.plex.addLoopCoro(self._watch_blobstor(blobstor, bsid, blobstorpath, stop_watching_event))
+        s_glob.plex.coroToTask(self._watch_blobstor(blobstor, bsid, blobstorpath, stop_watching_event))
 
     async def addBlobStor(self, blobstorpath):
         '''

--- a/synapse/cells.py
+++ b/synapse/cells.py
@@ -37,7 +37,7 @@ def add(name, ctor):
     '''
     ctors[name] = ctor
 
-def init(name, dirn):
+async def init(name, dirn):
     '''
     Initialize and return a Cell() object by alias.
     '''
@@ -45,9 +45,9 @@ def init(name, dirn):
     if ctor is None:
         raise s_exc.NoSuchName(name=name, mesg='No cell ctor by that name')
 
-    return ctor(dirn)
+    return await ctor.anit(dirn)
 
-def initFromDirn(dirn):
+async def initFromDirn(dirn):
     '''
     As above, but retrieves type from boot.yaml in dirn
     '''
@@ -55,7 +55,7 @@ def initFromDirn(dirn):
     kind = conf.get('type')
     if type is None:
         raise s_exc.BadConfValu('boot.yaml missing type key')
-    return init(kind, dirn)
+    return await init(kind, dirn)
 
 def deploy(name, dirn, boot=None):
     '''

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -7,6 +7,7 @@ import time
 import fcntl
 import types
 import base64
+import struct
 import fnmatch
 import hashlib
 import logging
@@ -43,7 +44,6 @@ version = (major, minor, micro)
 guidre = regex.compile('^[0-9a-f]{32}$')
 
 novalu = NoValu()
-
 
 def now():
     '''
@@ -601,6 +601,20 @@ def to_bytes(valu, size):
 
 def to_int(byts):
     return int.from_bytes(byts, 'little')
+
+_Int64be = struct.Struct('>Q')
+
+def int64en(i):
+    '''
+    Encode a 64-bit int into 8 byte big-endian bytes
+    '''
+    return _Int64be.pack(i)
+
+def int64un(b):
+    '''
+    Decode a 64-bit int from 8 byte big-endian
+    '''
+    return _Int64be.unpack(b)[0]
 
 def enbase64(b):
     return base64.b64encode(b).decode('utf8')

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -405,8 +405,7 @@ class Cortex(s_cell.Cell):
         self._initFeedLoops()
 
         async def fini():
-            futr = await asyncio.gather(layr.fini() for layr in self.layers)
-            futr.result()
+            await asyncio.gather(*[layr.fini() for layr in self.layers])
 
         self.onfini(fini)
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2,7 +2,6 @@ import json
 import asyncio
 import logging
 import pathlib
-import contextlib
 import collections
 
 import tornado.web as t_web
@@ -10,20 +9,17 @@ import tornado.netutil as t_netutil
 import tornado.httpserver as t_http
 
 import synapse.exc as s_exc
-import synapse.glob as s_glob
 import synapse.common as s_common
 import synapse.dyndeps as s_dyndeps
 import synapse.telepath as s_telepath
 import synapse.datamodel as s_datamodel
 
 import synapse.lib.cell as s_cell
-import synapse.lib.coro as s_coro
 import synapse.lib.lmdb as s_lmdb
 import synapse.lib.snap as s_snap
 import synapse.lib.cache as s_cache
 import synapse.lib.storm as s_storm
 import synapse.lib.layer as s_layer
-import synapse.lib.queue as s_queue
 import synapse.lib.syntax as s_syntax
 import synapse.lib.modules as s_modules
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -347,7 +347,6 @@ class Cortex(s_cell.Cell):
     def __init__(self, dirn):
         s_cell.Cell.__init__(self, dirn)
 
-        self.views = {}
         self.layers = []
         self.modules = {}
         self.feedfuncs = {}
@@ -979,7 +978,7 @@ class Cortex(s_cell.Cell):
             for node in snap.getNodesBy(full, valu, cmpr=cmpr):
                 yield node
 
-    def addNodes(self, nodedefs):
+    async def addNodes(self, nodedefs):
         '''
         Quickly add/modify a list of nodes from node definition tuples.
         This API is the simplest/fastest way to add nodes, set node props,
@@ -998,7 +997,8 @@ class Cortex(s_cell.Cell):
         '''
         with self.snap() as snap:
             snap.strict = False
-            yield from snap.addNodes(nodedefs)
+            async for node in snap.addNodes(nodedefs):
+                yield node
 
     def addFeedData(self, name, items, seqn=None):
         '''

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -897,14 +897,6 @@ class Cortex(s_cell.Cell):
             ret.append((modname, mod.conf))
         return ret
 
-    def eval(self, text, opts=None, user=None):
-        with self.snap(user=user) as snap:
-            yield from snap.eval(text, opts=opts, user=user)
-
-    def storm(self, text, opts=None, user=None):
-        # FIXME
-        pass
-
     async def eval(self, text, opts=None):
         '''
         Evaluate a storm query and yield Nodes only.

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -410,6 +410,8 @@ class Cortex(s_cell.Cell):
         self.onfini(fini)
 
     async def _initCoreLayers(self):
+        # FIXME
+        pass
 
     def onTagAdd(self, name, func):
         '''
@@ -905,6 +907,8 @@ class Cortex(s_cell.Cell):
             yield from snap.eval(text, opts=opts, user=user)
 
     def storm(self, text, opts=None, user=None):
+        # FIXME
+        pass
 
     async def eval(self, text, opts=None):
         '''

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -105,6 +105,7 @@ class Daemon(s_base.Base):
         EventBus.__init__(self)
 
         self.dirn = s_common.gendir(dirn)
+        self._shareLoopTasks = set()
 
         conf = self._loadDmonYaml()
         self.conf = s_common.config(conf, self.confdefs)
@@ -186,9 +187,17 @@ class Daemon(s_base.Base):
                 if isinstance(share, s_coro.Fini):
                     await share.fini()
 
+            for task in self._shareLoopTasks:
+                try:
+                    if task.done():
+                        continue
+                    task.cancel()
+                except Exception as e:
+                    logger.error('Error cancelling task: %s', str(e))
+
             await asyncio.wait([link.fini() for link in self.connectedlinks], loop=s_glob.plex.loop)
 
-        s_glob.plex.addLoopCoro(afini())
+        s_glob.plex.coroToTask(afini())
 
     def _getSslCtx(self):
         return None
@@ -404,11 +413,15 @@ class Daemon(s_base.Base):
                 async def spinshareloop():
                     try:
                         await valu._runShareLoop()
+                    except asyncio.CancelledError:
+                        pass
                     except Exception:
                         logger.exception('Error running %r', valu)
                     finally:
                         await valu.fini()
-                s_glob.plex.coroLoopTask(spinshareloop())
+                task = s_glob.plex.coroLoopTask(spinshareloop())
+                self._shareLoopTasks.add(task)
+                task.add_done_callback(self._getTaskResult)
 
         except Exception as e:
 
@@ -419,6 +432,22 @@ class Daemon(s_base.Base):
             await link.tx(
                 ('task:fini', {'task': task, 'retn': retn})
             )
+
+    def _getTaskResult(self, task):
+        result = s_common.novalu
+        try:
+            result = task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error('Error encountered for %s: [%s]',
+                         task, e)
+        finally:
+            try:
+                self._shareLoopTasks.remove(task)
+            except KeyError:
+                pass
+            return result
 
     def _getTestProxy(self, name, **kwargs):
         host, port = self.addr

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -15,9 +15,10 @@ import synapse.telepath as s_telepath
 
 from synapse.eventbus import EventBus
 
+import synapse.lib.base as s_base
 import synapse.lib.coro as s_coro
-import synapse.lib.urlhelp as s_urlhelp
 import synapse.lib.share as s_share
+import synapse.lib.urlhelp as s_urlhelp
 
 class Genr(s_share.Share):
 
@@ -84,7 +85,7 @@ dmonwrap = (
     (types.GeneratorType, Genr),
 )
 
-class Daemon(EventBus, s_coro.Anit, s_coro.Fini):
+class Daemon(s_base.Base):
 
     confdefs = (
 

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -13,8 +13,6 @@ import synapse.common as s_common
 import synapse.dyndeps as s_dyndeps
 import synapse.telepath as s_telepath
 
-from synapse.eventbus import EventBus
-
 import synapse.lib.base as s_base
 import synapse.lib.coro as s_coro
 import synapse.lib.share as s_share
@@ -102,7 +100,7 @@ class Daemon(s_base.Base):
 
     def __init__(self, dirn):
 
-        EventBus.__init__(self)
+        Base.__init__(self)
 
         self.dirn = s_common.gendir(dirn)
         self._shareLoopTasks = set()
@@ -172,15 +170,15 @@ class Daemon(s_base.Base):
         except Exception as e:
             logger.exception(f'onTeleShare() error for: {name}')
 
-    def _onDmonFini(self):
+    async def _onDmonFini(self):
         for s in self.listenservers:
             try:
                 s.close()
             except Exception as e:  # pragma: no cover
                 logger.warning('Error during socket server close()', exc_info=e)
         for name, share in self.shared.items():
-            if isinstance(share, EventBus):
-                share.fini()
+            if isinstance(share, s_base.Base):
+                await share.fini()
 
         async def afini():
             for name, share in self.shared.items():

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -1,9 +1,11 @@
 '''
 An API to assist with the creation and enforcement of cortex data models.
 '''
-import regex
+import asyncio
 import logging
 import collections
+
+import regex
 
 import synapse.exc as s_exc
 import synapse.dyndeps as s_dyndeps
@@ -55,7 +57,7 @@ class PropBase:
         '''
         self.ondels.append(func)
 
-    def wasSet(self, node, oldv):
+    async def wasSet(self, node, oldv):
         '''
         Fire the onset() handlers for this property.
 
@@ -65,7 +67,9 @@ class PropBase:
         '''
         for func in self.onsets:
             try:
-                func(node, oldv)
+                retn = func(node, oldv)
+                if asyncio.iscoroutine(retn):
+                    await retn
             except Exception as e:
                 logger.exception('onset() error for %s' % (self.full,))
 
@@ -250,13 +254,15 @@ class Form:
     def onDel(self, func):
         self.ondels.append(func)
 
-    def wasAdded(self, node):
+    async def wasAdded(self, node):
         '''
         Fire the onAdd() callbacks for node creation.
         '''
         for func in self.onadds:
             try:
-                func(node)
+                retn = func(node)
+                if asyncio.iscoroutine(retn):
+                    await retn
             except Exception as e:
                 logger.exception('error on onadd for %s' % (self.name,))
 

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -101,7 +101,6 @@ class Query(AstNode):
         # for options parsed from the query itself
         self.opts = {}
 
-<< << << < HEAD
         # used by the di-graph projection logic
         self._graph_done = {}
         self._graph_want = collections.deque()
@@ -274,7 +273,8 @@ class LiftOper(Oper):
 
     async def run(self, runt, genr):
 
-        yield from genr
+        for x in genr:
+            yield x
 
         for node in self.lift(runt):
             yield node, runt.initPath(node)
@@ -974,7 +974,8 @@ class EditNodeAdd(Edit):
         name = self.kids[0].value()
         formtype = runt.snap.model.types.get(name)
 
-        yield from genr
+        for x in genr:
+            yield x
 
         runt.allowed('node:add', name)
 

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -3,7 +3,6 @@ import atexit
 import signal
 import asyncio
 import logging
-import functools
 import threading
 import collections
 
@@ -63,7 +62,7 @@ class Base:
     @classmethod
     async def anit(cls, *args, **kwargs):
         self = cls(*args, **kwargs)
-        self.loop = asyncio.get_running_loop()
+        self.loop = asyncio.get_event_loop()
         await self.__anit__()
         return self
 
@@ -339,8 +338,11 @@ class Base:
             print('Caught SIGTERM, shutting down')
             await self.fini()
 
+        def handler():
+            asyncio.run_coroutine_threadsafe(sighandler(), loop=self.loop)
+
         try:
-            s_glob.plex.loop.add_signal_handler(signal.SIGTERM, functools.partial(asyncio.create_task, sighandler()))
+            s_glob.plex.loop.add_signal_handler(signal.SIGTERM, handler)
         except Exception as e:  # pragma: no cover
             logger.exception('Unable to register SIGTERM handler.')
 
@@ -356,6 +358,9 @@ class Base:
             print('ctrl-c caught: shutting down')
 
         finally:
+            # Avoid https://bugs.python.org/issue34680 by removing handler before closing down
+            s_glob.plex.loop.remove_signal_handler(signal.SIGTERM)
+
             asyncio.run_coroutine_threadsafe(self.fini(), loop=self.loop)
 
     def waiter(self, count, *names):

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -1,0 +1,482 @@
+import asyncio
+import logging
+import collections
+
+import synapse.exc as s_exc
+import synapse.common as s_common
+import synapse.lib.thishost as s_thishost
+
+logger = logging.getLogger(__name__)
+
+class Base:
+    '''
+    Base class for Synapse objects.
+
+    Acts as an observable, enables async init and fini.
+
+    Example:
+
+        class Foo(Anit):
+
+            def __init__(self, x):
+                self.x = x
+
+            async def __anit__(self):
+                await stuff()
+
+        foo = await Foo.anit(10)
+    '''
+    @classmethod
+    async def anit(cons, *args, **kwargs):
+        self = cons(*args, **kwargs)
+        await self.__anit__()
+        return self
+
+    def __init__(self):
+        self.isfini = False
+        self.entered = False
+        self.exitinfo = None
+        self.finievt = None
+
+        self.exitok = None
+        self.entered = False
+        self.exitinfo = None
+
+        self._syn_funcs = collections.defaultdict(list)
+
+        self._syn_refs = 1  # one ref for the ctor
+        self._syn_links = []
+        self._fini_funcs = []
+        self._fini_atexit = False
+
+    async def __anit__(self):
+        pass
+
+    def onfini(self, coro):
+        '''
+        Add a *coroutine* to be called on fini().
+        '''
+        self._fini_funcs.append(coro)
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exc, cls, tb):
+        self.exitok = cls is None
+        self.exitinfo = (exc, cls, tb)
+        await self.fini()
+
+    def _isExitExc(self):
+        # if entered but not exited *or* exitinfo has exc
+        if not self.entered:
+            return False
+
+        if self.exitinfo is None:
+            return True
+
+        return self.exitinfo[0] is not None
+
+    def incref(self):
+        '''
+        Increment the reference count for this event bus.
+        This API may be optionally used to control fini().
+        '''
+        self._syn_refs += 1
+        return self._syn_refs
+
+    def link(self, func):
+        '''
+        Add a callback function to receive *all* events.
+
+        Example:
+
+            bus1 = Base()
+            bus2 = Base()
+
+            bus1.link( bus2.dist )
+
+            # all events on bus1 are also propigated on bus2
+
+        '''
+        self._syn_links.append(func)
+
+    def unlink(self, func):
+        '''
+        Remove a callback function previously added with link()
+
+        Example:
+
+            bus.unlink( callback )
+
+        '''
+        if func in self._syn_links:
+            self._syn_links.remove(func)
+
+    def on(self, evnt, func, **filts):
+        '''
+        Add an event bus function callback for a specific event with optional filtering.
+        If the function returns a coroutine, it will be awaited.
+
+        Args:
+            evnt (str):         An event name
+            func (function):    A callback function to receive event tufo
+            **filts:            Optional positive filter values for the event tuple.
+
+        Examples:
+
+            Add a callback function and fire it:
+
+                async def baz(event):
+                    x = event[1].get('x')
+                    y = event[1].get('y')
+                    return x + y
+
+                d.on('foo', baz, x=10)
+
+                # this fire triggers baz...
+                d.fire('foo', x=10, y=20)
+
+                # this fire does not ( due to filt )
+                d.fire('foo', x=30, y=20)
+
+        Returns:
+            None:
+        '''
+        self._syn_funcs[evnt].append((func, tuple(filts.items())))
+
+    def off(self, evnt, func):
+        '''
+        Remove a previously registered event handler function.
+
+        Example:
+
+            bus.off( 'foo', onFooFunc )
+
+        '''
+        funcs = self._syn_funcs.get(evnt)
+        if funcs is not None:
+
+            for i in range(len(funcs)):
+
+                if funcs[i][0] == func:
+                    funcs.pop(i)
+                    break
+
+            if not funcs:
+                self._syn_funcs.pop(evnt, None)
+
+    async def fire(self, evtname, **info):
+        '''
+        Fire the given event name on the Base.
+        Returns a list of the return values of each callback.
+
+        Example:
+
+            for ret in d.fire('woot',foo='asdf'):
+                print('got: %r' % (ret,))
+
+        '''
+        event = (evtname, info)
+        if self.isfini:
+            return event
+
+        await self.dist(event)
+        return event
+
+    async def dist(self, mesg):
+        '''
+        Distribute an existing event tuple.
+
+        Args:
+            mesg ((str,dict)):  An event tuple.
+
+        Example:
+
+            base.dist( ('foo',{'bar':'baz'}) )
+
+        '''
+        if self.isfini:
+            return ()
+
+        ret = []
+        for func, filt in self._syn_funcs.get(mesg[0], ()):
+
+            try:
+
+                if any(True for k, v in filt if mesg[1].get(k) != v):
+                    continue
+
+                retn = func(mesg)
+                if asyncio.iscoroutine(retn):
+                    retn = await retn
+                ret.append(retn)
+
+            except Exception as e:
+                logger.exception('base %s error with mesg %s', self, mesg)
+
+        for func in self._syn_links:
+            try:
+                ret.append(await func(mesg))
+            except Exception as e:
+                logger.exception('base %s error with mesg %s', self, mesg)
+
+        return ret
+
+    async def fini(self):
+        '''
+        Shut down the object and notify any onfini() coroutines.
+
+        Returns:
+            Remaining ref count
+        '''
+        if self.isfini:
+            return
+
+        self._syn_refs -= 1
+        if self._syn_refs > 0:
+            return self._syn_refs
+
+        self.isfini = True
+
+        fevt = self.finievt
+        for fini in self._fini_funcs:
+
+            try:
+                await fini()
+
+            except Exception as e:
+                logger.exception('fini failed')
+
+        if fevt is not None:
+            fevt.set()
+        self._syn_funcs.clear()
+        del self._fini_funcs[:]
+        return 0
+
+    async def waitfini(self, timeout=None):
+        '''
+        Wait for the event bus to fini()
+
+        Example:
+
+            bus.waitfini(timeout=30)
+
+        '''
+
+        if self.isfini:
+            return True
+
+        if self.finievt is None:
+            self.finievt = asyncio.Event(loop=asyncio.get_running_loop())
+
+        try:
+            await asyncio.wait_for(self.finievt.wait(), timeout, loop=asyncio.get_running_loop())
+        except asyncio.TimeoutError:
+            return None
+        return True
+
+    def waiter(self, count, *names):
+        '''
+        Construct and return a new Waiter for events on this bus.
+
+        Example:
+
+            # wait up to 3 seconds for 10 foo:bar events...
+
+            waiter = bus.waiter(10,'foo:bar')
+
+            # .. fire thread that will cause foo:bar events
+
+            events = waiter.wait(timeout=3)
+
+            if events == None:
+                # handle the timout case...
+
+            for event in events:
+                # parse the events if you need...
+
+        NOTE: use with caution... it's easy to accidentally construct
+              race conditions with this mechanism ;)
+
+        '''
+        return Waiter(self, count, *names)
+
+    async def log(self, level, mesg, **info):
+        '''
+        Implements the log event convention for a Base.
+
+        Args:
+            level (int):  A python logger level for the event
+            mesg (str):   A log message
+            **info:       Additional log metadata
+
+        '''
+        info['time'] = s_common.now()
+        info['host'] = s_thishost.get('hostname')
+
+        info['level'] = level
+        info['class'] = self.__class__.__name__
+
+        await self.fire('log', mesg=mesg, **info)
+
+    async def exc(self, exc, **info):
+        '''
+        Implements the exception log convention for Base.
+        A caller is expected to be within the except frame.
+
+        Args:
+            exc (Exception):    The exception to log
+
+        Returns:
+            None
+        '''
+        info.update(s_common.excinfo(exc))
+        await self.log(logging.ERROR, str(exc), **info)
+
+class Waiter:
+    '''
+    A helper to wait for a given number of events on a Base.
+    '''
+    def __init__(self, bus, count, *names):
+        self.bus = bus
+        self.names = names
+        self.count = count
+        self.event = asyncio.Event(loop=asyncio.get_running_loop())
+
+        self.events = []
+
+        for name in names:
+            bus.on(name, self._onWaitEvent)
+
+        if not names:
+            bus.link(self._onWaitEvent)
+
+    def _onWaitEvent(self, mesg):
+        self.events.append(mesg)
+        if len(self.events) >= self.count:
+            self.event.set()
+
+    async def wait(self, timeout=None):
+        '''
+        Wait for the required number of events and return them or None on timeout.
+
+        Example:
+
+            evnts = waiter.wait(timeout=30)
+
+            if evnts == None:
+                handleTimedOut()
+                return
+
+            for evnt in evnts:
+                doStuff(evnt)
+
+        '''
+        try:
+            try:
+                await asyncio.wait_for(self.event.wait(), timeout, loop=asyncio.get_running_loop())
+            except asyncio.TimeoutError:
+                return None
+
+            return self.events
+
+        finally:
+            self.fini()
+
+    def fini(self):
+
+        for name in self.names:
+            self.bus.off(name, self._onWaitEvent)
+
+        if not self.names:
+            self.bus.unlink(self._onWaitEvent)
+        del self.event
+
+class BaseRef(Base):
+    '''
+    An object for managing multiple Base instances by name.
+    '''
+    def __init__(self, ctor=None):
+        Base.__init__(self)
+        self.ctor = ctor
+        self.base_by_name = {}
+        self.onfini(self._onBaseRefFini)
+
+    async def _onBaseRefFini(self):
+        await asyncio.gather(*[base.fini() for base in self.vals()])
+
+    def put(self, name, base):
+        '''
+        Add a Base (or sub-class) to the BaseRef by name.
+
+        Args:
+            name (str): The name/iden of the Base
+            base (Base): The Base instance
+
+        Returns:
+            (None)
+        '''
+        async def fini():
+            if self.base_by_name.get(name) is base:
+                self.base_by_name.pop(name, None)
+
+        # Remove myself from BaseRef when I fini
+        base.onfini(fini)
+        self.base_by_name[name] = base
+
+    def pop(self, name):
+        '''
+        Remove and return a Base from the BaseRef.
+
+        Args:
+            name (str): The name/iden of the Base instance
+
+        Returns:
+            (Base): The named event bus ( or None )
+        '''
+        return self.base_by_name.pop(name, None)
+
+    def get(self, name):
+        '''
+        Retrieve a Base instance by name.
+
+        Args:
+            name (str): The name/iden of the Base
+
+        Returns:
+            (Base): The Base instance (or None)
+        '''
+        return self.base_by_name.get(name)
+
+    async def gen(self, name):
+        '''
+        Atomically get/gen a Base and incref.
+        (requires ctor during BaseRef init)
+
+        Args:
+            name (str): The name/iden of the Base instance.
+        '''
+        if self.ctor is None:
+            raise s_exc.NoSuchCtor(name=name, mesg='BaseRef.gen() requires ctor')
+
+        base = self.base_by_name.get(name)
+
+        if base is None:
+            base = await self.ctor(name)
+            self.put(name, base)
+        else:
+            base.incref()
+
+        return base
+
+    def vals(self):
+        return list(self.base_by_name.values())
+
+    def items(self):
+        return list(self.base_by_name.items())
+
+    def __iter__(self):
+        # make a copy during iteration to prevent dict
+        # change during iteration exceptions
+        return iter(list(self.base_by_name.values()))

--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -1,8 +1,10 @@
 '''
 A few speed optimized (lockless) cache helpers.  Use carefully.
 '''
+import asyncio
 import collections
 
+import synapse.exc as s_exc
 import synapse.common as s_common
 
 def memoize(size=10000):
@@ -28,6 +30,7 @@ class FixedCache:
     def __init__(self, callback, size=10000):
         self.size = size
         self.callback = callback
+        self.iscorocall = asyncio.iscoroutinefunction(self.callback)
 
         self.cache = {}
         self.size = size
@@ -46,12 +49,35 @@ class FixedCache:
             self.cache.pop(key, None)
 
     def get(self, key):
+        if self.iscorocall:
+            raise s_exc.BadOperArg('cache was initialized with coroutine.  Must use aget')
 
         valu = self.cache.get(key, s_common.novalu)
         if valu is not s_common.novalu:
             return valu
 
         valu = self.callback(key)
+        if valu is s_common.novalu:
+            return valu
+
+        self.cache[key] = valu
+        self.fifo.append(key)
+
+        while len(self.fifo) > self.size:
+            key = self.fifo.popleft()
+            self.cache.pop(key, None)
+
+        return valu
+
+    async def aget(self, key):
+        if not self.iscorocall:
+            raise s_exc.BadOperArg('cache was initialized with non coroutine.  Must use get')
+
+        valu = self.cache.get(key, s_common.novalu)
+        if valu is not s_common.novalu:
+            return valu
+
+        valu = await self.callback(key)
         if valu is s_common.novalu:
             return valu
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -365,7 +365,7 @@ bootdefs = (
         'doc': 'Set to <user>:<passwd> (local only) to bootstrap an admin.'}),
 )
 
-class Cell(s_eventbus.EventBus, s_telepath.Aware, s_coro.Anit):
+class Cell(s_coro.Fini, s_eventbus.EventBus, s_telepath.Aware, s_coro.Anit):
     '''
     A Cell() implements a synapse micro-service.
     '''
@@ -385,7 +385,9 @@ class Cell(s_eventbus.EventBus, s_telepath.Aware, s_coro.Anit):
 
     def __init__(self, dirn):
 
+        s_coro.Fini.__init__(self)
         s_coro.Anit.__init__(self)
+        s_telepath.Aware.__init__(self)
         s_eventbus.EventBus.__init__(self)
 
         self.dirn = s_common.gendir(dirn)

--- a/synapse/lib/cmdr.py
+++ b/synapse/lib/cmdr.py
@@ -4,6 +4,7 @@ import synapse.cmds.cortex as s_cmds_cortex
 cmdsbycell = {
     'cortex': (
         s_cmds_cortex.StormCmd,
+        s_cmds_cortex.Log,
     ),
 }
 

--- a/synapse/lib/encoding.py
+++ b/synapse/lib/encoding.py
@@ -6,6 +6,7 @@ import codecs
 import xml.etree.ElementTree as x_etree
 
 import synapse.exc as s_exc
+import synapse.lib.msgpack as s_msgpack
 
 def _de_base64(item, **opts):
 
@@ -181,8 +182,12 @@ def _fmt_jsonl(fd, info):
     for line in fd:
         yield json.loads(line)
 
+def _fmt_mpk(fd, info):
+    yield from s_msgpack.iterfd(fd)
+
 fmtyielders = {
     'csv': _fmt_csv,
+    'mpk': _fmt_mpk,
     'xml': _fmt_xml,
     'json': _fmt_json,
     'jsonl': _fmt_jsonl,
@@ -190,6 +195,7 @@ fmtyielders = {
 }
 
 fmtopts = {
+    'mpk': {},
     'xml': {'mode': 'r', 'encoding': 'utf8'},
     'csv': {'mode': 'r', 'encoding': 'utf8'},
     'json': {'mode': 'r', 'encoding': 'utf8'},

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -48,11 +48,11 @@ class Layer(s_cell.Cell):
     async def getLiftRows(self, lops):
         for oper in lops:
 
-            func = await self._lift_funcs.get(oper[0])
+            func = self._lift_funcs.get(oper[0])
             if func is None:
                 raise s_exc.NoSuchLift(name=oper[0])
 
-            for row in func(oper):
+            async for row in func(oper):
                 yield row
 
     async def setOffset(self, iden, offs):  # pragma: no cover

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -2,21 +2,13 @@
 The layer library contains the base Layer object and helpers used for
 cortex construction.
 '''
-import os
-import lmdb
 import regex
 import logging
 import threading
-import contextlib
 import collections
 
 import synapse.exc as s_exc
-import synapse.common as s_common
-import synapse.eventbus as s_eventbus
-
 import synapse.lib.cell as s_cell
-import synapse.lib.msgpack as s_msgpack
-import synapse.lib.threads as s_threads
 
 logger = logging.getLogger(__name__)
 
@@ -28,15 +20,17 @@ class Utf8er(collections.defaultdict):
     def __missing__(self, name):
         return name.encode('utf8')
 
-class Xact(s_eventbus.EventBus):
+class Layer(s_cell.Cell):
     '''
-    A Layer transaction which encapsulates the storage implementation.
+    A layer implements btree indexed storage for a cortex.
+
+    TODO:
+        metadata for layer contents (only specific type / tag)
     '''
-
-    def __init__(self, layr, write=False):
-
-        s_eventbus.EventBus.__init__(self)
-
+    def __init__(self, dirn):
+        s_cell.Cell.__init__(self, dirn)
+        self.spliced = threading.Event()
+        self.onfini(self.spliced.set)
         self._lift_funcs = {
             'indx': self._liftByIndx,
             'prop:re': self._liftByPropRe,
@@ -50,85 +44,55 @@ class Xact(s_eventbus.EventBus):
         }
 
         self.splices = []
-        self.layr = layr
-        self.write = write
-        # our constructor gets a ref!
-        self.refs = 1
 
-    def getLiftRows(self, lops):
+    async def getLiftRows(self, lops):
         for oper in lops:
 
-            func = self._lift_funcs.get(oper[0])
+            func = await self._lift_funcs.get(oper[0])
             if func is None:
                 raise s_exc.NoSuchLift(name=oper[0])
 
-            yield from func(oper)
+            for row in func(oper):
+                yield row
 
-    @contextlib.contextmanager
-    def incxref(self):
-        '''
-        A reference count context manager for the Xact.
-
-        This API is *not* thread safe and is meant only for use
-        in determining when generators running within one thread
-        are complete.
-        '''
-        self.refs += 1
-
-        yield
-
-        self.decref()
-
-    def decref(self):
-        '''
-        Decrement the reference count for the Xact.
-
-        This API is *not* thread safe and is meant only for use
-        in determining when generators running within one thread
-        are complete.
-        '''
-        self.refs -= 1
-        if self.refs == 0:
-            self.commit()
-
-    def setOffset(self, iden, offs):  # pragma: no cover
+    async def setOffset(self, iden, offs):  # pragma: no cover
         raise NotImplementedError
 
-    def getOffset(self, iden):  # pragma: no cover
+    async def getOffset(self, iden):  # pragma: no cover
         raise NotImplementedError
 
-    def stor(self, sops):
+    async def stor(self, sops):
         '''
         Execute a series of storage operations.
         '''
         for oper in sops:
-            func = self._stor_funcs.get(oper[0])
+            func = await self._stor_funcs.get(oper[0])
             if func is None:
                 raise s_exc.NoSuchStor(name=oper[0])
             func(oper)
 
-    def abort(self):  # pragma: no cover
+    async def abort(self):  # pragma: no cover
         raise NotImplementedError
 
-    def commit(self):  # pragma: no cover
+    async def commit(self):  # pragma: no cover
         raise NotImplementedError
 
-    def getBuidProps(self, buid):  # pragma: no cover
+    async def getBuidProps(self, buid):  # pragma: no cover
         raise NotImplementedError
 
-    def _storPropSet(self, oper):  # pragma: no cover
+    async def _storPropSet(self, oper):  # pragma: no cover
         raise NotImplementedError
 
-    def _storPropDel(self, oper):  # pragma: no cover
+    async def _storPropDel(self, oper):  # pragma: no cover
         raise NotImplementedError
 
-    def _liftByFormRe(self, oper):
+    async def _liftByFormRe(self, oper):
 
         form, query, info = oper[1]
 
         regx = regex.compile(query)
 
-        for buid, valu in self.iterFormRows(form):
+        async for buid, valu in self.iterFormRows(form):
 
             # for now... but maybe repr eventually?
             if not isinstance(valu, str):
@@ -139,13 +103,13 @@ class Xact(s_eventbus.EventBus):
 
             yield (buid, )
 
-    def _liftByUnivRe(self, oper):
+    async def _liftByUnivRe(self, oper):
 
         prop, query, info = oper[1]
 
         regx = regex.compile(query)
 
-        for buid, valu in self.iterUnivRows(prop):
+        async for buid, valu in self.iterUnivRows(prop):
 
             # for now... but maybe repr eventually?
             if not isinstance(valu, str):
@@ -156,14 +120,14 @@ class Xact(s_eventbus.EventBus):
 
             yield (buid, )
 
-    def _liftByPropRe(self, oper):
+    async def _liftByPropRe(self, oper):
         # ('regex', (<form>, <prop>, <regex>, info))
         form, prop, query, info = oper[1]
 
         regx = regex.compile(query)
 
         # full table scan...
-        for buid, valu in self.iterPropRows(form, prop):
+        async for buid, valu in self.iterPropRows(form, prop):
 
             # for now... but maybe repr eventually?
             if not isinstance(valu, str):
@@ -172,65 +136,41 @@ class Xact(s_eventbus.EventBus):
             if not regx.search(valu):
                 continue
 
-            #yield buid, form, prop, valu
+            # yield buid, form, prop, valu
             yield (buid, )
 
-    def _liftByIndx(self, oper):  # pragma: no cover
+    async def _liftByIndx(self, oper):  # pragma: no cover
         raise NotImplementedError
 
-    def _rowsByEq(self, curs, pref, valu):  # pragma: no cover
+    async def _rowsByEq(self, curs, pref, valu):  # pragma: no cover
         raise NotImplementedError
 
-    def _rowsByPref(self, curs, pref, valu):  # pragma: no cover
+    async def _rowsByPref(self, curs, pref, valu):  # pragma: no cover
         raise NotImplementedError
 
-    def _rowsByRange(self, curs, pref, valu):  # pragma: no cover
+    async def _rowsByRange(self, curs, pref, valu):  # pragma: no cover
         raise NotImplementedError
 
-    def iterFormRows(self, form):  # pragma: no cover
+    async def iterFormRows(self, form):  # pragma: no cover
         '''
         Iterate (buid, valu) rows for the given form in this layer.
         '''
         raise NotImplementedError
 
-    def iterPropRows(self, form, prop):  # pragma: no cover
+    async def iterPropRows(self, form, prop):  # pragma: no cover
         '''
         Iterate (buid, valu) rows for the given form:prop in this layer.
         '''
         raise NotImplementedError
 
-    def iterUnivRows(self, prop):  # pragma: no cover
+    async def iterUnivRows(self, prop):  # pragma: no cover
         '''
         Iterate (buid, valu) rows for the given universal prop
         '''
         raise NotImplementedError
 
-class Layer(s_cell.Cell):
-    '''
-    A layer implements btree indexed storage for a cortex.
-
-    TODO:
-        metadata for layer contents (only specific type / tag)
-    '''
-    def __init__(self, dirn):
-        s_cell.Cell.__init__(self, dirn)
-        self.spliced = threading.Event()
-        self.onfini(self.spliced.set)
-
-    def getOffset(self, iden):  # pragma: no cover
+    async def stat(self):
         raise NotImplementedError()
 
-    def setOffset(self, iden, offs):  # pragma: no cover
+    async def splices(self, offs, size):  # pragma: no cover
         raise NotImplementedError()
-
-    def stat(self):
-        raise NotImplementedError()
-
-    def splices(self, offs, size):  # pragma: no cover
-        raise NotImplementedError()
-
-    def xact(self, write=False):  # pragma: no cover
-        '''
-        Return a transaction object for the layer.
-        '''
-        return Xact(self, write=write)

--- a/synapse/lib/lmdb.py
+++ b/synapse/lib/lmdb.py
@@ -38,9 +38,6 @@ LARGE_STRING_SIZE = 128
 MAX_INT_VAL = 2 ** 63 - 1
 MIN_INT_VAL = -1 * (2 ** 63)
 
-# Precompiled struct of a big-endian 64-bit int
-_IntStruct = struct.Struct('>Q')
-
 class Seqn:
     '''
     An append optimized sequence of byte blobs.

--- a/synapse/lib/lmdb.py
+++ b/synapse/lib/lmdb.py
@@ -852,7 +852,7 @@ class Slab(s_coro.Fini):
             if not self.recovering:
                 self._logXactOper(self.replace, lkey, lval, db=db)
 
-            retn = self.xact.put(lkey, lval, db=db)
+            retn = self.xact.replace(lkey, lval, db=db)
 
             # give the commit a chance...
             if not self.holders:

--- a/synapse/lib/lmdb.py
+++ b/synapse/lib/lmdb.py
@@ -38,6 +38,9 @@ LARGE_STRING_SIZE = 128
 MAX_INT_VAL = 2 ** 63 - 1
 MIN_INT_VAL = -1 * (2 ** 63)
 
+# Precompiled struct of a big-endian 64-bit int
+_IntStruct = struct.Struct('>Q')
+
 class Seqn:
     '''
     An append optimized sequence of byte blobs.
@@ -708,18 +711,18 @@ class Slab(s_coro.Fini):
 
                 yield lkey, lval
 
-    def scanByRange(self, lmin, lmax, db=None):
+    def scanByRange(self, lmin, lmax=None, db=None):
 
         with Scan(self, db) as scan:
 
             if not scan.set_range(lmin):
                 return
 
-            size = len(lmax)
+            size = len(lmax) if lmax is not None else None
 
             for lkey, lval in scan.iternext():
 
-                if lkey[:size] > lmax:
+                if lmax is not None and lkey[:size] > lmax:
                     return
 
                 yield lkey, lval
@@ -755,6 +758,61 @@ class Slab(s_coro.Fini):
         self._runXactOpers()
         self.recovering = False
 
+    # FIXME:  refactor delete/put/replace/pop common code
+    def pop(self, lkey, db=None):
+
+        try:
+
+            # if this is the first write for this xact, reset tick.
+            if not self.dirty:
+                self.tick = s_common.now()
+                self.dirty = True
+
+            if not self.recovering:
+                self._logXactOper(self.pop, lkey, db=db)
+
+            retn = self.xact.pop(lkey, db=db)
+
+            # give the commit a chance...
+            if not self.holders:
+                self.commit()
+
+            return retn
+
+        except lmdb.MapFullError as e:
+
+            with self.aborted():
+                self._growMapSize()
+
+            self.commit(force=True)
+
+    def delete(self, lkey, dupdata=False, db=None):
+
+        try:
+
+            # if this is the first write for this xact, reset tick.
+            if not self.dirty:
+                self.tick = s_common.now()
+                self.dirty = True
+
+            if not self.recovering:
+                self._logXactOper(self.delete, lkey, dupdata=dupdata, db=db)
+
+            self.xact.delete(lkey, dupdata=dupdata, db=db)
+
+            # give the commit a chance...
+            if not self.holders:
+                self.commit()
+
+            return
+
+        except lmdb.MapFullError as e:
+
+            with self.aborted():
+                self._growMapSize()
+
+            self.commit(force=True)
+
     def put(self, lkey, lval, dupdata=False, db=None):
 
         try:
@@ -768,6 +826,64 @@ class Slab(s_coro.Fini):
                 self._logXactOper(self.put, lkey, lval, dupdata=dupdata, db=db)
 
             self.xact.put(lkey, lval, dupdata=dupdata, db=db)
+
+            # give the commit a chance...
+            if not self.holders:
+                self.commit()
+
+            return
+
+        except lmdb.MapFullError as e:
+
+            with self.aborted():
+                self._growMapSize()
+
+            self.commit(force=True)
+
+    def replace(self, lkey, lval, db=None):
+        '''
+        Like put, but returns the previous value if existed
+        '''
+
+        try:
+
+            # if this is the first write for this xact, reset tick.
+            if not self.dirty:
+                self.tick = s_common.now()
+                self.dirty = True
+
+            if not self.recovering:
+                self._logXactOper(self.replace, lkey, lval, db=db)
+
+            retn = self.xact.put(lkey, lval, db=db)
+
+            # give the commit a chance...
+            if not self.holders:
+                self.commit()
+
+            return retn
+
+        except lmdb.MapFullError as e:
+
+            with self.aborted():
+                self._growMapSize()
+
+            self.commit(force=True)
+
+    def putmulti(self, kvpairs, dupdata=False, append=False, db=None):
+
+        try:
+
+            # if this is the first write for this xact, reset tick.
+            if not self.dirty:
+                self.tick = s_common.now()
+                self.dirty = True
+
+            if not self.recovering:
+                self._logXactOper(self.putmulti, kvpairs, dupdata=dupdata, append=True, db=db)
+
+            with self.xact.cursor(db=db) as curs:
+                curs.putmulti(kvpairs, dupdata=dupdata, append=append)
 
             # give the commit a chance...
             if not self.holders:
@@ -849,6 +965,12 @@ class Scan:
         self.bump()
 
         self.slab.scans.discard(self)
+
+    def last_key(self):
+        ''' Return the last key in the database.  Returns none if database is empty. '''
+        if not self.curs.last():
+            return None
+        return self.curs.key()
 
     def set_key(self, lkey):
 

--- a/synapse/lib/lmdb.py
+++ b/synapse/lib/lmdb.py
@@ -783,7 +783,7 @@ class Slab(s_coro.Fini):
 
             self.commit(force=True)
 
-    def delete(self, lkey, dupdata=False, db=None):
+    def delete(self, lkey, val=None, db=None):
 
         try:
 
@@ -793,9 +793,9 @@ class Slab(s_coro.Fini):
                 self.dirty = True
 
             if not self.recovering:
-                self._logXactOper(self.delete, lkey, dupdata=dupdata, db=db)
+                self._logXactOper(self.delete, lkey, val, db=db)
 
-            self.xact.delete(lkey, dupdata=dupdata, db=db)
+            self.xact.delete(lkey, val, db=db)
 
             # give the commit a chance...
             if not self.holders:
@@ -945,6 +945,7 @@ class Scan:
     def __init__(self, slab, db):
 
         self.slab = slab
+        self.db = db
 
         self.curs = self.slab.xact.cursor(db=db)
 

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -199,7 +199,7 @@ class LmdbLayer(s_layer.Layer):
 
     async def _rowsByEq(self, db, pref, valu):
         lkey = pref + valu
-        for _, byts in self.slab.scanByDups(lkey, db=db):
+        for byts in self.slab.scanByDups(lkey, db=db):
             yield s_msgpack.un(byts)
 
     async def _rowsByPref(self, db, pref, valu):

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -71,8 +71,6 @@ class LmdbLayer(s_layer.Layer):
         self.splicedb = await self.initdb('splices')
         self.splicelog = s_slabseqn.SlabSeqn(self.slab, 'splices')
 
-
-
     async def stor(self, sops):
         '''
         Execute a series of storage operations.
@@ -137,7 +135,7 @@ class LmdbLayer(s_layer.Layer):
 
             oldv, oldi = s_msgpack.un(byts)
 
-            self.delete(pvpref + oldi, pvvalu, db=self.byprop)
+            self.slab.delete(pvpref + oldi, pvvalu, db=self.byprop)
 
             if univ:
                 unkey = penc + oldi

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -4,340 +4,22 @@ cortex construction.
 '''
 import os
 import logging
-import threading
-import contextlib
-import collections
-
 import lmdb
 import regex
 
 import synapse.exc as s_exc
-import synapse.eventbus as s_eventbus
 
-import synapse.lib.cell as s_cell
 import synapse.lib.lmdb as s_lmdb
-import synapse.lib.cache as s_cache
+import synapse.lib.slabseqn as s_slabseqn
+import synapse.lib.slaboffs as s_slaboffs
 import synapse.lib.layer as s_layer
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.threads as s_threads
 
 logger = logging.getLogger(__name__)
 
-class LmdbXact(s_layer.Xact):
-    '''
-    A Layer transaction which encapsulates the storage implementation.
-    '''
-    def __init__(self, layr, write=False):
-
-        s_layer.Xact.__init__(self, layr, write)
-
-        self.layr = layr
-        self.write = write
-
-        self.indxfunc = {
-            'eq': self._rowsByEq,
-            'pref': self._rowsByPref,
-            'range': self._rowsByRange,
-        }
-
-        self._lift_funcs = {
-            'indx': self._liftByIndx,
-            'prop:re': self._liftByPropRe,
-            'univ:re': self._liftByUnivRe,
-            'form:re': self._liftByFormRe,
-        }
-
-        self.xact = layr.lenv.begin(write=write)
-
-        self.buidcurs = self.xact.cursor(db=layr.bybuid)
-        self.buidcache = s_cache.FixedCache(self._getBuidProps, size=10000)
-        self.tid = s_threads.iden()
-
-    def setOffset(self, iden, offs):
-        return self.layr.offs.xset(self.xact, iden, offs)
-
-    def getOffset(self, iden):
-        return self.layr.offs.xget(self.xact, iden)
-
-    def stor(self, sops):
-        '''
-        Execute a series of storage operations.
-        '''
-        for oper in sops:
-            func = self._stor_funcs.get(oper[0])
-            if func is None:
-                raise s_exc.NoSuchStor(name=oper[0])
-            func(oper)
-
-    def abort(self):
-
-        if self.tid != s_threads.iden():
-            raise s_exc.BadThreadIden()
-
-        self.xact.abort()
-
-        # LMDB transaction requires explicit delete to recover resources
-        del self.xact
-
-    def commit(self):
-
-        if self.tid != s_threads.iden():
-            raise s_exc.BadThreadIden()
-        if self.splices:
-            self.layr.splicelog.save(self.xact, self.splices)
-
-        self.xact.commit()
-
-        # LMDB transaction requires explicit delete to recover resources
-        del self.xact
-
-        # wake any splice waiters...
-        if self.splices:
-            self.layr.spliced.set()
-
-    def getBuidProps(self, buid):
-        return self.buidcache.get(buid)
-
-    def _getBuidProps(self, buid):
-
-        props = {}
-
-        if not self.buidcurs.set_range(buid):
-            return props
-
-        for lkey, lval in self.buidcurs.iternext():
-
-            if lkey[:32] != buid:
-                break
-
-            prop = lkey[32:].decode('utf8')
-            valu, indx = s_msgpack.un(lval)
-            props[prop] = valu
-
-        return props
-
-    def _storPropSet(self, oper):
-
-        _, (buid, form, prop, valu, indx, info) = oper
-
-        if len(indx) > 256: # max index size...
-            mesg = 'index bytes are too large'
-            raise s_exc.BadIndxValu(mesg=mesg, prop=prop, valu=valu)
-
-        fenc = self.layr.encoder[form]
-        penc = self.layr.encoder[prop]
-
-        univ = info.get('univ')
-
-        # special case for setting primary property
-        if not prop:
-            prop = '*' + form
-
-        bpkey = buid + self.layr.utf8[prop]
-
-        cacheval = self.buidcache.cache.get(buid)
-        if cacheval is not None:
-            cacheval[prop] = valu
-
-        bpval = s_msgpack.en((valu, indx))
-
-        pvpref = fenc + penc
-        pvvalu = s_msgpack.en((buid,))
-
-        byts = self.xact.replace(bpkey, bpval, db=self.layr.bybuid)
-        if byts is not None:
-
-            oldv, oldi = s_msgpack.un(byts)
-
-            self.xact.delete(pvpref + oldi, pvvalu, db=self.layr.byprop)
-
-            if univ:
-                unkey = penc + oldi
-                self.xact.delete(unkey, pvvalu, db=self.layr.byuniv)
-
-        self.xact.put(pvpref + indx, pvvalu, dupdata=True, db=self.layr.byprop)
-
-        if univ:
-            self.xact.put(penc + indx, pvvalu, dupdata=True, db=self.layr.byuniv)
-
-    def _storPropDel(self, oper):
-
-        _, (buid, form, prop, info) = oper
-
-        self.buidcache.pop(buid)
-
-        fenc = self.layr.encoder[form]
-        penc = self.layr.encoder[prop]
-
-        if prop:
-            bpkey = buid + self.layr.utf8[prop]
-        else:
-            bpkey = buid + b'*' + self.layr.utf8[form]
-
-        univ = info.get('univ')
-
-        byts = self.xact.pop(bpkey, db=self.layr.bybuid)
-        if byts is None:
-            return
-
-        oldv, oldi = s_msgpack.un(byts)
-
-        pvvalu = s_msgpack.en((buid,))
-        self.xact.delete(fenc + penc + oldi, pvvalu, db=self.layr.byprop)
-
-        if univ:
-            self.xact.delete(penc + oldi, pvvalu, db=self.layr.byuniv)
-
-    def _liftByIndx(self, oper):
-        # ('indx', (<dbname>, <prefix>, (<indxopers>...))
-        # indx opers:  ('eq', <indx>)  ('pref', <indx>) ('range', (<indx>, <indx>)
-        name, pref, iops = oper[1]
-
-        db = self.layr.dbs.get(name)
-        if db is None:
-            raise s_exc.NoSuchName(name=name)
-
-        # row operations...
-        with self.xact.cursor(db=db) as curs:
-
-            for (name, valu) in iops:
-
-                func = self.indxfunc.get(name)
-                if func is None:
-                    mesg = 'unknown index operation'
-                    raise s_exc.NoSuchName(name=name, mesg=mesg)
-
-                for row in func(curs, pref, valu):
-
-                    yield row
-
-    def _rowsByEq(self, curs, pref, valu):
-        lkey = pref + valu
-        if not curs.set_key(lkey):
-            return
-
-        for byts in curs.iternext_dup():
-            yield s_msgpack.un(byts)
-
-    def _rowsByPref(self, curs, pref, valu):
-        pref = pref + valu
-        if not curs.set_range(pref):
-            return
-
-        size = len(pref)
-        for lkey, byts in curs.iternext():
-
-            if lkey[:size] != pref:
-                return
-
-            yield s_msgpack.un(byts)
-
-    def _rowsByRange(self, curs, pref, valu):
-
-        lmin = pref + valu[0]
-        lmax = pref + valu[1]
-
-        size = len(lmax)
-        if not curs.set_range(lmin):
-            return
-
-        for lkey, byts in curs.iternext():
-
-            if lkey[:size] > lmax:
-                return
-
-            yield s_msgpack.un(byts)
-
-    def iterFormRows(self, form):
-        '''
-        Iterate (buid, valu) rows for the given form in this layer.
-        '''
-
-        # <form> 00 00 (no prop...)
-        pref = self.layr.encoder[form] + b'\x00'
-        penc = self.layr.utf8['*' + form]
-
-        with self.xact.cursor(db=self.layr.byprop) as curs:
-
-            if not curs.set_range(pref):
-                return
-
-            size = len(pref)
-
-            for lkey, pval in curs.iternext():
-
-                if lkey[:size] != pref:
-                    return
-
-                buid = s_msgpack.un(pval)[0]
-
-                byts = self.xact.get(buid + penc, db=self.layr.bybuid)
-                if byts is None:
-                    continue
-
-                valu, indx = s_msgpack.un(byts)
-
-                yield buid, valu
-
-    def iterPropRows(self, form, prop):
-        '''
-        Iterate (buid, valu) rows for the given form:prop in this layer.
-        '''
-        # iterate byprop and join bybuid to get to value
-
-        penc = self.layr.utf8[prop]
-        pref = self.layr.encoder[form] + self.layr.encoder[prop]
-
-        with self.xact.cursor(db=self.layr.byprop) as curs:
-
-            if not curs.set_range(pref):
-                return
-
-            size = len(pref)
-
-            for lkey, pval in curs.iternext():
-
-                if lkey[:size] != pref:
-                    return
-
-                buid = s_msgpack.un(pval)[0]
-
-                byts = self.xact.get(buid + penc, db=self.layr.bybuid)
-                if byts is None:
-                    continue
-
-                valu, indx = s_msgpack.un(byts)
-
-                yield buid, valu
-
-    def iterUnivRows(self, prop):
-        '''
-        Iterate (buid, valu) rows for the given universal prop
-        '''
-        penc = self.layr.utf8[prop]
-        pref = self.layr.encoder[prop]
-
-        with self.xact.cursor(db=self.layr.byuniv) as curs:
-
-            if not curs.set_range(pref):
-                return
-
-            size = len(pref)
-
-            for lkey, pval in curs.iternext():
-
-                if lkey[:size] != pref:
-                    return
-
-                buid = s_msgpack.un(pval)[0]
-
-                byts = self.xact.get(buid + penc, db=self.layr.bybuid)
-                if byts is None:
-                    continue
-
-                valu, indx = s_msgpack.un(byts)
-
-                yield buid, valu
+# Maximum number of bytes we're going to put in an index
+MAX_INDEX_LEN = 256
 
 class LmdbLayer(s_layer.Layer):
     '''
@@ -358,8 +40,7 @@ class LmdbLayer(s_layer.Layer):
 
         mapsize = self.conf.get('lmdb:mapsize')
         readahead = self.conf.get('lmdb:readahead')
-        self.lenv = lmdb.open(path, max_dbs=128, map_size=mapsize, writemap=True,
-                              readahead=readahead)
+        self.lenv = s_lmdb.Slab(path, max_dbs=128, map_size=mapsize, writemap=True, readahead=readahead)
 
         self.dbs = {}
 
@@ -371,10 +52,10 @@ class LmdbLayer(s_layer.Layer):
         self.byuniv = self.initdb('byuniv', dupsort=True) # <prop>00<indx>=<buid>
 
         offsdb = self.initdb('offsets')
-        self.offs = s_lmdb.Offs(self.lenv, offsdb)
+        self.offs = s_slaboffs.SlabOffs(self.lenv, offsdb)
 
         self.splicedb = self.initdb('splices')
-        self.splicelog = s_lmdb.Seqn(self.lenv, b'splices')
+        self.splicelog = s_slabseqn.SlabSeqn(self.lenv, b'splices')
 
         def finiLayer():
             self.lenv.sync()
@@ -382,33 +63,237 @@ class LmdbLayer(s_layer.Layer):
 
         self.onfini(finiLayer)
 
-    def getOffset(self, iden):
+        self.indxfunc = {
+            'eq': self._rowsByEq,
+            'pref': self._rowsByPref,
+            'range': self._rowsByRange,
+        }
+
+        self._lift_funcs = {
+            'indx': self._liftByIndx,
+            'prop:re': self._liftByPropRe,
+            'univ:re': self._liftByUnivRe,
+            'form:re': self._liftByFormRe,
+        }
+
+        self.tid = s_threads.iden()
+
+    async def stor(self, sops):
+        '''
+        Execute a series of storage operations.
+        '''
+        for oper in sops:
+            func = self._stor_funcs.get(oper[0])
+            if func is None:
+                raise s_exc.NoSuchStor(name=oper[0])
+            func(oper)
+
+    async def commit(self):
+
+        if self.splices:
+            self.splicelog.save(self.splices)
+
+        # wake any splice waiters...
+        if self.splices:
+            self.spliced.set()
+
+    async def getBuidProps(self, buid):
+
+        props = {}
+
+        for lkey, lval in self.lenv.scanByPref(buid, db=self.byguid):
+
+            prop = lkey[32:].decode('utf8')
+            valu, indx = s_msgpack.un(lval)
+            props[prop] = valu
+
+        return props
+
+    async def _storPropSet(self, oper):
+
+        _, (buid, form, prop, valu, indx, info) = oper
+
+        if len(indx) > MAX_INDEX_LEN:
+            mesg = 'index bytes are too large'
+            raise s_exc.BadIndxValu(mesg=mesg, prop=prop, valu=valu)
+
+        fenc = self.encoder[form]
+        penc = self.encoder[prop]
+
+        univ = info.get('univ')
+
+        # special case for setting primary property
+        if not prop:
+            prop = '*' + form
+
+        bpkey = buid + self.utf8[prop]
+
+        # FIXME:  might need to update any cortex buid cache
+
+        bpval = s_msgpack.en((valu, indx))
+
+        pvpref = fenc + penc
+        pvvalu = s_msgpack.en((buid,))
+
+        byts = self.lenv.replace(bpkey, bpval, db=self.bybuid)
+        if byts is not None:
+
+            oldv, oldi = s_msgpack.un(byts)
+
+            self.delete(pvpref + oldi, pvvalu, db=self.byprop)
+
+            if univ:
+                unkey = penc + oldi
+                self.lenv.delete(unkey, pvvalu, db=self.byuniv)
+
+        self.lenv.put(pvpref + indx, pvvalu, dupdata=True, db=self.byprop)
+
+        if univ:
+            self.lenv.put(penc + indx, pvvalu, dupdata=True, db=self.byuniv)
+
+    async def _storPropDel(self, oper):
+
+        _, (buid, form, prop, info) = oper
+
+        # FIXME:  update any cortex-wide buid cache
+        # FIXME:  this might not have the expected impact if
+
+        fenc = self.encoder[form]
+        penc = self.encoder[prop]
+
+        if prop:
+            bpkey = buid + self.utf8[prop]
+        else:
+            bpkey = buid + b'*' + self.utf8[form]
+
+        univ = info.get('univ')
+
+        byts = self.lenv.pop(bpkey, db=self.bybuid)
+        if byts is None:
+            return
+
+        oldv, oldi = s_msgpack.un(byts)
+
+        pvvalu = s_msgpack.en((buid,))
+        self.lenv.delete(fenc + penc + oldi, pvvalu, db=self.byprop)
+
+        if univ:
+            self.lenv.delete(penc + oldi, pvvalu, db=self.byuniv)
+
+    async def _liftByIndx(self, oper):
+        # ('indx', (<dbname>, <prefix>, (<indxopers>...))
+        # indx opers:  ('eq', <indx>)  ('pref', <indx>) ('range', (<indx>, <indx>)
+        name, pref, iops = oper[1]
+
+        db = self.dbs.get(name)
+        if db is None:
+            raise s_exc.NoSuchName(name=name)
+
+        for (name, valu) in iops:
+
+            func = self.indxfunc.get(name)
+            if func is None:
+                mesg = 'unknown index operation'
+                raise s_exc.NoSuchName(name=name, mesg=mesg)
+
+            for row in func(db, pref, valu):
+
+                yield row
+
+    async def _rowsByEq(self, db, pref, valu):
+        lkey = pref + valu
+        for _, byts in self.lenv.scanByDups(lkey, db=db):
+            yield s_msgpack.un(byts)
+
+    async def _rowsByPref(self, db, pref, valu):
+        pref = pref + valu
+        for _, byts in self.lenv.scanByPref(pref, db=db):
+            yield s_msgpack.un(byts)
+
+    async def _rowsByRange(self, db, pref, valu):
+        lmin = pref + valu[0]
+        lmax = pref + valu[1]
+
+        for _, byts in self.lenv.scanByRange(lmin, lmax, db=db):
+            yield s_msgpack.un(byts)
+
+    async def iterFormRows(self, form):
+        '''
+        Iterate (buid, valu) rows for the given form in this layer.
+        '''
+
+        # <form> 00 00 (no prop...)
+        pref = self.encoder[form] + b'\x00'
+        penc = self.utf8['*' + form]
+
+        for _, pval in self.lenv.scanByPref(pref, db=self.byprop):
+
+            buid = s_msgpack.un(pval)[0]
+
+            byts = self.lenv.get(buid + penc, db=self.bybuid)
+            if byts is None:
+                continue
+
+            valu, indx = s_msgpack.un(byts)
+
+            yield buid, valu
+
+    async def iterPropRows(self, form, prop):
+        '''
+        Iterate (buid, valu) rows for the given form:prop in this layer.
+        '''
+        # iterate byprop and join bybuid to get to value
+
+        penc = self.utf8[prop]
+        pref = self.encoder[form] + self.encoder[prop]
+
+        for _, pval in self.lenv.scanByPref(pref, db=self.byprop):
+
+            buid = s_msgpack.un(pval)[0]
+
+            byts = self.lenv.get(buid + penc, db=self.bybuid)
+            if byts is None:
+                continue
+
+            valu, indx = s_msgpack.un(byts)
+
+            yield buid, valu
+
+    async def iterUnivRows(self, prop):
+        '''
+        Iterate (buid, valu) rows for the given universal prop
+        '''
+        penc = self.utf8[prop]
+        pref = self.encoder[prop]
+
+        for _, pval in self.lenv.scanByPref(pref, db=self.byuniv):
+            buid = s_msgpack.un(pval)[0]
+
+            byts = self.lenv.get(buid + penc, db=self.bybuid)
+            if byts is None:
+                continue
+
+            valu, indx = s_msgpack.un(byts)
+
+            yield buid, valu
+
+    async def getOffset(self, iden):
         return self.offs.get(iden)
 
-    def setOffset(self, iden, offs):
+    async def setOffset(self, iden, offs):
         return self.offs.set(iden, offs)
 
-    def splices(self, offs, size):
-        with self.lenv.begin() as xact:
-            for i, mesg in self.splicelog.slice(xact, offs, size):
-                yield mesg
+    async def splices(self, offs, size):
+        for i, mesg in self.splicelog.slice(offs, size):
+            yield mesg
 
-    def stat(self):
+    async def stat(self):
         return {
             'splicelog_indx': self.splicelog.index(),
         }
 
-    def db(self, name):
+    async def db(self, name):
         return self.dbs.get(name)
 
-    def initdb(self, name, dupsort=False):
-        # FIXME:  need to consider whether this is the right public API
-        db = self.lenv.open_db(name.encode('utf8'), dupsort=dupsort)
-        self.dbs[name] = db
-        return db
-
-    def xact(self, write=False):
-        '''
-        Return a transaction object for the layer.
-        '''
-        return LmdbXact(self, write=write)
+    async def initdb(self, name, dupsort=False):
+        return self.lenv.initdb(name, dupsort)

--- a/synapse/lib/module.py
+++ b/synapse/lib/module.py
@@ -96,7 +96,7 @@ class CoreModule:
         dirn = self.getModDir()
         return s_common.genpath(dirn, *paths)
 
-    def initCoreModule(self):
+    async def initCoreModule(self):
         '''
         Module implementers may over-ride this method to initialize the
         module during initial construction.  Any exception raised within

--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -89,15 +89,15 @@ class Node:
 
         return node
 
-    def seen(self, tick, source=None):
+    async def seen(self, tick, source=None):
         '''
         Update the .seen interval and optionally a source specific seen node.
         '''
-        self.set('.seen', tick)
+        await self.set('.seen', tick)
 
         if source is not None:
-            seen = self.snap.addNode('seen', (source, self.ndef))
-            seen.set('.seen', tick)
+            seen = await self.snap.addNode('seen', (source, self.ndef))
+            await seen.set('.seen', tick)
 
     def getNodeRefs(self):
         '''
@@ -187,7 +187,7 @@ class Node:
         auto = self.snap.model.form(prop.type.name)
         if auto is not None:
             buid = s_common.buid((auto.name, norm))
-            self.snap._addNodeFnib((auto, norm, info, buid))
+            await self.snap._addNodeFnib((auto, norm, info, buid))
 
         # does the type think we have special auto nodes to add?
         # ( used only for adds which do not meet the above block )
@@ -195,7 +195,7 @@ class Node:
             auto = self.snap.model.form(autoname)
             autonorm, autoinfo = auto.type.norm(autovalu)
             buid = s_common.buid((auto.name, autonorm))
-            self.snap._addNodeFnib((auto, autovalu, autoinfo, buid))
+            await self.snap._addNodeFnib((auto, autovalu, autoinfo, buid))
 
         # do we need to set any sub props?
         subs = info.get('subs')
@@ -214,10 +214,10 @@ class Node:
         # last but not least, if we are *not* in init
         # we need to fire a Prop.onset() callback.
         if not self.init:
-            prop.wasSet(self, curv)
+            await prop.wasSet(self, curv)
             if prop.univ:
                 univ = self.snap.model.prop(prop.univ)
-                univ.wasSet(self, curv)
+                await univ.wasSet(self, curv)
 
     def has(self, name):
         return name in self.props

--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -124,7 +124,7 @@ class Node:
 
         return retn
 
-    def set(self, name, valu, init=False):
+    async def set(self, name, valu, init=False):
         '''
         Set a property on the node.
 
@@ -178,8 +178,8 @@ class Node:
 
         sops = prop.getSetOps(self.buid, norm)
 
-        self.snap.stor(sops)
-        self.snap.splice('prop:set', ndef=self.ndef, prop=prop.name, valu=norm, oldv=curv)
+        await self.snap.stor(sops)
+        await self.snap.splice('prop:set', ndef=self.ndef, prop=prop.name, valu=norm, oldv=curv)
 
         self.props[prop.name] = norm
 
@@ -317,13 +317,13 @@ class Node:
         name = s_chop.tag(name)
         return self.tags.get(name, defval)
 
-    def addTag(self, tag, valu=(None, None)):
+    async def addTag(self, tag, valu=(None, None)):
 
         path = s_chop.tagpath(tag)
 
         name = '.'.join(path)
 
-        tagnode = self.snap.addTagNode(name)
+        tagnode = await self.snap.addTagNode(name)
 
         # implement tag renames...
         isnow = tagnode.get('isnow')
@@ -351,7 +351,7 @@ class Node:
 
                 self._addTagRaw(tag, (None, None))
 
-            self._addTagRaw(tags[-1], valu)
+            await self._addTagRaw(tags[-1], valu)
             return
 
         # merge values into one interval
@@ -361,14 +361,14 @@ class Node:
         info = {'univ': True}
         self._setTagProp(name, valu, indx, info)
 
-    def _setTagProp(self, name, norm, indx, info):
+    async def _setTagProp(self, name, norm, indx, info):
         self.tags[name] = norm
-        self.snap.stor((('prop:set', (self.buid, self.form.name, '#' + name, norm, indx, info)),))
+        await self.snap.stor((('prop:set', (self.buid, self.form.name, '#' + name, norm, indx, info)),))
 
-    def _addTagRaw(self, name, norm):
+    async def _addTagRaw(self, name, norm):
 
         # these are cached based on norm...
-        self.snap.addTagNode(name)
+        await self.snap.addTagNode(name)
 
         info = {'univ': True}
         if norm == (None, None):
@@ -376,11 +376,11 @@ class Node:
         else:
             indx = self.snap.model.types['ival'].indx(norm)
 
-        self._setTagProp(name, norm, indx, info)
+        await self._setTagProp(name, norm, indx, info)
 
         # TODO: fire an onTagAdd handler...
-        self.snap.splice('tag:add', ndef=self.ndef, tag=name, valu=norm)
-        self.snap.core.runTagAdd(self, name, norm)
+        await self.snap.splice('tag:add', ndef=self.ndef, tag=name, valu=norm)
+        await self.snap.core.runTagAdd(self, name, norm)
 
         return True
 

--- a/synapse/lib/slaboffs.py
+++ b/synapse/lib/slaboffs.py
@@ -2,7 +2,7 @@ import synapse.common as s_common
 
 import synapse.lib.lmdb as s_lmdb
 
-class Offs:
+class SlabOffs:
 
     def __init__(self, slab: s_lmdb.Slab, db) -> None:
         self.db = db

--- a/synapse/lib/slaboffs.py
+++ b/synapse/lib/slaboffs.py
@@ -1,0 +1,25 @@
+import synapse.common as s_common
+
+import synapse.lib.lmdb as s_lmdb
+
+class Offs:
+
+    def __init__(self, slab: s_lmdb.Slab, db) -> None:
+        self.db = db
+        self.lenv = slab
+
+    def get(self, iden):
+
+        buid = s_common.uhex(iden)
+
+        byts = self.lenv.get(buid, db=self.db)
+        if byts is None:
+            return 0
+
+        return s_common.int64un(byts)
+
+    def set(self, iden, offs):
+        buid = s_common.uhex(iden)
+        byts = s_common.int64en(offs)
+        self.lenv.put(buid, byts, db=self.db)
+

--- a/synapse/lib/slabseqn.py
+++ b/synapse/lib/slabseqn.py
@@ -1,0 +1,96 @@
+import synapse.common as s_common
+
+import synapse.lib.lmdb as s_lmdb
+import synapse.lib.msgpack as s_msgpack
+
+class SlabSeqn:
+    '''
+    An append optimized sequence of byte blobs.
+
+    Args:
+        lenv (lmdb.Environment): The LMDB Environment.
+        name (str): The name of the sequence.
+    '''
+    def __init__(self, slab: s_lmdb.Slab, name: str) -> None:
+
+        self.lenv = slab
+        self.db = self.lenv.initdb(name)
+
+        self.indx = self.nextindx()
+
+    def save(self, items):
+        '''
+        Save a series of items to a sequence.
+
+        Args:
+            items (tuple): The series of items to save into the sequence.
+
+        Returns:
+            None
+        '''
+        rows = []
+        indx = self.indx
+
+        for item in items:
+
+            byts = s_msgpack.en(item)
+
+            lkey = s_common.int64en(indx)
+            indx += 1
+
+            rows.append((lkey, byts))
+
+        self.lenv.putmulti(rows, append=True, db=self.db)
+
+        self.indx = indx
+
+    def index(self):
+        '''
+        Return the current index to be used
+        '''
+        return self.indx
+
+    def nextindx(self):
+        '''
+        Determine the next insert offset according to storage.
+
+        Args:
+            xact (lmdb.Transaction): An LMDB transaction.
+
+        Returns:
+            int: The next insert offset.
+        '''
+        indx = 0
+        with s_lmdb.Scan(self.lenv, self.db) as curs:
+            last_key = curs.last_key()
+            if last_key is not None:
+                indx = s_common.int64un(last_key) + 1
+        return indx
+
+    def iter(self, offs):
+        '''
+        Iterate over items in a sequence from a given offset.
+
+        Args:
+            offs (int): The offset to begin iterating from.
+
+        Yields:
+            (indx, valu): The index and valu of the item.
+        '''
+        startkey = s_common.int64en(offs)
+
+        for lkey, lval in self.lenv.scanByRange(startkey, db=self.db):
+            indx = s_common.int64un(lkey)
+            valu = s_msgpack.un(lval)
+            yield indx, valu
+
+    def slice(self, offs, size):
+
+        imax = size - 1
+
+        for i, item in enumerate(self.iter(offs)):
+
+            yield item
+
+            if i == imax:
+                break

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -5,17 +5,18 @@ import contextlib
 import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.eventbus as s_eventbus
-import synapse.datamodel as s_datamodel
 
 import synapse.lib.chop as s_chop
+import synapse.lib.coro as s_coro
 import synapse.lib.node as s_node
 import synapse.lib.cache as s_cache
 import synapse.lib.storm as s_storm
-import synapse.lib.syntax as s_syntax
 
 logger = logging.getLogger(__name__)
 
-class Snap(s_eventbus.EventBus):
+# FIXME:  figure out eventbus and s_coro?!
+
+class Snap(s_eventbus.EventBus, s_coro.Fini):
     '''
     A "snapshot" is a transaction across multiple Cortex layers.
 
@@ -33,6 +34,7 @@ class Snap(s_eventbus.EventBus):
     def __init__(self, core, layers, write=False):
 
         s_eventbus.EventBus.__init__(self)
+        s_coro.Fini.__init__(self)
 
         self.stack = contextlib.ExitStack()
 
@@ -44,6 +46,7 @@ class Snap(s_eventbus.EventBus):
         self.core = core
         self.model = core.model
         self.layers = layers
+        self.wlyr = self.layers[-1]
 
         self.bulk = False
         self.bulksops = []
@@ -56,9 +59,6 @@ class Snap(s_eventbus.EventBus):
         self.debug = False      # Set to true to enable debug output.
         self.write = False      # True when the snap has a write lock on a layer.
 
-        self.xact = None
-        self.xacts = [l.xact() for l in layers]
-
         self.tagcache = s_cache.FixedCache(self._addTagNode, size=10000)
         self.buidcache = s_cache.FixedCache(self._getNodeByBuid, size=100000)
 
@@ -66,16 +66,16 @@ class Snap(s_eventbus.EventBus):
         self.changelog = []
         self.tagtype = core.model.type('ival')
 
-        def fini():
+        async def fini():
 
-            for x in self.xacts:
+            for layr in self.layers:
                 try:
-                    x.commit()
+                    await layr.commit()
                 except Exception as e:
-                    logger.exception('commit error for layer xact')
-                x.fini()
+                    logger.exception('commit error for layer')
+                await layr.fini()
 
-        self.onfini(fini)
+        s_coro.Fini.onfini(self, fini)
 
     @contextlib.contextmanager
     def getStormRuntime(self, opts=None, user=None):
@@ -84,7 +84,7 @@ class Snap(s_eventbus.EventBus):
         yield runt
         self.core.stormrunts.pop(runt.iden, None)
 
-    def iterStormPodes(self, text, opts=None, user=None):
+    async def iterStormPodes(self, text, opts=None, user=None):
         '''
         Yield packed node tuples for the given storm query text.
         '''
@@ -100,15 +100,16 @@ class Snap(s_eventbus.EventBus):
             pode[1].update(path.pack(path=dopath))
             yield pode
 
-    def storm(self, text, opts=None, user=None):
+    async def storm(self, text, opts=None, user=None):
         '''
         Execute a storm query and yield (Node(), Path()) tuples.
         '''
         query = self.core.getStormQuery(text)
         with self.getStormRuntime(opts=opts, user=user) as runt:
-            yield from runt.iterStormQuery(query)
+            for x in runt.iterStormQuery(query):
+                yield x
 
-    def eval(self, text, opts=None, user=None):
+    async def eval(self, text, opts=None, user=None):
         '''
         Run a storm query and yield Node() objects.
         '''
@@ -118,44 +119,14 @@ class Snap(s_eventbus.EventBus):
             for node, path in runt.iterStormQuery(query):
                 yield node
 
-    def writeable(self):
-        '''
-        Ensure that the snap() is writable and record our write tick.
-        '''
-        if self.write:
-            return True
+    async def setOffset(self, iden, offs):
+        return self.wlyr.setOffset(iden, offs)
 
-        self.xacts[-1].decref()
-
-        self.xact = self.layers[-1].xact(write=True)
-
-        self.write = True
-        self.xacts[-1] = self.xact
-
-    def setOffset(self, iden, offs):
-        self.writeable()
-        return self.xact.setOffset(iden, offs)
-
-    def getOffset(self, iden, offs):
-        return self.xact.getOffset(iden, offs)
+    async def getOffset(self, iden, offs):
+        return self.wlyr.getOffset(iden, offs)
 
     def setUser(self, user):
         self.user = user
-
-    @contextlib.contextmanager
-    def allowall(self):
-        '''
-        DANGER DANGER DANGER
-
-        This is used as context manager to perform a operation which disables
-        permission checking on a snap.
-
-        Never ever hold this while *yielding* nodes into a storm pipeline.
-        Doing that will allow subsequent operations to be done without any
-        permissions enforcement.
-        '''
-        logger.warning('allowall() is deprecated and will be removed!')
-        yield
 
     def printf(self, mesg):
         self.fire('print', mesg=mesg)
@@ -175,7 +146,7 @@ class Snap(s_eventbus.EventBus):
             ((str,dict)): The node tuple or None.
 
         '''
-        return self.buidcache.get(buid)
+        return await self.buidcache.aget(buid)
 
     async def getNodeByNdef(self, ndef):
         '''
@@ -190,8 +161,8 @@ class Snap(s_eventbus.EventBus):
         buid = s_common.buid(ndef)
         return await self.getNodeByBuid(buid)
 
-    def _getNodesByTag(self, name, valu=None, cmpr='='):
-
+    async def _getNodesByTag(self, name, valu=None, cmpr='='):
+        breakpoint()
         # TODO interval indexing for valu... and @=
         name = s_chop.tag(name)
         pref = b'#' + name.encode('utf8') + b'\x00'
@@ -208,7 +179,7 @@ class Snap(s_eventbus.EventBus):
         for row, node in self.getLiftNodes(lops, '#' + name):
             yield node
 
-    def _getNodesByFormTag(self, name, tag, valu=None, cmpr='='):
+    async def _getNodesByFormTag(self, name, tag, valu=None, cmpr='='):
 
         filt = None
         form = self.model.form(name)
@@ -250,7 +221,7 @@ class Snap(s_eventbus.EventBus):
             if filt(valu):
                 yield node
 
-    def getNodesBy(self, full, valu=None, cmpr='='):
+    async def getNodesBy(self, full, valu=None, cmpr='='):
         '''
         The main function for retrieving nodes by prop.
 
@@ -267,19 +238,26 @@ class Snap(s_eventbus.EventBus):
 
         # special handling for by type (*type=) here...
         if cmpr == '*type=':
-            return self._getNodesByType(full, valu=valu)
+            async for node in self._getNodesByType(full, valu=valu):
+                yield node
+            return
 
         if full.startswith('#'):
-            return self._getNodesByTag(full, valu=valu, cmpr=cmpr)
+            async for node in self._getNodesByTag(full, valu=valu, cmpr=cmpr):
+                yield node
+            return
 
         fields = full.split('#', 1)
         if len(fields) > 1:
             form, tag = fields
-            return self._getNodesByFormTag(form, tag, valu=valu, cmpr=cmpr)
+            async for node in self._getNodesByFormTag(form, tag, valu=valu, cmpr=cmpr):
+                yield node
+            return
 
-        return self._getNodesByProp(full, valu=valu, cmpr=cmpr)
+        async for node in self._getNodesByProp(full, valu=valu, cmpr=cmpr):
+            yield node
 
-    def _getNodesByProp(self, full, valu=None, cmpr='='):
+    async def _getNodesByProp(self, full, valu=None, cmpr='='):
 
         prop = self.model.prop(full)
         if prop is None:
@@ -287,10 +265,10 @@ class Snap(s_eventbus.EventBus):
 
         lops = prop.getLiftOps(valu, cmpr=cmpr)
         cmpf = prop.type.getLiftHintCmpr(valu, cmpr=cmpr)
-        for row, node in self.getLiftNodes(lops, prop.name, cmpf):
+        async for row, node in self.getLiftNodes(lops, prop.name, cmpf):
             yield node
 
-    def _getNodesByType(self, name, valu=None, addform=True):
+    async def _getNodesByType(self, name, valu=None, addform=True):
 
         _type = self.model.types.get(name)
         if _type is None:
@@ -308,7 +286,7 @@ class Snap(s_eventbus.EventBus):
             for row, node in self.getLiftNodes(lops, prop):
                 yield node
 
-    def addNode(self, name, valu, props=None):
+    async def addNode(self, name, valu, props=None):
         '''
         Add a node by form name and value with optional props.
 
@@ -322,7 +300,7 @@ class Snap(s_eventbus.EventBus):
             try:
 
                 fnib = self._getNodeFnib(name, valu)
-                return self._addNodeFnib(fnib, props=props)
+                return await self._addNodeFnib(fnib, props=props)
 
             except Exception as e:
 
@@ -333,7 +311,7 @@ class Snap(s_eventbus.EventBus):
 
                 return None
 
-    def addFeedNodes(self, name, items):
+    async def addFeedNodes(self, name, items):
         '''
         Call a feed function and return what it returns (typically yields Node()s).
 
@@ -353,7 +331,7 @@ class Snap(s_eventbus.EventBus):
 
         return func(self, items)
 
-    def addFeedData(self, name, items, seqn=None):
+    async def addFeedData(self, name, items, seqn=None):
 
         func = self.core.getFeedFunc(name)
         if func is None:
@@ -377,16 +355,16 @@ class Snap(s_eventbus.EventBus):
 
             return nextoff
 
-    def addTagNode(self, name):
+    async def addTagNode(self, name):
         '''
         Ensure that the given syn:tag node exists.
         '''
-        return self.tagcache.get(name)
+        return await self.tagcache.aget(name)
 
-    def _addTagNode(self, name):
-        return self.addNode('syn:tag', name)
+    async def _addTagNode(self, name):
+        return await self.addNode('syn:tag', name)
 
-    def _addNodeFnib(self, fnib, props=None):
+    async def _addNodeFnib(self, fnib, props=None):
         '''
         Add a node via (form, norm, info, buid)
         '''
@@ -397,13 +375,13 @@ class Snap(s_eventbus.EventBus):
 
         sops = []
 
-        node = self.getNodeByBuid(buid)
+        node = await self.getNodeByBuid(buid)
         if node is not None:
 
             # maybe set some props...
             for name, valu in props.items():
                 # TODO: node.merge(name, valu)
-                node.set(name, valu)
+                await node.set(name, valu)
 
             return node
 
@@ -416,11 +394,11 @@ class Snap(s_eventbus.EventBus):
         node.ndef = (form.name, norm)
 
         sops = form.getSetOps(buid, norm)
-        self.stor(sops)
+        await self.stor(sops)
 
         self.buidcache.put(buid, node)
 
-        self.splice('node:add', ndef=node.ndef)
+        await self.splice('node:add', ndef=node.ndef)
 
         # update props with any subs from form value
         subs = info.get('subs')
@@ -435,11 +413,11 @@ class Snap(s_eventbus.EventBus):
 
         # set all the properties with init=True
         for name, valu in props.items():
-            node.set(name, valu, init=True)
+            await node.set(name, valu, init=True)
 
         # set our global properties
         tick = s_common.now()
-        node.set('.created', tick, init=True)
+        await node.set('.created', tick, init=True)
 
         # we are done initializing.
         node.init = False
@@ -459,7 +437,7 @@ class Snap(s_eventbus.EventBus):
             raise ctor(mesg=mesg, **info)
         return False
 
-    def splice(self, name, **info):
+    async def splice(self, name, **info):
         '''
         Construct and log a splice record to be saved on commit().
         '''
@@ -473,7 +451,7 @@ class Snap(s_eventbus.EventBus):
         self.fire(name, **info)
 
         mesg = (name, info)
-        self.xact.splices.append(mesg)
+        self.wlyr.splices.append(mesg)
 
         return (name, info)
 
@@ -493,7 +471,7 @@ class Snap(s_eventbus.EventBus):
         buid = s_common.buid((form.name, norm))
         return form, norm, info, buid
 
-    def addNodes(self, nodedefs):
+    async def addNodes(self, nodedefs):
         '''
         Add/merge nodes in bulk.
 
@@ -519,35 +497,35 @@ class Snap(s_eventbus.EventBus):
                 if props is not None:
                     props.pop('.created', None)
 
-                node = self.addNode(formname, formvalu, props=props)
+                node = await self.addNode(formname, formvalu, props=props)
                 if node is not None:
                     tags = forminfo.get('tags')
                     if tags is not None:
                         for tag, asof in tags.items():
-                            node.addTag(tag, valu=asof)
+                            await node.addTag(tag, valu=asof)
 
                 yield node
 
-    def stor(self, sops):
-
-        self.writeable()
+    async def stor(self, sops):
 
         if self.bulk:
             self.bulksops.extend(sops)
             return
 
-        self.xact.stor(sops)
+        await self.wlyr.stor(sops)
 
+    # FIXME: remove?
     @contextlib.contextmanager
     def bulkload(self):
 
         yield None
 
-    def getLiftNodes(self, lops, rawprop, cmpr=None):
+    async def getLiftNodes(self, lops, rawprop, cmpr=None):
         genr = self.getLiftRows(lops)
-        return self.getRowNodes(genr, rawprop, cmpr)
+        async for node in self.getRowNodes(genr, rawprop, cmpr):
+            yield node
 
-    def getLiftRows(self, lops):
+    async def getLiftRows(self, lops):
         '''
         Yield row tuples from a series of lift operations.
 
@@ -560,11 +538,11 @@ class Snap(s_eventbus.EventBus):
         Yields:
             (tuple): (layer_indx, (buid, ...)) rows.
         '''
-        for layer_idx, xact in enumerate(self.xacts):
-            with xact.incxref():
-                yield from ((layer_idx, x) for x in xact.getLiftRows(lops))
+        for layer_idx, layr in enumerate(self.layers):
+            async for x in layr.getLiftRows(lops):
+                yield layer_idx, x
 
-    def getRowNodes(self, rows, rawprop, cmpr=None):
+    async def getRowNodes(self, rows, rawprop, cmpr=None):
         '''
         Join a row generator into (row, Node()) tuples.
 
@@ -580,14 +558,14 @@ class Snap(s_eventbus.EventBus):
         Yields:
             (tuple): (row, node)
         '''
-        for origlayer, row in rows:
+        async for origlayer, row in rows:
             props = {}
             buid = row[0]
             node = self.buidcache.cache.get(buid)
             # Evaluate layers top-down to more quickly abort if we've found a higher layer with the property set
-            for layeridx in range(len(self.xacts) - 1, -1, -1):
-                x = self.xacts[layeridx]
-                layerprops = x.getBuidProps(buid)
+            for layeridx in range(len(self.layers) - 1, -1, -1):
+                layr = self.layers[layeridx]
+                layerprops = await layr.getBuidProps(buid)
                 # We mark this node to drop iff we see the prop set in this layer *and* we're looking at the props
                 # from a higher (i.e. closer to write, higher idx) layer.
                 if layeridx > origlayer and rawprop in layerprops:
@@ -620,11 +598,10 @@ class Snap(s_eventbus.EventBus):
 
                 yield row, node
 
-    def _getNodeByBuid(self, buid):
+    async def _getNodeByBuid(self, buid):
         props = {}
-        # this is essentially atomic and doesn't need xact.incxref
-        for layeridx, x in enumerate(self.xacts):
-            layerprops = x.getBuidProps(buid)
+        for layr in self.layers:
+            layerprops = await layr.getBuidProps(buid)
             props.update(layerprops)
 
         node = s_node.Node(self, buid, props.items())

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -168,7 +168,6 @@ class Snap(s_eventbus.EventBus, s_coro.Fini):
         return await self.getNodeByBuid(buid)
 
     async def _getNodesByTag(self, name, valu=None, cmpr='='):
-        breakpoint()
         # TODO interval indexing for valu... and @=
         name = s_chop.tag(name)
         pref = b'#' + name.encode('utf8') + b'\x00'
@@ -428,12 +427,12 @@ class Snap(s_eventbus.EventBus, s_coro.Fini):
         # we are done initializing.
         node.init = False
 
-        form.wasAdded(node)
+        await form.wasAdded(node)
 
         # now we must fire all his prop sets
         for name, valu in tuple(node.props.items()):
             prop = node.form.props.get(name)
-            prop.wasSet(node, None)
+            await prop.wasSet(node, None)
 
         return node
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -138,9 +138,9 @@ class Parser(argparse.ArgumentParser):
         self.exited = False
 
         argparse.ArgumentParser.__init__(self,
-            prog=prog,
-            description=descr,
-            formatter_class=argparse.RawDescriptionHelpFormatter)
+                                         prog=prog,
+                                         description=descr,
+                                         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     def exit(self, status=0, message=None):
         '''
@@ -249,6 +249,7 @@ class LimitCmd(Cmd):
             count += 1
 
             if count >= self.opts.count:
+                # FIXME:
                 snap.printf(f'limit reached: {self.opts.count}')
 
 class UniqCmd(Cmd):
@@ -336,13 +337,13 @@ class SudoCmd(Cmd):
             yield x
 
 # TODO
-#class AddNodeCmd(Cmd):     # addnode inet:ipv4 1.2.3.4 5.6.7.8
-#class DelPropCmd(Cmd):     # | delprop baz
-#class SetPropCmd(Cmd):     # | setprop foo bar
-#class AddTagCmd(Cmd):      # | addtag --time 2015 #hehe.haha
-#class DelTagCmd(Cmd):      # | deltag #foo.bar
-#class SeenCmd(Cmd):        # | seen --from <guid>update .seen and seen=(src,node).seen
-#class SourcesCmd(Cmd):     # | sources ( <nodes> -> seen:ndef :source -> source )
+# class AddNodeCmd(Cmd):     # addnode inet:ipv4 1.2.3.4 5.6.7.8
+# class DelPropCmd(Cmd):     # | delprop baz
+# class SetPropCmd(Cmd):     # | setprop foo bar
+# class AddTagCmd(Cmd):      # | addtag --time 2015 #hehe.haha
+# class DelTagCmd(Cmd):      # | deltag #foo.bar
+# class SeenCmd(Cmd):        # | seen --from <guid>update .seen and seen=(src,node).seen
+# class SourcesCmd(Cmd):     # | sources ( <nodes> -> seen:ndef :source -> source )
 
 class ReIndexCmd(Cmd):
     '''
@@ -524,7 +525,7 @@ class CountCmd(Cmd):
         async for item in genr:
             yield item
             i += 1
-
+        # FIXME:
         snap.printf(f'Counted {i} nodes.')
 
 class IdenCmd(Cmd):
@@ -601,6 +602,7 @@ class NoderefsCmd(Cmd):
 
     '''
     name = 'noderefs'
+
     def getArgParser(self):
         pars = Cmd.getArgParser(self)
         pars.add_argument('-d', '--degrees', type=int, default=1, action='store',
@@ -692,7 +694,7 @@ class NoderefsCmd(Cmd):
                     if self.omit_tags.intersection(set(pnode.tags.keys())):
                         continue
 
-                    yield  pnode, ppath
+                    yield pnode, ppath
 
                     # Can we traverse across this node?
                     if pnode.ndef[0] in self.omit_traversal_forms:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -317,7 +317,8 @@ class DelNodeCmd(Cmd):
             await node.delete(force=self.opts.force)
 
         # a bit odd, but we need to be detected as a generator
-        yield from ()
+        if False:
+            yield
 
 class SudoCmd(Cmd):
     '''
@@ -331,7 +332,8 @@ class SudoCmd(Cmd):
 
     async def execStormCmd(self, runt, genr):
         runt.elevate()
-        yield from genr
+        for x in genr:
+            yield x
 
 # TODO
 #class AddNodeCmd(Cmd):     # addnode inet:ipv4 1.2.3.4 5.6.7.8
@@ -543,7 +545,8 @@ class IdenCmd(Cmd):
 
     async def execStormCmd(self, runt, genr):
 
-        yield from genr
+        for x in genr:
+            yield x
 
         for iden in self.opts.iden:
             try:
@@ -653,7 +656,8 @@ class NoderefsCmd(Cmd):
             async for item in self.doRefs(node, path, visited):
                 yield item
 
-            yield from self.doRefs(node, path, visited)
+            for x in self.doRefs(node, path, visited):
+                yield x
 
     async def doRefs(self, srcnode, srcpath, visited):
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -120,13 +120,13 @@ class Runtime:
             count += 1
         return count
 
-    def iterStormQuery(self, query):
+    async def iterStormQuery(self, query):
         # init any options from the query
         # (but dont override our own opts)
         for name, valu in query.opts.items():
             self.opts.setdefault(name, valu)
 
-        for node, path in query.iterNodePaths(self):
+        async for node, path in query.iterNodePaths(self):
             self.tick()
             yield node, path
 

--- a/synapse/lib/syntax.py
+++ b/synapse/lib/syntax.py
@@ -756,7 +756,7 @@ class Parser:
             return self.edittagdel()
 
         if self.nextstr('-'):
-            return self.editnodedel()
+            self._raiseSyntaxError('Cannot delete nodes via edit syntax. Use the delnode command instead.')
 
         return self.editnodeadd()
 
@@ -781,17 +781,6 @@ class Parser:
         valu = self.valu()
 
         return s_ast.EditNodeAdd(kids=(absp, valu))
-
-    def editnodedel(self):
-        '''
-        -foo:bar
-        '''
-        self.ignore(whitespace)
-
-        self.nextmust('-')
-
-        absp = self.absprop()
-        return s_ast.EditNodeDel(kids=(absp,))
 
     def nextmust(self, text):
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -584,46 +584,46 @@ class InetModule(s_module.CoreModule):
         node.set('sha1', hashlib.sha1(byts).hexdigest())
         node.set('sha256', hashlib.sha256(byts).hexdigest())
 
-    def _onAddFqdn(self, node):
+    async def _onAddFqdn(self, node):
 
         fqdn = node.ndef[1]
         domain = node.get('domain')
 
         if domain is None:
-            node.set('issuffix', True)
+            await node.set('issuffix', True)
             return
 
         # almost certainly in the cache anyway....
-        parent = node.snap.getNodeByNdef(('inet:fqdn', domain))
+        parent = await node.snap.getNodeByNdef(('inet:fqdn', domain))
 
         if parent.get('issuffix'):
-            node.set('iszone', True)
-            node.set('zone', fqdn)
+            await node.set('iszone', True)
+            await node.set('zone', fqdn)
             return
 
         if parent.get('iszone'):
-            node.set('zone', domain)
+            await node.set('zone', domain)
             return
 
         zone = parent.get('zone')
         if zone is not None:
-            node.set('zone', zone)
+            await node.set('zone', zone)
 
-    def _onSetFqdnIsSuffix(self, node, oldv):
+    async def _onSetFqdnIsSuffix(self, node, oldv):
 
         fqdn = node.ndef[1]
 
         issuffix = node.get('issuffix')
-        for child in node.snap.getNodesBy('inet:fqdn:domain', fqdn):
-            child.set('iszone', issuffix)
+        async for child in node.snap.getNodesBy('inet:fqdn:domain', fqdn):
+            await child.set('iszone', issuffix)
 
-    def _onSetFqdnIsZone(self, node, oldv):
+    async def _onSetFqdnIsZone(self, node, oldv):
 
         fqdn = node.ndef[1]
 
         iszone = node.get('iszone')
         if iszone:
-            node.set('zone', fqdn)
+            await node.set('zone', fqdn)
             return
 
         # we are not a zone...
@@ -633,7 +633,7 @@ class InetModule(s_module.CoreModule):
             node.pop('zone')
             return
 
-        parent = node.snap.getNodeByNdef(('inet:fqdn', domain))
+        parent = await node.snap.getNodeByNdef(('inet:fqdn', domain))
 
         zone = parent.get('zone')
         if zone is None:
@@ -642,19 +642,19 @@ class InetModule(s_module.CoreModule):
 
         node.set('zone', zone)
 
-    def _onSetFqdnZone(self, node, oldv):
+    async def _onSetFqdnZone(self, node, oldv):
 
         fqdn = node.ndef[1]
         zone = node.get('zone')
 
-        for child in node.snap.getNodesBy('inet:fqdn:domain', fqdn):
+        async for child in node.snap.getNodesBy('inet:fqdn:domain', fqdn):
 
             # if they are their own zone level, skip
             if child.get('iszone'):
                 continue
 
             # the have the same zone we do
-            child.set('zone', zone)
+            await child.set('zone', zone)
 
     def getModelDefs(self):
         return (

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -570,7 +570,7 @@ class Url(s_types.Type):
 
 class InetModule(s_module.CoreModule):
 
-    def initCoreModule(self):
+    async def initCoreModule(self):
         self.model.form('inet:fqdn').onAdd(self._onAddFqdn)
         self.model.prop('inet:fqdn:zone').onSet(self._onSetFqdnZone)
         self.model.prop('inet:fqdn:iszone').onSet(self._onSetFqdnIsZone)

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -63,7 +63,7 @@ class SemVer(s_types.Type):
         return valu.to_bytes(8, 'big')
 
 class ItModule(s_module.CoreModule):
-    def initCoreModule(self):
+    async def initCoreModule(self):
         self.model.form('it:dev:str').onAdd(self._onFormItDevStr)
         self.model.form('it:dev:pipe').onAdd(self._onFormMakeDevStr)
         self.model.form('it:dev:mutex').onAdd(self._onFormMakeDevStr)

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -236,7 +236,7 @@ class OuModule(s_module.CoreModule):
 # FIXME: What do we want to do with seedCtors?
 class Fixme:
 
-    def initCoreModule(self):
+    async def initCoreModule(self):
         self.core.addSeedCtor('ou:org:name', self.seedOrgName)
         self.core.addSeedCtor('ou:org:alias', self.seedOrgAlias)
 

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -188,7 +188,7 @@ class PsModule(s_module.CoreModule):
 
 # FIXME - what do we want to do with seed ctors?
 class Fixme:
-    def initCoreModule(self):
+    async def initCoreModule(self):
         self.core.addSeedCtor('ps:person:guidname', self.seedPersonGuidName)
         self.core.addSeedCtor('ps:persona:guidname', self.seedPersonaGuidName)
 

--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -4,7 +4,6 @@ import logging
 
 import unittest.mock as mock
 
-
 loglevel = os.getenv('SYN_TEST_LOG_LEVEL', 'WARNING')
 logging.basicConfig(level=loglevel,
                     format='%(asctime)s [%(levelname)s] %(message)s [%(filename)s:%(funcName)s:%(threadName)s:%(processName)s]')

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -13,7 +13,7 @@ import synapse.lib.threads as s_threads
 
 import synapse.tests.common as s_test
 
-from synapse.tests.utils import SyncToAsyncCMgr
+from synapse.tests.utils import SyncToAsyncCMgr, alist
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +22,6 @@ bbuf = b'0123456' * 4793491
 
 bbufhash = hashlib.sha256(bbuf).digest()
 asdfhash = hashlib.sha256(b'asdfasdf').digest()
-
-async def alist(coro):
-    return [x async for x in coro]
 
 class AxonTest(s_test.SynTest):
 

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -164,7 +164,7 @@ class AxonTest(s_test.SynTest):
     async def test_axon(self):
         with self.getTestDir() as dirn:
             path0 = os.path.join(dirn, 'axon0')
-            async with SyncToAsyncCMgr(self.getTestDmon, mirror='axondmon') as dmon, \
+            async with self.getTestDmon(mirror='axondmon') as dmon, \
                     await dmon._getTestProxy('blobstor00') as blobstor0, \
                     SyncToAsyncCMgr(s_axon.Axon, path0, conf={'mapsize': s_test.TEST_MAP_SIZE}) as axon:
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -122,9 +122,8 @@ class CortexTest(s_test.SynTest):
 
             self.eq((10, 20), tuple(sorted([row[1] for row in rows])))
 
-            with core.layer.xact() as xact:
-                # rows are (buid, valu) tuples
-                rows = tuple(xact.iterUnivRows('.seen'))
+            # rows are (buid, valu) tuples
+            rows = await alist(core.layer.iterUnivRows('.seen'))
 
             ivals = ((1420070400000, 1420070400001), (1451606400000, 1451606400001))
             self.eq(ivals, tuple(sorted([row[1] for row in rows])))
@@ -138,17 +137,15 @@ class CortexTest(s_test.SynTest):
                 node = snap.addNode('teststr', 'hezipha', props={'.favcolor': 'red'})
                 node = snap.addNode('testcomp', (20, 'lulzlulz'))
 
-            self.len(0, core.eval('testcomp:haha~="^zerg"'))
-            self.len(1, core.eval('testcomp:haha~="^lulz"'))
+            self.len(0, await alist(core.eval('testcomp:haha~="^zerg"')))
+            self.len(1, await alist(core.eval('testcomp:haha~="^lulz"')))
 
-            self.len(1, core.eval('teststr~="zip"'))
-            self.len(1, core.eval('teststr~="zip"'))
-            self.len(1, core.eval('.favcolor~="^r"'))
+            self.len(1, await alist(core.eval('teststr~="zip"')))
+            self.len(1, await alist(core.eval('teststr~="zip"')))
+            self.len(1, await alist(core.eval('.favcolor~="^r"')))
 
     @patch('synapse.lib.lmdb.DEFAULT_MAP_SIZE', s_test.TEST_MAP_SIZE)
-    @s_glob.synchelp
-    async def test_feed_conf(self):
-
+    def test_feed_conf(self):
         with self.getTestDmon(mirror='cryodmon') as dst_dmon:
 
             name = 'cryo00'
@@ -167,6 +164,8 @@ class CortexTest(s_test.SynTest):
                 ],
                 'modules': ('synapse.tests.utils.TestModule',),
             }
+
+            breakpoint()
 
             # initialize the tank and get his iden
             with s_telepath.openurl(tank_addr) as tank:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -753,6 +753,7 @@ class CortexTest(s_test.SynTest):
             self.genraises(s_exc.NoSuchCmpr, core.eval, 'teststr +#test*near=newp')
             self.genraises(s_exc.NoSuchCmpr, core.eval, 'teststr +teststr:tick*near=newp')
             self.genraises(s_exc.BadStormSyntax, core.eval, ' | | ')
+            self.genraises(s_exc.BadStormSyntax, core.eval, '[-teststr]')
 
             self.len(2, list(core.eval(('[ teststr=foo teststr=bar ]'))))
             self.len(1, list(core.eval(('teststr %limit=1'))))

--- a/synapse/tests/test_lib_base.py
+++ b/synapse/tests/test_lib_base.py
@@ -362,9 +362,7 @@ class BaseTest(s_t_utils.ASynTest):
         ctx = multiprocessing.get_context('spawn')
 
         evt1 = ctx.Event()
-        # evt1.clear()
         evt2 = ctx.Event()
-        # evt2.clear()
 
         proc = ctx.Process(target=block_processing, args=(evt1, evt2))
         proc.start()

--- a/synapse/tests/test_lib_base.py
+++ b/synapse/tests/test_lib_base.py
@@ -1,34 +1,18 @@
 import os
 import sys
-import time
 import signal
 import asyncio
 import multiprocessing
 
 import synapse.exc as s_exc
 import synapse.glob as s_glob
-import synapse.common as s_common
 
 import synapse.lib.base as s_base
 import synapse.tests.utils as s_t_utils
 
-@s_common.firethread
-def send_sig(pid, sig):
-    '''
-    Sent a signal to a process.
-
-    Args:
-        pid (int): Process id to send the signal too.
-        sig (int): Signal to send.
-
-    Returns:
-        None
-    '''
-    os.kill(pid, sig)
-
 def block_processing(evt1, evt2):
     '''
-    Function to make a baseand call main().  Used as a Process target.
+    Function to make a base and call main().  Used as a Process target.
 
     Args:
         evt1 (multiprocessing.Event): event to twiddle
@@ -50,7 +34,6 @@ def block_processing(evt1, evt2):
     sys.exit(137)
 
 class BaseTest(s_t_utils.ASynTest):
-
     async def test_base_basics(self):
         base = await s_base.Base.anit()
 
@@ -166,6 +149,10 @@ class BaseTest(s_t_utils.ASynTest):
         evts = await wait1.wait(timeout=0.1)
         self.none(evts)
 
+<<<<<<< HEAD
+=======
+    @s_glob.synchelp
+>>>>>>> all-our-base
     async def test_base_filt(self):
 
         base = await s_base.Base.anit()
@@ -189,6 +176,10 @@ class BaseTest(s_t_utils.ASynTest):
         mesg = await base.fire('rofl', foo=10)
         self.true(mesg[1].get('woot'))
 
+<<<<<<< HEAD
+=======
+    @s_glob.synchelp
+>>>>>>> all-our-base
     async def test_base_log(self):
 
         logs = []
@@ -203,6 +194,10 @@ class BaseTest(s_t_utils.ASynTest):
         self.eq(mesg[1].get('mesg'), 'omg woot')
         self.eq(mesg[1].get('level'), 100)
 
+<<<<<<< HEAD
+=======
+    @s_glob.synchelp
+>>>>>>> all-our-base
     async def test_base_exc(self):
 
         logs = []
@@ -217,6 +212,10 @@ class BaseTest(s_t_utils.ASynTest):
         mesg = logs[0]
         self.eq(mesg[1].get('err'), 'NoSuchObj')
 
+<<<<<<< HEAD
+=======
+    @s_glob.synchelp
+>>>>>>> all-our-base
     async def test_baseref(self):
 
         bref = await s_base.BaseRef.anit()
@@ -241,6 +240,10 @@ class BaseTest(s_t_utils.ASynTest):
         await bref.fini()
         self.true(base0.isfini)
 
+<<<<<<< HEAD
+=======
+    @s_glob.synchelp
+>>>>>>> all-our-base
     async def test_base_waitfini(self):
 
         base = await s_base.Base.anit()
@@ -248,16 +251,27 @@ class BaseTest(s_t_utils.ASynTest):
         self.false(await base.waitfini(timeout=0.1))
 
         async def callfini():
+<<<<<<< HEAD
             await asyncio.sleep(0.1, loop=asyncio.get_running_loop())
             await base.fini()
 
         asyncio.get_running_loop().create_task(callfini())
+=======
+            await asyncio.sleep(0.1, loop=asyncio.get_event_loop())
+            await base.fini()
+
+        asyncio.get_event_loop().create_task(callfini())
+>>>>>>> all-our-base
         # actually wait...
         self.true(await base.waitfini(timeout=0.3))
 
         # bounce off the isfini block
         self.true(await base.waitfini(timeout=0.3))
 
+<<<<<<< HEAD
+=======
+    @s_glob.synchelp
+>>>>>>> all-our-base
     async def test_base_refcount(self):
         base = await s_base.Base.anit()
 
@@ -269,6 +283,10 @@ class BaseTest(s_t_utils.ASynTest):
         self.eq(await base.fini(), 0)
         self.true(base.isfini)
 
+<<<<<<< HEAD
+=======
+    @s_glob.synchelp
+>>>>>>> all-our-base
     async def test_baseref_gen(self):
 
         async with await s_base.BaseRef.anit() as refs:
@@ -300,6 +318,10 @@ class BaseTest(s_t_utils.ASynTest):
             self.false(refs.get('woot') is woot)
             self.eq(0, woot._syn_refs)
 
+<<<<<<< HEAD
+=======
+    @s_glob.synchelp
+>>>>>>> all-our-base
     async def test_baseref_items(self):
 
         bref = await s_base.BaseRef.anit()
@@ -341,18 +363,15 @@ class BaseTest(s_t_utils.ASynTest):
         ctx = multiprocessing.get_context('spawn')
 
         evt1 = ctx.Event()
-        evt1.clear()
         evt2 = ctx.Event()
-        evt2.clear()
 
         proc = ctx.Process(target=block_processing, args=(evt1, evt2))
         proc.start()
 
         self.true(evt1.wait(timeout=10))
-        foo = send_sig(proc.pid, signal.SIGTERM)
+        os.kill(proc.pid, signal.SIGTERM)
         self.true(evt2.wait(timeout=10))
         proc.join(timeout=10)
-        foo.join()
         self.eq(proc.exitcode, 137)
 
     def test_base_main_sigint(self):
@@ -368,8 +387,8 @@ class BaseTest(s_t_utils.ASynTest):
         proc.start()
 
         self.true(evt1.wait(timeout=10))
-        foo = send_sig(proc.pid, signal.SIGINT)
+        os.kill(proc.pid, signal.SIGINT)
+
         self.true(evt2.wait(timeout=10))
         proc.join(timeout=10)
-        foo.join()
         self.eq(proc.exitcode, 137)

--- a/synapse/tests/test_lib_base.py
+++ b/synapse/tests/test_lib_base.py
@@ -1,0 +1,294 @@
+import time
+import asyncio
+
+import synapse.exc as s_exc
+import synapse.glob as s_glob
+import synapse.common as s_common
+
+import synapse.lib.base as s_base
+import synapse.tests.utils as s_t_utils
+
+class BaseTest(s_t_utils.ASynTest):
+
+    async def test_base_basics(self):
+        base = await s_base.Base.anit()
+
+        def foo(event):
+            x = event[1].get('x')
+            y = event[1].get('y')
+            event[1]['ret'] = x + y
+
+        base.on('woot', foo)
+
+        event = await base.fire('woot', x=3, y=5, ret=[])
+        self.eq(event[1]['ret'], 8)
+
+    async def test_base_link(self):
+
+        base1 = await s_base.Base.anit()
+        base2 = await s_base.Base.anit()
+
+        base1.link(base2.dist)
+
+        data = {}
+
+        async def woot(event):
+            data['woot'] = True
+
+        base2.on('woot', woot)
+
+        await base1.fire('woot')
+
+        self.true(data.get('woot'))
+
+    async def test_base_unlink(self):
+
+        base = await s_base.Base.anit()
+
+        mesgs = []
+
+        async def woot(mesg):
+            mesgs.append(mesg)
+
+        base.link(woot)
+
+        await base.fire('haha')
+        self.eq(len(mesgs), 1)
+
+        base.unlink(woot)
+
+        await base.fire('haha')
+        self.eq(len(mesgs), 1)
+
+        await base.fini()
+
+    async def test_base_withfini(self):
+
+        data = {'count': 0}
+
+        def onfini():
+            data['count'] += 1
+
+        async with s_base.Base() as base:
+            base.onfini(onfini)
+
+        self.eq(data['count'], 1)
+
+    async def test_base_finionce(self):
+
+        data = {'count': 0}
+
+        async def onfini():
+            data['count'] += 1
+
+        base = await s_base.Base.anit()
+        base.onfini(onfini)
+
+        await base.fini()
+        await base.fini()
+
+        self.eq(data['count'], 1)
+
+    async def test_base_off(self):
+        base = await s_base.Base.anit()
+
+        data = {'count': 0}
+
+        async def woot(mesg):
+            data['count'] += 1
+
+        base.on('hehe', woot)
+
+        await base.fire('hehe')
+
+        base.off('hehe', woot)
+
+        await base.fire('hehe')
+
+        await base.fini()
+
+        self.eq(data['count'], 1)
+
+    async def test_base_waiter(self):
+        base0 = await s_base.Base.anit()
+
+        wait0 = base0.waiter(3, 'foo:bar')
+
+        await base0.fire('foo:bar')
+        await base0.fire('foo:bar')
+        await base0.fire('foo:bar')
+
+        evts = await wait0.wait(timeout=3)
+        self.eq(len(evts), 3)
+
+        wait1 = base0.waiter(3, 'foo:baz')
+        evts = await wait1.wait(timeout=0.1)
+        self.none(evts)
+
+    async def test_base_filt(self):
+
+        base = await s_base.Base.anit()
+
+        def wootfunc(mesg):
+            mesg[1]['woot'] = True
+
+        base.on('lol', wootfunc)
+
+        base.on('rofl', wootfunc, foo=10)
+
+        mesg = await base.fire('lol')
+        self.true(mesg[1].get('woot'))
+
+        mesg = await base.fire('rofl')
+        self.false(mesg[1].get('woot'))
+
+        mesg = await base.fire('rofl', foo=20)
+        self.false(mesg[1].get('woot'))
+
+        mesg = await base.fire('rofl', foo=10)
+        self.true(mesg[1].get('woot'))
+
+    async def test_base_log(self):
+
+        logs = []
+        async with await s_base.Base.anit() as base:
+            base.on('log', logs.append)
+
+            await base.log(100, 'omg woot', foo=10)
+
+        mesg = logs[0]
+        self.eq(mesg[0], 'log')
+        self.eq(mesg[1].get('foo'), 10)
+        self.eq(mesg[1].get('mesg'), 'omg woot')
+        self.eq(mesg[1].get('level'), 100)
+
+    async def test_base_exc(self):
+
+        logs = []
+        async with await s_base.Base.anit() as base:
+            base.on('log', logs.append)
+
+            try:
+                raise s_exc.NoSuchObj(name='hehe')
+            except Exception as e:
+                await base.exc(e)
+
+        mesg = logs[0]
+        self.eq(mesg[1].get('err'), 'NoSuchObj')
+
+    async def test_baseref(self):
+
+        bref = await s_base.BaseRef.anit()
+
+        base0 = await s_base.Base.anit()
+        base1 = await s_base.Base.anit()
+        base2 = await s_base.Base.anit()
+
+        bref.put('foo', base0)
+        bref.put('bar', base1)
+        bref.put('baz', base2)
+
+        await base1.fini()
+        self.nn(bref.get('foo'))
+        self.none(bref.get('bar'))
+
+        self.len(2, list(bref))
+
+        self.true(bref.pop('baz') is base2)
+        self.len(1, list(bref))
+
+        await bref.fini()
+        self.true(base0.isfini)
+
+    async def test_base_waitfini(self):
+
+        base = await s_base.Base.anit()
+
+        self.false(await base.waitfini(timeout=0.1))
+
+        async def callfini():
+            await asyncio.sleep(0.1, loop=asyncio.get_running_loop())
+            await base.fini()
+
+        asyncio.get_running_loop().create_task(callfini())
+        # actually wait...
+        self.true(await base.waitfini(timeout=0.3))
+
+        # bounce off the isfini block
+        self.true(await base.waitfini(timeout=0.3))
+
+    async def test_base_refcount(self):
+        base = await s_base.Base.anit()
+
+        self.eq(base.incref(), 2)
+
+        self.eq(await base.fini(), 1)
+        self.false(base.isfini)
+
+        self.eq(await base.fini(), 0)
+        self.true(base.isfini)
+
+    async def test_baseref_gen(self):
+
+        async with await s_base.BaseRef.anit() as refs:
+            await self.asyncraises(s_exc.NoSuchCtor, refs.gen('woot'))
+
+        async def ctor(name):
+            return await s_base.Base.anit()
+
+        async with await s_base.BaseRef.anit(ctor=ctor) as refs:
+
+            self.none(refs.get('woot'))
+
+            woot = await refs.gen('woot')
+            self.eq(1, woot._syn_refs)
+
+            self.nn(woot)
+            self.true(await refs.gen('woot') is woot)
+            self.eq(2, woot._syn_refs)
+
+            await woot.fini()
+            self.false(woot.isfini)
+            self.true(refs.get('woot') is woot)
+            self.eq(1, woot._syn_refs)
+
+            await woot.fini()
+            self.eq(0, woot._syn_refs)
+
+            self.true(woot.isfini)
+            self.false(refs.get('woot') is woot)
+            self.eq(0, woot._syn_refs)
+
+    async def test_baseref_items(self):
+
+        bref = await s_base.BaseRef.anit()
+
+        base0 = await s_base.Base.anit()
+        base1 = await s_base.Base.anit()
+        base2 = await s_base.Base.anit()
+
+        bref.put('foo', base0)
+        bref.put('bar', base1)
+        bref.put('baz', base2)
+
+        items = bref.items()
+        self.isin(('foo', base0), items)
+        self.isin(('bar', base1), items)
+        self.isin(('baz', base2), items)
+
+        await base1.fini()
+        items = bref.items()
+        self.isin(('foo', base0), items)
+        self.isin(('baz', base2), items)
+
+        await base2.fini()
+        items = bref.items()
+        self.isin(('foo', base0), items)
+
+        await base0.fini()
+        items = bref.items()
+        self.eq(items, [])
+
+        await bref.fini()
+        items = bref.items()
+        self.eq(items, [])

--- a/synapse/tests/test_lib_base.py
+++ b/synapse/tests/test_lib_base.py
@@ -149,10 +149,6 @@ class BaseTest(s_t_utils.ASynTest):
         evts = await wait1.wait(timeout=0.1)
         self.none(evts)
 
-<<<<<<< HEAD
-=======
-    @s_glob.synchelp
->>>>>>> all-our-base
     async def test_base_filt(self):
 
         base = await s_base.Base.anit()
@@ -176,10 +172,6 @@ class BaseTest(s_t_utils.ASynTest):
         mesg = await base.fire('rofl', foo=10)
         self.true(mesg[1].get('woot'))
 
-<<<<<<< HEAD
-=======
-    @s_glob.synchelp
->>>>>>> all-our-base
     async def test_base_log(self):
 
         logs = []
@@ -194,10 +186,6 @@ class BaseTest(s_t_utils.ASynTest):
         self.eq(mesg[1].get('mesg'), 'omg woot')
         self.eq(mesg[1].get('level'), 100)
 
-<<<<<<< HEAD
-=======
-    @s_glob.synchelp
->>>>>>> all-our-base
     async def test_base_exc(self):
 
         logs = []
@@ -212,10 +200,6 @@ class BaseTest(s_t_utils.ASynTest):
         mesg = logs[0]
         self.eq(mesg[1].get('err'), 'NoSuchObj')
 
-<<<<<<< HEAD
-=======
-    @s_glob.synchelp
->>>>>>> all-our-base
     async def test_baseref(self):
 
         bref = await s_base.BaseRef.anit()
@@ -240,10 +224,6 @@ class BaseTest(s_t_utils.ASynTest):
         await bref.fini()
         self.true(base0.isfini)
 
-<<<<<<< HEAD
-=======
-    @s_glob.synchelp
->>>>>>> all-our-base
     async def test_base_waitfini(self):
 
         base = await s_base.Base.anit()
@@ -251,27 +231,16 @@ class BaseTest(s_t_utils.ASynTest):
         self.false(await base.waitfini(timeout=0.1))
 
         async def callfini():
-<<<<<<< HEAD
-            await asyncio.sleep(0.1, loop=asyncio.get_running_loop())
-            await base.fini()
-
-        asyncio.get_running_loop().create_task(callfini())
-=======
             await asyncio.sleep(0.1, loop=asyncio.get_event_loop())
             await base.fini()
 
         asyncio.get_event_loop().create_task(callfini())
->>>>>>> all-our-base
         # actually wait...
         self.true(await base.waitfini(timeout=0.3))
 
         # bounce off the isfini block
         self.true(await base.waitfini(timeout=0.3))
 
-<<<<<<< HEAD
-=======
-    @s_glob.synchelp
->>>>>>> all-our-base
     async def test_base_refcount(self):
         base = await s_base.Base.anit()
 
@@ -283,10 +252,6 @@ class BaseTest(s_t_utils.ASynTest):
         self.eq(await base.fini(), 0)
         self.true(base.isfini)
 
-<<<<<<< HEAD
-=======
-    @s_glob.synchelp
->>>>>>> all-our-base
     async def test_baseref_gen(self):
 
         async with await s_base.BaseRef.anit() as refs:
@@ -318,10 +283,6 @@ class BaseTest(s_t_utils.ASynTest):
             self.false(refs.get('woot') is woot)
             self.eq(0, woot._syn_refs)
 
-<<<<<<< HEAD
-=======
-    @s_glob.synchelp
->>>>>>> all-our-base
     async def test_baseref_items(self):
 
         bref = await s_base.BaseRef.anit()

--- a/synapse/tests/test_lib_encoding.py
+++ b/synapse/tests/test_lib_encoding.py
@@ -3,6 +3,7 @@ import json
 
 import synapse.common as s_common
 
+import synapse.lib.msgpack as s_msgpack
 import synapse.lib.encoding as s_encoding
 
 import synapse.tests.common as s_test
@@ -128,6 +129,20 @@ class EncTest(s_test.SynTest):
             with s_common.genfile(linep) as fd:
                 lines = list(s_encoding.iterdata(fd, close_fd=False,
                                                  format='lines'))
+                self.len(2, lines)
+                e = ['foo.com', 'bar.com']
+                self.eq(lines, e)
+
+    def test_fmt_mpk(self):
+        with self.getTestDir() as dirn:
+            fp = s_common.genpath(dirn, 'woot.mpk')
+            with s_common.genfile(fp) as fd:
+                fd.write(s_msgpack.en('foo.com'))
+                fd.write(s_msgpack.en('bar.com'))
+
+            with s_common.genfile(fp) as fd:
+                lines = list(s_encoding.iterdata(fd, close_fd=False,
+                                                 format='mpk'))
                 self.len(2, lines)
                 e = ['foo.com', 'bar.com']
                 self.eq(lines, e)

--- a/synapse/tests/test_lib_lmdb.py
+++ b/synapse/tests/test_lib_lmdb.py
@@ -60,7 +60,7 @@ class LmdbTest(SynTest):
             with lenv.begin() as xact:
                 self.raises(lmdb.ReadonlyError, seqn.save, xact, items)
 
-            # A subseqeunt write works.
+            # A subsequent write works.
             with lenv.begin(write=True) as xact:
                 seqn.save(xact, items)
                 retn = tuple(seqn.iter(xact, 0))

--- a/synapse/tests/test_lib_plex.py
+++ b/synapse/tests/test_lib_plex.py
@@ -52,36 +52,35 @@ class PlexTest(s_test.SynTest):
         '''
         Have two plexes connect to each other, send messages, and then server disconnects
         '''
-        plex1 = s_plex.Plex()
-        plex2 = s_plex.Plex()
         steps = self.getTestSteps(['onlink', 'onrx1', 'client_rx', 'link_fini'])
+        with s_plex.Plex() as plex1, s_plex.Plex() as plex2:
 
-        async def server_onlink(link):
-            steps.done('onlink')
+            async def server_onlink(link):
+                steps.done('onlink')
 
-            async def do_rx(msg):
-                self.eq(msg, 'foo')
-                steps.done('onrx1')
-                await link.tx('bar')
-                await link.fini()
+                async def do_rx(msg):
+                    self.eq(msg, 'foo')
+                    steps.done('onrx1')
+                    await link.tx('bar')
+                    await link.fini()
 
-            link.onrx(do_rx)
+                link.onrx(do_rx)
 
-        server = plex1.listen('127.0.0.1', None, onlink=server_onlink)
-        _, port = server.sockets[0].getsockname()
-        link2 = plex2.connect('127.0.0.1', port)
-        steps.wait('onlink', timeout=1)
+            server = plex1.listen('127.0.0.1', None, onlink=server_onlink)
+            _, port = server.sockets[0].getsockname()
+            link2 = plex2.connect('127.0.0.1', port)
+            steps.wait('onlink', timeout=1)
 
-        async def client_do_rx(msg):
-            self.eq(msg, 'bar')
-            steps.done('client_rx')
-        link2.onrx(client_do_rx)
+            async def client_do_rx(msg):
+                self.eq(msg, 'bar')
+                steps.done('client_rx')
+            link2.onrx(client_do_rx)
 
-        async def onlinkfini():
-            steps.done('link_fini')
+            async def onlinkfini():
+                steps.done('link_fini')
 
-        link2.onfini(onlinkfini)
-        await link2.tx('foo')
-        steps.wait('onrx1', timeout=1)
-        steps.wait('client_rx', timeout=1)
-        steps.wait('link_fini')
+            link2.onfini(onlinkfini)
+            await link2.tx('foo')
+            steps.wait('onrx1', timeout=1)
+            steps.wait('client_rx', timeout=1)
+            steps.wait('link_fini')

--- a/synapse/tests/test_lib_slabseqn.py
+++ b/synapse/tests/test_lib_slabseqn.py
@@ -1,0 +1,63 @@
+import os
+import lmdb
+
+import synapse.glob as s_glob
+
+import synapse.lib.lmdb as s_lmdb
+import synapse.lib.slabseqn as s_slabseqn
+
+from synapse.tests.common import SynTest
+
+class SlabSeqn(SynTest):
+
+    @s_glob.synchelp
+    async def test_slab_seqn(self):
+
+        with self.getTestDir() as dirn:
+
+            path = os.path.join(dirn, 'test.lmdb')
+            slab = s_lmdb.Slab(path, map_size=1000000)
+
+            seqn = s_slabseqn.SlabSeqn(slab, 'seqn:test')
+
+            self.eq(seqn.nextindx(), 0)
+            items = ('foo', 10, 20)
+            seqn.save(items)
+            retn = tuple(seqn.iter(0))
+            self.eq(retn, ((0, 'foo'), (1, 10), (2, 20)))
+
+            self.raises(TypeError, seqn.save, ({'set'},))
+            retn = tuple(seqn.iter(0))
+            self.eq(retn, ((0, 'foo'), (1, 10), (2, 20)))
+
+            self.eq(seqn.nextindx(), 3)
+
+            await slab.fini()
+
+            # Reopen the seqn and continue where we left off
+            slab = s_lmdb.Slab(path, map_size=1000000)
+
+            seqn = s_slabseqn.SlabSeqn(slab, 'seqn:test')
+            self.eq(seqn.index(), 3)
+
+            self.eq(seqn.nextindx(), 3)
+            seqn.save(items)
+
+            retn = tuple(seqn.iter(0))
+            self.eq(retn, ((0, 'foo'), (1, 10), (2, 20),
+                           (3, 'foo'), (4, 10), (5, 20)))
+            self.eq(seqn.nextindx(), 6)
+
+            # We can also start in the middle of the sequence
+            retn = tuple(seqn.iter(4))
+            self.eq(retn, ((4, 10), (5, 20)))
+
+            # iterating past the end yields nothing
+            retn = tuple(seqn.iter(100))
+            self.eq(retn, ())
+
+            seqn.save(items)
+            retn = tuple(seqn.iter(0))
+            self.len(9, retn)
+
+            await slab.fini()

--- a/synapse/tests/test_lib_snap.py
+++ b/synapse/tests/test_lib_snap.py
@@ -1,24 +1,25 @@
 import os
 import contextlib
+import synapse.glob as s_glob
 
-import synapse.exc as s_exc
-import synapse.lib.auth as s_auth
+from synapse.tests.utils import SyncToAsyncCMgr, alist
 import synapse.tests.common as s_t_common
 
 class SnapTest(s_t_common.SynTest):
 
-    def test_snap_eval_storm(self):
+    @s_glob.synchelp
+    async def test_snap_eval_storm(self):
 
         with self.getTestCore() as core:
 
             with core.snap() as snap:
 
-                snap.addNode('teststr', 'hehe')
-                snap.addNode('teststr', 'haha')
+                await snap.addNode('teststr', 'hehe')
+                await snap.addNode('teststr', 'haha')
 
                 self.len(2, snap.eval('teststr'))
 
-                snap.addNode('teststr', 'hoho')
+                await snap.addNode('teststr', 'hoho')
 
                 self.len(3, snap.storm('teststr'))
 
@@ -53,16 +54,17 @@ class SnapTest(s_t_common.SynTest):
                 nodes = list(snap.addFeedNodes('test.genr', []))
                 self.len(2, nodes)
 
-    def test_addNodes(self):
-        with self.getTestCore() as core:
+    @s_glob.synchelp
+    async def test_addNodes(self):
+        async with self.agetTestCore() as core:
             with core.snap() as snap:
                 ndefs = ()
-                self.len(0, list(snap.addNodes(ndefs)))
+                self.len(0, await alist(snap.addNodes(ndefs)))
 
                 ndefs = (
                     (('teststr', 'hehe'), {'props': {'.created': 5, 'tick': 3}, 'tags': {'cool': (1, 2)}}, ),
                 )
-                result = list(snap.addNodes(ndefs))
+                result = await alist(snap.addNodes(ndefs))
                 self.len(1, result)
 
                 node = result[0]
@@ -70,7 +72,7 @@ class SnapTest(s_t_common.SynTest):
                 self.ge(node.props.get('.created', 0), 5)
                 self.eq(node.tags.get('cool'), (1, 2))
 
-                nodes = list(snap.getNodesBy('teststr', 'hehe'))
+                nodes = await alist(snap.getNodesBy('teststr', 'hehe'))
                 self.len(1, nodes)
                 self.eq(nodes[0], node)
 

--- a/synapse/tests/test_lib_snap.py
+++ b/synapse/tests/test_lib_snap.py
@@ -10,48 +10,50 @@ class SnapTest(s_t_common.SynTest):
     @s_glob.synchelp
     async def test_snap_eval_storm(self):
 
-        with self.getTestCore() as core:
+        async with self.agetTestCore() as core:
 
             with core.snap() as snap:
 
                 await snap.addNode('teststr', 'hehe')
                 await snap.addNode('teststr', 'haha')
 
-                self.len(2, snap.eval('teststr'))
+                self.len(2, await snap.eval('teststr'))
 
                 await snap.addNode('teststr', 'hoho')
 
-                self.len(3, snap.storm('teststr'))
+                self.len(3, await alist(snap.storm('teststr')))
 
-    def test_stor(self):
-        with self.getTestCore() as core:
+    @s_glob.synchelp
+    async def test_stor(self):
+        async with self.agetTestCore() as core:
 
             # Bulk
             with core.snap() as snap:
                 snap.bulk = True
                 self.eq(snap.bulksops, ())
 
-                self.none(snap.stor((1,)))
+                self.none(await snap.stor((1,)))
                 self.eq(snap.bulksops, (1,))
 
-                self.none(snap.stor((2,)))
+                self.none(await snap.stor((2,)))
                 self.eq(snap.bulksops, (1, 2,))
 
-    def test_snap_feed_genr(self):
+    @s_glob.synchelp
+    async def test_snap_feed_genr(self):
 
         def testGenrFunc(snap, items):
             yield snap.addNode('teststr', 'foo')
             yield snap.addNode('teststr', 'bar')
 
-        with self.getTestCore() as core:
+        async with self.agetTestCore() as core:
 
             core.setFeedFunc('test.genr', testGenrFunc)
 
             core.addFeedData('test.genr', [])
-            self.len(2, core.eval('teststr'))
+            self.len(2, await alist(core.eval('teststr')))
 
             with core.snap() as snap:
-                nodes = list(snap.addFeedNodes('test.genr', []))
+                nodes = await alist(snap.addFeedNodes('test.genr', []))
                 self.len(2, nodes)
 
     @s_glob.synchelp
@@ -76,8 +78,8 @@ class SnapTest(s_t_common.SynTest):
                 self.len(1, nodes)
                 self.eq(nodes[0], node)
 
-    @contextlib.contextmanager
-    def _getTestCoreMultiLayer(self, first_dirn):
+    @contextlib.asynccontextmanager
+    async def _getTestCoreMultiLayer(self, first_dirn):
         '''
         Custom logic to make a second cortex that puts another cortex's layer underneath.
 
@@ -85,66 +87,68 @@ class SnapTest(s_t_common.SynTest):
             This method is broken out so subclasses can override.
         '''
         layerfn = os.path.join(first_dirn, 'layers', '000-default')
-        with self.getTestCore(extra_layers=[layerfn]) as core:
+        async with self.agetTestCore(extra_layers=[layerfn]) as core:
             yield core
 
-    def test_cortex_lift_layers_bad_filter(self):
+    @s_glob.synchelp
+    async def test_cortex_lift_layers_bad_filter(self):
         '''
         Test a two layer cortex where a lift operation gives the wrong result
         '''
-        with self.getTestCore() as core1:
+        async with self.agetTestCore() as core1:
             node = (('inet:ipv4', 1), {'props': {'asn': 42, '.seen': (1, 2)}, 'tags': {'woot': (1, 2)}})
-            nodes_core1 = list(core1.addNodes([node]))
+            nodes_core1 = await alist(core1.addNodes([node]))
 
-            with self._getTestCoreMultiLayer(core1.dirn) as core, core.snap() as snap:
+            async with self._getTestCoreMultiLayer(core1.dirn) as core, core.snap() as snap:
                 # Basic sanity check
-                nodes = list(snap.getNodesBy('inet:ipv4', 1))
+                nodes = await alist(snap.getNodesBy('inet:ipv4', 1))
                 self.len(1, nodes)
-                nodes = list(snap.getNodesBy('inet:ipv4.seen', 1))
+                nodes = await alist(snap.getNodesBy('inet:ipv4.seen', 1))
                 self.len(1, nodes)
                 self.eq(nodes_core1[0].pack(), nodes[0].pack())
-                nodes = list(snap.getNodesBy('inet:ipv4#woot', 1))
+                nodes = await alist(snap.getNodesBy('inet:ipv4#woot', 1))
                 self.len(1, nodes)
-                nodes = list(snap.getNodesBy('inet:ipv4#woot', 99))
-                self.len(0, nodes)
+                nodes = await alist(snap.getNodesBy('inet:ipv4#woot', 99))
+                self.len(0, await nodes)
 
                 # Now change asn in the "higher" layer
                 changed_node = (('inet:ipv4', 1), {'props': {'asn': 43, '.seen': (3, 4)}, 'tags': {'woot': (3, 4)}})
-                nodes = list(snap.addNodes([changed_node]))
+                nodes = await alist(snap.addNodes([changed_node]))
                 # Lookup by prop
-                nodes = list(snap.getNodesBy('inet:ipv4:asn', 42))
+                nodes = await alist(snap.getNodesBy('inet:ipv4:asn', 42))
                 self.len(0, nodes)
 
                 # Lookup by univ prop
-                nodes = list(snap.getNodesBy('inet:ipv4.seen', 1))
+                nodes = await alist(snap.getNodesBy('inet:ipv4.seen', 1))
                 self.len(0, nodes)
 
                 # Lookup by formtag
-                nodes = list(snap.getNodesBy('inet:ipv4#woot', 1))
+                nodes = await alist(snap.getNodesBy('inet:ipv4#woot', 1))
                 self.len(0, nodes)
 
                 # Lookup by tag
-                nodes = list(snap.getNodesBy('#woot', 1))
+                nodes = await alist(snap.getNodesBy('#woot', 1))
                 self.len(0, nodes)
 
-    def test_cortex_lift_layers_dup(self):
+    @s_glob.synchelp
+    async def test_cortex_lift_layers_dup(self):
         '''
         Test a two layer cortex where a lift operation might give the same node twice incorrectly
         '''
-        with self.getTestCore() as core1:
+        async with self.agetTestCore() as core1:
             node = (('inet:ipv4', 1), {'props': {'asn': 42}})
-            nodes_core1 = list(core1.addNodes([node]))
+            nodes_core1 = await alist(core1.addNodes([node]))
 
-            with self._getTestCoreMultiLayer(core1.dirn) as core, core.snap() as snap:
+            async with self._getTestCoreMultiLayer(core1.dirn) as core, core.snap() as snap:
                 # Basic sanity check
-                nodes = list(snap.getNodesBy('inet:ipv4', 1))
+                nodes = await alist(snap.getNodesBy('inet:ipv4', 1))
                 self.len(1, nodes)
                 self.eq(nodes_core1[0].pack(), nodes[0].pack())
 
                 # Now set asn in the "higher" layer to the same (by changing it, then changing it back)
                 changed_node = (('inet:ipv4', 1), {'props': {'asn': 43}})
-                nodes = list(snap.addNodes([changed_node]))
+                nodes = await alist(snap.addNodes([changed_node]))
                 changed_node = (('inet:ipv4', 1), {'props': {'asn': 42}})
-                nodes = list(snap.addNodes([changed_node]))
-                nodes = list(snap.getNodesBy('inet:ipv4:asn', 42))
+                nodes = await alist(snap.addNodes([changed_node]))
+                nodes = await alist(snap.getNodesBy('inet:ipv4:asn', 42))
                 self.len(1, nodes)

--- a/synapse/tests/test_lib_snap.py
+++ b/synapse/tests/test_lib_snap.py
@@ -2,7 +2,7 @@ import os
 import contextlib
 import synapse.glob as s_glob
 
-from synapse.tests.utils import SyncToAsyncCMgr, alist
+from synapse.tests.utils import alist
 import synapse.tests.common as s_t_common
 
 class SnapTest(s_t_common.SynTest):

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -56,6 +56,28 @@ class StormTest(s_test_common.SynTest):
                 self.none(node.tags.get('hehe'))
                 self.none(node.tags.get('hehe.haha'))
 
+        with self.getTestCore() as core:
+
+            with core.snap() as snap:
+                node = snap.addNode('teststr', 'foo')
+                node.addTag('hehe', valu=(20, 30))
+
+                tagnode = snap.getNodeByNdef(('syn:tag', 'hehe'))
+
+                tagnode.set('doc', 'haha doc')
+
+            list(core.eval('movetag #hehe #woot'))
+
+            self.len(0, list(core.eval('#hehe')))
+
+            self.len(1, list(core.eval('#woot')))
+
+            with core.snap() as snap:
+
+                newt = core.getNodeByNdef(('syn:tag', 'woot'))
+
+                self.eq(newt.get('doc'), 'haha doc')
+
     def test_storm_spin(self):
 
         with self.getTestCore() as core:

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -6,9 +6,11 @@ logger = logging.getLogger(__name__)
 
 import synapse.exc as s_exc
 import synapse.glob as s_glob
+import synapse.common as s_common
 import synapse.telepath as s_telepath
 
 import synapse.lib.share as s_share
+import synapse.lib.scope as s_scope
 import synapse.tests.common as s_test
 
 from synapse.tests.utils import SyncToAsyncCMgr
@@ -20,10 +22,20 @@ class CustomShare(s_share.Share):
     typename = 'customshare'
 
     async def _runShareLoop(self):
-        await s_glob.plex.sleep(10)
+        try:
+            await s_glob.plex.sleep(10)
+        except asyncio.CancelledError as e:
+            raise e
 
     def boo(self, x):
         return x
+
+class Beep:
+    def __init__(self, path):
+        self.path = path
+
+    def beep(self):
+        return f'{self.path}: beep'
 
 class Foo:
 
@@ -66,7 +78,10 @@ class Foo:
     async def corogenr(self, x):
         for i in range(x):
             yield i
-            await s_glob.plex.sleep(0.1)
+            try:
+                await s_glob.plex.sleep(0.1)
+            except asyncio.CancelledError:
+                return
 
     def boom(self):
         return Boom()
@@ -99,6 +114,20 @@ class TeleApi:
         return CustomShare(self.link, 42)
 
 class TeleAware(s_telepath.Aware):
+    def __init__(self):
+        s_telepath.Aware.__init__(self)
+        self.beeps = {}
+
+    def _initBeep(self, path):
+        beep = self.beeps.get(path)
+        if beep:
+            return beep
+        beep = Beep(path)
+        self.beeps[path] = beep
+        return beep
+
+    def onTeleOpen(self, link, path):
+        return self._initBeep(path[1])
 
     def getTeleApi(self, link, mesg):
         return TeleApi(self, link)
@@ -168,6 +197,7 @@ class TeleTest(s_test.SynTest):
         # Fini'ing a daemon fini's proxies connected to it.
         self.true(evt.wait(2))
         self.true(prox.isfini)
+        self.raises(s_exc.IsFini, prox.bar, (10, 20))
 
     @s_glob.synchelp
     async def test_telepath_async(self):
@@ -251,12 +281,16 @@ class TeleTest(s_test.SynTest):
 
         with self.getTestDmon() as dmon:
             dmon.share('woke', item)
-            proxy = dmon._getTestProxy('woke')
-            self.eq(10, proxy.getFooBar(20, 10))
+            with dmon._getTestProxy('woke') as proxy:
+                self.eq(10, proxy.getFooBar(20, 10))
 
-            # check a custom share works
-            obj = proxy.customshare()
-            self.eq(999, obj.boo(999))
+                # check a custom share works
+                obj = proxy.customshare()
+                self.eq(999, obj.boo(999))
+
+            # check that a dynamic share works
+            with dmon._getTestProxy('woke/up') as proxy:
+                self.eq('up: beep', proxy.beep())
 
     def test_telepath_auth(self):
 
@@ -284,3 +318,39 @@ class TeleTest(s_test.SynTest):
             host, port = dmon.listen('tcp://127.0.0.1:0/')
 
             self.raises(s_exc.BadMesgVers, s_telepath.openurl, 'tcp://127.0.0.1/', port=port)
+
+    def test_alias(self):
+        item = TeleAware()
+        name = 'item'
+
+        with self.getTestDmon() as dmon:
+            addr = dmon.listen('tcp://127.0.0.1:0')
+            dmon.share(name, item)
+            dirn = s_scope.get('dirn')
+
+            url = f'tcp://{addr[0]}:{addr[1]}/{name}'
+            beepbeep_alias = url + '/beepbeep'
+            aliases = {name: url,
+                       f'{name}/borp': beepbeep_alias}
+
+            with self.setSynDir(dirn):
+                fp = s_common.getSynPath('aliases.yaml')
+                s_common.yamlsave(aliases, fp)
+
+                # None existent aliases return None
+                self.none(s_telepath.alias('newp'))
+                self.none(s_telepath.alias('newp/path'))
+
+                # An exact match wins
+                self.eq(s_telepath.alias(name), url)
+                self.eq(s_telepath.alias(f'{name}/borp'), beepbeep_alias)
+                # Dynamic aliases are valid.
+                self.eq(s_telepath.alias(f'{name}/beepbeep'), beepbeep_alias)
+
+                with s_telepath.openurl(name) as prox:
+                    self.eq(10, prox.getFooBar(20, 10))
+
+                # Check to see that we can connect to an aliased name
+                # with a dynamic share attached to it.
+                with s_telepath.openurl(f'{name}/bar') as prox:
+                    self.eq('bar: beep', prox.beep())

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -603,10 +603,9 @@ class SynTest(unittest.TestCase):
             with s_cortex.Cortex(dirn) as core:
                 yield core
 
-    @contextlib.contextmanager
-    def getTestDmon(self, mirror='dmontest'):
+    @contextlib.asynccontextmanager
+    async def getTestDmon(self, mirror='dmontest'):
 
-        breakpoint()
         with self.getTestDir(mirror=mirror) as dirn:
             coredir = pathlib.Path(dirn, 'cells', 'core')
             if coredir.is_dir():
@@ -616,7 +615,7 @@ class SynTest(unittest.TestCase):
 
             certdir = s_certdir.defdir
 
-            with s_daemon.Daemon(dirn) as dmon:
+            async with s_daemon.Daemon(dirn) as dmon:
 
                 # act like synapse.tools.dmon...
                 s_certdir.defdir = s_common.genpath(dirn, 'certs')
@@ -1175,6 +1174,7 @@ class SynTest(unittest.TestCase):
 
             yield dmon
 
+# FIXME:  we could just incorporate this into SynTest
 class ASynTest(SynTest):
     '''
     Identical to SynTest, except that all async test methods are s_glob.synchelp decorated
@@ -1183,7 +1183,7 @@ class ASynTest(SynTest):
         '''
         '''
         attr = SynTest.__getattribute__(self, s)
-        # If attribute is an instance method and starts with 'test_'
+        # If s is an instance method and starts with 'test_', synchelp wrap it
         if s.startswith('test_') and inspect.ismethod(attr) and inspect.iscoroutinefunction(attr):
             return s_glob.synchelp(attr)
         else:

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -549,20 +549,6 @@ class SynTest(unittest.TestCase):
             if s_thishost.get(k) == v:
                 raise unittest.SkipTest('skip thishost: %s==%r' % (k, v))
 
-class ASynTest(SynTest):
-    '''
-    Identical to SynTest, except that all async test methods are s_glob.synchelp decorated
-    '''
-    def __getattribute__(self, s):
-        '''
-        '''
-        attr = SynTest.__getattribute__(self, s)
-        # If attribute is an instance method and starts with 'test_'
-        if s.startswith('test_') and inspect.ismethod(attr) and inspect.iscoroutinefunction(attr):
-            return s_glob.synchelp(attr)
-        else:
-            return attr
-
     # Note: required Python 3.7
     @contextlib.asynccontextmanager
     async def agetTestCore(self, mirror='testcore', conf=None, extra_layers=None):
@@ -1188,6 +1174,21 @@ class ASynTest(SynTest):
                     core.addUserRole('root', 'deleter')
 
             yield dmon
+
+class ASynTest(SynTest):
+    '''
+    Identical to SynTest, except that all async test methods are s_glob.synchelp decorated
+    '''
+    def __getattribute__(self, s):
+        '''
+        '''
+        attr = SynTest.__getattribute__(self, s)
+        # If attribute is an instance method and starts with 'test_'
+        if s.startswith('test_') and inspect.ismethod(attr) and inspect.iscoroutinefunction(attr):
+            return s_glob.synchelp(attr)
+        else:
+            return attr
+
 
 class SyncToAsyncCMgr():
     ''' Wraps a regular context manager in an async one '''

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -605,6 +605,7 @@ class SynTest(unittest.TestCase):
     @contextlib.contextmanager
     def getTestDmon(self, mirror='dmontest'):
 
+        breakpoint()
         with self.getTestDir(mirror=mirror) as dirn:
             coredir = pathlib.Path(dirn, 'cells', 'core')
             if coredir.is_dir():

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -830,6 +830,24 @@ class SynTest(unittest.TestCase):
 
         self.raises(exc, testfunc)
 
+    @contextlib.contextmanager
+    def setSynDir(self, dirn):
+        '''
+        Sets s_common.syndir to a specific directory and then unsets it afterwards.
+
+        Args:
+            dirn (str): Directory to set syndir to.
+
+        Notes:
+            This is to be used as a context manager.
+        '''
+        olddir = s_common.syndir
+        try:
+            s_common.syndir = dirn
+            yield None
+        finally:
+            s_common.syndir = olddir
+
     def eq(self, x, y, msg=None):
         '''
         Assert X is equal to Y

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -19,6 +19,7 @@ import os
 import sys
 import types
 import shutil
+import inspect
 import logging
 import pathlib
 import tempfile
@@ -547,6 +548,20 @@ class SynTest(unittest.TestCase):
         for k, v in props.items():
             if s_thishost.get(k) == v:
                 raise unittest.SkipTest('skip thishost: %s==%r' % (k, v))
+
+class ASynTest(SynTest):
+    '''
+    Identical to SynTest, except that all async test methods are s_glob.synchelp decorated
+    '''
+    def __getattribute__(self, s):
+        '''
+        '''
+        attr = SynTest.__getattribute__(self, s)
+        # If attribute is an instance method and starts with 'test_'
+        if s.startswith('test_') and inspect.ismethod(attr) and inspect.iscoroutinefunction(attr):
+            return s_glob.synchelp(attr)
+        else:
+            return attr
 
     # Note: required Python 3.7
     @contextlib.asynccontextmanager

--- a/synapse/tools/cmdr.py
+++ b/synapse/tools/cmdr.py
@@ -1,3 +1,4 @@
+import synapse.glob as s_glob
 import synapse.telepath as s_telepath
 
 import synapse.lib.cmdr as s_cmdr
@@ -8,16 +9,16 @@ def main(argv):  # pragma: no cover
         print('usage: python -m synapse.tools.cmdr <url>')
         return -1
 
-    item = s_telepath.openurl(argv[1])
+    with s_telepath.openurl(argv[1]) as item:
 
-    cmdr = s_cmdr.getItemCmdr(item)
-    # This causes a dropped connection to the cmdr'd item to
-    # cause cmdr to exit. We can't safely test this in CI since
-    # the fini handler sends a SIGINT to mainthread; which can
-    # be problematic for test runners.
-    cmdr.finikill = True
-
-    cmdr.runCmdLoop()
+        cmdr = s_cmdr.getItemCmdr(item)
+        # This causes a dropped connection to the cmdr'd item to
+        # cause cmdr to exit. We can't safely test this in CI since
+        # the fini handler sends a SIGINT to mainthread; which can
+        # be problematic for test runners.
+        cmdr.finikill = True
+        cmdr.runCmdLoop()
+        cmdr.finikill = False
 
 if __name__ == '__main__':  # pragma: no cover
     import sys


### PR DESCRIPTION
Fill in placeholders for missing funcs that cause syntax errors.

yield from foo -> for x in foo.

Remove layer.xact class, merged into Layer class.

Made layer methods async.

Add some missing Slab methods needed for SlabSeqn.

Add SlabSeqn and SlabOffs versions of lmdb class that take a slab.