### PR TITLE
010 - time type filtering tweak

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -1137,6 +1137,7 @@ class Time(IntBase):
         self.setNormFunc(str, self._normPyStr)
 
         self.setCmprCtor('@=', self._ctorCmprAt)
+        self.setCmprCtor('=', self._ctorCmprEq)
 
         self.ismin = self.opts.get('ismin')
         self.ismax = self.opts.get('ismax')
@@ -1230,3 +1231,31 @@ class Time(IntBase):
             return self._indxTimeRange(tick, tock)
 
         return Type.indxByEq(self, valu)
+
+    def _ctorCmprEq(self, text):
+
+        if isinstance(text, (tuple, list)):
+
+            _tick = self._getLiftValu(text[0])
+
+            if text[1].startswith(('+-', '-+')):
+                delt = s_time.delta(text[1][2:])
+                # order matters
+                _tock = _tick + delt
+                _tick = _tick - delt
+            else:
+                _tock = self._getLiftValu(text[1], relto=_tick)
+
+            tick = min(_tick, _tock)
+            tock = max(_tick, _tock)
+
+            def cmpr(valu):
+                return valu >= tick and valu < tock
+            return cmpr
+
+        norm, info = self.norm(text)
+
+        def cmpr(valu):
+            return norm == valu
+
+        return cmpr

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -457,6 +457,8 @@ class TypesTest(s_test.SynTest):
             self.eq({node.ndef[1] for node in nodes}, {'a', 'b'})
             nodes = list(core.getNodesBy('teststr:tick', ('20131231', '+2 days')))
             self.eq({node.ndef[1] for node in nodes}, {'a'})
+            nodes = list(core.eval('teststr:tick=(20131231, "+2 days")'))
+            self.eq({node.ndef[1] for node in nodes}, {'a'})
             nodes = list(core.getNodesBy('teststr:tick', ('-1 day', '+1 day')))
             self.eq({node.ndef[1] for node in nodes}, {'d'})
             nodes = list(core.getNodesBy('teststr:tick', ('-1 days', 'now', )))
@@ -476,3 +478,11 @@ class TypesTest(s_test.SynTest):
             self.true(t.cmpr('20150202', '<=', '2016'))
             self.true(t.cmpr('20150202', '<', '2016'))
             self.false(t.cmpr('2015', '<', '2015'))
+
+            self.len(1, core.eval('teststr +:tick=2015'))
+
+            self.len(1, core.eval('teststr +:tick=(2015, "+1 day")'))
+            self.len(1, core.eval('teststr +:tick=(20150102, "-3 day")'))
+            self.len(0, core.eval('teststr +:tick=(20150201, "+1 day")'))
+
+            self.len(1, core.eval('teststr +:tick=(20150102, "+- 2day")'))


### PR DESCRIPTION
Allow a `=` filter for the time type to take a pair of values and filter them based on a range.  This is similar to behavior we allow for a lift operation.