### PR TITLE
Recover from failed pre-010 migration bootloop

### DIFF
--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -104,7 +104,7 @@ class LmdbLayer(s_layer.Layer):
             return False
 
         if newslab.dbexists(dbname):
-            logger.info('Incomplete migration detected.  Dropping new splices to restart...')
+            logger.warning('Incomplete migration detected.  Dropping new splices to restart.')
             newslab.dropdb(dbname)
             logger.info('New splice dropping complete.')
 

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -61,6 +61,9 @@ class LmdbLayer(s_layer.Layer):
                                                      growsize=growsize, writemap=True, readahead=readahead)
         self.onfini(self.spliceslab.fini)
 
+        metadb = self.layrslab.initdb('meta')
+        self.metadict = s_lmdbslab.SlabDict(self.layrslab, metadb)
+
         self._migrate_splices_pre010()
 
         self.dbs = {}
@@ -83,7 +86,13 @@ class LmdbLayer(s_layer.Layer):
 
         Returns (bool): True if a migration occurred, else False
         '''
+        donekey = f'migrdone:{dbname}'
+
+        if self.metadict.get(donekey, False):
+            return
+
         if not self.layrslab.dbexists(dbname):
+            self.metadict.set(donekey, True)
             return False
 
         oldslab = self.layrslab
@@ -91,7 +100,13 @@ class LmdbLayer(s_layer.Layer):
 
         entries = oldslab.stat(olddb)['entries']
         if not entries:
+            self.metadict.set(donekey, True)
             return False
+
+        if newslab.dbexists(dbname):
+            logger.info('Incomplete migration detected.  Dropping new splices to restart...')
+            newslab.dropdb(dbname)
+            logger.info('New splice dropping complete.')
 
         logger.info('Pre-010 %s migration starting.  Total rows: %d...', dbname, entries)
 
@@ -102,6 +117,8 @@ class LmdbLayer(s_layer.Layer):
         logger.info('Pre-010 %s migration copying done.  Deleting from old location...', dbname)
         oldslab.dropdb(dbname)
         logger.info('Pre-010 %s migration completed.', dbname)
+
+        self.metadict.set(donekey, True)
 
         return True
 

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -81,9 +81,6 @@ class LayerTest(s_t_utils.SynTest):
                     mesgs = stream.read()
                     self.isin('Incomplete migration', mesgs)
 
-                    # Make sure progress got printed out
-                    self.isin('Progress', mesgs)
-
             with self.getLoggerStream('synapse.lib.lmdblayer') as stream:
                 # Make sure the third time around we didn't migrate and we still have our splices
                 async with await s_cortex.Cortex.anit(dirn) as core:
@@ -91,8 +88,7 @@ class LayerTest(s_t_utils.SynTest):
 
                 self.eq(splices1, splices3)
 
-            # Test for no hint of migration happening
-            stream.seek(0)
-            mesgs = stream.read()
-            self.notin('migration', mesgs)
-
+                # Test for no hint of migration happening
+                stream.seek(0)
+                mesgs = stream.read()
+                self.notin('migration', mesgs)

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -1,5 +1,10 @@
 import contextlib
+from unittest.mock import patch
+
+import synapse.exc as s_exc
+import synapse.cortex as s_cortex
 import synapse.tests.utils as s_t_utils
+import synapse.lib.layer as s_layer
 
 
 async def iterPropForm(self, form=None, prop=None):
@@ -49,6 +54,45 @@ class LayerTest(s_t_utils.SynTest):
 
     async def test_splicemigration_pre010(self):
         async with self.getRegrCore('pre-010') as core:
-            splices = await s_t_utils.alist(core.layer.splices(0, 1000))
-            self.gt(len(splices), 100)
+            splices1 = await s_t_utils.alist(core.layer.splices(0, 1000))
+            self.gt(len(splices1), 100)
             self.false(core.layer.layrslab.dbexists('splices'))
+
+        def baddrop(self, name):
+            raise s_exc.DbOutOfSpace()
+
+        with self.getRegrDir('cortexes', 'pre-010') as dirn:
+            # Simulate a crash during recovery
+            with self.raises(s_exc.DbOutOfSpace):
+                with patch('synapse.lib.lmdbslab.Slab.dropdb', baddrop):
+                    async with await s_cortex.Cortex.anit(dirn) as core:
+                        pass
+
+            # Make sure when it comes back we're not stuck
+            with patch('synapse.lib.lmdbslab.PROGRESS_PERIOD', 50), patch('synapse.lib.lmdbslab.COPY_CHUNKSIZE', 50):
+                with self.getLoggerStream('synapse.lib.lmdblayer') as stream:
+                    async with await s_cortex.Cortex.anit(dirn) as core:
+                        splices2 = await s_t_utils.alist(core.layer.splices(0, 1000))
+                        self.false(core.layer.layrslab.dbexists('splices'))
+
+                    self.eq(splices1, splices2)
+
+                    stream.seek(0)
+                    mesgs = stream.read()
+                    self.isin('Incomplete migration', mesgs)
+
+                    # Make sure progress got printed out
+                    self.isin('Progress', mesgs)
+
+            with self.getLoggerStream('synapse.lib.lmdblayer') as stream:
+                # Make sure the third time around we didn't migrate and we still have our splices
+                async with await s_cortex.Cortex.anit(dirn) as core:
+                    splices3 = await s_t_utils.alist(core.layer.splices(0, 1000))
+
+                self.eq(splices1, splices3)
+
+            # Test for no hint of migration happening
+            stream.seek(0)
+            mesgs = stream.read()
+            self.notin('migration', mesgs)
+


### PR DESCRIPTION
Persistently record when a migration succeeds so we can safely nuke the potentially partially migrated rows on detecting a prior migration failure.