### PR TITLE
Change trigger, agenda storage to store useriden instead of usernames

### DIFF
--- a/synapse/cmds/cron.py
+++ b/synapse/cmds/cron.py
@@ -5,7 +5,6 @@ import datetime
 import functools
 
 import synapse.exc as s_exc
-import synapse.common as s_common
 import synapse.lib.cli as s_cli
 import synapse.lib.cmd as s_cmd
 import synapse.lib.time as s_time
@@ -160,7 +159,7 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
         exactly one.
         '''
         idens = [iden for iden, trig in await core.listCronJobs()]
-        matches = [iden for iden in idens if s_common.ehex(iden).startswith(prefix)]
+        matches = [iden for iden in idens if iden.startswith(prefix)]
         if len(matches) == 1:
             return matches[0]
         elif len(matches) == 0:
@@ -425,7 +424,7 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
         query = opts.query[1:-1]
 
         iden = await core.addCronJob(query, reqdict, incunit, incval)
-        self.printf(f'Created cron job {s_common.ehex(iden)}')
+        self.printf(f'Created cron job {iden}')
 
     @staticmethod
     def _format_timestamp(ts):
@@ -443,7 +442,7 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
             f'{"# start":7} {"last start":16} {"last end":16} {"query"}')
 
         for iden, cron in cronlist:
-            idenf = s_common.ehex(iden)[:8] + '..'
+            idenf = iden[:8] + '..'
             user = cron.get('username') or '<None>'
             query = cron.get('query') or '<missing>'
             isrecur = 'Y' if cron.get('recur') else 'N'
@@ -469,7 +468,7 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
         if iden is None:
             return
         await core.updateCronJob(iden, query)
-        self.printf(f'Modified cron job {s_common.ehex(iden)}')
+        self.printf(f'Modified cron job {iden}')
 
     async def _handle_del(self, core, opts):
         prefix = opts.prefix
@@ -477,14 +476,14 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
         if iden is None:
             return
         await core.delCronJob(iden)
-        self.printf(f'Deleted cron job {s_common.ehex(iden)}')
+        self.printf(f'Deleted cron job {iden}')
 
     async def _handle_stat(self, core, opts):
         ''' Prints details about a particular cron job. Not actually a different API call '''
         prefix = opts.prefix
         crons = await core.listCronJobs()
         idens = [cron[0] for cron in crons]
-        matches = [iden for iden in idens if s_common.ehex(iden).startswith(prefix)]
+        matches = [iden for iden in idens if iden.startswith(prefix)]
         if len(matches) == 0:
             self.printf('Error: provided iden does not match any valid authorized cron job')
             return
@@ -495,7 +494,6 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
         iden = matches[0]
         cron = [cron[1] for cron in crons if cron[0] == iden][0]
 
-        idenf = s_common.ehex(iden)
         user = cron.get('username') or '<None>'
         query = cron.get('query') or '<missing>'
         isrecur = 'Yes' if cron.get('recur') else 'No'
@@ -507,7 +505,7 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
         lastend = 'Never' if lastend is None else self._format_timestamp(lastend)
         lastresult = cron.get('lastresult') or '<None>'
 
-        self.printf(f'iden:            {idenf}')
+        self.printf(f'iden:            {iden}')
         self.printf(f'user:            {user}')
         self.printf(f'recurring:       {isrecur}')
         self.printf(f'# starts:        {startcount}')
@@ -672,4 +670,4 @@ Examples:
         reqdicts = [_ts_to_reqdict(ts) for ts in tslist]
 
         iden = await core.addCronJob(query, reqdicts, None, None)
-        self.printf(f'Created cron job {s_common.ehex(iden)}')
+        self.printf(f'Created cron job {iden}')

--- a/synapse/cmds/trigger.py
+++ b/synapse/cmds/trigger.py
@@ -96,7 +96,7 @@ A subcommand is required.  Use `trigger -h` for more detailed help.
         exactly one.
         '''
         idens = [iden for iden, trig in await core.listTriggers()]
-        matches = [iden for iden in idens if s_common.ehex(iden).startswith(prefix)]
+        matches = [iden for iden in idens if iden.startswith(prefix)]
         if len(matches) == 1:
             return matches[0]
         elif len(matches) == 0:
@@ -185,7 +185,7 @@ A subcommand is required.  Use `trigger -h` for more detailed help.
         query = query[1:-1]
 
         iden = await core.addTrigger(cond, query, info={'form': form, 'tag': tag, 'prop': prop})
-        self.printf(f'Added trigger {s_common.ehex(iden)}')
+        self.printf(f'Added trigger {iden}')
 
     async def _handle_list(self, core, opts):
         triglist = await core.listTriggers()
@@ -197,8 +197,8 @@ A subcommand is required.  Use `trigger -h` for more detailed help.
         self.printf(f'{"user":10} {"iden":12} {"cond":9} {"object":14} {"":10} {"storm query"}')
 
         for iden, trig in triglist:
-            idenf = s_common.ehex(iden)[:8] + '..'
-            user = trig.get('user') or '<None>'
+            idenf = iden[:8] + '..'
+            user = trig.get('username') or '<None>'
             query = trig.get('storm') or '<missing>'
             cond = trig.get('cond') or '<missing'
             if cond.startswith('tag:'):
@@ -222,7 +222,7 @@ A subcommand is required.  Use `trigger -h` for more detailed help.
         if iden is None:
             return
         await core.updateTrigger(iden, query)
-        self.printf(f'Modified trigger {s_common.ehex(iden)}')
+        self.printf(f'Modified trigger {iden}')
 
     async def _handle_del(self, core, opts):
         prefix = opts.prefix
@@ -230,7 +230,7 @@ A subcommand is required.  Use `trigger -h` for more detailed help.
         if iden is None:
             return
         await core.delTrigger(iden)
-        self.printf(f'Deleted trigger {s_common.ehex(iden)}')
+        self.printf(f'Deleted trigger {iden}')
 
     async def runCmdOpts(self, opts):
         line = opts.get('line')

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -193,13 +193,12 @@ class CoreApi(s_cell.CellApi):
         '''
         Adds a trigger to the cortex
         '''
-        iden = self.cell.triggers.add(self.user.name, condition, query, info=info)
+        iden = self.cell.triggers.add(self.user.iden, condition, query, info=info)
         return iden
 
-    def _auth_check(self, user):
+    def _trig_auth_check(self, useriden):
         ''' Check that, as a non-admin, may only manipulate resources created by you. '''
-        username = None if self.user is None else self.user.name
-        if username is not None and (not self.user.admin) and username != user:
+        if not self.user.admin and useriden != self.user.iden:
             raise s_exc.AuthDeny(user=self.user.name, mesg='As non-admin, may only manipulate triggers created by you')
 
     async def delTrigger(self, iden):
@@ -207,7 +206,7 @@ class CoreApi(s_cell.CellApi):
         Deletes a trigger from the cortex
         '''
         trig = self.cell.triggers.get(iden)
-        self._auth_check(trig.get('user'))
+        self._trig_auth_check(trig.get('useriden'))
         self.cell.triggers.delete(iden)
 
     async def updateTrigger(self, iden, query):
@@ -215,16 +214,20 @@ class CoreApi(s_cell.CellApi):
         Change an existing trigger's query
         '''
         trig = self.cell.triggers.get(iden)
-        self._auth_check(trig.get('user'))
+        self._trig_auth_check(trig.get('useriden'))
         self.cell.triggers.mod(iden, query)
 
     async def listTriggers(self):
         '''
         Lists all the triggers that the current user is authorized to access
         '''
-        username = None if self.user is None else self.user.name
-        return [(iden, trig) for (iden, trig) in self.cell.triggers.list()
-                if username is None or self.user.admin or trig.get('user') == username]
+        trigs = []
+        for (iden, trig) in self.cell.triggers.list():
+            if not (self.user.admin or trig['useriden'] == self.user.iden):
+                continue
+            trig['username'] = self.cell.auth.user(trig['useriden']).name
+            trigs.append((iden, trig))
+        return trigs
 
     async def addCronJob(self, query, reqs, incunit=None, incval=1):
         '''
@@ -272,8 +275,7 @@ class CoreApi(s_cell.CellApi):
         except KeyError:
             raise s_exc.BadConfValu('Unrecognized time unit')
 
-        username = None if self.user is None else self.user.name
-        return await self.cell.agenda.add(username, query, newreqs, incunit, incval)
+        return await self.cell.agenda.add(self.user.iden, query, newreqs, incunit, incval)
 
     async def delCronJob(self, iden):
         '''
@@ -285,7 +287,7 @@ class CoreApi(s_cell.CellApi):
         cron = self.cell.agenda.appts.get(iden)
         if cron is None:
             raise s_exc.NoSuchIden()
-        self._auth_check(cron.username)
+        self._trig_auth_check(cron.useriden)
         await self.cell.agenda.delete(iden)
 
     async def updateCronJob(self, iden, query):
@@ -298,16 +300,21 @@ class CoreApi(s_cell.CellApi):
         cron = self.cell.agenda.appts.get(iden)
         if cron is None:
             raise s_exc.NoSuchIden()
-        self._auth_check(cron.username)
+        self._trig_auth_check(cron.useriden)
         await self.cell.agenda.mod(iden, query)
 
     async def listCronJobs(self):
         '''
         Get information about all the cron jobs accessible to the current user
         '''
-        username = None if self.user is None else self.user.name
-        return [(iden, cron) for (iden, cron) in self.cell.agenda.list()
-                if username is None or self.user.admin or cron.get('user') == username]
+        crons = []
+        for iden, cron in self.cell.agenda.list():
+            if not (self.user.admin or cron['useriden'] == self.user.iden):
+                continue
+            cron['username'] = self.cell.auth.user(cron['useriden']).name
+            crons.append((iden, cron))
+
+        return crons
 
     async def addNodeTag(self, iden, tag, valu=(None, None)):
         '''

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -223,10 +223,13 @@ class CoreApi(s_cell.CellApi):
         '''
         trigs = []
         for (iden, trig) in self.cell.triggers.list():
-            if not (self.user.admin or trig['useriden'] == self.user.iden):
+            useriden = trig['useriden']
+            if not (self.user.admin or useriden == self.user.iden):
                 continue
-            trig['username'] = self.cell.auth.user(trig['useriden']).name
+            user = self.cell.auth.user(useriden)
+            trig['username'] = '<unknown>' if user is None else user.name
             trigs.append((iden, trig))
+
         return trigs
 
     async def addCronJob(self, query, reqs, incunit=None, incval=1):
@@ -309,9 +312,11 @@ class CoreApi(s_cell.CellApi):
         '''
         crons = []
         for iden, cron in self.cell.agenda.list():
-            if not (self.user.admin or cron['useriden'] == self.user.iden):
+            useriden = cron['useriden']
+            if not (self.user.admin or useriden == self.user.iden):
                 continue
-            cron['username'] = self.cell.auth.user(cron['useriden']).name
+            user = self.cell.auth.user(useriden)
+            cron['username'] = '<unknown>' if user is None else user.name
             crons.append((iden, cron))
 
         return crons

--- a/synapse/lib/agenda.py
+++ b/synapse/lib/agenda.py
@@ -241,12 +241,12 @@ class _Appt:
     Each such entry has a list of ApptRecs.  Each time the appointment is scheduled, the nexttime of the appointment is
     the lowest nexttime of all its ApptRecs.
     '''
-    def __init__(self, iden, recur, indx, query, username, recs, nexttime=None):
+    def __init__(self, iden, recur, indx, query, useriden, recs, nexttime=None):
         self.iden = iden
         self.recur = recur # does this appointment repeat
         self.indx = indx  # incremented for each appt added ever.  Used for nexttime tiebreaking for stable ordering
         self.query = query  # query to run
-        self.username = username  # user to run query as
+        self.useriden = useriden # user iden to run query as
         self.recs = recs  # List[ApptRec]  list of the individual entries to calculate next time from
         self._recidxnexttime = None # index of rec who is up next
 
@@ -278,13 +278,13 @@ class _Appt:
 
     def pack(self):
         return {
-            'ver': 0,
+            'ver': 1,
             'enabled': self.enabled,
             'recur': self.recur,
             'iden': self.iden,
             'indx': self.indx,
             'query': self.query,
-            'username': self.username,
+            'useriden': self.useriden,
             'recs': [d.pack() for d in self.recs],
             'nexttime': self.nexttime,
             'startcount': self.startcount,
@@ -296,10 +296,10 @@ class _Appt:
 
     @classmethod
     def unpack(cls, val):
-        if val['ver'] != 0:
+        if val['ver'] != 1:
             raise s_exc.BadStorageVersion  # pragma: no cover
         recs = [ApptRec.unpack(tupl) for tupl in val['recs']]
-        appt = cls(val['iden'], val['recur'], val['indx'], val['query'], val['username'], recs, val['nexttime'])
+        appt = cls(val['iden'], val['recur'], val['indx'], val['query'], val['useriden'], recs, val['nexttime'])
         appt.startcount = val['startcount']
         appt.laststarttime = val['laststarttime']
         appt.lastfinishtime = val['lastfinishtime']
@@ -398,21 +398,21 @@ class Agenda(s_base.Base):
         Load all the appointments from persistent storage
         '''
         to_delete = []
-        for idenf, val in self._hivedict.items():
+        for iden, val in self._hivedict.items():
             try:
-                iden = s_common.uhex(idenf)
                 appt = _Appt.unpack(val)
                 if appt.iden != iden:
                     raise s_exc.InconsistentStorage(mesg='iden inconsistency')
                 self._addappt(iden, appt)
                 self._next_indx = max(self._next_indx, appt.indx + 1)
-            except (s_exc.InconsistentStorage, s_exc.BadTime, TypeError, KeyError) as e:
+            except (s_exc.InconsistentStorage, s_exc.BadStorageVersion, s_exc.BadTime, TypeError, KeyError,
+                    UnicodeDecodeError) as e:
                 logger.warning('Invalid appointment %r found in storage: %r.  Removing', iden, e)
                 to_delete.append(iden)
                 continue
 
         for iden in to_delete:
-            await self._hivedict.pop(s_common.ehex(iden))
+            await self._hivedict.pop(iden)
 
         # Make sure we don't assign the same index to 2 appointments
         if self.appts:
@@ -431,7 +431,7 @@ class Agenda(s_base.Base):
 
     async def _storeAppt(self, appt):
         ''' Store a single appointment '''
-        await self._hivedict.set(s_common.ehex(appt.iden), appt.pack())
+        await self._hivedict.set(appt.iden, appt.pack())
 
     @staticmethod
     def _dictproduct(rdict):
@@ -455,7 +455,7 @@ class Agenda(s_base.Base):
     def list(self):
         return [(iden, (appt.pack())) for (iden, appt) in self.appts.items()]
 
-    async def add(self, username, query: str, reqs, incunit=None, incvals=None):
+    async def add(self, useriden, query: str, reqs, incunit=None, incvals=None):
         '''
         Persistently adds an appointment
 
@@ -479,7 +479,7 @@ class Agenda(s_base.Base):
         Returns:
             iden of new appointment
         '''
-        iden = os.urandom(16)
+        iden = s_common.guid()
         recur = incunit is not None
         indx = self._next_indx
         self._next_indx += 1
@@ -508,7 +508,7 @@ class Agenda(s_base.Base):
                 incvals = (incvals, )
             recs.extend(ApptRec(rd, incunit, v) for (rd, v) in itertools.product(reqdicts, incvals))
 
-        appt = _Appt(iden, recur, indx, query, username, recs)
+        appt = _Appt(iden, recur, indx, query, useriden, recs)
         self._addappt(iden, appt)
 
         await self._storeAppt(appt)
@@ -556,7 +556,7 @@ class Agenda(s_base.Base):
                 heapq.heapify(self.apptheap)
 
         del self.appts[iden]
-        await self._hivedict.pop(s_common.ehex(iden))
+        await self._hivedict.pop(iden)
 
     async def _scheduleLoop(self):
         '''
@@ -584,7 +584,7 @@ class Agenda(s_base.Base):
                 if appt.isrunning:
                     logger.warning(
                         'Appointment %s is still running from previous time when scheduled to run.  Skipping.',
-                        s_common.ehex(appt.iden))
+                        appt.iden)
                 else:
                     await self._execute(appt)
 
@@ -592,14 +592,11 @@ class Agenda(s_base.Base):
         '''
         Fire off the task to make the storm query
         '''
-        if appt.username is None or self.core.auth is None:
-            user = None
-        else:
-            user = self.core.auth.getUserByName(appt.username)
-            if user is None:
-                logger.warning('Unknown username %s in stored appointment', appt.username)
-                return
-        await self.core.boss.execute(self._runJob(user, appt), f'Agenda {s_common.ehex(appt.iden)}', user)
+        user = self.core.auth.user(appt.useriden)
+        if user is None:
+            logger.warning('Unknown user %s in stored appointment', appt.useriden)
+            return
+        await self.core.boss.execute(self._runJob(user, appt), f'Agenda {appt.iden}', user)
 
     async def _runJob(self, user, appt):
         '''
@@ -610,9 +607,10 @@ class Agenda(s_base.Base):
         appt.laststarttime = time.time()
         appt.startcount += 1
         await self._storeAppt(appt)
-        idenf = s_common.ehex(appt.iden)
-        with s_provenance.claim('cron', iden=idenf):
-            logger.info(f'Agenda executing for iden={idenf}, user={user}: query={{appt.query}}')
+
+        with s_provenance.claim('cron', iden=appt.iden):
+            logger.info('Agenda executing for iden=%s, user=%s, query={%s}', appt.iden, user.name, appt.query)
+            starttime = time.time()
             try:
                 async for _ in self.core.eval(appt.query, user=user):  # NOQA
                     count += 1
@@ -621,12 +619,13 @@ class Agenda(s_base.Base):
                 raise
             except Exception as e:
                 result = f'raised exception {e}'
-                logger.exception('Agenda job %s raised exception', idenf)
+                logger.exception('Agenda job %s raised exception', iden)
             else:
                 result = f'finished successfully with {count} nodes'
             finally:
                 finishtime = time.time()
-                logger.info(f'Agenda completed query for iden={idenf} with result="{result}" took {finishtime:0.2}')
+                logger.info('Agenda completed query for iden=%s with result "%s" took %0.3fs',
+                            appt.iden, result, finishtime - starttime)
                 appt.lastfinishtime = finishtime
                 appt.isrunning = False
                 appt.lastresult = result

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -69,7 +69,6 @@ class CellApi(s_base.Base):
 
         retn = []
 
-        admin = False
         admin = self.user.admin
 
         for synt in self.cell.boss.ps():

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -79,7 +79,6 @@ class CellApi(s_base.Base):
 
     async def kill(self, iden):
 
-        admin = False
         admin = self.user.admin
 
         logger.info(f'User [{str(self.user)}] Requesting task kill: {iden}')

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -53,6 +53,7 @@ class CellApi(s_base.Base):
         await s_base.Base.__anit__(self)
         self.cell = cell
         self.link = link
+        assert user
         self.user = user
 
     def getCellType(self):
@@ -69,8 +70,7 @@ class CellApi(s_base.Base):
         retn = []
 
         admin = False
-        if self.user is not None:
-            admin = self.user.admin
+        admin = self.user.admin
 
         for synt in self.cell.boss.ps():
             if admin or synt.user == self.user:
@@ -81,8 +81,7 @@ class CellApi(s_base.Base):
     async def kill(self, iden):
 
         admin = False
-        if self.user is not None:
-            admin = self.user.admin
+        admin = self.user.admin
 
         logger.info(f'User [{str(self.user)}] Requesting task kill: {iden}')
         task = self.cell.boss.get(iden)

--- a/synapse/lib/trigger.py
+++ b/synapse/lib/trigger.py
@@ -32,16 +32,16 @@ class Triggers:
 
     @dataclasses.dataclass
     class Rule:
-        ver: int  # version: must be 0
+        ver: int  # version: must be 1
         cond: str  # condition from above list
-        user: str  # username
+        useriden: str
         storm: str  # storm query
         form: Optional[str] = dataclasses.field(default=None) # form name
         tag: Optional[str] = dataclasses.field(default=None) # tag name
         prop: Optional[str] = dataclasses.field(default=None) # property name
 
         def __post_init__(self):
-            if self.ver != 0:
+            if self.ver != 1:
                 raise s_exc.BadOptValu(mesg='Unexpected rule version')
             if self.cond not in Conditions:
                 raise s_exc.BadOptValu(mesg='Invalid trigger condition')
@@ -71,13 +71,10 @@ class Triggers:
             if vars is not None:
                 opts['vars'] = vars
 
-            if node.snap.core.auth is not None:
-                user = node.snap.core.auth.getUserByName(self.user)
-                if user is None:
-                    logger.warning('Unknown user %s in stored trigger', self.user)
-                    return
-            else:
-                user = None
+            user = node.snap.core.auth.user(self.useriden)
+            if user is None:
+                logger.warning('Unknown user %s in stored trigger', self.useriden)
+                return
 
             with s_provenance.claim('trig', cond=self.cond, form=self.form, tag=self.tag, prop=self.prop):
 
@@ -107,7 +104,7 @@ class Triggers:
         self.nodedel = collections.defaultdict(list)   # form: rule
         self.propset = collections.defaultdict(list)   # prop: rule
 
-        self._load_all(self.core.slab)
+        self._load_all()
 
     async def runNodeAdd(self, node):
         with self._recursion_check():
@@ -169,21 +166,52 @@ class Triggers:
                 for expr, rule in globs.get(tag):
                     await rule.execute(node, vars=vars)
 
-    def _load_all(self, slab):
-        for iden, val in self.core.slab.scanByFull(db=self.trigdb):
+    def migrate_v0_rules(self):
+        '''
+        Remove any v0 rules from storage and replace them with v1 rules.
+
+        Notes:
+            v0 had two differences user was a username.  Replaced with iden of user as 'iden' field.
+            Also 'iden' was storage as binary.  Now it is stored as hex string.
+        '''
+        for iden, valu in self.core.slab.scanByFull(db=self.trigdb):
+            ruledict = s_msgpack.un(valu)
+            ver = ruledict.get('ver')
+            if ver != 0:
+                continue
+
+            user = ruledict.pop('user')
+            if user is None:
+                logger.warning('Username missing in stored trigger rule %r', iden)
+                continue
+
+            # In v0, stored user was username, in >0 user is useriden
+            user = self.core.auth.getUserByName(user).iden
+            if user is None:
+                logger.warning('Unrecognized username in stored trigger rule %r', iden)
+                continue
+
+            ruledict['ver'] = 1
+            ruledict['useriden'] = user
+            newiden = s_common.ehex(iden)
+            self.core.slab.pop(iden)
+            self.core.slab.put(newiden.encode(), s_msgpack.en(ruledict), db=self.trigdb)
+
+    def _load_all(self):
+        self.migrate_v0_rules()
+        for iden, valu in self.core.slab.scanByFull(db=self.trigdb):
             try:
-                ruledict = s_msgpack.un(val)
+                ruledict = s_msgpack.un(valu)
                 ver = ruledict.pop('ver')
                 cond = ruledict.pop('cond')
-                user = ruledict.pop('user')
+                user = ruledict.pop('useriden')
                 query = ruledict.pop('storm')
-                self._load_rule(iden, ver, cond, user, query, info=ruledict)
+                self._load_rule(iden.decode(), ver, cond, user, query, info=ruledict)
             except (KeyError, s_exc.SynErr) as e:
                 logger.warning('Invalid rule %r found in storage: %r', iden, e)
                 continue
 
     def _load_rule(self, iden, ver, cond, user, query, info):
-
         rule = Triggers.Rule(ver, cond, user, query, **info)
 
         # Make sure the query parses
@@ -235,7 +263,7 @@ class Triggers:
         self.core.getStormQuery(query)
 
         rule.storm = query
-        self.core.slab.put(iden, rule.en(), db=self.trigdb)
+        self.core.slab.put(iden.encode(), rule.en(), db=self.trigdb)
 
     @contextlib.contextmanager
     def _recursion_check(self):
@@ -252,17 +280,16 @@ class Triggers:
         finally:
             RecursionDepth.reset(token)
 
-    def add(self, username, condition, query, info):
-
-        iden = os.urandom(16)
+    def add(self, useriden, condition, query, info):
+        iden = s_common.guid()
 
         if not query:
             raise ValueError('empty query')
 
         self.core.getStormQuery(query)
 
-        rule = self._load_rule(iden, 0, condition, username, query, info=info)
-        self.core.slab.put(iden, rule.en(), db=self.trigdb)
+        rule = self._load_rule(iden, 1, condition, useriden, query, info=info)
+        self.core.slab.put(iden.encode(), rule.en(), db=self.trigdb)
         return iden
 
     def delete(self, iden):
@@ -271,7 +298,7 @@ class Triggers:
         if rule is None:
             raise s_exc.NoSuchIden()
 
-        self.core.slab.delete(iden, db=self.trigdb)
+        self.core.slab.delete(iden.encode(), db=self.trigdb)
 
         if rule.cond == 'node:add':
             self.nodeadd[rule.form].remove(rule)

--- a/synapse/lib/trigger.py
+++ b/synapse/lib/trigger.py
@@ -194,7 +194,7 @@ class Triggers:
             ruledict['ver'] = 1
             ruledict['useriden'] = user
             newiden = s_common.ehex(iden)
-            self.core.slab.pop(iden)
+            self.core.slab.pop(iden, db=self.trigdb)
             self.core.slab.put(newiden.encode(), s_msgpack.en(ruledict), db=self.trigdb)
 
     def _load_all(self):

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -1,6 +1,7 @@
 import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.telepath as s_telepath
+import synapse.lib.msgpack as s_msgpack
 import synapse.tests.utils as s_t_utils
 
 class TrigTest(s_t_utils.SynTest):
@@ -17,7 +18,8 @@ class TrigTest(s_t_utils.SynTest):
                 'modules': ('synapse.tests.utils.TestModule',),
             }
             async with await self.getTestCell(fdir, 'cortex', conf=conf) as core:
-                core.triggers.add('root', 'node:add', '[inet:user=1] | testcmd', info={'form': 'inet:ipv4'})
+                rootiden = core.auth.getUserByName('root').iden
+                core.triggers.add(rootiden, 'node:add', '[inet:user=1] | testcmd', info={'form': 'inet:ipv4'})
                 triggers = core.triggers.list()
                 self.eq(triggers[0][1].get('storm'), '[inet:user=1] | testcmd')
                 iden = triggers[0][0]
@@ -29,10 +31,22 @@ class TrigTest(s_t_utils.SynTest):
                 self.raises(s_exc.BadStormSyntax, core.triggers.mod, iden, ' | | badstorm ')
                 self.raises(s_exc.NoSuchIden, core.triggers.mod, 'deadb33f', 'inet:user')
 
+                # Manually store a v0 trigger
+                ruledict = {'ver': 0, 'cond': 'node:add', 'form': 'inet:ipv4', 'user': 'root', 'storm': 'testcmd'}
+                iden = b'\xff' * 16
+                core.slab.put(iden, s_msgpack.en(ruledict), db=core.triggers.trigdb)
+
             async with await self.getTestCell(fdir, 'cortex', conf=conf) as core:
                 triggers = core.triggers.list()
-                self.len(1, triggers)
+                self.len(2, triggers)
                 self.eq(triggers[0][1].get('storm'), '[inet:user=2 .test:univ=4] | testcmd')
+
+                # Verify that the v0 trigger was migrated correctly
+                iden2, trig2 = triggers[1]
+                self.eq(iden2, 'ff' * 16)
+                self.eq(trig2['useriden'], rootiden)
+                self.eq(trig2['ver'], 1)
+                self.eq(trig2['storm'], 'testcmd')
 
     async def test_trigger_basics(self):
 
@@ -170,10 +184,11 @@ class TrigTest(s_t_utils.SynTest):
     async def test_trigger_delete(self):
 
         async with self.getTestCore() as core:
+            rootiden = core.auth.getUserByName('root').iden
 
-            iden0 = core.triggers.add('root', 'node:add', '[test:str=add]', {'form': 'test:guid'})
-            iden1 = core.triggers.add('root', 'node:del', '[test:str=del]', {'form': 'test:guid'})
-            iden2 = core.triggers.add('root', 'prop:set', '[test:str=set]', {'prop': 'test:guid:tick'})
+            iden0 = core.triggers.add(rootiden, 'node:add', '[test:str=add]', {'form': 'test:guid'})
+            iden1 = core.triggers.add(rootiden, 'node:del', '[test:str=del]', {'form': 'test:guid'})
+            iden2 = core.triggers.add(rootiden, 'prop:set', '[test:str=set]', {'prop': 'test:guid:tick'})
 
             await core.eval('[test:guid="*" :tick=2015] | delnode').list()
             self.len(3, await core.eval('test:str').list())
@@ -191,8 +206,9 @@ class TrigTest(s_t_utils.SynTest):
 
         async with self.getTestCore() as core:
 
-            iden0 = core.triggers.add('root', 'tag:add', '[ +#count0 ]', {'tag': 'foo.*.bar'})
-            iden1 = core.triggers.add('root', 'tag:del', '[ +#count1 ]', {'tag': 'baz.*.faz'})
+            rootiden = core.auth.getUserByName('root').iden
+            iden0 = core.triggers.add(rootiden, 'tag:add', '[ +#count0 ]', {'tag': 'foo.*.bar'})
+            iden1 = core.triggers.add(rootiden, 'tag:del', '[ +#count1 ]', {'tag': 'baz.*.faz'})
 
             await core.eval('[ test:guid="*" +#foo.asdf.bar ]').list()
             await core.eval('[ test:guid="*" +#baz.asdf.faz ]').list()


### PR DESCRIPTION
Migrate v0 triggers to v1 triggers at startup.

Don't worry about migrating cron for now.

In a couple of provenance frames store the useriden instead of names.

Use string idens instead of binary ones