### PR TITLE
Fix implict form pivot bug, also multiple-matching source props issue.

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -636,9 +636,11 @@ class FormPivot(PivotOper):
 
         @s_cache.memoize()
         def getsrc(form):
+            names = []
             for name, prop in form.props.items():
                 if prop.type.name == destform:
-                    return name
+                    names.append(name)
+            return names
 
         async for node, path in genr:
 
@@ -662,15 +664,15 @@ class FormPivot(PivotOper):
 
                 continue
 
-            name = getsrc(node.form)
-            if name is None:
-                continue
+            for name in getsrc(node.form):
 
-            # TODO: bypass normalization
-            valu = node.get(name)
+                # TODO: bypass normalization
+                valu = node.get(name)
+                if valu is None:
+                    continue
 
-            async for pivo in runt.snap.getNodesBy(prop.name, valu):
-                yield pivo, path.fork(pivo)
+                async for pivo in runt.snap.getNodesBy(prop.name, valu):
+                    yield pivo, path.fork(pivo)
 
 class PropPivotOut(PivotOper):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1011,6 +1011,19 @@ class CortexTest(s_t_utils.SynTest):
             self.len(1, nodes)
             self.eq(nodes[0][0], ('pivtarg', 'foo'))
 
+            # Regression test:  bug in implicit form pivot where absence of foreign key in source node was treated like
+            # a match-any
+            await alist(core.eval('[ testint=42 ]'))
+            q = 'pivcomp -> testint'
+            nodes = await getPackNodes(core, q)
+            self.len(0, nodes)
+
+            # Multiple props of source form have type of destination form:  pivot through all the matching props.
+            await alist(core.eval('[ pivcomp=(xxx,yyy) :width=42 ]'))
+            q = 'pivcomp -> testint'
+            nodes = await getPackNodes(core, q)
+            self.len(1, nodes)
+
             q = 'pivcomp=(foo,bar) :targ -> pivtarg'
             nodes = await getPackNodes(core, q)
             self.len(1, nodes)

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -181,6 +181,8 @@ testmodel = {
             ('targ', ('pivtarg', {}), {}),
             ('lulz', ('teststr', {}), {}),
             ('tick', ('time', {}), {}),
+            ('size', ('testint', {}), {}),
+            ('width', ('testint', {}), {}),
         )),
     ),
 }


### PR DESCRIPTION
Absence of value in source prop was treated like a match-any.