### PR TITLE
010 bug iden lifts

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -124,17 +124,6 @@ class Query(AstNode):
 
         self.canceled = True
 
-    async def getInput(self, snap):
-        for ndef in self.opts.get('ndefs', ()):
-            node = await snap.getNodeByNdef(ndef)
-            if node is not None:
-                yield node, node.initPath()
-        for iden in self.opts.get('idens', ()):
-            buid = s_common.uhex(iden)
-            node = await snap.getNodeByBuid(buid)
-            if node is not None:
-                yield node, node.initPath()
-
     async def run(self, runt, genr):
 
         for oper in self.kids:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -93,6 +93,8 @@ class Runtime:
         for iden in self.opts.get('idens', ()):
 
             buid = s_common.uhex(iden)
+            if len(buid) != 32:
+                raise s_exc.NoSuchIden(mesg='Iden must be 32 bytes', iden=iden)
 
             node = await self.snap.getNodeByBuid(buid)
             if node is not None:
@@ -667,6 +669,9 @@ class IdenCmd(Cmd):
                 buid = s_common.uhex(iden)
             except Exception as e:
                 await runt.warn(f'Failed to decode iden: [{iden}]')
+                continue
+            if len(buid) != 32:
+                await runt.warn(f'iden must be 32 bytes [{iden}]')
                 continue
 
             node = await runt.snap.getNodeByBuid(buid)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -698,6 +698,10 @@ class CortexTest(s_t_utils.SynTest):
             self.len(1, nodes)
             self.eq(nodes[0].pack()[0], ('teststr', 'foo bar'))
 
+            # Seed nodes in the query invalid idens
+            opts = {'idens': ('deadb33f',)}
+            await self.agenraises(s_exc.NoSuchIden, core.eval('', opts=opts))
+
             # Test and/or/not
             await alist(core.eval('[testcomp=(1, test) +#meep.morp +#bleep.blorp +#cond]'))
             await alist(core.eval('[testcomp=(2, test) +#meep.morp +#bleep.zlorp +#cond]'))

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -188,6 +188,11 @@ class StormTest(s_t_utils.SynTest):
                 await self.agenlen(0, core.eval(q))
                 self.true(stream.wait(1))
 
+            q = 'iden deadb33f'
+            with self.getLoggerStream('synapse.lib.snap', 'iden must be 32 bytes') as stream:
+                await self.agenlen(0, core.eval(q))
+                self.true(stream.wait(1))
+
     async def test_storm_input(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
Protect user inputs passed to getNodeByBuid to prevent prefix scans for idens which may generate incorrect nodes.