### PR TITLE
Fix documentation error for httpapi login example

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Bugfixes
 Improved Documentation
 ----------------------
 
-- Write awesome docs (`#XXX <https://github.com/vertexproject/synapse/pull/XXX>`_)
+- Fix error in the HTTP API documentation. (`#1204 <https://github.com/vertexproject/synapse/pull/1204>`_)
 
 
 v0.1.2 - 2018-04-03

--- a/docs/synapse/httpapi.rst
+++ b/docs/synapse/httpapi.rst
@@ -56,7 +56,7 @@ session may then be used to call other HTTP API endpoints as the authenticated u
 
         async with aiohttp.ClientSession() as sess:
 
-            info = {'name': 'visi', 'passwd': 'secret'}
+            info = {'user': 'visi', 'passwd': 'secret'}
             async with sess.post(f'https://localhost:56443/api/v1/login', json=info) as resp:
                 item = await resp.json()
                 if item.get('status') != 'ok':


### PR DESCRIPTION
ensure docs line up with https://github.com/vertexproject/synapse/blob/v0.1.2/synapse/lib/httpapi.py#L254