### PR TITLE
010 bug pivot

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -856,7 +856,7 @@ class FormPivot(PivotOper):
                         yield pivo, path.fork(pivo)
                 except (s_exc.BadTypeValu, s_exc.BadLiftValu) as e:
                     if not warned:
-                        logger.warning('Caught error during pivot', exc_info=e)
+                        logger.warning(f'Caught error during pivot: {e.items()}')
                         warned = True
                     items = e.items()
                     mesg = items.pop('mesg', '')
@@ -1011,7 +1011,7 @@ class PropPivot(PivotOper):
                     yield pivo, path.fork(pivo)
             except (s_exc.BadTypeValu, s_exc.BadLiftValu) as e:
                 if not warned:
-                    logger.warning('Caught error during pivot', exc_info=e)
+                    logger.warning(f'Caught error during pivot: {e.items()}')
                     warned = True
                 items = e.items()
                 mesg = items.pop('mesg', '')

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -851,8 +851,15 @@ class FormPivot(PivotOper):
                 valu = node.ndef[1]
 
                 # TODO cache/bypass normalization in loop!
-                async for pivo in runt.snap.getNodesBy(prop.full, valu):
-                    yield pivo, path.fork(pivo)
+                try:
+                    async for pivo in runt.snap.getNodesBy(prop.full, valu):
+                        yield pivo, path.fork(pivo)
+                except (s_exc.BadTypeValu, s_exc.BadLiftValu) as e:
+                    logger.warning('Caught error during pivot', exc_info=e)
+                    items = e.items()
+                    mesg = items.pop('mesg', '')
+                    mesg = ': '.join((f'{e.__class__.__qualname__} [{repr(valu)}] during pivot', mesg))
+                    await runt.snap.warn(mesg, **items)
 
         # form -> form pivot is nonsensical. Lets help out...
 

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -820,7 +820,7 @@ class PivotInFrom(PivotOper):
 class FormPivot(PivotOper):
 
     async def run(self, runt, genr):
-
+        warned = False
         name = self.kids[0].value()
 
         prop = runt.snap.model.props.get(name)
@@ -855,11 +855,13 @@ class FormPivot(PivotOper):
                     async for pivo in runt.snap.getNodesBy(prop.full, valu):
                         yield pivo, path.fork(pivo)
                 except (s_exc.BadTypeValu, s_exc.BadLiftValu) as e:
-                    logger.warning('Caught error during pivot', exc_info=e)
+                    if not warned:
+                        logger.warning('Caught error during pivot', exc_info=e)
+                        warned = True
                     items = e.items()
                     mesg = items.pop('mesg', '')
                     mesg = ': '.join((f'{e.__class__.__qualname__} [{repr(valu)}] during pivot', mesg))
-                    await runt.snap.warn(mesg, **items)
+                    await runt.snap.fire('warn', mesg=mesg, **items)
 
         # form -> form pivot is nonsensical. Lets help out...
 
@@ -985,7 +987,7 @@ class PropPivotOut(PivotOper):
 class PropPivot(PivotOper):
 
     async def run(self, runt, genr):
-
+        warned = False
         name = self.kids[1].value()
 
         prop = runt.snap.model.props.get(name)
@@ -1008,11 +1010,13 @@ class PropPivot(PivotOper):
                 async for pivo in runt.snap.getNodesBy(prop.full, valu):
                     yield pivo, path.fork(pivo)
             except (s_exc.BadTypeValu, s_exc.BadLiftValu) as e:
-                logger.warning('Caught error during pivot', exc_info=e)
+                if not warned:
+                    logger.warning('Caught error during pivot', exc_info=e)
+                    warned = True
                 items = e.items()
                 mesg = items.pop('mesg', '')
                 mesg = ': '.join((f'{e.__class__.__qualname__} [{repr(valu)}] during pivot', mesg))
-                await runt.snap.warn(mesg, **items)
+                await runt.snap.fire('warn', mesg=mesg, **items)
 
 class Cond(AstNode):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1747,7 +1747,12 @@ class CortexTest(s_t_utils.SynTest):
 
             await self.agenlen(2, core.eval('syn:tag=foo.bar -> *'))
 
-            await self.agenraises(s_exc.BadTypeValu, core.eval('syn:tag=foo.bar -> teststr:tick'))
+            # Attempt a formpivot from a syn:tag node to a secondary property
+            # which is not valid
+            with self.getAsyncLoggerStream('synapse.lib.ast',
+                                           'Unknown time format') as stream:
+                self.len(0, await core.eval('syn:tag=foo.bar -> teststr:tick').list())
+                self.true(await stream.wait(4))
 
     async def test_storm_tagtags(self):
 


### PR DESCRIPTION
- Add pivot safety for FormPivots (see #854 )
- Made it so pivot warnings were only fired once per Ast node on the server side and removed full tracebacks.
- User warnings are now fed directly through the snap instead of being run through snap.warn() so they are not logged.