### PR TITLE
010 docs highlighting control

### DIFF
--- a/docs/synapse/contributing/doc_mastering.ipynb
+++ b/docs/synapse/contributing/doc_mastering.ipynb
@@ -233,6 +233,42 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    "- In the above example, there is some Python syntax highlighting occuring. This may\n",
+    "  not be desired.  In order to disable that, add the following to the first line of\n",
+    "  the RST body of a document:\n",
+    "  \n",
+    "  ``.. highlight:: none``\n",
+    "\n",
+    "  This will disable all code highlighting in a given document, until another\n",
+    "  ``highlight`` directive is encountered.  \n",
+    "  \n",
+    "- The following code and output will have their highlighting disabled, via the use \n",
+    "  of a pair of ``highlight`` directives before and after the code cell. The first\n",
+    "  directive disabled highlighting, and the subsequent directive re-enabled it for\n",
+    "  python3 highlighting.\n",
+    "  \n",
+    "  Read the Sphinx Literal_ documentation for additional information about highlighting\n",
+    "  controls.\n",
+    "\n",
+    ".. highlight:: none"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the help command again.\n",
+    "text = 'help'\n",
+    "await corecmdr.runCmdLine(text)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. highlight:: python3\n",
     "- When we are done with the CoreCmdr object, we should ``fini()`` is to\n",
     "  remove any resources it may have created.  This is done below."
    ]
@@ -289,7 +325,9 @@
     "Building documents on ReadTheDocs.org using cPython 3.7 is currently an\n",
     "unsupported operation. This is accomplished using a ``readthedocs.yml`` file,\n",
     "which uses ``environment_docs.yml`` to configure an 3.7 Anaconda environment.\n",
-    "This is the environment which"
+    "This is the environment which\n",
+    "\n",
+    ".. _Literal: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks\n"
    ]
   }
  ],

--- a/docs/synapse/contributing/doc_mastering.ipynb
+++ b/docs/synapse/contributing/doc_mastering.ipynb
@@ -325,7 +325,8 @@
     "Building documents on ReadTheDocs.org using cPython 3.7 is currently an\n",
     "unsupported operation. This is accomplished using a ``readthedocs.yml`` file,\n",
     "which uses ``environment_docs.yml`` to configure an 3.7 Anaconda environment.\n",
-    "This is the environment which\n",
+    "This is the environment which is used do actually execute sphinx and the\n",
+    "associated ipython notebooks to generate RST documents.\n",
     "\n",
     ".. _Literal: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks\n"
    ]


### PR DESCRIPTION
Add a note about the use of the highlight directive for disabling syntax highlighting.