### PR TITLE
Catch and log 'path too long' errors when starting a unix socket server that is too long.

### DIFF
--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -176,7 +176,14 @@ class Daemon(s_base.Base):
 
         if scheme == 'unix':
             path = info.get('path')
-            server = await s_link.unixlisten(path, self._onLinkInit)
+            try:
+                server = await s_link.unixlisten(path, self._onLinkInit)
+            except OSError as e:
+                if 'path too long' in str(e):
+                    logger.error(f'unix:// exceeds OS supported UNIX socket path length: {path}')
+                raise
+            except Exception as e:  # pragma: no cover
+                raise
 
         else:
 

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -178,11 +178,9 @@ class Daemon(s_base.Base):
             path = info.get('path')
             try:
                 server = await s_link.unixlisten(path, self._onLinkInit)
-            except OSError as e:
+            except Exception as e:
                 if 'path too long' in str(e):
                     logger.error(f'unix:// exceeds OS supported UNIX socket path length: {path}')
-                raise
-            except Exception as e:  # pragma: no cover
                 raise
 
         else:

--- a/synapse/tests/test_daemon.py
+++ b/synapse/tests/test_daemon.py
@@ -1,5 +1,6 @@
 import synapse.cells as s_cells
 import synapse.common as s_common
+import synapse.daemon as s_daemon
 import synapse.telepath as s_telepath
 
 import synapse.lib.cell as s_cell
@@ -46,3 +47,21 @@ class DaemonTest(s_t_utils.SynTest):
             async with await s_telepath.openurl('tcp:///echo00', host=host, port=port) as prox:
 
                 self.eq('woot', await prox.ping('woot'))
+
+    async def test_unixsock_longpath(self):
+
+        # Explicit failure for starting a daemon with a path too deep
+        # this also covers a cell failure case since the cell may start
+        # a daemon.
+        # This fails because of limitations onf the path length for a UNIX
+        # socket being no greater than what may be stored in a mbuf.
+        # The maximum length is OS dependent; with Linux using 108 characters
+        # and BSD's using 104.
+        with self.getTestDir() as dirn:
+            extrapath = 108 * 'A'
+            longdirn = s_common.genpath(dirn, extrapath)
+            listpath = f'unix://{s_common.genpath(longdirn, "sock")}'
+            with self.getAsyncLoggerStream('synapse.daemon',
+                                           'exceeds OS supported UNIX socket path length') as stream:
+                await self.asyncraises(OSError, s_daemon.Daemon.anit(longdirn, conf={'listen': listpath}))
+                self.true(await stream.wait(1))


### PR DESCRIPTION
not really a bug but codifying a behavior we're going to have to consider a known limitation.