### PR TITLE
coverage for cmpr function change

### DIFF
--- a/synapse/tests/test_model_geospace.py
+++ b/synapse/tests/test_model_geospace.py
@@ -4,6 +4,36 @@ import synapse.common as s_common
 import synapse.tests.utils as s_t_utils
 from synapse.tests.utils import alist
 
+import synapse.lib.module as s_module
+
+geotestmodel = {
+
+    'ctors': (
+        ('testsub', 'synapse.tests.utils.TestSubType', {}, {}),
+        ('testtype', 'synapse.tests.utils.TestType', {}, {}),
+        ('testthreetype', 'synapse.tests.utils.ThreeType', {}, {}),
+    ),
+
+    'types': (
+        ('test:latlong', ('geo:latlong', {}), {}),
+    ),
+
+    'forms': (
+
+        ('test:latlong', {}, (
+            ('lat', ('geo:latitude', {}), {}),
+            ('long', ('geo:longitude', {}), {}),
+        )),
+    ),
+}
+
+class GeoTstModule(s_module.CoreModule):
+    def getModelDefs(self):
+        return (
+            ('geo:test', geotestmodel),
+        )
+
+
 class GeoTest(s_t_utils.SynTest):
 
     async def test_types_forms(self):
@@ -231,6 +261,7 @@ class GeoTest(s_t_utils.SynTest):
             self.len(1, nodes)
 
         async with self.getTestCore() as core:
+            await core.loadCoreModule('synapse.tests.test_model_geospace.GeoTstModule')
             # Lift behavior for a node whose has a latlong as their primary property
             nodes = await core.eval('[test:latlong=(10, 10) test:latlong=(10.1, 10.1) test:latlong=(3, 3)]').list()
             self.len(3, nodes)

--- a/synapse/tests/test_model_geospace.py
+++ b/synapse/tests/test_model_geospace.py
@@ -229,3 +229,13 @@ class GeoTest(s_t_utils.SynTest):
                 f'tel:mob:telem:latlong*near=($latlong, $radius)'
             nodes = await alist(core.eval(q))
             self.len(1, nodes)
+
+        async with self.getTestCore() as core:
+            # Lift behavior for a node whose has a latlong as their primary property
+            nodes = await core.eval('[test:latlong=(10, 10) test:latlong=(10.1, 10.1) test:latlong=(3, 3)]').list()
+            self.len(3, nodes)
+
+            nodes = await core.eval('test:latlong*near=((10, 10), 5km)').list()
+            self.len(1, nodes)
+            nodes = await core.eval('test:latlong*near=((10, 10), 30km)').list()
+            self.len(2, nodes)

--- a/synapse/tests/test_model_geospace.py
+++ b/synapse/tests/test_model_geospace.py
@@ -8,11 +8,7 @@ import synapse.lib.module as s_module
 
 geotestmodel = {
 
-    'ctors': (
-        ('testsub', 'synapse.tests.utils.TestSubType', {}, {}),
-        ('testtype', 'synapse.tests.utils.TestType', {}, {}),
-        ('testthreetype', 'synapse.tests.utils.ThreeType', {}, {}),
-    ),
+    'ctors': (),
 
     'types': (
         ('test:latlong', ('geo:latlong', {}), {}),

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -151,7 +151,7 @@ testmodel = {
 
         ('test:ndef', ('ndef', {}), {}),
         ('test:runt', ('str', {'lower': True, 'strip': True}), {'doc': 'A Test runt node'}),
-
+        ('test:latlong', ('geo:latlong', {}), {}),
     ),
 
     'forms': (
@@ -247,6 +247,11 @@ testmodel = {
             ('tick', ('time', {}), {'ro': True}),
             ('lulz', ('str', {}), {}),
             ('newp', ('str', {}), {'doc': 'A stray property we never use in nodes.'}),
+        )),
+
+        ('test:latlong', {}, (
+            ('lat', ('geo:latitude', {}), {}),
+            ('long', ('geo:longitude', {}), {}),
         )),
     ),
 }

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -151,7 +151,7 @@ testmodel = {
 
         ('test:ndef', ('ndef', {}), {}),
         ('test:runt', ('str', {'lower': True, 'strip': True}), {'doc': 'A Test runt node'}),
-        ('test:latlong', ('geo:latlong', {}), {}),
+
     ),
 
     'forms': (
@@ -247,11 +247,6 @@ testmodel = {
             ('tick', ('time', {}), {'ro': True}),
             ('lulz', ('str', {}), {}),
             ('newp', ('str', {}), {'doc': 'A stray property we never use in nodes.'}),
-        )),
-
-        ('test:latlong', {}, (
-            ('lat', ('geo:latitude', {}), {}),
-            ('long', ('geo:longitude', {}), {}),
         )),
     ),
 }


### PR DESCRIPTION
Add a *near test for a test:latlong node whose primary property is a geo:latlong type.  This exercises part of the cmpr function helpers.