### PR TITLE
00x migration fixes for inet:dns:soa and it:dev:regval

### DIFF
--- a/synapse/tests/test_tools_migrate_010.py
+++ b/synapse/tests/test_tools_migrate_010.py
@@ -3,9 +3,12 @@ import tempfile
 
 import synapse.cortex as s_cortex
 import synapse.common as s_common
+
 import synapse.lib.iq as s_iq
+import synapse.lib.tufo as s_tufo
 import synapse.lib.hashset as s_hashset
 import synapse.lib.msgpack as s_msgpack
+
 import synapse.tools.migrate_010 as s_migrate
 
 class Migrate010Test(s_iq.SynTest):
@@ -312,12 +315,23 @@ class Migrate010Test(s_iq.SynTest):
     def test_inet_dns_soa(self):
         self.maxDiff = None
         with self.getTestDir() as dirn, self.getRamCore() as core:
-            core.formTufoByProp('inet:dns:soa', s_common.guid(), ns='foo.bar.com', email='bob@foo.bar.com')
+            # This is kind of worst case - where someone made a inet:dns:soa
+            # node as a comp with optional field and set a third property
+            # after the fact.
+            node = core.formTufoByProp('inet:dns:soa',
+                                       {'fqdn': 'vertex.link', 'ns': 'foo.bar.com'},
+                                       email='bob@foo.bar.com')
+            _, pprop = s_tufo.ndef(node)
+            self.true(s_common.isguid(pprop))
+
             fh = tempfile.TemporaryFile(dir=dirn)
             s_migrate.Migrator(core, fh, tmpdir=dirn).migrate()
             nodes = self.get_formfile('inet:dns:soa', fh)
             self.eq(len(nodes), 1)
-            self.eq(nodes[0][0], ('inet:dns:soa', ('foo.bar.com', 'bob@foo.bar.com')))
+            self.eq(nodes[0][0], ('inet:dns:soa', pprop))
+            self.eq(nodes[0][1].get('props').get('fqdn'), 'vertex.link')
+            self.eq(nodes[0][1].get('props').get('email'), 'bob@foo.bar.com')
+            self.eq(nodes[0][1].get('props').get('ns'), 'foo.bar.com')
             fh.close()
 
     def test_ps_personx(self):

--- a/synapse/tools/migrate_010.py
+++ b/synapse/tools/migrate_010.py
@@ -42,10 +42,10 @@ _subs_to_save = [
     'ps:persona:name:given',
     'ps:persona:name:middle']
 
-_comps_to_keep = [
+_comps_to_keep = {
     'inet:dns:soa:fqdn',
     'it:dev:regval:key'
-]
+}
 
 def _enc_iden(iden):
     return unhexlify(iden)
@@ -173,10 +173,7 @@ class Migrator:
         self.subs = set(subs) - set(_subs_to_save)
         self.xrefs = set(xrefs)
         self.seprfields = set(seprfields)
-        for field in _comps_to_keep:
-            if field in compfields:
-                compfields.remove(field)
-        self.compfields = set(compfields)
+        self.compfields = set(compfields) - _comps_to_keep
 
     def migrate(self):
         '''
@@ -354,7 +351,7 @@ class Migrator:
                             self.write_node_to_file(node)
                         else:
                             logger.debug('Cannot convert %s', props)
-                    except Exception as e:
+                    except Exception:
                         logger.debug('Failed on processing node with props: %s', props, exc_info=True)
                         if self.rejects_fh is not None:
                             self.rejects_fh.write(s_msgpack.en(props))


### PR DESCRIPTION
`inet:dns;soa` and `it:dev:regval` nodes are the only comps with optional fields in 00x.  The migration of these needs to account for their conversion to guid types by preserving their existing guids AND migrate the comp keys which were required for their creation as comps with optional fields.