### PR TITLE
Allow synapse to travel at 88mph

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -58,7 +58,7 @@ def now():
     Returns:
         int: Epoch time in milliseconds.
     '''
-    return int(time.time() * 1000)
+    return time.time_ns() // 1000000
 
 def guid(valu=None):
     '''


### PR DESCRIPTION
Before:
```
$ python -m timeit -n 10000 -s "import synapse.common as s_common" -u nsec "s_common.now()"
10000 loops, best of 5: 309 nsec per loop
```

After:
```
$ python -m timeit -n 10000 -s "import synapse.common as s_common" -u nsec "s_common.now()"
10000 loops, best of 5: 245 nsec per loop
```