### PR TITLE
Fix cmdr help summary

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -188,6 +188,10 @@ class Log(s_cli.Cmd):
 
 class PsCmd(s_cli.Cmd):
 
+    '''
+    List running tasks in the cortex.
+    '''
+
     _cmd_name = 'ps'
     _cmd_syntax = ()
 

--- a/synapse/cmds/cron.py
+++ b/synapse/cmds/cron.py
@@ -139,8 +139,10 @@ Examples:
 
 class Cron(s_cli.Cmd):
     '''
-Manages cron jobs in a cortex.  Cron jobs are rules persistently stored in a
-cortex such that storm queries automatically run on a time schedule.
+Manages cron jobs in a cortex.
+
+Cron jobs are rules persistently stored in a cortex such that storm queries
+automatically run on a time schedule.
 
 Cron jobs may be be recurring or one-time.  Use the 'at' command to add
 one-time jobs.
@@ -546,8 +548,9 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
 
 class At(s_cli.Cmd):
     '''
-Adds a non-recurring cron job that will execute a Storm query at one or more
-specified times.
+Adds a non-recurring cron job.
+
+It will execute a Storm query at one or more specified times.
 
 List/details/deleting cron jobs created with 'at' use the same commands as
 other cron jobs:  cron list/stat/del respectively.

--- a/synapse/cmds/trigger.py
+++ b/synapse/cmds/trigger.py
@@ -77,9 +77,10 @@ Notes:
 
 class Trigger(s_cli.Cmd):
     '''
-Manipulate triggers in a cortex.  Triggers are rules persistently stored in
-a cortex such that storm queries automatically run when a particular event
-happens.
+Manipulate triggers in a cortex.
+
+Triggers are rules persistently stored in a cortex such that storm queries
+automatically run when a particular event happens.
 
 A subcommand is required.  Use `trigger -h` for more detailed help.
 '''

--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -485,7 +485,7 @@ class CmdHelp(Cmd):
 
 class CmdLocals(Cmd):
     '''
-    List the current locals for a given CLI object
+    List the current locals for a given CLI object.
     '''
     _cmd_name = 'locs'
 


### PR DESCRIPTION
Only comments are changed. Reformatted so that plain 'help' from cmdr doesn't have chopped sentences. Added a missing part too.