### PR TITLE
Move provenance, splice DB locations, make remote layers read-only

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -628,9 +628,6 @@ class Cortex(s_cell.Cell):
 
         self.model = s_datamodel.Model()
 
-        self.provstor = await s_provenance.ProvStor.anit(self.dirn)
-        self.onfini(self.provstor.fini)
-
         # Perform module loading
         mods = list(s_modules.coremods)
         mods.extend(self.conf.get('modules'))
@@ -640,6 +637,10 @@ class Cortex(s_cell.Cell):
         await self._initCoreLayers()
         await self._checkLayerModels()
         await self._initCoreViews()
+
+        self.provstor = await s_provenance.ProvStor.anit(self.dirn)
+        self.onfini(self.provstor.fini)
+        self.provstor.migrate_pre010(self.layer)
 
         async def fini():
             await asyncio.gather(*[view.fini() for view in self.views.values()])

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -640,7 +640,7 @@ class Cortex(s_cell.Cell):
 
         self.provstor = await s_provenance.ProvStor.anit(self.dirn)
         self.onfini(self.provstor.fini)
-        self.provstor.migrate_pre010(self.layer)
+        self.provstor.migratePre010(self.layer)
 
         async def fini():
             await asyncio.gather(*[view.fini() for view in self.views.values()])

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -84,6 +84,10 @@ class View(s_base.Base):
                 logger.warning('view %r has missing layer %r' % (self.iden, iden))
                 continue
 
+            if not self.layers and layr.readonly:
+                self.borked = iden
+                raise s_exc.ReadOnlyLayer(mesg=f'First layer {iden} must not be read-only')
+
             self.layers.append(layr)
 
     async def snap(self, user):
@@ -102,8 +106,12 @@ class View(s_base.Base):
 
     async def addLayer(self, layr, indx=None):
         if indx is None:
+            if not self.layers and layr.readonly:
+                raise s_exc.ReadOnlyLayer(mesg=f'First layer {layr.iden} must not be read-only')
             self.layers.append(layr)
         else:
+            if indx == 0 and layr.readonly:
+                raise s_exc.ReadOnlyLayer(mesg=f'First layer {layr.iden} must not be read-only')
             self.layers.insert(indx, layr)
         await self.info.set('layers', [l.iden for l in self.layers])
 
@@ -118,6 +126,8 @@ class View(s_base.Base):
             layr = self.core.layers.get(iden)
             if layr is None:
                 raise s_exc.NoSuchLayer(iden=iden)
+            if not layrs and layr.readonly:
+                raise s_exc.ReadOnlyLayer(mesg=f'First layer {layr.iden} must not be read-only')
 
             layrs.append(layr)
 

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -223,4 +223,10 @@ class InconsistentStorage(SynErr):
     '''
     pass
 
+class DataAlreadyExists(SynErr):
+    '''
+    Cannot copy data to a location that already contains data
+    '''
+    pass
+
 class BadTime(SynErr): pass

--- a/synapse/lib/agenda.py
+++ b/synapse/lib/agenda.py
@@ -297,7 +297,7 @@ class _Appt:
     @classmethod
     def unpack(cls, val):
         if val['ver'] != 1:
-            raise s_exc.BadStorageVersion  # pragma: no cover
+            raise s_exc.BadStorageVersion(mesg=f"Found version {val['ver']}")  # pragma: no cover
         recs = [ApptRec.unpack(tupl) for tupl in val['recs']]
         appt = cls(val['iden'], val['recur'], val['indx'], val['query'], val['useriden'], recs, val['nexttime'])
         appt.startcount = val['startcount']
@@ -407,7 +407,7 @@ class Agenda(s_base.Base):
                 self._next_indx = max(self._next_indx, appt.indx + 1)
             except (s_exc.InconsistentStorage, s_exc.BadStorageVersion, s_exc.BadTime, TypeError, KeyError,
                     UnicodeDecodeError) as e:
-                logger.warning('Invalid appointment %r found in storage: %r.  Removing', iden, e)
+                logger.warning('Invalid appointment %r found in storage: %r.  Removing.', iden, e)
                 to_delete.append(iden)
                 continue
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -448,7 +448,7 @@ class Cell(s_base.Base, s_telepath.Aware):
         except asyncio.CancelledError:  # pragma: no cover
             raise
         except OSError as e:
-            logger.error(f'Failed to lissten on unix socket at: [{sockpath}][{e}]')
+            logger.error(f'Failed to listen on unix socket at: [{sockpath}][{e}]')
             logger.error('LOCAL UNIX SOCKET WILL BE UNAVAILABLE')
         except Exception as e:  # pragma: no cover
             logging.exception('Unknown dmon listen error.')

--- a/synapse/lib/editatom.py
+++ b/synapse/lib/editatom.py
@@ -94,7 +94,10 @@ class EditAtom:
 
         splices = [snap.splice('node:add', ndef=node.ndef) for node in self.mybldgbuids.values()]
         for node, prop, oldv, valu in self.npvs:
-            splices.append(snap.splice('prop:set', ndef=node.ndef, prop=prop.name, valu=valu, oldv=oldv))
+            info = {'ndef': node.ndef, 'prop': prop.name, 'valu': valu}
+            if oldv is not None:
+                info['oldv'] = oldv
+            splices.append(snap.splice('prop:set', **info))
 
         await snap.stor(self.sops, splices)
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -379,3 +379,6 @@ class Layer(s_base.Base):
 
     async def getNodeNdef(self, buid):  # pragma: no cover
         raise NotImplementedError
+
+    def migrate_provstack_pre010(self, slab):  # pragma: no cover
+        raise NotImplementedError

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -3,7 +3,6 @@ The layer library contains the base Layer object and helpers used for
 cortex construction.
 '''
 import asyncio
-import hashlib
 import logging
 import collections
 
@@ -15,7 +14,6 @@ import synapse.exc as s_exc
 
 import synapse.lib.base as s_base
 import synapse.lib.cell as s_cell
-import synapse.lib.msgpack as s_msgpack
 
 logger = logging.getLogger(__name__)
 
@@ -154,9 +152,6 @@ class Layer(s_base.Base):
             async for row in func(oper):
                 yield row
 
-    async def getproviden(self, provstack):
-        return await self._storProvStack(provstack)
-
     async def stor(self, sops, splices=None):
         '''
         Execute a series of storage operations.
@@ -171,25 +166,6 @@ class Layer(s_base.Base):
             await self._storSplices(splices)
             self.spliced.set()
             self.spliced.clear()
-
-    async def getProvStack(self, iden):  # pragma: no cover
-        '''
-        Returns the provenance stack given the iden to it
-        '''
-        raise NotImplementedError
-
-    async def provStacks(self, offs, size):  # pragma: no cover
-        '''
-        Returns a stream of provenance stacks at the given offset
-        '''
-        raise NotImplementedError
-
-    @staticmethod
-    def _providen(prov):
-        '''
-        Calculates a provenance iden from a provenance stack
-        '''
-        return hashlib.md5(s_msgpack.en(prov)).digest()
 
     async def _storSplices(splices):  # pragma: no cover
         raise NotImplementedError

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -380,5 +380,5 @@ class Layer(s_base.Base):
     async def getNodeNdef(self, buid):  # pragma: no cover
         raise NotImplementedError
 
-    def migrate_provstack_pre010(self, slab):  # pragma: no cover
+    def migrateProvPre010(self, slab):  # pragma: no cover
         raise NotImplementedError

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -81,7 +81,6 @@ class LmdbLayer(s_layer.Layer):
         Once complete, drop the database from me with the name 'dbname'
 
         Returns (bool): True if a migration occurred, else False
-
         '''
         if not self.layrslab.dbexists(dbname):
             return False
@@ -108,7 +107,7 @@ class LmdbLayer(s_layer.Layer):
     def _migrate_splices_pre010(self):
         self._migrate_db_pre010('splices', self.spliceslab)
 
-    def migrate_provstack_pre010(self, newslab):
+    def migrateProvPre010(self, newslab):
         '''
         Check for any pre-010 provstacks and migrate those to the new slab.
         '''

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -38,7 +38,7 @@ class LmdbLayer(s_layer.Layer):
         ('lmdb:readahead', {'type': 'bool', 'defval': True}),
     )
 
-    def migrate_splices_pre010(self):
+    def _migrate_splices_pre010(self):
         '''
         Check for any pre-010 splices and migrate those to the new location (same base directory, separate file)
 
@@ -60,8 +60,8 @@ class LmdbLayer(s_layer.Layer):
             logger.info('Progress %d/%d (%2.2f%)', count, entries, count / entries * 100)
 
         oldslab.copydb(olddb, self.spliceslab, destdbname='splices', progresscb=progfunc)
-        logger.info('Pre-010 splice migration copying done.  Deleting from old location.')
-        oldslab.drop(olddb)
+        logger.info('Pre-010 splice migration copying done.  Deleting from old location...')
+        oldslab.dropdb(olddb)
         logger.info('Pre-010 splice migration completed.')
 
     async def __anit__(self, core, node):

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -43,6 +43,7 @@ class LmdbLayer(s_layer.Layer):
         await s_layer.Layer.__anit__(self, core, node)
 
         path = os.path.join(self.dirn, 'layer.lmdb')
+        splicepath = os.path.join(self.dirn, 'splices.lmdb')
 
         self.fresh = not os.path.exists(path)
 
@@ -53,8 +54,11 @@ class LmdbLayer(s_layer.Layer):
 
         self.layrslab = await s_lmdbslab.Slab.anit(path, max_dbs=128, map_size=mapsize, maxsize=maxsize,
                                                    growsize=growsize, writemap=True, readahead=readahead)
-
         self.onfini(self.layrslab.fini)
+
+        self.spliceslab = await s_lmdbslab.Slab.anit(splicepath, max_dbs=128, map_size=mapsize, maxsize=maxsize,
+                                                     growsize=growsize, writemap=True, readahead=readahead)
+        self.onfini(self.spliceslab.fini)
 
         self.dbs = {}
 
@@ -66,7 +70,7 @@ class LmdbLayer(s_layer.Layer):
         self.byuniv = await self.initdb('byuniv', dupsort=True) # <prop>00<indx>=<buid>
         offsdb = await self.initdb('offsets')
         self.offs = s_slaboffs.SlabOffs(self.layrslab, offsdb)
-        self.splicelog = s_slabseqn.SlabSeqn(self.layrslab, 'splices')
+        self.splicelog = s_slabseqn.SlabSeqn(self.spliceslab, 'splices')
 
     async def getModelVers(self):
         byts = self.layrslab.get(b'layer:model:version')

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -67,8 +67,6 @@ class LmdbLayer(s_layer.Layer):
         offsdb = await self.initdb('offsets')
         self.offs = s_slaboffs.SlabOffs(self.layrslab, offsdb)
         self.splicelog = s_slabseqn.SlabSeqn(self.layrslab, 'splices')
-        self.provdb = await self.initdb('prov') # md5 -> provenance stack
-        self.provseq = s_slabseqn.SlabSeqn(self.layrslab, 'provs')
 
     async def getModelVers(self):
         byts = self.layrslab.get(b'layer:model:version')
@@ -202,32 +200,6 @@ class LmdbLayer(s_layer.Layer):
 
     async def _storSplices(self, splices):
         self.splicelog.save(splices)
-
-    async def _storProvStack(self, prov):
-        iden = self._providen(prov)
-        misc, frames = prov
-        # Convert each frame back from (k, v) tuples to a dict
-        dictframes = [(typ, {k: v for (k, v) in info}) for (typ, info) in frames]
-        bytz = s_msgpack.en((misc, dictframes))
-        didwrite = self.layrslab.put(iden, bytz, overwrite=False, db=self.provdb)
-        if didwrite:
-            self.provseq.save([iden])
-
-        return iden
-
-    async def getProvStack(self, iden: bytes):
-        retn = self.layrslab.get(iden, db=self.provdb)
-        if retn is None:
-            return None
-
-        return s_msgpack.un(retn)
-
-    async def provStacks(self, offs, size):
-        for _, iden in self.provseq.slice(offs, size):
-            stack = await self.getProvStack(iden)
-            if stack is None:
-                continue
-            yield (iden, stack)
 
     async def _liftByIndx(self, oper):
         # ('indx', (<dbname>, <prefix>, (<indxopers>...))

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -313,6 +313,13 @@ class Slab(s_base.Base):
                 except lmdb.MapFullError:
                     self._growMapSize()
 
+    def dbexists(self, name):
+        '''
+        The DB exists already if there's a key in the default DB with the name of the database
+        '''
+        valu = self.get(name.encode())
+        return valu is not None
+
     @contextlib.contextmanager
     def _noCoXact(self):
         if not self.readonly or self.txnrefcount:

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -15,12 +15,15 @@ import synapse.lib.base as s_base
 import synapse.lib.const as s_const
 import synapse.lib.msgpack as s_msgpack
 
-class _LmdbDatabase():
+COPY_CHUNKSIZE = 512
+PROGRESS_PERIOD = COPY_CHUNKSIZE * 128
+
+class LmdbDatabase():
     def __init__(self, db, dupsort):
         self.db = db
         self.dupsort = dupsort
 
-_DefaultDB = _LmdbDatabase(None, False)
+_DefaultDB = LmdbDatabase(None, False)
 
 class Hist:
     '''
@@ -306,7 +309,7 @@ class Slab(s_base.Base):
             while True:
                 try:
                     db = self.lenv.open_db(name.encode('utf8'), dupsort=dupsort)
-                    return _LmdbDatabase(db, dupsort)
+                    return LmdbDatabase(db, dupsort)
                 except lmdb.MapFullError:
                     self._growMapSize()
 
@@ -495,6 +498,49 @@ class Slab(s_base.Base):
 
         except lmdb.MapFullError:
             return self._handle_mapfull()
+
+    def dropdb(self, db):
+        '''
+        Deletes an **entire database** (i.e. a table), losing all data.
+        '''
+        self.xact.drop(db.db, delete=True)
+
+    def copydb(self, sourcedb, destslab, destdbname=None, progresscb=None):
+        '''
+        Copy an entire database in this slab to a new database in potentially another slab.
+
+        Args:
+            sourcedb (LmdbDatabase): which database in this slab to copy rows from
+            destslab (LmdbSlab): which slab to copy rows to
+            destdbname (str): the name of the database to copy rows to in destslab
+            progresscb (Callable[int]):  if not None, this function will be periodically called with the number of rows
+                                         completed
+
+        Returns:
+            (int): the number of rows copied
+
+        Note:
+            If any rows already exist in the target database, this method returns an error.  This means that one cannot
+            use destdbname=None unless there are no explicit databases in the destination slab.
+        '''
+        destdb = destslab.initdb(destdbname, sourcedb.dupsort)
+
+        hasdata = destslab.last(db=destdb)
+        if hasdata is not None:
+            raise s_exc.DataAlreadyExists()
+
+        rowcount = 0
+
+        for chunk in s_common.chunks(self.scanByFull(db=sourcedb), COPY_CHUNKSIZE):
+            ccount, acount = destslab.putmulti(chunk, dupdata=True, append=True, db=destdb)
+            if ccount != len(chunk) or acount != len(chunk):
+                raise s_exc.BadCoreStore(mesg='Unexpected number of values written')
+
+            rowcount += len(chunk)
+            if progresscb is not None and 0 == (rowcount % PROGRESS_PERIOD):
+                progresscb(rowcount)
+
+        return rowcount
 
     def pop(self, lkey, db=None):
         return self._xact_action(self.pop, lmdb.Transaction.pop, lkey, db=db)

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -525,8 +525,8 @@ class Slab(s_base.Base):
         '''
         destdb = destslab.initdb(destdbname, sourcedb.dupsort)
 
-        hasdata = destslab.last(db=destdb)
-        if hasdata is not None:
+        statdict = destslab.stat(db=destdb)
+        if statdict['entries'] > 0:
             raise s_exc.DataAlreadyExists()
 
         rowcount = 0

--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -285,7 +285,9 @@ class Node:
         return self.props.get(name)
 
     async def pop(self, name, init=False):
-
+        '''
+        Remove a property from a node and return the value
+        '''
         prop = self.form.prop(name)
         if prop is None:
             if self.snap.strict:

--- a/synapse/lib/provenance.py
+++ b/synapse/lib/provenance.py
@@ -179,3 +179,10 @@ class ProvStor(s_base.Base):
             providen = self.getProvIden(provstack)
             setiden(providen)
         return wasnew, s_common.ehex(providen), provstack
+
+    def migrate_pre010(self, layer):
+        '''
+        Ask layer to migrate its old provstack DBs into me
+        '''
+        layer.migrate_provstack_pre010(self.slab)
+

--- a/synapse/lib/provenance.py
+++ b/synapse/lib/provenance.py
@@ -180,9 +180,8 @@ class ProvStor(s_base.Base):
             setiden(providen)
         return wasnew, s_common.ehex(providen), provstack
 
-    def migrate_pre010(self, layer):
+    def migratePre010(self, layer):
         '''
         Ask layer to migrate its old provstack DBs into me
         '''
-        layer.migrate_provstack_pre010(self.slab)
-
+        layer.migrateProvPre010(self.slab)

--- a/synapse/lib/remotelayer.py
+++ b/synapse/lib/remotelayer.py
@@ -81,9 +81,6 @@ class RemoteLayer(s_layer.Layer):
     async def stor(self, sops, splices=None):
         raise s_exc.ReadOnlyLayer(mesg='Remote layer does not support writing')
 
-    async def _storProvStack(self, prov):
-        raise s_exc.ReadOnlyLayer(mesg='Remote layer does not support writing')
-
     # Hack to get around issue that telepath is not async-generator-transparent
     async def getBuidProps(self, buid):
         await self._readyPlayerOne()

--- a/synapse/lib/remotelayer.py
+++ b/synapse/lib/remotelayer.py
@@ -27,6 +27,9 @@ class RemoteLayer(s_layer.Layer):
         ('readywait', {'type': 'int', 'defval': 30, 'doc': 'Max time to wait for layer ready.'}),
     )
 
+    # Remote layers can't be written to
+    readonly = True
+
     async def __anit__(self, core, node):
 
         await s_layer.Layer.__anit__(self, core, node)
@@ -75,9 +78,11 @@ class RemoteLayer(s_layer.Layer):
         timeout = self.conf.get('readywait')
         await asyncio.wait_for(self.ready.wait(), timeout=timeout)
 
-    async def stor(self, sops, prov=None, splices=None):
-        await self._readyPlayerOne()
-        return await self.proxy.stor(sops, prov, splices)
+    async def stor(self, sops, splices=None):
+        raise s_exc.ReadOnlyLayer(mesg='Remote layer does not support writing')
+
+    async def _storProvStack(self, prov):
+        raise s_exc.ReadOnlyLayer(mesg='Remote layer does not support writing')
 
     # Hack to get around issue that telepath is not async-generator-transparent
     async def getBuidProps(self, buid):

--- a/synapse/lib/trigger.py
+++ b/synapse/lib/trigger.py
@@ -168,7 +168,7 @@ class Triggers:
 
     def migrate_v0_rules(self):
         '''
-        Remove any v0 rules from storage and replace them with v1 rules.
+        Remove any v0 (i.e. pre-010) rules from storage and replace them with v1 rules.
 
         Notes:
             v0 had two differences user was a username.  Replaced with iden of user as 'iden' field.

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1,7 +1,5 @@
-import copy
 import time
 import asyncio
-import unittest
 
 from unittest.mock import patch
 
@@ -817,7 +815,7 @@ class CortexTest(s_t_utils.SynTest):
             mesg = ('node:add', {'ndef': ('test:str', 'hello')})
             self.isin(mesg, splices)
 
-            mesg = ('prop:set', {'ndef': ('test:str', 'hello'), 'prop': 'tick', 'valu': 978307200000, 'oldv': None})
+            mesg = ('prop:set', {'ndef': ('test:str', 'hello'), 'prop': 'tick', 'valu': 978307200000})
             self.isin(mesg, splices)
 
             mesg = ('prop:set',

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2542,3 +2542,10 @@ class CortexTest(s_t_utils.SynTest):
             self.len(2, await core.eval('test:str +#foo.**.baz').list())
             self.len(1, await core.eval('test:str +#**.bar.baz').list())
             self.len(2, await core.eval('test:str +#**.baz').list())
+
+    async def test_provstackmigration_pre010(self):
+        async with self.getRegrCore('pre-010') as core:
+            provstacks = list(core.provstor.provStacks(0, 1000))
+            self.gt(len(provstacks), 5)
+            self.false(core.layer.layrslab.dbexists('prov'))
+            self.false(core.layer.layrslab.dbexists('provs'))

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -30,9 +30,9 @@ class LayerTest(s_t_utils.SynTest):
 
             async with await core.snap() as snap:
 
-                node = await snap.addNode('test:str', 'a', {'tick': '1970'})
-                node = await snap.addNode('test:str', 'b', {'tick': '19700101'})
-                node = await snap.addNode('test:str', 'c', {'tick': '1972'})
+                await snap.addNode('test:str', 'a', {'tick': '1970'})
+                await snap.addNode('test:str', 'b', {'tick': '19700101'})
+                await snap.addNode('test:str', 'c', {'tick': '1972'})
                 oper = ('test:str', 'tick', (0, 24 * 60 * 60 * 366))
 
                 async def liftByHandler(lopf, expt):
@@ -52,4 +52,3 @@ class LayerTest(s_t_utils.SynTest):
             splices = await s_t_utils.alist(core.layer.splices(0, 1000))
             self.gt(len(splices), 100)
             self.false(core.layer.layrslab.dbexists('splices'))
-

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -46,3 +46,10 @@ class LayerTest(s_t_utils.SynTest):
                     await liftByHandler('prop:ival', 1)
                     await liftByHandler('univ:ival', 1)
                     await liftByHandler('form:ival', 1)
+
+    async def test_splicemigration_pre010(self):
+        async with self.getRegrCore('pre-010') as core:
+            splices = await s_t_utils.alist(core.layer.splices(0, 1000))
+            self.gt(len(splices), 100)
+            self.false(core.layer.layrslab.dbexists('splices'))
+

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -90,8 +90,9 @@ class LmdbSlabTest(s_t_utils.SynTest):
             # Test slab.drop
             self.nn(slab.last(db=foo2))
             slab.dropdb(foo2)
-            foo2 = slab.initdb('foo2')
-            self.none(slab.last(db=foo2))
+
+            # Actually test for presence of DB by looking in the default DB for a key with the name of the DB
+            self.none(slab.get(b'foo2'))
 
             # start a scan and then fini the whole db...
             scan = slab.scanByPref(b'\x00', db=foo)

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -87,12 +87,10 @@ class LmdbSlabTest(s_t_utils.SynTest):
                     self.eq(4, slab.copydb(foo2, slab2, destdbname='foo2', progresscb=progfunc))
                     self.gt(vardict.get('prog', 0), 0)
 
-            # Test slab.drop
-            self.nn(slab.last(db=foo2))
+            # Test slab.drop and slab.dbexists
+            self.true(slab.dbexists('foo2'))
             slab.dropdb(foo2)
-
-            # Actually test for presence of DB by looking in the default DB for a key with the name of the DB
-            self.none(slab.get(b'foo2'))
+            self.false(slab.dbexists('foo2'))
 
             # start a scan and then fini the whole db...
             scan = slab.scanByPref(b'\x00', db=foo)

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -4,6 +4,8 @@ import multiprocessing
 import synapse.exc as s_exc
 import synapse.common as s_common
 
+from unittest.mock import patch
+
 import synapse.lib.lmdbslab as s_lmdbslab
 
 import synapse.tests.utils as s_t_utils
@@ -64,6 +66,32 @@ class LmdbSlabTest(s_t_utils.SynTest):
 
             items = list(scan)
             self.eq(items, ((b'\x00\x02', b'visi'), (b'\x00\x02', b'zomg')))
+
+            # Copy a database inside the same slab
+            self.raises(s_exc.DataAlreadyExists, slab.copydb, foo, slab, 'bar')
+            self.eq(3, slab.copydb(foo, slab, 'foo2'))
+
+            # Increase the size of the new source DB to trigger a resize on the next copydb
+            foo2 = slab.initdb('foo2')
+            slab.put(b'bigkey', b'x' * 1024 * 1024, dupdata=True, db=foo2)
+
+            vardict = {}
+
+            def progfunc(count):
+                vardict['prog'] = count
+
+            # Copy a database to a different slab
+            path2 = os.path.join(dirn, 'test2.lmdb')
+            async with await s_lmdbslab.Slab.anit(path2, map_size=512 * 1024) as slab2:
+                with patch('synapse.lib.lmdbslab.PROGRESS_PERIOD', 2):
+                    self.eq(4, slab.copydb(foo2, slab2, destdbname='foo2', progresscb=progfunc))
+                    self.gt(vardict.get('prog', 0), 0)
+
+            # Test slab.drop
+            self.nn(slab.last(db=foo2))
+            slab.dropdb(foo2)
+            foo2 = slab.initdb('foo2')
+            self.none(slab.last(db=foo2))
 
             # start a scan and then fini the whole db...
             scan = slab.scanByPref(b'\x00', db=foo)

--- a/synapse/tests/test_lib_remotelayer.py
+++ b/synapse/tests/test_lib_remotelayer.py
@@ -3,14 +3,13 @@ import contextlib
 
 import synapse.exc as s_exc
 import synapse.common as s_common
-import synapse.cortex as s_cortex
 
 import synapse.lib.remotelayer as s_remotelayer
 
-import synapse.tests.utils as s_test
+import synapse.tests.utils as s_t_utils
 import synapse.tests.test_cortex as t_cortex
 
-class RemoteLayerTest(t_cortex.CortexTest):
+class RemoteLayerTest(s_t_utils.SynTest):
 
     @contextlib.asynccontextmanager
     async def getTestCore(self, conf=None, dirn=None):
@@ -25,20 +24,38 @@ class RemoteLayerTest(t_cortex.CortexTest):
 
     @contextlib.asynccontextmanager
     async def getRemoteCores(self, conf0=None, conf1=None, dirn0=None, dirn1=None):
+        '''
+        Returns a cortex and a second cortex that has a second remote layer pointing to the first cortex's layer
+        '''
         async with t_cortex.CortexTest.getTestCore(self, conf=conf0, dirn=dirn0) as core0:
             async with t_cortex.CortexTest.getTestCore(self, conf=conf1, dirn=dirn1) as core1:
                 conf = {'url': core0.getLocalUrl('*/layer')}
                 layr = await core1.addLayer(type='remote', config=conf)
-                await core1.view.addLayer(layr, indx=0)
+                await core1.view.addLayer(layr)
                 yield core0, core1
+
+    async def test_cortex_readonly_toplayer(self):
+        '''
+        Test the various ways to incorrectly put a remote layer as the write layer
+        '''
+        async with t_cortex.CortexTest.getTestCore(self) as core0:
+            async with t_cortex.CortexTest.getTestCore(self) as core1:
+                conf = {'url': core0.getLocalUrl('*/layer')}
+                layr = await core1.addLayer(type='remote', config=conf)
+                await self.asyncraises(s_exc.ReadOnlyLayer, core1.view.addLayer(layr, indx=0))
+                await self.asyncraises(s_exc.ReadOnlyLayer, core1.view.setLayers([layr.iden]))
+                await self.asyncraises(s_exc.ReadOnlyLayer, core1.addView(s_common.guid(), 'root', [layr.iden]))
+                view = await core1.addView(s_common.guid(), 'root', [])
+                await self.asyncraises(s_exc.ReadOnlyLayer, view.addLayer(layr))
 
     async def test_cortex_remote_layer(self):
 
-        async with self.getTestCore() as core:
+        async with self.getRemoteCores() as (directcore, core):
+            # We write to directcore and make sure we can read from core
 
-            await s_common.aspin(core.eval('[ test:str=woot :tick=2015 ]'))
+            await s_common.aspin(directcore.eval('[ test:str=woot :tick=2015 ]'))
 
-            layr = core.view.layers[0]
+            layr = core.view.layers[1]
             self.true(isinstance(layr, s_remotelayer.RemoteLayer))
 
             self.len(1, [x async for x in layr.iterFormRows('test:str')])
@@ -76,16 +93,14 @@ class RemoteLayerTest(t_cortex.CortexTest):
             self.len(1, await core1.eval('test:str=woot').list())
 
             # hulk smash the proxy
-            await core1.view.layers[0].proxy.fini()
+            await core1.view.layers[1].proxy.fini()
 
             # cause a reconnect...
             self.len(1, await core1.eval('test:str=woot').list())
 
-class RemoteLayerConfigTest(s_test.SynTest):
+class RemoteLayerConfigTest(s_t_utils.SynTest):
 
     async def test_cortex_remote_config(self):
-        # Full telepath / auth stack
-        pconf = {'user': 'root', 'passwd': 'root'}
 
         # use the original API so we dont do yodawg layers remote layers
         async with self.getTestCoreAndProxy() as (core0, prox0):


### PR DESCRIPTION
Include migration code. Provenance is now a cortex function, not a layer function.