### PR TITLE
Add model/norm API endpoint via POST

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features and Enhancements
 -------------------------
 
 - Add POST support to the ``/api/v1/model/norm`` HTTP API endpoint. (`#1207 <https://github.com/vertexproject/synapse/pull/1207>`_)
+- Add ``getPropNorm()`` and ``getTypeNorm()`` Telepath API endpoints to the Cortex and CoreApi. (`#1207 <https://github.com/vertexproject/synapse/pull/1207>`_)
 
 Bugfixes
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,7 @@ v0.1.4 - TBD
 Features and Enhancements
 -------------------------
 
-
-- Add new features (`#XXX <https://github.com/vertexproject/synapse/pull/XXX>`_)
+- Add POST support to the ``/api/v1/model/norm`` HTTP API endpoint. (`#1207 <https://github.com/vertexproject/synapse/pull/1207>`_)
 
 Bugfixes
 --------

--- a/docs/synapse/httpapi.rst
+++ b/docs/synapse/httpapi.rst
@@ -298,9 +298,10 @@ of results as the reader consumes them.
 ~~~~~~~~~~~~~~~~~~
 
 *Method*
-    GET
+    GET, POST
 
-    This API allows the caller to normalize a value based on the Cortex data model.
+    This API allows the caller to normalize a value based on the Cortex data model.  This may be called via a GET or
+    POST requests.
 
     *Input*
         The API expects the following JSON body::

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -529,6 +529,23 @@ class CoreApi(s_cell.CellApi):
         '''
         return self.cell.provstor.getProvStack(s_common.uhex(iden))
 
+    async def norm(self, prop, valu):
+        '''
+        Get the normalized property value based on the Cortex data model.
+
+        Args:
+            prop (str): The property to normalize.
+            valu: The value to normalize.
+
+        Returns:
+            (tuple): A two item tuple, containing the normed value and the info dictionary.
+
+        Raises:
+            s_exc.NoSuchProp: If the prop does not exist.
+            s_exc.BadTypeValu: If the value fails to normalize.
+        '''
+        return self.cell.norm(prop, valu)
+
 class Cortex(s_cell.Cell):
     '''
     A Cortex implements the synapse hypergraph.
@@ -1903,6 +1920,28 @@ class Cortex(s_cell.Cell):
             'formcounts': self.counts,
         }
         return stats
+
+    def norm(self, prop, valu):
+        '''
+        Get the normalized property value based on the Cortex data model.
+
+        Args:
+            prop (str): The property to normalize.
+            valu: The value to normalize.
+
+        Returns:
+            (tuple): A two item tuple, containing the normed value and the info dictionary.
+
+        Raises:
+            s_exc.NoSuchProp: If the prop does not exist.
+            s_exc.BadTypeValu: If the value fails to normalize.
+        '''
+        pobj = self.model.prop(prop)
+        if pobj is None:
+            raise s_exc.NoSuchProp(mesg=f'The property {prop} does not exist.',
+                                   prop=prop)
+        norm, info = pobj.type.norm(valu)
+        return norm, info
 
 @contextlib.asynccontextmanager
 async def getTempCortex(mods=None):

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -548,7 +548,7 @@ class CoreApi(s_cell.CellApi):
 
     async def getTypeNorm(self, name, valu):
         '''
-        Get the normalized property value based on the Cortex data model.
+        Get the normalized type value based on the Cortex data model.
 
         Args:
             name (str): The type to normalize.
@@ -558,7 +558,7 @@ class CoreApi(s_cell.CellApi):
             (tuple): A two item tuple, containing the normed value and the info dictionary.
 
         Raises:
-            s_exc.NoSuchType: If the prop does not exist.
+            s_exc.NoSuchType: If the type does not exist.
             s_exc.BadTypeValu: If the value fails to normalize.
         '''
         return await self.cell.getTypeNorm(name, valu)
@@ -1962,7 +1962,7 @@ class Cortex(s_cell.Cell):
 
     async def getTypeNorm(self, name, valu):
         '''
-        Get the normalized property value based on the Cortex data model.
+        Get the normalized type value based on the Cortex data model.
 
         Args:
             name (str): The type to normalize.
@@ -1972,7 +1972,7 @@ class Cortex(s_cell.Cell):
             (tuple): A two item tuple, containing the normed value and the info dictionary.
 
         Raises:
-            s_exc.NoSuchType: If the prop does not exist.
+            s_exc.NoSuchType: If the type does not exist.
             s_exc.BadTypeValu: If the value fails to normalize.
         '''
         tobj = self.model.type(name)

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -529,7 +529,7 @@ class CoreApi(s_cell.CellApi):
         '''
         return self.cell.provstor.getProvStack(s_common.uhex(iden))
 
-    async def norm(self, prop, valu):
+    async def getPropNorm(self, prop, valu):
         '''
         Get the normalized property value based on the Cortex data model.
 
@@ -544,7 +544,24 @@ class CoreApi(s_cell.CellApi):
             s_exc.NoSuchProp: If the prop does not exist.
             s_exc.BadTypeValu: If the value fails to normalize.
         '''
-        return self.cell.norm(prop, valu)
+        return await self.cell.getPropNorm(prop, valu)
+
+    async def getTypeNorm(self, name, valu):
+        '''
+        Get the normalized property value based on the Cortex data model.
+
+        Args:
+            name (str): The type to normalize.
+            valu: The value to normalize.
+
+        Returns:
+            (tuple): A two item tuple, containing the normed value and the info dictionary.
+
+        Raises:
+            s_exc.NoSuchType: If the prop does not exist.
+            s_exc.BadTypeValu: If the value fails to normalize.
+        '''
+        return await self.cell.getTypeNorm(name, valu)
 
 class Cortex(s_cell.Cell):
     '''
@@ -1921,7 +1938,7 @@ class Cortex(s_cell.Cell):
         }
         return stats
 
-    def norm(self, prop, valu):
+    async def getPropNorm(self, prop, valu):
         '''
         Get the normalized property value based on the Cortex data model.
 
@@ -1941,6 +1958,28 @@ class Cortex(s_cell.Cell):
             raise s_exc.NoSuchProp(mesg=f'The property {prop} does not exist.',
                                    prop=prop)
         norm, info = pobj.type.norm(valu)
+        return norm, info
+
+    async def getTypeNorm(self, name, valu):
+        '''
+        Get the normalized property value based on the Cortex data model.
+
+        Args:
+            name (str): The type to normalize.
+            valu: The value to normalize.
+
+        Returns:
+            (tuple): A two item tuple, containing the normed value and the info dictionary.
+
+        Raises:
+            s_exc.NoSuchType: If the prop does not exist.
+            s_exc.BadTypeValu: If the value fails to normalize.
+        '''
+        tobj = self.model.type(name)
+        if tobj is None:
+            raise s_exc.NoSuchType(mesg=f'The type {name} does not exist.',
+                                   name=name)
+        norm, info = tobj.norm(valu)
         return norm, info
 
 @contextlib.asynccontextmanager

--- a/synapse/lib/httpapi.py
+++ b/synapse/lib/httpapi.py
@@ -559,7 +559,7 @@ class AuthDelRoleV1(Handler):
 class ModelNormV1(Handler):
 
     async def post(self):
-        await self.get()
+        return await self.get()
 
     async def get(self):
 

--- a/synapse/lib/httpapi.py
+++ b/synapse/lib/httpapi.py
@@ -558,6 +558,9 @@ class AuthDelRoleV1(Handler):
 
 class ModelNormV1(Handler):
 
+    async def post(self):
+        await self.get()
+
     async def get(self):
 
         if not await self.reqAuthUser():

--- a/synapse/lib/httpapi.py
+++ b/synapse/lib/httpapi.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 import tornado.web as t_web
 import tornado.websocket as t_websocket
 
+import synapse.exc as s_exc
 import synapse.common as s_common
 
 import synapse.lib.base as s_base
@@ -577,13 +578,11 @@ class ModelNormV1(Handler):
             self.sendRestErr('MissingField', 'The property normalization API requires a prop name.')
             return
 
-        prop = self.cell.model.props.get(propname)
-        if prop is None:
-            return self.sendRestErr('NoSuchProp', 'The property {propname} does not exist.')
-
         try:
-            valu, info = prop.type.norm(propvalu)
-            self.sendRestRetn({'norm': valu, 'info': info})
-
+            valu, info = await self.cell.getPropNorm(propname, propvalu)
+        except s_exc.NoSuchProp:
+            return self.sendRestErr('NoSuchProp', 'The property {propname} does not exist.')
         except Exception as e:
             return self.sendRestExc(e)
+        else:
+            self.sendRestRetn({'norm': valu, 'info': info})

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2559,27 +2559,63 @@ class CortexBasicTest(s_t_utils.SynTest):
             mesg = ('node:del', {'ndef': ('test:str', 'hello')})
             self.isin(mesg, splices)
 
-    async def test_norm(self):
+    async def test_norms(self):
         async with self.getTestCoreAndProxy() as (core, prox):
-
-            norm, info = core.norm('test:str', 1234)
+            # getPropNorm base tests
+            norm, info = await core.getPropNorm('test:str', 1234)
             self.eq(norm, '1234')
             self.eq(info, {})
 
-            norm, info = core.norm('test:comp', ('1234', '1234'))
+            norm, info = await core.getPropNorm('test:comp', ('1234', '1234'))
             self.eq(norm, (1234, '1234'))
             self.eq(info, {'subs': {'hehe': 1234, 'haha': '1234'}, 'adds': []})
 
-            self.raises(s_exc.BadTypeValu, core.norm, 'test:int', 'newp')
-            self.raises(s_exc.NoSuchProp, core.norm, 'test:newp', 'newp')
+            await self.asyncraises(s_exc.BadTypeValu, core.getPropNorm('test:int', 'newp'))
+            await self.asyncraises(s_exc.NoSuchProp, core.getPropNorm('test:newp', 'newp'))
 
-            norm, info = await prox.norm('test:str', 1234)
+            norm, info = await prox.getPropNorm('test:str', 1234)
             self.eq(norm, '1234')
             self.eq(info, {})
 
-            norm, info = await prox.norm('test:comp', ('1234', '1234'))
+            norm, info = await prox.getPropNorm('test:comp', ('1234', '1234'))
             self.eq(norm, (1234, '1234'))
             self.eq(info, {'subs': {'hehe': 1234, 'haha': '1234'}, 'adds': ()})
 
-            await self.asyncraises(s_exc.BadTypeValu, prox.norm('test:int', 'newp'))
-            await self.asyncraises(s_exc.NoSuchProp, prox.norm('test:newp', 'newp'))
+            await self.asyncraises(s_exc.BadTypeValu, prox.getPropNorm('test:int', 'newp'))
+            await self.asyncraises(s_exc.NoSuchProp, prox.getPropNorm('test:newp', 'newp'))
+
+            # getTypeNorm base tests
+            norm, info = await core.getTypeNorm('test:str', 1234)
+            self.eq(norm, '1234')
+            self.eq(info, {})
+
+            norm, info = await core.getTypeNorm('test:comp', ('1234', '1234'))
+            self.eq(norm, (1234, '1234'))
+            self.eq(info, {'subs': {'hehe': 1234, 'haha': '1234'}, 'adds': []})
+
+            await self.asyncraises(s_exc.BadTypeValu, core.getTypeNorm('test:int', 'newp'))
+            await self.asyncraises(s_exc.NoSuchType, core.getTypeNorm('test:newp', 'newp'))
+
+            norm, info = await prox.getTypeNorm('test:str', 1234)
+            self.eq(norm, '1234')
+            self.eq(info, {})
+
+            norm, info = await prox.getTypeNorm('test:comp', ('1234', '1234'))
+            self.eq(norm, (1234, '1234'))
+            self.eq(info, {'subs': {'hehe': 1234, 'haha': '1234'}, 'adds': ()})
+
+            await self.asyncraises(s_exc.BadTypeValu, prox.getTypeNorm('test:int', 'newp'))
+            await self.asyncraises(s_exc.NoSuchType, prox.getTypeNorm('test:newp', 'newp'))
+
+            # getPropNorm can norm sub props
+            norm, info = await core.getPropNorm('test:str:tick', '3001')
+            self.eq(norm, 32535216000000)
+            self.eq(info, {})
+            # but getTypeNorm won't handle that
+            await self.asyncraises(s_exc.NoSuchType, core.getTypeNorm('test:str:tick', '3001'))
+
+            # getTypeNorm can norm types which aren't defined as forms/props
+            norm, info = await core.getTypeNorm('test:lower', 'ASDF')
+            self.eq(norm, 'asdf')
+            # but getPropNorm won't handle that
+            await self.asyncraises(s_exc.NoSuchProp, core.getPropNorm('test:lower', 'ASDF'))

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2558,3 +2558,28 @@ class CortexBasicTest(s_t_utils.SynTest):
 
             mesg = ('node:del', {'ndef': ('test:str', 'hello')})
             self.isin(mesg, splices)
+
+    async def test_norm(self):
+        async with self.getTestCoreAndProxy() as (core, prox):
+
+            norm, info = core.norm('test:str', 1234)
+            self.eq(norm, '1234')
+            self.eq(info, {})
+
+            norm, info = core.norm('test:comp', ('1234', '1234'))
+            self.eq(norm, (1234, '1234'))
+            self.eq(info, {'subs': {'hehe': 1234, 'haha': '1234'}, 'adds': []})
+
+            self.raises(s_exc.BadTypeValu, core.norm, 'test:int', 'newp')
+            self.raises(s_exc.NoSuchProp, core.norm, 'test:newp', 'newp')
+
+            norm, info = await prox.norm('test:str', 1234)
+            self.eq(norm, '1234')
+            self.eq(info, {})
+
+            norm, info = await prox.norm('test:comp', ('1234', '1234'))
+            self.eq(norm, (1234, '1234'))
+            self.eq(info, {'subs': {'hehe': 1234, 'haha': '1234'}, 'adds': ()})
+
+            await self.asyncraises(s_exc.BadTypeValu, prox.norm('test:int', 'newp'))
+            await self.asyncraises(s_exc.NoSuchProp, prox.norm('test:newp', 'newp'))

--- a/synapse/tests/test_lib_httpapi.py
+++ b/synapse/tests/test_lib_httpapi.py
@@ -444,6 +444,7 @@ class HttpApiTest(s_tests.SynTest):
                     self.eq('ok', retn.get('status'))
                     self.eq('visi', retn['result']['name'])
 
+                # Norm via GET
                 body = {'prop': 'inet:ipv4', 'value': '1.2.3.4'}
                 async with sess.get(f'https://localhost:{port}/api/v1/model/norm', json=body) as resp:
                     retn = await resp.json()
@@ -460,6 +461,14 @@ class HttpApiTest(s_tests.SynTest):
                 async with sess.get(f'https://localhost:{port}/api/v1/model/norm', json=body) as resp:
                     retn = await resp.json()
                     self.eq('MissingField', retn.get('code'))
+
+                # Norm via POST
+                body = {'prop': 'inet:ipv4', 'value': '1.2.3.4'}
+                async with sess.post(f'https://localhost:{port}/api/v1/model/norm', json=body) as resp:
+                    retn = await resp.json()
+                    self.eq('ok', retn.get('status'))
+                    self.eq(0x01020304, retn['result']['norm'])
+                    self.eq('unicast', retn['result']['info']['subs']['type'])
 
     async def test_http_storm(self):
 

--- a/synapse/tests/test_model_base.py
+++ b/synapse/tests/test_model_base.py
@@ -64,6 +64,7 @@ class BaseTest(s_t_utils.SynTest):
                 props = {
                     'type': 'HeHe HaHa',
                     'time': '2015',
+                    'name': 'Magic Pony',
                     'data': ('some', 'data', 'here'),
                 }
 
@@ -74,6 +75,7 @@ class BaseTest(s_t_utils.SynTest):
                 self.eq(node.get('type'), 'HeHe HaHa')
                 self.eq(node.get('time'), 1420070400000)
                 self.eq(node.get('data'), ('some', 'data', 'here'))
+                self.eq(node.get('name'), 'Magic Pony')
 
     async def test_model_base_edge(self):
 


### PR DESCRIPTION
- Add getTypeNorm and getPropNorm routines to the Cortex and CoreApi
- Add POST support to the norm httpapi endpoint
- Change norm httpapi endpoint to self.cell as the entrypoint for calling getPropNorm 