### PR TITLE
010 noderefs bug

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -756,11 +756,8 @@ class NoderefsCmd(Cmd):
             # Don't revisit the inbound node from genr
             visited.add(node.buid)
 
-            async for item in self.doRefs(node, path, visited):
-                yield item
-
-            async for x in self.doRefs(node, path, visited):
-                yield x
+            async for nnode, npath in self.doRefs(node, path, visited):
+                yield nnode, npath
 
     async def doRefs(self, srcnode, srcpath, visited):
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -840,6 +840,9 @@ class NoderefsCmd(Cmd):
         # type as me!
         name, valu = srcnode.ndef
         for prop in self.snap.model.propsbytype.get(name, ()):
+            # Do not do pivot-in when we know we don't want the form of the resulting node.
+            if prop.form.full in self.omit_forms:
+                continue
             async for pivo in self.snap.getNodesBy(prop.full, valu):
                 yield pivo, srcpath.fork(pivo)
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -323,3 +323,10 @@ class StormTest(s_t_utils.SynTest):
             q = 'teststr | noderefs -d 3 -u'
             nodes = await alist(core.eval(q))
             self.len(8, nodes)
+
+            # Coverage for the pivot-in optimization.
+            guid = s_common.guid()
+            await alist(core.eval(f'[inet:ipv4=1.2.3.4 :asn=10] [seen=({guid}, (inet:asn, 10))]'))
+            nodes = await alist(core.eval('inet:asn=10 | noderefs -of inet:ipv4 --join -d 3'))
+            forms = {node.form.full for node in nodes}
+            self.eq(forms, {'source', 'inet:asn', 'seen'})


### PR DESCRIPTION
- Only do noderefs work once.
- Optimize the pivot-in operation to skip forms which are explicitly omitted.