### PR TITLE
010-bug-univdel

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -1725,9 +1725,10 @@ class EditUnivDel(Edit):
         if univ is None:
             raise s_exc.NoSuchProp(name=name)
 
-        runt.allowed('prop:del', name)
-
         async for node, path in genr:
+
+            runt.allowed('prop:del', name)
+
             await node.pop(name)
             yield node, path
 


### PR DESCRIPTION
Move the permission check for a universal property deletion inside ther genr consumption so a sudo is always activated prior to permission checking.