### PR TITLE
a bunch of noms ( details in comment )

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -7,6 +7,7 @@ import synapse.common as s_common
 import synapse.reactor as s_reactor
 
 import synapse.lib.cli as s_cli
+import synapse.lib.node as s_node
 import synapse.lib.time as s_time
 import synapse.lib.queue as s_queue
 import synapse.lib.msgpack as s_msgpack
@@ -260,8 +261,16 @@ class StormCmd(s_cli.Cmd):
 
         if not opts.get('hide-tags'):
 
-            for name, valu in sorted(node[1]['tags'].items()):
-                self.printf(f'        #{name} = {valu}')
+            for tag in s_node.tags(node, leaf=True):
+
+                valu = node[1]['tags'].get(tag)
+                if valu == (None, None):
+                    self.printf(f'        #{tag}')
+                    continue
+
+                mint = s_time.repr(valu[0])
+                maxt = s_time.repr(valu[1])
+                self.printf(f'        #{tag} = ({mint}, {maxt})')
 
     def _onInit(self, mesg):
         pass

--- a/synapse/lib/time.py
+++ b/synapse/lib/time.py
@@ -59,6 +59,9 @@ def repr(tick, pack=False):
     Returns:
         (str):  A date time string
     '''
+    if tick == 0x7fffffffffffffff:
+        return '?'
+
     dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=tick)
     millis = dt.microsecond / 1000
     if pack:

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -731,8 +731,13 @@ class Ival(Type):
         return (valu, valu + 1), {}
 
     def _normPyStr(self, valu):
+
+        if valu == '?':
+            raise s_exc.BadTypeValu(name=self.name, valu=valu, mesg='interval requires begin time')
+
         norm, info = self.timetype.norm(valu)
         # TODO until we support 2013+2years syntax...
+
         return (norm, norm + 1), {}
 
     def _normPyIter(self, valu):

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -63,28 +63,28 @@ class CmdCoreTest(s_test.SynTest):
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             cmdr.runCmdLine('storm teststr=abcd')
             outp.expect(':tick = 1970/01/01 00:00:00.123')
-            outp.expect('#cool = (None, None)')
+            outp.expect('#cool')
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             cmdr.runCmdLine('storm --hide-tags teststr=abcd')
             outp.expect(':tick = 1970/01/01 00:00:00.123')
-            self.false(outp.expect('#cool = (None, None)', throw=False))
+            self.false(outp.expect('#cool', throw=False))
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             cmdr.runCmdLine('storm --hide-props teststr=abcd')
             self.false(outp.expect(':tick = 1970/01/01 00:00:00.123', throw=False))
-            outp.expect('#cool = (None, None)')
+            outp.expect('#cool')
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
             cmdr = s_cmdr.getItemCmdr(core, outp=outp)
             cmdr.runCmdLine('storm --hide-tags --hide-props teststr=abcd')
             self.false(outp.expect(':tick = 1970/01/01 00:00:00.123', throw=False))
-            self.false(outp.expect('#cool = (None, None)', throw=False))
+            self.false(outp.expect('#cool', throw=False))
             outp.expect('complete. 1 nodes')
 
             outp = self.getTestOutp()
@@ -120,6 +120,13 @@ class CmdCoreTest(s_test.SynTest):
             cmdr.runCmdLine(q)
             self.true(outp.expect("('testint', 1234)"))
             self.true(outp.expect("'path'"))
+
+            outp = self.getTestOutp()
+            cmdr = s_cmdr.getItemCmdr(core, outp=outp)
+            cmdr.runCmdLine('storm [ teststr=foo +#bar.baz=(2015,?) ]')
+            self.true(outp.expect('#bar.baz = (2015/01/01 00:00:00.000, ?)', throw=False))
+            self.false(outp.expect('#bar ', throw=False))
+            outp.expect('complete. 1 nodes')
 
     def test_log(self):
         with self.getTestDmon('dmoncore') as dmon:

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -291,6 +291,8 @@ class TypesTest(s_test.SynTest):
         self.eq((1451606400000, 1451606400001), ival.norm(1451606400000)[0])
         self.eq((1451606400000, 1483228800000), ival.norm(('2016', '2017'))[0])
 
+        self.raises(s_exc.BadTypeValu, ival.norm, '?')
+
     def test_loc(self):
         model = s_datamodel.Model()
         loctype = model.types.get('loc')


### PR DESCRIPTION
delnode on a syn:tag will error when nodes still have the tag ( unless --force )
cmdr prints tag times in humon form
cmdr prints tags with no times without (None, None)
interval norm now complains about the value "?" rather than exploding

"tag the tags" lift is now via
```
##foo.bar
```

totags() funcionality via
```
-> #  ( pivot to leaf tag nodes )
-> #*  (pivot to all tag nodes )
-> #foo.*  ( pivot to all matching tag nodes )
-> #foo.bar ( pivot to exact syn:tag=foo.bar if present )
```

fromtags() functionality via:
```
<syn:tag>  -> *   ( pivot to all nodes with the inbound tag )
<syn:tag> -> inet:ipv4  ( pivot to all ipv4 nodes with the given tag )
```