### PR TITLE
Cortex anit cleanup and module bootstraping

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1762,7 +1762,7 @@ class Cortex(s_cell.Cell):
 
             mods.append(modu)
 
-            try:  # pragma: no cover
+            try:
                 await s_coro.ornot(modu.preCoreModule)
             except asyncio.CancelledError:  # pragma: no cover
                 raise
@@ -1783,7 +1783,7 @@ class Cortex(s_cell.Cell):
 
             try:
                 await s_coro.ornot(modu.initCoreModule)
-            except asyncio.CancelledError:
+            except asyncio.CancelledError:  # pragma: no cover
                 raise
             except Exception as e:
                 logger.exception(f'module initCoreModule failed: {ctor}')

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -568,21 +568,71 @@ class Cortex(s_cell.Cell):
 
         self.views = {}
         self.layers = {}
-
-        self.layrctors = {
-            'lmdb': s_lmdblayer.LmdbLayer,
-            'remote': s_remotelayer.RemoteLayer,
-        }
-
+        self.counts = {}
         self.modules = {}
+        self.splicers = {}
+        self.layrctors = {}
         self.feedfuncs = {}
-
         self.stormcmds = {}
         self.stormrunts = {}
+
+        self._runtLiftFuncs = {}
+        self._runtPropSetFuncs = {}
+        self._runtPropDelFuncs = {}
+
+        self.ontagadds = collections.defaultdict(list)
+        self.ontagdels = collections.defaultdict(list)
 
         self.libroot = (None, {}, {})
         self.bldgbuids = {} # buid -> (Node, Event)  Nodes under construction
 
+        self._initSplicers()
+        self._initStormCmds()
+        self._initStormLibs()
+        self._initFeedFuncs()
+        self._initFormCounts()
+        self._initLayerCtors()
+        self._initCortexHttpApi()
+
+        self.model = s_datamodel.Model()
+
+        # Perform module loading
+        mods = list(s_modules.coremods)
+        mods.extend(self.conf.get('modules'))
+        await self._loadCoreMods(mods)
+
+        # Initialize our storage and views
+        await self._initCoreLayers()
+        await self._checkLayerModels()
+        await self._initCoreViews()
+
+        async def fini():
+            await asyncio.gather(*[view.fini() for view in self.views.values()])
+            await asyncio.gather(*[layr.fini() for layr in self.layers.values()])
+
+        self.onfini(fini)
+
+        # our "main" view has the same iden as we do
+        self.view = self.views.get(self.iden)
+
+        self.triggers = s_trigger.Triggers(self)
+        self.agenda = await s_agenda.Agenda.anit(self)
+        self.onfini(self.agenda)
+
+        if self.conf.get('cron:enable'):
+            await self.agenda.enable()
+
+        await self._initCoreMods()
+
+        # Initialize free-running tasks.
+        self._initCryoLoop()
+        self._initPushLoop()
+        self._initFeedLoops()
+
+    def _initStormCmds(self):
+        '''
+        Registration for built-in Storm commands.
+        '''
         self.addStormCmd(s_storm.MaxCmd)
         self.addStormCmd(s_storm.MinCmd)
         self.addStormCmd(s_storm.HelpCmd)
@@ -599,66 +649,46 @@ class Cortex(s_cell.Cell):
         self.addStormCmd(s_storm.ReIndexCmd)
         self.addStormCmd(s_storm.NoderefsCmd)
 
+    def _initStormLibs(self):
+        '''
+        Registration for built-in Storm Libraries
+        '''
         self.addStormLib(('time',), s_stormtypes.LibTime)
 
-        self.splicers = {
+    def _initSplicers(self):
+        '''
+        Registration for splice handlers.
+        '''
+        splicers = {
+            'tag:add': self._onFeedTagAdd,
+            'tag:del': self._onFeedTagDel,
             'node:add': self._onFeedNodeAdd,
             'node:del': self._onFeedNodeDel,
             'prop:set': self._onFeedPropSet,
             'prop:del': self._onFeedPropDel,
-            'tag:add': self._onFeedTagAdd,
-            'tag:del': self._onFeedTagDel,
         }
+        self.splicers.update(**splicers)
 
+    def _initLayerCtors(self):
+        '''Registration for built-in Layer ctors'''
+        ctors = {
+            'lmdb': s_lmdblayer.LmdbLayer,
+            'remote': s_remotelayer.RemoteLayer,
+        }
+        self.layrctors.update(**ctors)
+
+    def _initFeedFuncs(self):
+        '''
+        Registration for built-in Cortex feed functions.
+        '''
         self.setFeedFunc('syn.nodes', self._addSynNodes)
         self.setFeedFunc('syn.splice', self._addSynSplice)
         self.setFeedFunc('syn.ingest', self._addSynIngest)
 
-        await self._initCoreLayers()
-        await self._checkLayerModels()
-
-        await self._initCoreViews()
-
-        async def fini():
-            await asyncio.gather(*[view.fini() for view in self.views.values()])
-            await asyncio.gather(*[layr.fini() for layr in self.layers.values()])
-
-        self.onfini(fini)
-
-        # these may be used directly
-        self.model = s_datamodel.Model()
-
-        # our "main" view has the same iden as we do
-        self.view = self.views.get(self.iden)
-
-        self.ontagadds = collections.defaultdict(list)
-        self.ontagdels = collections.defaultdict(list)
-
-        self._runtLiftFuncs = {}
-        self._runtPropSetFuncs = {}
-        self._runtPropDelFuncs = {}
-
-        mods = list(s_modules.coremods)
-        mods.extend(self.conf.get('modules'))
-
-        await self._loadCoreMods(mods)
-
-        self._initFormCounts()
-
-        self.triggers = s_trigger.Triggers(self)
-
-        self.agenda = await s_agenda.Agenda.anit(self)
-        self.onfini(self.agenda)
-
-        if self.conf.get('cron:enable'):
-            await self.agenda.enable()
-
-        await self._initCoreMods()
-
-        self._initCryoLoop()
-        self._initPushLoop()
-        self._initFeedLoops()
-
+    def _initCortexHttpApi(self):
+        '''
+        Registration for built-in Cortex httpapi endpoints
+        '''
         self.addHttpApi('/api/v1/storm', s_httpapi.StormV1, {'cell': self})
         self.addHttpApi('/api/v1/storm/nodes', s_httpapi.StormNodesV1, {'cell': self})
         self.addHttpApi('/api/v1/model/norm', s_httpapi.ModelNormV1, {'cell': self})
@@ -686,7 +716,6 @@ class Cortex(s_cell.Cell):
 
     def _initFormCounts(self):
 
-        self.counts = {}
         self.formcountdb = self.slab.initdb('form:counts')
 
         for lkey, lval in self.slab.scanByFull(db=self.formcountdb):
@@ -1348,9 +1377,6 @@ class Cortex(s_cell.Cell):
 
         await node.delTag(tag)
 
-    # def _addSynUndo(self, snap, items):
-        # TODO apply splices in reverse
-
     async def _addSynIngest(self, snap, items):
 
         for item in items:
@@ -1693,13 +1719,30 @@ class Cortex(s_cell.Cell):
 
         modu = self._loadCoreModule(ctor)
 
+        try:
+            await s_coro.ornot(modu.preCoreModule)
+        except asyncio.CancelledError:  # pragma: no cover
+            raise
+        except Exception as e:
+            logger.exception(f'module preCoreModule failed: {ctor}')
+            self.modules.pop(ctor, None)
+            return
+
         mdefs = modu.getModelDefs()
         self.model.addDataModels(mdefs)
 
         cmds = modu.getStormCmds()
         [self.addStormCmd(c) for c in cmds]
 
-        await s_coro.ornot(modu.initCoreModule)
+        try:
+            await s_coro.ornot(modu.initCoreModule)
+        except asyncio.CancelledError:  # pragma: no cover
+            raise
+        except Exception as e:
+            logger.exception(f'module initCoreModule failed: {ctor}')
+            self.modules.pop(ctor, None)
+            return
+
         await self.fire('core:module:load', module=ctor)
 
         return modu
@@ -1719,6 +1762,15 @@ class Cortex(s_cell.Cell):
 
             mods.append(modu)
 
+            try:  # pragma: no cover
+                await s_coro.ornot(modu.preCoreModule)
+            except asyncio.CancelledError:  # pragma: no cover
+                raise
+            except Exception as e:
+                logger.exception(f'module preCoreModule failed: {ctor}')
+                self.modules.pop(ctor, None)
+                continue
+
             cmds.extend(modu.getStormCmds())
             mdefs.extend(modu.getModelDefs())
 
@@ -1727,16 +1779,15 @@ class Cortex(s_cell.Cell):
 
     async def _initCoreMods(self):
 
-        for name, modu in self.modules.items():
+        for ctor, modu in list(self.modules.items()):
 
             try:
                 await s_coro.ornot(modu.initCoreModule)
-
             except asyncio.CancelledError:
                 raise
-
             except Exception as e:
-                logger.exception(f'module init failed: {name}')
+                logger.exception(f'module initCoreModule failed: {ctor}')
+                self.modules.pop(ctor, None)
 
     def _loadCoreModule(self, ctor):
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -670,7 +670,9 @@ class Cortex(s_cell.Cell):
         self.splicers.update(**splicers)
 
     def _initLayerCtors(self):
-        '''Registration for built-in Layer ctors'''
+        '''
+        Registration for built-in Layer ctors
+        '''
         ctors = {
             'lmdb': s_lmdblayer.LmdbLayer,
             'remote': s_remotelayer.RemoteLayer,

--- a/synapse/lib/module.py
+++ b/synapse/lib/module.py
@@ -84,7 +84,6 @@ class CoreModule:
         ret = self.mod_name
         if ret is None:
             ret = self.__class__.__name__
-            self.mod_name = ret
         return ret.lower()
 
     def getModPath(self, *paths):

--- a/synapse/lib/module.py
+++ b/synapse/lib/module.py
@@ -27,7 +27,7 @@ class CoreModule:
 
     def getStormCmds(self):  # pragma: no cover
         '''
-        Module implementers may over-ride this to provide a list of Storm
+        Module implementers may override this to provide a list of Storm
         commands which will be loaded into the Cortex.
 
         Returns:
@@ -104,7 +104,7 @@ class CoreModule:
 
     async def preCoreModule(self):
         '''
-        Module implementers may over-ride this method to execute code
+        Module implementers may override this method to execute code
         immediately after a module has been loaded.
 
         No Cortex layer/storage operations will function in preCoreModule.
@@ -119,7 +119,7 @@ class CoreModule:
 
     async def initCoreModule(self):
         '''
-        Module implementers may over-ride this method to initialize the
+        Module implementers may override this method to initialize the
         module after the Cortex has completed and is accessible to perform
         storage operations.
 

--- a/synapse/lib/module.py
+++ b/synapse/lib/module.py
@@ -3,8 +3,6 @@ import os
 import synapse.common as s_common
 
 class CoreModule:
-    '''
-    '''
 
     confdefs = ()
     mod_name = None
@@ -13,6 +11,8 @@ class CoreModule:
 
         self.core = core        # type: synapse.cortex.Cortex
         self.model = core.model # type: synapse.datamodel.Model
+        if self.mod_name is None:
+            self.mod_name = self.getModName()
 
         # Avoid getModPath / getConfPath during __init__ since these APIs
         # will create directories. We do not need that behavior by default.
@@ -36,9 +36,6 @@ class CoreModule:
         return ()
 
     def getModelDefs(self):
-        return ()
-
-    def getModelRevs(self):
         return ()
 
     def getConfPath(self):
@@ -77,7 +74,9 @@ class CoreModule:
         Notes:
             This pulls the ``mod_name`` attribute on the class. This allows
             an implementer to set a arbitrary name for the module.  If this
-            attribute is not set, it defaults to ``self.__class__.__name__``.
+            attribute is not set, it defaults to
+            ``self.__class__.__name__.lower()`` and sets ``mod_name`` to
+            that value.
 
         Returns:
             (str): The module name.
@@ -85,6 +84,7 @@ class CoreModule:
         ret = self.mod_name
         if ret is None:
             ret = self.__class__.__name__
+            self.mod_name = ret
         return ret.lower()
 
     def getModPath(self, *paths):
@@ -103,17 +103,37 @@ class CoreModule:
         dirn = self.getModDir()
         return s_common.genpath(dirn, *paths)
 
+    async def preCoreModule(self):
+        '''
+        Module implementers may over-ride this method to execute code
+        immediately after a module has been loaded.
+
+        No Cortex layer/storage operations will function in preCoreModule.
+
+        Any exception raised within this method will halt additional
+        loading of the module.
+
+        Returns:
+            None
+        '''
+        pass
+
     async def initCoreModule(self):
         '''
         Module implementers may over-ride this method to initialize the
-        module during initial construction.  Any exception raised within
-        this method will be raised from the constructor and mark the module
-        as failed.
+        module after the Cortex has completed and is accessible to perform
+        storage operations.
 
         Notes:
+            Any exception raised within this method will remove the module from
+            the list of currently loaded modules.
+
             This is called for modules after getModelDefs() and getStormCmds()
             has been called, in order to allow for model loading and storm
             command loading prior to code execution offered by initCoreModule.
+
+            A failure during initCoreModule will not unload data model or storm
+            commands registered by the module.
 
         Returns:
             None

--- a/synapse/lib/module.py
+++ b/synapse/lib/module.py
@@ -107,10 +107,14 @@ class CoreModule:
         Module implementers may override this method to execute code
         immediately after a module has been loaded.
 
-        No Cortex layer/storage operations will function in preCoreModule.
+        Notes:
+            The ``initCoreModule`` function is preferred for overriding
+            instead of ``preCoreModule()``.
 
-        Any exception raised within this method will halt additional
-        loading of the module.
+            No Cortex layer/storage operations will function in preCoreModule.
+
+            Any exception raised within this method will halt additional
+            loading of the module.
 
         Returns:
             None
@@ -124,6 +128,9 @@ class CoreModule:
         storage operations.
 
         Notes:
+            This is the preferred function to override for implementing custom
+            code that needs to be executed during Cortex startup.
+
             Any exception raised within this method will remove the module from
             the list of currently loaded modules.
 

--- a/synapse/tests/test_lib_module.py
+++ b/synapse/tests/test_lib_module.py
@@ -59,7 +59,7 @@ class CoreModTest(s_t_utils.SynTest):
             # preload a config file for the BarModule
             dirn = s_common.gendir(core.dirn, 'mods', 'barmod')
             s_common.yamlsave({'test': 1, 'duck': 'quack'}, dirn, 'conf.yaml')
-            # barmodule laods a layerctor
+            # barmodule loads a layerctor
             self.false(core.layrctors.get('newp') is int)
 
             barmod = await core.loadCoreModule(bar_ctor)


### PR DESCRIPTION
* Reorganize how the Cortex startup works to pre-initialize all static data/variables as early as possible, pre-initalize modules prior to bringing storage online, and actually remove modules from the module list that fail their init or pre functions.  This also allows hooking in additional layer ctors.
* Update cormeodule unit tests.