### PR TITLE
010 ival rel time

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -774,9 +774,9 @@ class Ival(Type):
         vals = []
         relvals = []
         for val in valu:
-            if not val:
+            if val is None:
                 continue
-            if isinstance(val, str) and val[0] in ('-', '+'):
+            if val and isinstance(val, str) and val[0] in ('-', '+'):
                 relvals.append(val)
                 continue
             vals.append(self.timetype.norm(val)[0])

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -731,21 +731,58 @@ class Ival(Type):
     def _normPyInt(self, valu):
         return (valu, valu + 1), {}
 
+    def _normRelStr(self, valu, relto=None):
+        valu = valu.strip().lower()
+        if valu == 'now':
+            return self._normPyInt(s_common.now())[0]
+
+        # an unspecififed time in the future...
+        if valu == '?':
+            return 0x7fffffffffffffff
+
+        if valu[0] in ('-', '+'):
+            splitter = valu[0]
+
+            delt = s_time.delta(valu)
+            if not relto:
+                relto = s_common.now()
+
+            return delt + relto
+
+        valu = s_time.parse(valu)
+        return self._normPyInt(valu)[0]
+
     def _normPyStr(self, valu):
+        valu = valu.strip().lower()
 
         if valu == '?':
             raise s_exc.BadTypeValu(name=self.name, valu=valu, mesg='interval requires begin time')
 
-        norm, info = self.timetype.norm(valu)
-        # TODO until we support 2013+2years syntax...
+        norm, _ = self.timetype.norm(valu)
 
         return (norm, norm + 1), {}
 
     def _normPyIter(self, valu):
 
-        vals = [self.timetype.norm(v)[0] for v in valu if v is not None]
-        if len(vals) == 1:
+        # split self contained from relative values
+        vals = []
+        relvals = []
+        for val in valu:
+            if val is None:
+                continue
+            if isinstance(val, str) and val[0] in ('-', '+'):
+                relvals.append(val)
+                continue
+            vals.append(self.timetype.norm(val)[0])
+        if len(vals) + len(relvals) == 1:
             vals.append(vals[0] + 1)
+        val = vals[0]
+        if len(vals) + len(relvals) != 2:
+            raise s_exc.BadTypeValu(name=self.name, valu=valu, mesg='interval requires at most 2 time arguments')
+
+        # make absolute vals assuming the current val
+        absvals = [self._normRelStr(r, relto=val) for r in relvals if r is not None]
+        vals += absvals
 
         norm = (min(vals), max(vals))
         return norm, {}
@@ -1217,6 +1254,25 @@ class Time(IntBase):
         # an unspecififed time in the future...
         if valu == '?':
             return 0x7fffffffffffffff, {}
+
+        # self contained relative time string
+
+        # we need to be pretty sure this is meant for us, otherwise it might
+        # just be a slightly messy time parse
+        unitcheck = [u for u in s_time.timeunits.keys() if u in valu]
+        if unitcheck and '-' in valu or '+' in valu:
+            splitter = '+'
+            if '-' in valu:
+                splitter = '-'
+
+            bgn, end = valu.split(splitter, 1)
+            delt = s_time.delta(splitter + end)
+            if bgn:
+                bgn = self._normPyStr(bgn)[0]
+            else:
+                bgn = s_common.now()
+
+            return delt + bgn, {}
 
         valu = s_time.parse(valu)
         return self._normPyInt(valu)

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -784,7 +784,7 @@ class Ival(Type):
         vals = []
         relvals = []
         for val in valu:
-            if val is None:
+            if not val:
                 continue
             if isinstance(val, str) and val[0] in ('-', '+'):
                 relvals.append(val)
@@ -792,9 +792,9 @@ class Ival(Type):
             vals.append(self.timetype.norm(val)[0])
         if len(vals) + len(relvals) == 1:
             vals.append(vals[0] + 1)
-        val = vals[0]
         if len(vals) + len(relvals) != 2:
-            raise s_exc.BadTypeValu(name=self.name, valu=valu, mesg='interval requires at most 2 time arguments')
+            raise s_exc.BadTypeValu(name=self.name, valu=valu, mesg='interval requires 1 and at most 2 time arguments')
+        val = vals[0]
 
         # make absolute vals assuming the current val
         absvals = [self._normRelStr(r, relto=val) for r in relvals if r is not None]

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -291,6 +291,11 @@ class TypesTest(s_t_utils.SynTest):
         model = s_datamodel.Model()
         ival = model.types.get('ival')
 
+        self.eq(b'', ival.indx(None))
+        self.eq(('2016/01/01 00:00:00.000', '2017/01/01 00:00:00.000'), ival.repr(ival.norm(('2016', '2017'))[0]))
+
+        self.gt(s_common.now(), ival._normRelStr('-1 min'))
+
         self.eq((1451606400000, 1451606400001), ival.norm('2016')[0])
         self.eq((1451606400000, 1451606400001), ival.norm(1451606400000)[0])
         self.eq((1451606400000, 1451606400001), ival.norm('2016')[0])
@@ -325,13 +330,18 @@ class TypesTest(s_t_utils.SynTest):
                 node = await snap.addNode('teststr', 'b', {'tick': '2015'})
                 node = await snap.addNode('teststr', 'c', {'tick': '2016'})
                 node = await snap.addNode('teststr', 'd', {'tick': 'now'})
+                node = await snap.addNode('teststr', 'e', {'tick': 'now-3days'})
 
             await self.agenraises(s_exc.BadStormSyntax, core.eval('teststr :tick=(20150102, "-4 day")'))
 
+            await self.agenlen(1, core.eval('teststr +:tick@=("-1 day")'))
             await self.agenlen(1, core.eval('teststr +:tick@=(2015)'))
             await self.agenlen(1, core.eval('teststr +:tick@=(2015, "+1 day")'))
             await self.agenlen(1, core.eval('teststr +:tick@=(20150102+1day, "-4 day")'))
             await self.agenlen(1, core.eval('teststr +:tick@=(20150102, "-4 day")'))
+            await self.agenlen(1, core.eval('teststr +:tick@=(now, "-1 day")'))
+            await self.agenlen(1, core.eval('teststr +:tick@=("now-1day", "?")'))
+            await self.agenlen(1, core.eval('teststr +:tick@=("now+2days", "-3 day")'))
 
     async def test_loc(self):
         model = s_datamodel.Model()
@@ -521,6 +531,11 @@ class TypesTest(s_t_utils.SynTest):
         self.eq('is.ｂob.evil', tagtype.norm('is.\uff42ob.evil')[0])
 
     async def test_time(self):
+
+        model = s_datamodel.Model()
+        ttime = model.types.get('time')
+
+        self.gt(s_common.now(), ttime.norm('-1hour')[0])
 
         async with self.getTestCore() as core:
 

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -296,6 +296,7 @@ class TypesTest(s_t_utils.SynTest):
 
         self.gt(s_common.now(), ival._normRelStr('-1 min'))
 
+        self.eq((0, 5356800000), ival.norm((0, '1970-03-04'))[0])
         self.eq((1451606400000, 1451606400001), ival.norm('2016')[0])
         self.eq((1451606400000, 1451606400001), ival.norm(1451606400000)[0])
         self.eq((1451606400000, 1451606400001), ival.norm('2016')[0])


### PR DESCRIPTION
This allows the use of relative time strings intervals as well as self-contained strings:
('2016', '+2 days')
'2016 + 2 days'