### PR TITLE
Implement offTagAdd, offTagDel, async fixes

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -499,7 +499,10 @@ class BlobStor(s_cell.Cell):
                     cur_offset = last_offset + 1
                     await self.writer.updateCloneProgress(cur_offset)
 
-            except Exception:
+            except asyncio.CancelledError:  # pragma: no cover
+                break
+
+            except Exception:  # pragma: no cover
                 if not self.isfini:
                     logger.exception('BlobStor.cloneeLoop error')
 
@@ -729,6 +732,10 @@ class _ProxyKeeper(s_base.Base):
         for bsid in bsidsrot:
             try:
                 blobstor = await self.get(bsid)
+
+            except asyncio.CancelledError:  # pragma: no cover
+                break
+
             except Exception:
                 logger.warning('Trouble connecting to BSID %r', bsid)
                 continue
@@ -887,6 +894,10 @@ class Axon(s_cell.Cell):
             for path in paths:
                 try:
                     await self._start_watching_blobstor(path)
+
+                except asyncio.CancelledError:  # pragma: no cover
+                    break
+
                 except Exception:
                     logger.error('At axon startup, failed to connect to stored blobstor path %s', _path_sanitize(path))
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -618,6 +618,22 @@ class Cortex(s_cell.Cell):
         # TODO allow name wild cards
         self.ontagadds[name].append(func)
 
+    def offTagAdd(self, name, func):
+        '''
+        Unregister a callback for tag addition.
+        Args:
+            name (str): The name of the tag.
+            func (function): The callback func(node, tagname, tagval).
+
+        '''
+        cblist = self.ontagadds.get(name)
+        if cblist is None:
+            return
+        try:
+            cblist.remove(func)
+        except ValueError:
+            pass
+
     def onTagDel(self, name, func):
         '''
         Register a callback for tag deletion.

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -3,7 +3,7 @@ import logging
 import pathlib
 import contextlib
 import collections
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 
 import regex
 
@@ -610,6 +610,7 @@ class Cortex(s_cell.Cell):
     def onTagAdd(self, name, func):
         '''
         Register a callback for tag addition.
+
         Args:
             name (str): The name of the tag.
             func (function): The callback func(node, tagname, tagval).
@@ -621,6 +622,7 @@ class Cortex(s_cell.Cell):
     def offTagAdd(self, name, func):
         '''
         Unregister a callback for tag addition.
+
         Args:
             name (str): The name of the tag.
             func (function): The callback func(node, tagname, tagval).
@@ -637,6 +639,7 @@ class Cortex(s_cell.Cell):
     def onTagDel(self, name, func):
         '''
         Register a callback for tag deletion.
+
         Args:
             name (str): The name of the tag.
             func (function): The callback func(node, tagname, tagval).
@@ -644,6 +647,23 @@ class Cortex(s_cell.Cell):
         '''
         # TODO allow name wild cards
         self.ontagdels[name].append(func)
+
+    def offTagDel(self, name, func):
+        '''
+        Unregister a callback for tag deletion.
+
+        Args:
+            name (str): The name of the tag.
+            func (function): The callback func(node, tagname, tagval).
+
+        '''
+        cblist = self.ontagdels.get(name)
+        if cblist is None:
+            return
+        try:
+            cblist.remove(func)
+        except ValueError:
+            pass
 
     def addRuntLift(self, prop, func):
         '''

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -325,6 +325,8 @@ class Base:
         return threading.get_ident() == self.ident
 
     async def _kill_active_tasks(self):
+        # FIXME: distinguish between the CancelledError from task being cancelled and *running* task being cancelled
+
         if not self._active_tasks:
             return
 

--- a/synapse/lib/link.py
+++ b/synapse/lib/link.py
@@ -155,7 +155,7 @@ class Link(s_base.Base):
 
             except asyncio.CancelledError as e:
                 await self.fini()
-                return None
+                raise
 
             except Exception as e:
                 logger.exception('rx error')

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import synapse.exc as s_exc
@@ -141,6 +142,8 @@ class ItModule(s_module.CoreModule):
             await node.set('semver', valu)
             for k, v in subs.items():
                 await node.set(f'semver:{k}', v)
+        except asyncio.CancelledError as e:  # pragma: no cover
+            raise
         except Exception as e:
             logger.exception('Failed to brute force version string [%s]', prop)
 

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -462,6 +462,9 @@ class Proxy(s_base.Base):
 
                     await func(mesg)
 
+                except asyncio.CancelledError:
+                    raise
+
                 except Exception as e:
                     logger.exception('Proxy.rxloop for %r' % (mesg,))
 

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -462,7 +462,7 @@ class Proxy(s_base.Base):
 
                     await func(mesg)
 
-                except asyncio.CancelledError:
+                except asyncio.CancelledError:  # pragma: no cover
                     raise
 
                 except Exception as e:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1547,7 +1547,7 @@ class CortexTest(s_t_utils.SynTest):
             await self.agenlen(1, core.eval('testint>20'))
             await self.agenlen(0, core.eval('testint<20'))
 
-    async def test_cortex_ontag(self):
+    async def test_cortex_onofftag(self):
 
         async with self.getTestCore() as core:
 
@@ -1584,6 +1584,18 @@ class CortexTest(s_t_utils.SynTest):
 
                 self.none(tags.get('foo.bar'))
                 self.none(tags.get('foo.bar.baz'))
+
+                core.offTagAdd('foo.bar', onadd)
+                core.offTagDel('foo.bar', ondel)
+                core.offTagAdd('foo.bar', lambda x: 0)
+                core.offTagDel('foo.bar', lambda x: 0)
+
+                await node.addTag('foo.bar', valu=(200, 300))
+                self.none(tags.get('foo.bar'))
+
+                tags['foo.bar'] = 'fake'
+                await node.delTag('foo.bar')
+                self.eq(tags.get('foo.bar'), 'fake')
 
     async def test_cortex_univ(self):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1836,7 +1836,7 @@ class CortexTest(s_t_utils.SynTest):
 
                 self.eq(1, core.counts['teststr'])
 
-    async def test_cortex_latency(self):
+    async def test_cortex_greedy(self):
         ''' Issue a large snap request, and make sure we can still do stuff in a reasonable amount of time'''
 
         async with self.getTestCore() as core:
@@ -1862,6 +1862,10 @@ class CortexTest(s_t_utils.SynTest):
 
                 # Note: before latency improvement, delta was > 4 seconds
                 self.lt(delta, 0.5)
+
+            # Make sure the task in flight can be killed in a reasonable time
+            delta = time.time() - before
+            self.lt(delta, 1.0)
 
     async def test_storm_switchcase(self):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1597,6 +1597,11 @@ class CortexTest(s_t_utils.SynTest):
                 await node.delTag('foo.bar')
                 self.eq(tags.get('foo.bar'), 'fake')
 
+                # Coverage for removing something from a
+                # tag we never added a handler for.
+                core.offTagAdd('test.newp', lambda x: 0)
+                core.offTagDel('test.newp', lambda x: 0)
+
     async def test_cortex_univ(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_remotelayer.py
+++ b/synapse/tests/test_lib_remotelayer.py
@@ -1,13 +1,10 @@
 import os
 import contextlib
 
-import synapse.glob as s_glob
 import synapse.cells as s_cells
 import synapse.common as s_common
 
 import synapse.tests.test_cortex as t_cortex
-import synapse.tests.test_lib_snap as t_snap
-import synapse.tests.test_lib_layer as t_layer
 
 class RemoteLayerTest(t_cortex.CortexTest):
 


### PR DESCRIPTION
Implement methods to remove `onTagAdd`, `onTagDel` callbacks.

Add some missing `asyncio.CancelledError` carve outs. Fix a long-standing `CancelledError` swallow.