### PR TITLE
When initializing a cell, accept a readonly flag in kwargs which sets…

### DIFF
--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -193,7 +193,7 @@ class Cell(s_base.Base, s_telepath.Aware):
     confbase = ()
     confdefs = ()
 
-    async def __anit__(self, dirn):
+    async def __anit__(self, dirn, readonly=False):
 
         await s_base.Base.__anit__(self)
 
@@ -228,13 +228,13 @@ class Cell(s_base.Base, s_telepath.Aware):
             self.cellname = self.__class__.__name__
 
         await self._initCellAuth()
-        await self._initCellSlab()
+        await self._initCellSlab(readonly=readonly)
 
-    async def _initCellSlab(self):
+    async def _initCellSlab(self, readonly=False):
 
         s_common.gendir(self.dirn, 'slabs')
         path = os.path.join(self.dirn, 'slabs', 'cell.lmdb')
-        self.slab = await s_lmdbslab.Slab.anit(path, map_size=SLAB_MAP_SIZE)
+        self.slab = await s_lmdbslab.Slab.anit(path, map_size=SLAB_MAP_SIZE, readonly=readonly)
         self.onfini(self.slab.fini)
 
     async def _initCellAuth(self):

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -31,7 +31,7 @@ class Layer(s_cell.Cell):
     '''
     async def __anit__(self, dirn, readonly=False):
 
-        await s_cell.Cell.__anit__(self, dirn)
+        await s_cell.Cell.__anit__(self, dirn, readonly=readonly)
 
         self._lift_funcs = {
             'indx': self._liftByIndx,

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1,5 +1,6 @@
 import synapse.exc as s_exc
 import synapse.cells as s_cells
+import synapse.common as s_common
 import synapse.telepath as s_telepath
 
 import synapse.lib.cell as s_cell
@@ -57,3 +58,11 @@ class CellTest(s_t_utils.SynTest):
                 self.true(await proxy.allowed(('foo', 'bar')))
                 self.false(await proxy.isadmin())
                 self.false(await proxy.allowed(('hehe', 'haha')))
+
+    async def test_cell_readonly(self):
+        with self.getTestDir() as dirn:
+            async with await s_cells.init('echoauth', dirn) as cell:
+                self.false(cell.slab.readonly)
+
+            async with await s_cells.init('echoauth', dirn, readonly=True) as cell:
+                self.true(cell.slab.readonly)

--- a/synapse/tests/test_lib_snap.py
+++ b/synapse/tests/test_lib_snap.py
@@ -101,7 +101,9 @@ class SnapTest(s_t_utils.SynTest):
 
                 # Make sure only the top layer is writeable
                 self.true(core.layers[0].readonly)
+                self.true(core.layers[0].slab.readonly)
                 self.false(core.layers[1].readonly)
+                self.false(core.layers[1].slab.readonly)
 
                 nodes = await alist(snap.getNodesBy('inet:ipv4', 1))
                 self.len(1, nodes)


### PR DESCRIPTION
… the cell slab to be readonly.