### PR TITLE
Fix fairness issue with a large lift

### DIFF
--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -562,7 +562,11 @@ class Snap(s_base.Base):
         Yields:
             (tuple): (row, node)
         '''
+        count = 0
         async for origlayer, row in rows:
+            count += 1
+            if not count % 5:
+                await asyncio.sleep(0)  # give other tasks some time
             props = {}
             buid = row[0]
             node = self.buidcache.cache.get(buid)


### PR DESCRIPTION
E.g. storm inet:ipv4 | limit 9000 | +:loc^=nl | limit 5

Tuned on a box with slow spinning disks so that worst case between
sleeps is ~100ms.