### PR TITLE
Fix two level runtsafe dereference storm query bug

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -439,22 +439,16 @@ class VarSetOper(Oper):
         name = self.kids[0].value()
         vkid = self.kids[1]
 
-        if vkid.isRuntSafe(runt):
-
-            valu = await vkid.runtval(runt)
-            runt.setVar(name, valu)
-
-            # yield from :(
-            async for item in genr:
-                yield item
-
-            return
-
         async for node, path in genr:
             valu = await vkid.compute(path)
             path.set(name, valu)
             runt.vars[name] = valu
             yield node, path
+
+        if vkid.isRuntSafe(runt):
+
+            valu = await vkid.runtval(runt)
+            runt.setVar(name, valu)
 
     def getRuntVars(self, runt):
         if not self.kids[1].isRuntSafe(runt):

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -1474,8 +1474,7 @@ class RunValue(CompValue):
         return await self.runtval(path.runt)
 
     def isRuntSafe(self, runt):
-        if all([k.isRuntSafe(runt) for k in self.kids]):
-            return True
+        return all(k.isRuntSafe(runt) for k in self.kids)
 
 class Value(RunValue):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2359,6 +2359,13 @@ class CortexTest(s_t_utils.SynTest):
             self.len(1, nodes)
             self.eq(20000, nodes[0].get('dob'))
 
+    async def test_storm_two_level_assignment(self):
+        async with self.getTestCore() as core:
+            q = '$foo=baz $bar=$foo [teststr=$bar]'
+            nodes = await core.eval(q).list()
+            self.len(1, nodes)
+            self.eq('baz', nodes[0].ndef[1])
+
     async def test_storm_lib_custom(self):
 
         async with self.getTestCore() as core:
@@ -2372,6 +2379,12 @@ class CortexTest(s_t_utils.SynTest):
             nodes = await core.eval(q).list()
             self.len(1, nodes)
             self.eq('A test beep!', nodes[0].ndef[1])
+
+            # Regression:  variable substitution in function raises exception
+            q = '$foo=baz $test = $lib.test.beep($foo) [teststr=$test]'
+            nodes = await core.eval(q).list()
+            self.len(1, nodes)
+            self.eq('A baz beep!', nodes[0].ndef[1])
 
     async def test_storm_type_node(self):
 


### PR DESCRIPTION
Running `$foo=baz $bar=$foo [teststr=$bar]` raised `synapse.exc.NoSuchVar: NoSuchVar: name='foo'`.

This fixes that.