### PR TITLE
Fix pivot bug where an edge to a deleted node yields None

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -951,7 +951,7 @@ class Cortex(s_cell.Cell):
                         count += 1
 
             except asyncio.CancelledError:
-                logger.exception('Storm runtime cancelled.')
+                logger.warning('Storm runtime cancelled.')
                 cancelled = True
                 raise
 

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -423,6 +423,9 @@ class PivotOut(PivotOper):
             if isinstance(node.form.type, s_types.Edge):
                 n2def = node.get('n2')
                 pivo = await runt.snap.getNodeByNdef(n2def)
+                if pivo is None:
+                    logger.warning(f'Missing node corresponding to ndef {n2def} on edge')
+                    continue
                 yield pivo, path.fork(pivo)
                 continue
 

--- a/synapse/tests/test_model_base.py
+++ b/synapse/tests/test_model_base.py
@@ -129,6 +129,12 @@ class BaseTest(s_t_utils.SynTest):
             self.raises(s_exc.BadTypeValu, t.norm, (n1def, ('testint', 1)))
             self.raises(s_exc.BadTypeValu, t.norm, (('testint', 1), n2def))
 
+            # Make sure we don't return None nodes if one node of an edge is deleted
+            node = await core.getNodeByNdef(n2def)
+            await node.delete()
+            opts = {'vars': {'pers': pers}}
+            await self.agenlen(0, core.eval('ps:person=$pers -> wentto -> *', opts=opts))
+
     async def test_model_base_source(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
Also made cancelling query less noisy.