### PR TITLE
Optimize snap.getNodesBy in common case

### DIFF
--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -194,6 +194,7 @@ class Univ(PropBase):
         PropBase.__init__(self)
         self.modl = modl
         self.name = name
+        self.isform = False     # for quick Prop()/Form() detection
         self.type = modl.getTypeClone(typedef)
         self.info = propinfo
         self.pref = name.encode('utf8') + b'\x00'

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -303,7 +303,7 @@ class Snap(s_base.Base):
 
         lops = prop.getLiftOps(valu, cmpr=cmpr)
 
-        if prop.isform and cmpr == '=' and valu is not None and lops[0][1][2][0][0] == 'eq':
+        if prop.isform and cmpr == '=' and valu is not None and len(lops) == 1 and lops[0][1][2][0][0] == 'eq':
             # Shortcut to buid lookup if primary prop = valu
             norm, _ = prop.type.norm(valu)
             node = await self.getNodeByNdef((full, norm))


### PR DESCRIPTION
When lifting for equality for a primary prop, lift by buid