### PR TITLE
Fix lmdb failure on large splice retrieval

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -396,7 +396,11 @@ class CoreApi(s_cell.CellApi):
         '''
         Return the list of splices at the given offset.
         '''
+        count = 0
         async for mesg in self.cell.layer.splices(offs, size):
+            count += 1
+            if not count % 1000:
+                await asyncio.sleep(0)
             yield mesg
 
 class Cortex(s_cell.Cell):

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -61,7 +61,6 @@ class Slab(s_base.Base):
         self.lenv = lmdb.open(path, **opts)
 
         self.scans = set()
-        self.dbdupsortmap = {id(None): False}  # Keep which open dbs are dupsort
 
         self.holders = 0
 

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 logger = logging.getLogger(__name__)
 
-import lmdb  # type: ignore
+import lmdb
 
 import synapse.exc as s_exc
 import synapse.glob as s_glob
@@ -54,6 +54,7 @@ class Slab(s_base.Base):
         self.lenv = lmdb.open(path, **opts)
 
         self.scans = set()
+        self.dbdupsortmap = {id(None): False}
 
         self.holders = 0
 
@@ -127,7 +128,6 @@ class Slab(s_base.Base):
             self._growMapSize(size=size)
 
     def _growMapSize(self, size=None):
-
         mapsize = self.mapsize
 
         if size is not None:
@@ -154,8 +154,13 @@ class Slab(s_base.Base):
         return self.mapsize
 
     def initdb(self, name, dupsort=False):
+
         with self._noCoXact():
-            return self.lenv.open_db(name.encode('utf8'), dupsort=dupsort)
+            db = self.lenv.open_db(name.encode('utf8'), dupsort=dupsort)
+
+        self.dbdupsortmap[id(db)] = dupsort
+
+        return db
 
     @contextlib.contextmanager
     def _noCoXact(self):
@@ -179,7 +184,7 @@ class Slab(s_base.Base):
 
     def scanByDups(self, lkey, db=None):
 
-        with Scan(self, db) as scan:
+        with Scan(self, db, self.dbdupsortmap[id(db)]) as scan:
 
             if not scan.set_key(lkey):
                 return
@@ -188,7 +193,7 @@ class Slab(s_base.Base):
 
     def scanByPref(self, byts, db=None):
 
-        with Scan(self, db) as scan:
+        with Scan(self, db, self.dbdupsortmap[id(db)]) as scan:
 
             if not scan.set_range(byts):
                 return
@@ -203,7 +208,7 @@ class Slab(s_base.Base):
 
     def scanByRange(self, lmin, lmax=None, db=None):
 
-        with Scan(self, db) as scan:
+        with Scan(self, db, self.dbdupsortmap[id(db)]) as scan:
 
             if not scan.set_range(lmin):
                 return
@@ -219,7 +224,7 @@ class Slab(s_base.Base):
 
     def scanByFull(self, db=None):
 
-        with Scan(self, db) as scan:
+        with Scan(self, db, self.dbdupsortmap[id(db)]) as scan:
 
             if not scan.first():
                 return
@@ -233,7 +238,7 @@ class Slab(s_base.Base):
     def _initCoXact(self):
         try:
             self.xact = self.lenv.begin(write=not self.readonly)
-        except lmdb.MapResizedError as e:
+        except lmdb.MapResizedError:
             # This is what happens when some *other* process increased the mapsize.  setting mapsize to 0 should
             # set my mapsize to whatever the other process raised it to
             self.lenv.set_mapsize(0)
@@ -290,7 +295,7 @@ class Slab(s_base.Base):
 
             return xact_func(self.xact, lkey, *args, db=db, **kwargs)
 
-        except lmdb.MapFullError as e:
+        except lmdb.MapFullError:
             return self._handle_mapfull()
 
     def putmulti(self, kvpairs, dupdata=False, append=False, db=None):
@@ -308,7 +313,7 @@ class Slab(s_base.Base):
 
             return retn
 
-        except lmdb.MapFullError as e:
+        except lmdb.MapFullError:
             return self._handle_mapfull()
 
     def pop(self, lkey, db=None):
@@ -358,10 +363,15 @@ class Scan:
     '''
     A state-object used by Slab.  Not to be instantiated directly.
     '''
-    def __init__(self, slab, db):
+    def __init__(self, slab, db, dupsort):
+        '''
+        Args:
+            dupsort: must match how db was opened
+        '''
 
         self.slab = slab
         self.db = db
+        self.dupsort = dupsort
 
         self.atitem = None
         self.bumped = False
@@ -379,19 +389,27 @@ class Scan:
         self.slab._relXactForReading()
 
     def last_key(self):
-        ''' Return the last key in the database.  Returns none if database is empty. '''
+        '''
+        Return the last key in the database.  Returns none if database is empty.
+        '''
         if not self.curs.last():
             return None
+
         return self.curs.key()
 
     def first(self):
 
-        if self.curs.first():
-            self.genr = self.curs.iternext()
-            self.atitem = next(self.genr)
-            return True
+        if not self.curs.first():
+            return False
 
-        return False
+        if self.dupsort:
+            self.iterfunc = functools.partial(lmdb.Cursor.iternext_dup, keys=True)
+        else:
+            self.iterfunc = lmdb.Cursor.iternext
+
+        self.genr = self.curs.iternext()
+        self.atitem = next(self.genr)
+        return True
 
     def set_key(self, lkey):
 
@@ -399,7 +417,11 @@ class Scan:
             return False
 
         # set_key for a scan is only logical if it's a dup scan
-        self.iterfunc = functools.partial(lmdb.Cursor.iternext_dup, keys=True)
+        if self.dupsort:
+            self.iterfunc = functools.partial(lmdb.Cursor.iternext_dup, keys=True)
+        else:
+            self.iterfunc = lmdb.Cursor.iternext
+
         self.genr = self.iterfunc(self.curs)
         self.atitem = next(self.genr)
         return True
@@ -431,7 +453,10 @@ class Scan:
                     self.bumped = False
 
                     self.curs = self.slab.xact.cursor(db=self.db)
-                    self.curs.set_range_dup(*self.atitem)
+                    if self.dupsort:
+                        self.curs.set_range_dup(*self.atitem)
+                    else:
+                        self.curs.set_range(self.atitem[0])
 
                     self.genr = self.iterfunc(self.curs)
 

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -54,7 +54,7 @@ class Slab(s_base.Base):
         self.lenv = lmdb.open(path, **opts)
 
         self.scans = set()
-        self.dbdupsortmap = {id(None): False}
+        self.dbdupsortmap = {id(None): False}  # Keep which open dbs are dupsort
 
         self.holders = 0
 

--- a/synapse/lib/slabseqn.py
+++ b/synapse/lib/slabseqn.py
@@ -61,7 +61,7 @@ class SlabSeqn:
             int: The next insert offset.
         '''
         indx = 0
-        with s_lmdbslab.Scan(self.lenv, self.db) as curs:
+        with s_lmdbslab.Scan(self.lenv, self.db, dupsort=False) as curs:
             last_key = curs.last_key()
             if last_key is not None:
                 indx = s_common.int64un(last_key) + 1

--- a/synapse/lib/slabseqn.py
+++ b/synapse/lib/slabseqn.py
@@ -61,7 +61,7 @@ class SlabSeqn:
             int: The next insert offset.
         '''
         indx = 0
-        with s_lmdbslab.Scan(self.lenv, self.db, False) as curs:
+        with s_lmdbslab.Scan(self.lenv, self.db) as curs:
             last_key = curs.last_key()
             if last_key is not None:
                 indx = s_common.int64un(last_key) + 1

--- a/synapse/lib/slabseqn.py
+++ b/synapse/lib/slabseqn.py
@@ -61,7 +61,7 @@ class SlabSeqn:
             int: The next insert offset.
         '''
         indx = 0
-        with s_lmdbslab.Scan(self.lenv, self.db, dupsort=False) as curs:
+        with s_lmdbslab.Scan(self.lenv, self.db, False) as curs:
             last_key = curs.last_key()
             if last_key is not None:
                 indx = s_common.int64un(last_key) + 1

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -118,7 +118,7 @@ class LmdbSlabTest(s_t_utils.SynTest):
                 iter = slab.scanByDups(multikey, db=foo)
                 next(iter)
 
-                iter2 = slab.scanByRange(b'', db=foo2)
+                iter2 = slab.scanByFull(db=foo2)
                 next(iter2)
 
                 multikey = b'\xff\xff\xff\xff' + s_common.guid().encode('utf8')


### PR DESCRIPTION
Issue was that lmdb call used to reset position after a bump was only appropriate for dupsort=True DBs. Also found a similar issue for Scans with initial position set via first()