### PR TITLE
Fix multi layer bug, reorganize cortex tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Features and Enhancements
 Bugfixes
 --------
 
-- Fix old bugs (`#XXX <https://github.com/vertexproject/synapse/pull/XXX>`_)
+- Fix remote layer bug injected by previous optimization that would result in missing nodes from lifts when the node
+  only resides in the distant layer. (`#1203 <https://github.com/vertexproject/synapse/pull/1203>`_)
 
 Improved Documentation
 ----------------------

--- a/synapse/lib/remotelayer.py
+++ b/synapse/lib/remotelayer.py
@@ -85,7 +85,6 @@ class RemoteLayer(s_layer.Layer):
     async def stor(self, sops, splices=None):
         raise s_exc.ReadOnlyLayer(mesg='Remote layer does not support writing')
 
-    # Hack to get around issue that telepath is not async-generator-transparent
     async def getBuidProps(self, buid):
         await self._readyPlayerOne()
         return await self.proxy.getBuidProps(buid)

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -337,7 +337,7 @@ class Snap(s_base.Base):
 
         for prop in self.model.getPropsByType(name):
             lops = prop.getLiftOps(valu)
-            async for row, node in self.getLiftNodes(lops, prop):
+            async for row, node in self.getLiftNodes(lops, prop.name):
                 yield node
 
     async def addNode(self, name, valu, props=None):
@@ -666,7 +666,8 @@ class Snap(s_base.Base):
                 self.livenodes[buid] = node
 
             # If the node's prop I'm filtering on came from a different layer, skip it
-            if node.proplayr[rawprop] != self.layers[origlayer]:
+            rawrawprop = ('*' if rawprop == node.form.name else '') + rawprop
+            if node.proplayr[rawrawprop] != self.layers[origlayer]:
                 continue
 
             if cmpf:

--- a/synapse/tests/test_lib_remotelayer.py
+++ b/synapse/tests/test_lib_remotelayer.py
@@ -10,11 +10,10 @@ import synapse.lib.remotelayer as s_remotelayer
 import synapse.tests.utils as s_t_utils
 import synapse.tests.test_cortex as t_cortex
 
-class RemoteLayerTest(s_t_utils.SynTest):
+class RemoteLayerTest(t_cortex.CortexTest):
 
     @contextlib.asynccontextmanager
     async def getTestCore(self, conf=None, dirn=None):
-
         # make remote core from provided dirn for repeatability
         dirn0 = None
         if dirn is not None:
@@ -22,6 +21,15 @@ class RemoteLayerTest(s_t_utils.SynTest):
 
         async with self.getRemoteCores(dirn0=dirn0, conf1=conf, dirn1=dirn) as (core0, core1):
             yield core1
+
+    @contextlib.asynccontextmanager
+    async def getTestReadWriteCores(self, conf=None, dirn=None):
+        dirn0 = None
+        if dirn is not None:
+            dirn0 = s_common.gendir(dirn, 'remotecore')
+
+        async with self.getRemoteCores(dirn0=dirn0, conf1=conf, dirn1=dirn) as (core0, core1):
+            yield core1, core0
 
     @contextlib.asynccontextmanager
     async def getRemoteCores(self, conf0=None, conf1=None, dirn0=None, dirn1=None):
@@ -77,14 +85,8 @@ class RemoteLayerTest(s_t_utils.SynTest):
             self.eq(s_modelrev.maxvers, await layr.getModelVers())
             await self.asyncraises(s_exc.SynErr, layr.setModelVers((9, 9, 9)))
 
-    async def test_splice_generation(self):
+    async def test_cortex_iter_props(self):
         self.skip('test_splice_generation directly uses layers')
-
-    async def test_splice_cryo(self):
-        self.skip('test_splice_generation directly uses layers')
-
-    async def test_splice_sync(self):
-        self.skip('test_splice_sync directly uses events')
 
     async def test_cortex_remote_reconn(self):
 

--- a/synapse/tests/test_lib_remotelayer.py
+++ b/synapse/tests/test_lib_remotelayer.py
@@ -86,7 +86,7 @@ class RemoteLayerTest(t_cortex.CortexTest):
             await self.asyncraises(s_exc.SynErr, layr.setModelVers((9, 9, 9)))
 
     async def test_cortex_iter_props(self):
-        self.skip('test_splice_generation directly uses layers')
+        self.skip('test_cortex_iter_props directly uses layers')
 
     async def test_cortex_remote_reconn(self):
 

--- a/synapse/tests/test_lib_snap.py
+++ b/synapse/tests/test_lib_snap.py
@@ -263,4 +263,3 @@ class SnapTest(s_t_utils.SynTest):
             # now set one to a diff value that we will ask for but should be masked
             self.len(1, await core0.eval('[ inet:ipv4=1.2.3.4 :asn=99 ]').list())
             self.len(0, await core1.eval('inet:ipv4:asn=99').list())
-

--- a/synapse/tests/test_lib_snap.py
+++ b/synapse/tests/test_lib_snap.py
@@ -220,6 +220,16 @@ class SnapTest(s_t_utils.SynTest):
                 await core1.view.addLayer(layr)
                 yield core0, core1
 
+    async def test_cortex_lift_layers_simple(self):
+        async with self._getTestCoreMultiLayer() as (core0, core1):
+            ''' Test that you can write to core0 and read it from core 1 '''
+            self.len(1, await core0.eval('[ inet:ipv4=1.2.3.4 :asn=42 +#woot=(2014, 2015)]').list())
+            self.len(1, await core1.eval('inet:ipv4').list())
+            self.len(1, await core1.eval('inet:ipv4=1.2.3.4').list())
+            self.len(1, await core1.eval('inet:ipv4:asn=42').list())
+            self.len(1, await core1.eval('inet:ipv4 +:asn=42').list())
+            self.len(1, await core1.eval('inet:ipv4 +#woot').list())
+
     async def test_cortex_lift_layers_bad_filter(self):
         '''
         Test a two layer cortex where a lift operation gives the wrong result
@@ -253,3 +263,4 @@ class SnapTest(s_t_utils.SynTest):
             # now set one to a diff value that we will ask for but should be masked
             self.len(1, await core0.eval('[ inet:ipv4=1.2.3.4 :asn=99 ]').list())
             self.len(0, await core1.eval('inet:ipv4:asn=99').list())
+

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -774,6 +774,11 @@ class SynTest(unittest.TestCase):
             yield
 
     @contextlib.asynccontextmanager
+    async def getTestReadWriteCores(self, conf=None, dirn=None):
+        async with self.getTestCore(conf=conf, dirn=dirn) as core:
+            yield core, core
+
+    @contextlib.asynccontextmanager
     async def getTestCore(self, conf=None, dirn=None):
         '''
         Return a simple test Cortex.


### PR DESCRIPTION
Divide CortexTest into CortexTest and CortexBasicTest, so that
CortexTest can be inherited by tests with different layers and not have
superfluous tests.

Have RemoteLayerTest inherit from CortexTest again for better coverage
of cortexes with a two-layer setup with a remote layer.

Add a simple test to snap to directly test the bug found:  lifting by
primary property from a lower layer when an upper layer didn't have the
node improperly skipped it.