### PR TITLE
010 bug time ival

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -1247,6 +1247,8 @@ class Time(IntBase):
     )
 
     def postTypeInit(self):
+        self.futsize = 0x7fffffffffffffff
+        self.maxsize = 253402300799999  # 9999/12/31 23:59:59.999
 
         self.setNormFunc(int, self._normPyInt)
         self.setNormFunc(str, self._normPyStr)
@@ -1286,12 +1288,15 @@ class Time(IntBase):
             else:
                 bgn = s_common.now()
 
-            return delt + bgn, {}
+            return self.norm(delt + bgn)
 
         valu = s_time.parse(valu)
         return self._normPyInt(valu)
 
     def _normPyInt(self, valu):
+        if valu > self.maxsize and valu != self.futsize:
+            mesg = f'Time exceeds max size [{self.maxsize}] allowed for a non-future marker.'
+            raise s_exc.BadTypeValu(mesg=mesg, valu=valu, name=self.name)
         return valu, {}
 
     def merge(self, oldv, newv):
@@ -1333,7 +1338,7 @@ class Time(IntBase):
                 if relto is None:
                     relto = s_common.now()
 
-                return delt + relto
+                return self.norm(delt + relto)[0]
 
         return self.norm(valu)[0]
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -756,7 +756,7 @@ class Ival(Type):
         if not relto:
             relto = s_common.now()
 
-        return delt + relto
+        return self.timetype.norm(delt + relto)[0]
 
     def _normPyStr(self, valu):
         valu = valu.strip().lower()

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -640,6 +640,7 @@ class TypesTest(s_t_utils.SynTest):
             # Explicitly test our max time vs. future marker
             maxtime = 253402300799999  # 9999/12/31 23:59:59.999
             self.eq(t.norm(maxtime)[0], maxtime)
+            self.eq(t.repr(maxtime), '9999/12/31 23:59:59.999')
             self.eq(t.norm('9999/12/31 23:59:59.999')[0], maxtime)
             self.raises(s_exc.BadTypeValu, t.norm, maxtime + 1)
 

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -488,27 +488,27 @@ class TypesTest(s_t_utils.SynTest):
                 node = await alist(core.eval('[refs=((testcomp, (9001, "A mean one")), (testcomp, (40000, greeneggs)))]'))
                 node = await alist(core.eval('[refs=((testint, 16), (testcomp, (9999, greenham)))]'))
 
-            # nodes = await alist(core.eval('teststr=a +:tick*range=(20000101, 20101201)'))
-            # self.eq(0, len(nodes))
-            # nodes = await alist(core.eval('teststr +:tick*range=(19701125, 20151212)'))
-            # self.eq({node.ndef[1] for node in nodes}, {'a', 'b'})
-            # nodes = await alist(core.eval('testcomp +:haha*range=(grinch, meanone)'))
-            # self.eq({node.ndef[1] for node in nodes}, {(2048, 'horton')})
-            # nodes = await alist(core.eval('teststr +:.seen*range=((20090601, 20090701), (20110905, 20110906,))'))
-            # self.eq({node.ndef[1] for node in nodes}, {'b'})
-            # nodes = await alist(core.eval('teststr +:bar*range=((teststr, c), (teststr, q))'))
-            # self.eq({node.ndef[1] for node in nodes}, {'m'})
-            # nodes = await alist(core.eval('testcomp +testcomp*range=((1024, grinch), (4096, zemeanone))'))
-            # self.eq({node.ndef[1] for node in nodes}, {(2048, 'horton'), (4096, 'whoville')})
-            # guid0 = 'B' * 32
-            # guid1 = 'D' * 32
-            # nodes = await alist(core.eval(f'testguid +testguid*range=({guid0}, {guid1})'))
-            # self.eq({node.ndef[1] for node in nodes}, {'c' * 32})
-            # nodes = await alist(core.eval('testint | noderefs | +testcomp*range=((1000, grinch), (4000, whoville))'))
-            # self.eq({node.ndef[1] for node in nodes}, {(2048, 'horton')})
-            # nodes = await alist(core.eval('refs +:n1*range=((testcomp, (1000, green)), (testcomp, (3000, ham)))'))
-            # self.eq({node.ndef[1] for node in nodes},
-            #         {(('testcomp', (2048, 'horton')), ('testcomp', (4096, 'whoville')))})
+            nodes = await alist(core.eval('teststr=a +:tick*range=(20000101, 20101201)'))
+            self.eq(0, len(nodes))
+            nodes = await alist(core.eval('teststr +:tick*range=(19701125, 20151212)'))
+            self.eq({node.ndef[1] for node in nodes}, {'a', 'b'})
+            nodes = await alist(core.eval('testcomp +:haha*range=(grinch, meanone)'))
+            self.eq({node.ndef[1] for node in nodes}, {(2048, 'horton')})
+            nodes = await alist(core.eval('teststr +:.seen*range=((20090601, 20090701), (20110905, 20110906,))'))
+            self.eq({node.ndef[1] for node in nodes}, {'b'})
+            nodes = await alist(core.eval('teststr +:bar*range=((teststr, c), (teststr, q))'))
+            self.eq({node.ndef[1] for node in nodes}, {'m'})
+            nodes = await alist(core.eval('testcomp +testcomp*range=((1024, grinch), (4096, zemeanone))'))
+            self.eq({node.ndef[1] for node in nodes}, {(2048, 'horton'), (4096, 'whoville')})
+            guid0 = 'B' * 32
+            guid1 = 'D' * 32
+            nodes = await alist(core.eval(f'testguid +testguid*range=({guid0}, {guid1})'))
+            self.eq({node.ndef[1] for node in nodes}, {'c' * 32})
+            nodes = await alist(core.eval('testint | noderefs | +testcomp*range=((1000, grinch), (4000, whoville))'))
+            self.eq({node.ndef[1] for node in nodes}, {(2048, 'horton')})
+            nodes = await alist(core.eval('refs +:n1*range=((testcomp, (1000, green)), (testcomp, (3000, ham)))'))
+            self.eq({node.ndef[1] for node in nodes},
+                    {(('testcomp', (2048, 'horton')), ('testcomp', (4096, 'whoville')))})
 
             # The following tests show range working against a string
             nodes = await alist(core.eval('teststr*range=(b, m)'))

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -327,6 +327,7 @@ class TypesTest(s_t_utils.SynTest):
         self.raises(s_exc.BadTypeValu, ival.norm, '?')
         self.raises(s_exc.BadTypeValu, ival.norm, ('', ''))
         self.raises(s_exc.BadTypeValu, ival.norm, ('2016-3days', '+77days', '-40days'))
+        self.raises(s_exc.BadTypeValu, ival.norm, ('?', '-1 day'))
 
         async with self.getTestCore() as core:
 


### PR DESCRIPTION
Add some seatbelts around time normalization to prevent normalized times to exceed what `datetime` can repr for us.