### PR TITLE
ensure that univ props can be loaded via datamodel definition

### DIFF
--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -9,6 +9,7 @@ import synapse.exc as s_exc
 import synapse.glob as s_glob
 import synapse.common as s_common
 import synapse.telepath as s_telepath
+import synapse.datamodel as s_datamodel
 
 import synapse.lib.coro as s_coro
 import synapse.lib.node as s_node
@@ -1616,6 +1617,11 @@ class CortexTest(s_t_utils.SynTest):
 
         async with self.getTestCore() as core:
 
+            # Ensure that the test model loads a univ property
+            prop = core.model.prop('.test:univ')
+            self.isinstance(prop, s_datamodel.Univ)
+
+            # Add a univprop directly via API for testing
             core.model.addUnivProp('hehe', ('int', {}), {})
 
             await self.agenlen(1, core.eval('[ teststr=woot .hehe=20 ]'))

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -21,9 +21,9 @@ class TrigTest(s_t_utils.SynTest):
                 triggers = core.triggers.list()
                 self.eq(triggers[0][1].get('storm'), '[inet:user=1] | testcmd')
                 iden = triggers[0][0]
-                core.triggers.mod(iden, '[inet:user=2 .testuniv=4] | testcmd')
+                core.triggers.mod(iden, '[inet:user=2 .test:univ=4] | testcmd')
                 triggers = core.triggers.list()
-                self.eq(triggers[0][1].get('storm'), '[inet:user=2 .testuniv=4] | testcmd')
+                self.eq(triggers[0][1].get('storm'), '[inet:user=2 .test:univ=4] | testcmd')
 
                 # Sad case
                 self.raises(s_exc.BadStormSyntax, core.triggers.mod, iden, ' | | badstorm ')
@@ -31,10 +31,8 @@ class TrigTest(s_t_utils.SynTest):
 
             async with await self.getTestCell(fdir, 'cortex', conf=conf) as core:
                 triggers = core.triggers.list()
-
-                # FIXME:  two phase problem this fails
-                # self.len(1, triggers)
-                # self.eq(triggers[0][1].get('storm'), '[inet:user=2 .testuniv] | testcmd')
+                self.len(1, triggers)
+                self.eq(triggers[0][1].get('storm'), '[inet:user=2 .test:univ=4] | testcmd')
 
     async def test_trigger_basics(self):
 
@@ -102,13 +100,13 @@ class TrigTest(s_t_utils.SynTest):
                 await self.agenlen(0, await core.eval('testint=6'))
 
                 # Prop set univ
-                await core.addTrigger('prop:set', '[ testint=7 ]', info={'prop': '.testuniv'})
-                await s_common.aspin(await core.eval('[ testtype10=1 .testuniv=1 ]'))
+                await core.addTrigger('prop:set', '[ testint=7 ]', info={'prop': '.test:univ'})
+                await s_common.aspin(await core.eval('[ testtype10=1 .test:univ=1 ]'))
                 await self.agenlen(1, await core.eval('testint=7'))
 
                 # Prop set form specific univ
-                await core.addTrigger('prop:set', '[ testint=8 ]', info={'prop': 'teststr.testuniv'})
-                await s_common.aspin(await core.eval('[ teststr=beep .testuniv=1 ]'))
+                await core.addTrigger('prop:set', '[ testint=8 ]', info={'prop': 'teststr.test:univ'})
+                await s_common.aspin(await core.eval('[ teststr=beep .test:univ=1 ]'))
                 await self.agenlen(1, await core.eval('testint=8'))
 
                 # Bad trigger parms

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -158,6 +158,10 @@ testmodel = {
 
     ),
 
+    'univs': (
+        ('test:univ', ('int', {'min': -1, 'max': 10}), {'doc': 'A test universal property.'}),
+    ),
+
     'forms': (
 
         ('testtype10', {}, (
@@ -282,8 +286,6 @@ class TestModule(s_module.CoreModule):
             await snap.addNode('source', self.testguid, {'name': 'test'})
 
         self.core.addStormLib(('test',), LibTst)
-
-        self.core.model.addUnivProp('testuniv', ('int', {'min': -1, 'max': 10}), {})
 
         self._runtsByBuid = {}
         self._runtsByPropValu = collections.defaultdict(list)


### PR DESCRIPTION
* Ensure that univ props are loaded via the 'univs' data model key. 
*  Update tests to ensure that occurs and re-enabled trigger persistence test case.