### PR TITLE
Fix 3 lmdbslab bugs

### DIFF
--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -268,6 +268,7 @@ class Slab(s_base.Base):
         self.xact.abort()
 
         del self.xact
+        self.xact = None  # Note: it is possible for us to be fini'd in the following yield
 
         yield
 
@@ -306,14 +307,22 @@ class Slab(s_base.Base):
             return self._handle_mapfull()
 
     def putmulti(self, kvpairs, dupdata=False, append=False, db=_DefaultDB):
+        '''
+        Returns:
+            Tuple of number of items consumed, number of items added
+        '''
         if self.readonly:
             raise s_exc.IsReadOnly()
+
+        # Log playback isn't compatible with generators
+        if not isinstance(kvpairs, list):
+            kvpairs = list(kvpairs)
 
         try:
             self.dirty = True
 
             if not self.recovering:
-                self._logXactOper(self.putmulti, kvpairs, dupdata=dupdata, append=True, db=db)
+                self._logXactOper(self.putmulti, kvpairs, dupdata=dupdata, append=append, db=db)
 
             with self.xact.cursor(db=db.db) as curs:
                 retn = curs.putmulti(kvpairs, dupdata=dupdata, append=append)

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -176,6 +176,29 @@ class LmdbSlabTest(s_t_utils.SynTest):
                 # Now trigger a remap for me
                 newdb.get(multikey, db=foo)
 
+    async def test_lmdbslab_grow_putmulti(self):
+        '''
+        Test for a regression where putmulti's across a grow could corrupt the database
+
+        Test for a regression where a generator being passed into a putmulti would result in a partial write
+        '''
+        with self.getTestDir() as dirn:
+
+            path = os.path.join(dirn, 'test.lmdb')
+            data = [i.to_bytes(4, 'little') for i in range(1000)]
+
+            async with await s_lmdbslab.Slab.anit(path, map_size=10000) as slab:
+                # A putmulti across a grow
+                kvpairs = [(x, x) for x in data]
+                retn = slab.putmulti(kvpairs)
+                self.eq(retn, (1000, 1000))
+
+                # A putmulti across a grow with a generator passed in
+                kvpairs = ((b' ' + x, x) for x in data)
+                retn = slab.putmulti(kvpairs)
+                self.eq(retn, (1000, 1000))
+
+
     async def test_lmdbslab_iternext_repeat_regression(self):
         '''
         Test for a scan being bumped in an iternext where the cursor is in the middle of a list of values with the same

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -189,14 +189,20 @@ class LmdbSlabTest(s_t_utils.SynTest):
 
             async with await s_lmdbslab.Slab.anit(path, map_size=10000) as slab:
                 # A putmulti across a grow
+                before_mapsize = slab.mapsize
                 kvpairs = [(x, x) for x in data]
                 retn = slab.putmulti(kvpairs)
                 self.eq(retn, (1000, 1000))
+
+                after_mapsize1 = slab.mapsize
+                self.gt(after_mapsize1, before_mapsize)
 
                 # A putmulti across a grow with a generator passed in
                 kvpairs = ((b' ' + x, x) for x in data)
                 retn = slab.putmulti(kvpairs)
                 self.eq(retn, (1000, 1000))
+                after_mapsize2 = slab.mapsize
+                self.gt(after_mapsize2, after_mapsize1)
 
 
     async def test_lmdbslab_iternext_repeat_regression(self):


### PR DESCRIPTION
* A slab fini into the middle of the aborted context manager would fail

* A mapsize grow in the middle of a putmulti might corrupt the DB

* A generator passed into putmulti and a grow event would result in all the items before
the grow being dropped.