### PR TITLE
010 bug tagadd

### DIFF
--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -432,7 +432,6 @@ class Node:
 
         await self._setTagProp(name, norm, indx, info)
 
-        await self.snap.splice('tag:add', ndef=self.ndef, tag=name, valu=norm)
         await self.snap.core.runTagAdd(self, name, norm)
         await self.snap.core.triggers.run(self, 'tag:add', info={'form': self.form.name, 'tag': name})
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -830,6 +830,10 @@ class CortexTest(s_t_utils.SynTest):
                 splice[1].pop('user', None)
                 splice[1].pop('time', None)
                 splices.append(splice)
+
+            # Ensure the splices are unique
+            self.len(len(splices), {s_msgpack.en(s) for s in splices})
+
             # Check to ensure a few expected splices exist
             mesg = ('node:add', {'ndef': ('teststr', 'hello')})
             self.isin(mesg, splices)


### PR DESCRIPTION
The merge of https://github.com/vertexproject/synapse/pull/965 had a merge commit (0a0ee31101d5ce4f751b8fefd9fcda59ba9abd02) which conflicted with the changes from https://github.com/vertexproject/synapse/pull/961.  

This PR adds a uniqueness constraint to the splice generation test and removes the erroneous splice message.