### PR TITLE
Re-enable synase.lib.scrape tests

### DIFF
--- a/synapse/lib/scrape.py
+++ b/synapse/lib/scrape.py
@@ -30,7 +30,7 @@ def scrape(text, ptype=None):
 
     Args:
         text (str): Text to scrape.
-        ptype (srt): Optional ptype to scrape. If present, only scrape rules which match the provided type.
+        ptype (str): Optional ptype to scrape. If present, only scrape rules which match the provided type.
 
     Returns:
         (str, str): Yield tuples of type, valu strings.

--- a/synapse/lib/scrape.py
+++ b/synapse/lib/scrape.py
@@ -24,11 +24,21 @@ scrape_types = [
 
 regexes = {name: regex.compile(rule, regex.IGNORECASE) for (name, rule, opts) in scrape_types}
 
-def scrape(text):
+def scrape(text, ptype=None):
     '''
     Scrape types from a blob of text and return node tuples.
+
+    Args:
+        text (str): Text to scrape.
+        ptype (srt): Optional ptype to scrape. If present, only scrape rules which match the provided type.
+
+    Returns:
+        (str, str): Yield tuples of type, valu strings.
     '''
-    for ptype, rule, info in scrape_types:
-        regx = regexes.get(ptype)
+
+    for ruletype, rule, info in scrape_types:
+        if ptype and ptype != ruletype:
+            continue
+        regx = regexes.get(ruletype)
         for valu in regx.findall(text):
-            yield (ptype, valu)
+            yield (ruletype, valu)

--- a/synapse/tests/test_lib_scrape.py
+++ b/synapse/tests/test_lib_scrape.py
@@ -20,26 +20,26 @@ and BOB@WOOT.COM is another
 
 '''
 
-import unittest
-raise unittest.SkipTest('SHOULD WORK. REGEX DEBUGGING?')
-
 class ScrapeTest(s_t_utils.SynTest):
 
     def test_scrape(self):
 
-        nodes = dict(s_scrape.scrape(data0))
+        nodes = set(s_scrape.scrape(data0))
 
-        print(repr(nodes))
+        self.len(10, nodes)
+        nodes.remove(('hash:md5', 'a' * 32))
+        nodes.remove(('inet:ipv4', '1.2.3.4'))
+        nodes.remove(('inet:ipv4', '5.6.7.8'))
+        nodes.remove(('inet:fqdn', 'WOOT.COM'))
+        nodes.remove(('inet:fqdn', 'hehe.taxi'))
+        nodes.remove(('inet:fqdn', 'vertex.link'))
+        nodes.remove(('inet:server', '5.6.7.8:16'))
+        nodes.remove(('inet:email', 'BOB@WOOT.COM'))
+        nodes.remove(('inet:email', 'visi@vertex.link'))
+        self.len(0, nodes)
 
-        nodes.pop(('inet:email', 'visi@vertex.link'))
-
-        nodes.pop(('inet:email', 'BOB@WOOT.COM'))
-        nodes.pop(('inet:fqdn', 'hehe.taxi'))
-
-        nodes.pop(('inet:ipv4', 0x01020304))
-        nodes.pop(('inet:ipv4', 0x05060708))
-        nodes.pop(('inet:tcp4', 0x050607080010))
-
-        nodes.pop(('hash:md5', 'a' * 32))
-
+        nodes = set(s_scrape.scrape(data0, 'inet:email'))
+        self.len(2, nodes)
+        nodes.remove(('inet:email', 'visi@vertex.link'))
+        nodes.remove(('inet:email', 'BOB@WOOT.COM'))
         self.len(0, nodes)

--- a/synapse/tests/test_lib_scrape.py
+++ b/synapse/tests/test_lib_scrape.py
@@ -40,6 +40,6 @@ class ScrapeTest(s_t_utils.SynTest):
 
         nodes = set(s_scrape.scrape(data0, 'inet:email'))
         self.len(2, nodes)
-        nodes.remove(('inet:email', 'visi@vertex.link'))
         nodes.remove(('inet:email', 'BOB@WOOT.COM'))
+        nodes.remove(('inet:email', 'visi@vertex.link'))
         self.len(0, nodes)

--- a/synapse/tests/test_lib_scrape.py
+++ b/synapse/tests/test_lib_scrape.py
@@ -26,7 +26,7 @@ class ScrapeTest(s_t_utils.SynTest):
 
         nodes = set(s_scrape.scrape(data0))
 
-        self.len(10, nodes)
+        self.len(9, nodes)
         nodes.remove(('hash:md5', 'a' * 32))
         nodes.remove(('inet:ipv4', '1.2.3.4'))
         nodes.remove(('inet:ipv4', '5.6.7.8'))


### PR DESCRIPTION
 Add a optional ptype argument to scrape to limit the amount of work done on a blob of text.