### PR TITLE
010 - restore manifest.in use for now

### DIFF
--- a/docker/images/cortex/Dockerfile
+++ b/docker/images/cortex/Dockerfile
@@ -12,6 +12,7 @@ FROM vertexproject/synapse-base-image2:py37
 
 COPY synapse /build/synapse/synapse
 COPY setup.py /build/synapse/setup.py
+COPY MANIFEST.in /build/synapse/MANIFEST.in
 
 COPY docker/images/cortex/bootstrap.sh /build/synapse/bootstrap.sh
 COPY docker/images/cortex/entrypoint.sh /vertex/synapse/entrypoint.sh

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,7 @@ setup(
     packages=find_packages(exclude=['scripts',
                                     ]),
 
-    package_data={
-        'synapse': [
-            'data/*.mpk',
-        ],
-    },
+    include_package_data=True,
 
     install_requires=[
         'pyOpenSSL>=16.2.0,<18.0.0',


### PR DESCRIPTION
Copy the MANIFEST.in file into the docker/images/cortex/Dockerfile for building. Remove the explicit package_data structure.