### PR TITLE
Bug reflection

### DIFF
--- a/synapse/lib/reflect.py
+++ b/synapse/lib/reflect.py
@@ -64,15 +64,13 @@ def getShareInfo(item):
     Returns:
         dict: A dictionary of methods requiring special handling by the proxy.
     '''
-    info = getattr(item, '_syn_sharinfo', None)
+    key = f'_syn_sharinfo_{item.__class__.__module__}_{item.__class__.__qualname__}'
+    info = getattr(item, key, None)
     if info is not None:
-        logger.error(f'Object {item} aready had {info}/{id(info)}')
         return info
 
     meths = {}
     info = {'meths': meths}
-
-    logger.error(f'Inspecting: {item}')
 
     for name in dir(item):
         if name.startswith('_'):
@@ -94,19 +92,13 @@ def getShareInfo(item):
             meths[name] = {'genr': True}
 
     try:
-        setattr(item, '_syn_sharinfo', info)
+        setattr(item, key, info)
     except Exception as e:  # pragma: no cover
         logger.exception(f'Failed to set magic on {item}')
-    else:
-        logger.error(f'Set _syn_sharinfo on {item}/{info}/{id(info)}')
 
     try:
-        setattr(item.__class__, '_syn_sharinfo', info)
+        setattr(item.__class__, key, info)
     except Exception as e:  # pragma: no cover
         logger.exception(f'Failed to set magic on {item.__class__}')
-    else:
-        logger.error(f'Set _syn_sharinfo on {item.__class__}/{info}/{id(info)}')
-
-    logger.error(f'Got {info}/{id(info)}')
 
     return info

--- a/synapse/tests/test_lib_reflect.py
+++ b/synapse/tests/test_lib_reflect.py
@@ -30,13 +30,13 @@ class ReflectTest(s_t_utils.SynTest):
         self.isin('synapse.tests.test_lib_reflect.Foo', names)
 
     async def test_telemeth(self):
-        self.none(getattr(Echo, '_syn_sharinfo', None))
+        self.none(getattr(Echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo', None))
         async with self.getTestDmon() as dmon:
             echo = await Echo.anit()
             dmon.share('echo', echo)
-            self.none(getattr(echo, '_syn_sharinfo', None))
-            self.none(getattr(Echo, '_syn_sharinfo', None))
+            self.none(getattr(echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo', None))
+            self.none(getattr(Echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo', None))
             async with await self.getTestProxy(dmon, 'echo') as proxy:
                 pass
-            self.isinstance(getattr(echo, '_syn_sharinfo', None), dict)
-            self.isinstance(getattr(Echo, '_syn_sharinfo', None), dict)
+            self.isinstance(getattr(echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo', None), dict)
+            self.isinstance(getattr(Echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo', None), dict)

--- a/synapse/tests/test_servers_univ.py
+++ b/synapse/tests/test_servers_univ.py
@@ -4,6 +4,7 @@ import synapse.telepath as s_telepath
 
 import synapse.servers.cell as s_s_univ
 import synapse.servers.cortex as s_s_cortex
+import synapse.servers.cryotank as s_s_cryo
 
 import synapse.tests.utils as s_t_utils
 
@@ -67,3 +68,86 @@ class UnivServerTest(s_t_utils.SynTest):
             # Coverage test, for a bad configuration
             with self.raises(OverflowError):
                 obj = await s_s_univ.main(argu, outp=outp)
+
+    async def test_break(self):
+        with self.getTestDir() as dirn:
+
+            outp = self.getTestOutp()
+            guid = s_common.guid()
+
+            argv = ['--telepath', 'tcp://127.0.0.1:0/',
+                    '--https', '0',
+                    '--name', 'univtest',
+                    ]
+            argu = list(argv)
+            argu.extend(['synapse.cortex.Cortex', dirn])
+            # Start a cortex with the universal loader
+            async with await s_s_univ.main(argu, outp=outp) as core:
+
+                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
+                    podes = await s_t_utils.alist(proxy.eval(f'[ou:org={guid}]'))
+                    self.len(1, podes)
+                    self.eq('cortex', await proxy.getCellType())
+
+                self.true(core.dmon.shared.get('univtest') is core)
+
+            # And data persists... and can be seen with the regular synapse cortex server
+            argu = list(argv)
+            argu.append(dirn)
+            async with await s_s_cortex.main(argu, outp=outp) as core:
+                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
+                    podes = await s_t_utils.alist(proxy.eval(f'ou:org={guid}'))
+                    self.len(1, podes)
+
+            argu = list(argv)
+            argu.extend(['synapse.lib.cell.Cell', dirn])
+            # Start a cortex as a regular Cell
+            async with await s_s_univ.main(argu, outp=outp) as cell:
+                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
+                    self.eq('cell', await proxy.getCellType())
+
+            argu = list(argv)
+            argu.extend(['synapse.tests.test_lib_cell.EchoAuth', dirn])
+            # Or start the Cortex off a a EchoAuth (don't do this in practice...)
+            async with await s_s_univ.main(argu, outp=outp) as cell:
+                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
+                    self.eq('echoauth', await proxy.getCellType())
+
+            argu = list(argv)
+            argu.extend(['synapse.lib.newp.Newp', dirn])
+            with self.raises(s_exc.NoSuchCtor):
+                async with await s_s_univ.main(argu, outp=outp) as core:
+                    pass
+
+            argu = ['synapse.lib.cell.Cell', dirn,
+                    '--telepath', 'tcp://127.0.0.1:9999999/',
+                    '--https', '0',
+                    '--name', 'telecore']
+            # Coverage test, for a bad configuration
+            with self.raises(OverflowError):
+                obj = await s_s_univ.main(argu, outp=outp)
+
+        recs = (
+            ('hehe', {'haha': 1}),
+            ('woah', {'dude': 1}),
+        )
+
+        with self.getTestDir() as dirn:
+            outp = self.getTestOutp()
+
+            argv = [dirn,
+                    '--telepath', 'tcp://127.0.0.1:0/',
+                    '--https', '0',
+                    '--name', 'telecryo']
+            async with await s_s_cryo.main(argv, outp=outp) as cryotank:
+                async with cryotank.getLocalProxy() as proxy:
+                    await proxy.puts('foo', recs)
+
+                self.true(cryotank.dmon.shared.get('telecryo') is cryotank)
+
+            # And data persists...
+            async with await s_s_cryo.main(argv, outp=outp) as telecryo:
+                async with telecryo.getLocalProxy() as proxy:
+                    precs = await s_t_utils.alist(proxy.slice('foo', 0, 100))
+                    precs = [rec for offset, rec in precs]
+                    self.eq(precs, recs)

--- a/synapse/tests/test_servers_univ.py
+++ b/synapse/tests/test_servers_univ.py
@@ -21,31 +21,6 @@ class UnivServerTest(s_t_utils.SynTest):
                     '--https', '0',
                     '--name', 'univtest',
                     ]
-
-            argu = list(argv)
-            argu.extend(['synapse.lib.cell.Cell', dirn])
-            # Start a cortex as a regular Cell
-            async with await s_s_univ.main(argu, outp=outp) as cell:
-                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
-                    self.eq('cell', await proxy.getCellType())
-
-            argu = list(argv)
-            argu.extend(['synapse.tests.test_lib_cell.EchoAuth', dirn])
-            # Or start the Cortex off a a EchoAuth (don't do this in practice...)
-            async with await s_s_univ.main(argu, outp=outp) as cell:
-                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
-                    self.eq('echoauth', await proxy.getCellType())
-
-    async def test_break(self):
-        with self.getTestDir() as dirn:
-
-            outp = self.getTestOutp()
-            guid = s_common.guid()
-
-            argv = ['--telepath', 'tcp://127.0.0.1:0/',
-                    '--https', '0',
-                    '--name', 'univtest',
-                    ]
             argu = list(argv)
             argu.extend(['synapse.cortex.Cortex', dirn])
             # Start a cortex with the universal loader
@@ -93,6 +68,31 @@ class UnivServerTest(s_t_utils.SynTest):
             # Coverage test, for a bad configuration
             with self.raises(OverflowError):
                 obj = await s_s_univ.main(argu, outp=outp)
+
+    async def test_break(self):
+        with self.getTestDir() as dirn:
+
+            outp = self.getTestOutp()
+            guid = s_common.guid()
+
+            argv = ['--telepath', 'tcp://127.0.0.1:0/',
+                    '--https', '0',
+                    '--name', 'univtest',
+                    ]
+
+            argu = list(argv)
+            argu.extend(['synapse.lib.cell.Cell', dirn])
+            # Start a cortex as a regular Cell
+            async with await s_s_univ.main(argu, outp=outp) as cell:
+                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
+                    self.eq('cell', await proxy.getCellType())
+
+            argu = list(argv)
+            argu.extend(['synapse.tests.test_lib_cell.EchoAuth', dirn])
+            # Or start the Cortex off a a EchoAuth (don't do this in practice...)
+            async with await s_s_univ.main(argu, outp=outp) as cell:
+                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
+                    self.eq('echoauth', await proxy.getCellType())
 
         recs = (
             ('hehe', {'haha': 1}),

--- a/synapse/tests/test_servers_univ.py
+++ b/synapse/tests/test_servers_univ.py
@@ -21,25 +21,6 @@ class UnivServerTest(s_t_utils.SynTest):
                     '--https', '0',
                     '--name', 'univtest',
                     ]
-            argu = list(argv)
-            argu.extend(['synapse.cortex.Cortex', dirn])
-            # Start a cortex with the universal loader
-            async with await s_s_univ.main(argu, outp=outp) as core:
-
-                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
-                    podes = await s_t_utils.alist(proxy.eval(f'[ou:org={guid}]'))
-                    self.len(1, podes)
-                    self.eq('cortex', await proxy.getCellType())
-
-                self.true(core.dmon.shared.get('univtest') is core)
-
-            # And data persists... and can be seen with the regular synapse cortex server
-            argu = list(argv)
-            argu.append(dirn)
-            async with await s_s_cortex.main(argu, outp=outp) as core:
-                async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
-                    podes = await s_t_utils.alist(proxy.eval(f'ou:org={guid}'))
-                    self.len(1, podes)
 
             argu = list(argv)
             argu.extend(['synapse.lib.cell.Cell', dirn])
@@ -54,20 +35,6 @@ class UnivServerTest(s_t_utils.SynTest):
             async with await s_s_univ.main(argu, outp=outp) as cell:
                 async with await s_telepath.openurl(f'cell://{dirn}') as proxy:
                     self.eq('echoauth', await proxy.getCellType())
-
-            argu = list(argv)
-            argu.extend(['synapse.lib.newp.Newp', dirn])
-            with self.raises(s_exc.NoSuchCtor):
-                async with await s_s_univ.main(argu, outp=outp) as core:
-                    pass
-
-            argu = ['synapse.lib.cell.Cell', dirn,
-                    '--telepath', 'tcp://127.0.0.1:9999999/',
-                    '--https', '0',
-                    '--name', 'telecore']
-            # Coverage test, for a bad configuration
-            with self.raises(OverflowError):
-                obj = await s_s_univ.main(argu, outp=outp)
 
     async def test_break(self):
         with self.getTestDir() as dirn:


### PR DESCRIPTION
synapse.lib.reflect.getShareInfo could return incorrect data depending on execution order.