### PR TITLE
010 - bug - hive test

### DIFF
--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -178,7 +178,12 @@ class Daemon(s_base.Base):
 
         server = await s_link.listen(host, port, self._onLinkInit, ssl=sslctx)
         self.listenservers.append(server)
-        return server.sockets[0].getsockname()
+        ret = server.sockets[0].getsockname()
+
+        if self.addr is None:
+            self.addr = ret
+
+        return ret
 
     def share(self, name, item):
         '''

--- a/synapse/tests/test_lib_hive.py
+++ b/synapse/tests/test_lib_hive.py
@@ -36,8 +36,7 @@ class HiveTest(s_test.SynTest):
 
             async with self.getTestHiveFromDirn(dirn) as hive:
 
-                async with await s_daemon.Daemon.anit(dirn) as dmon:
-
+                async with await s_daemon.Daemon.anit(dirn, conf={'listen': None}) as dmon:
                     await dmon.listen('tcp://127.0.0.1:0/')
                     dmon.share('hive', hive)
 


### PR DESCRIPTION
- Make the hive daemon not listen by default
- On a Daemon, if listen() **is** called and self.addr is none, set addr appropriately.