### PR TITLE
Allow log to pack raw nodes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Features and Enhancements
 - Add POST support to the ``/api/v1/model/norm`` HTTP API endpoint. (`#1207 <https://github.com/vertexproject/synapse/pull/1207>`_)
 - Add ``getPropNorm()`` and ``getTypeNorm()`` Telepath API endpoints to the Cortex and CoreApi. (`#1207 <https://github.com/vertexproject/synapse/pull/1207>`_)
 - Add list ``length()`` and ``index()`` methods to Storm types. (`#1208 <https://github.com/vertexproject/synapse/pull/1208>`_)
+- Add ``--nodes-only`` to the Cmdr ``log`` command to only record raw nodes. (`#1213 <https://github.com/vertexproject/synapse/pull/1213>`_)
 
 Bugfixes
 --------

--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -4,7 +4,6 @@ import shlex
 import pprint
 import logging
 
-
 import synapse.exc as s_exc
 import synapse.common as s_common
 

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -189,7 +189,6 @@ class CmdCoreTest(s_t_utils.SynTest):
                 with s_common.genfile(fp) as fd:
                     genr = s_encoding.iterdata(fd, close_fd=False, format='mpk')
                     objs = list(genr)
-                print(objs)
                 self.eq(objs[0][0], ('test:str', 'I am a message!'))
 
                 outp = self.getTestOutp()
@@ -203,6 +202,13 @@ class CmdCoreTest(s_t_utils.SynTest):
                 await cmdr.runCmdLine('log')
                 await cmdr.fini()
                 self.true(outp.expect('log: error: one of the arguments --on --off is required'))
+
+                outp = self.getTestOutp()
+                cmdr = await s_cmdr.getItemCmdr(core, outp=outp)
+                await cmdr.runCmdLine('log --on --splices-only --nodes-only')
+                await cmdr.fini()
+                e = 'log: error: argument --nodes-only: not allowed with argument --splices-only'
+                self.true(outp.expect(e))
 
     async def test_ps_kill(self):
 

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -179,13 +179,13 @@ class CmdCoreTest(s_t_utils.SynTest):
                 cmdr = await s_cmdr.getItemCmdr(core, outp=outp)
                 await cmdr.runCmdLine('log --on --off')
                 await cmdr.fini()
-                self.true(outp.expect('Pick one'))
+                self.true(outp.expect('log: error: argument --off: not allowed with argument --on'))
 
                 outp = self.getTestOutp()
                 cmdr = await s_cmdr.getItemCmdr(core, outp=outp)
                 await cmdr.runCmdLine('log')
                 await cmdr.fini()
-                self.true(outp.expect('Pick one'))
+                self.true(outp.expect('log: error: one of the arguments --on --off is required'))
 
     async def test_ps_kill(self):
 

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -177,6 +177,23 @@ class CmdCoreTest(s_t_utils.SynTest):
 
                 outp = self.getTestOutp()
                 cmdr = await s_cmdr.getItemCmdr(core, outp=outp)
+                # Our default format is mpk
+                fp = os.path.join(dirn, 'loggyMcNodeFace.mpk')
+                await cmdr.runCmdLine(f'log --on --nodes-only --path {fp}')
+                fp = cmdr.locs.get('log:fp')
+                await cmdr.runCmdLine('storm [test:str="I am a message!" :tick=1999 +#oh.my] ')
+                await cmdr.runCmdLine('log --off')
+                await cmdr.fini()
+
+                self.true(os.path.isfile(fp))
+                with s_common.genfile(fp) as fd:
+                    genr = s_encoding.iterdata(fd, close_fd=False, format='mpk')
+                    objs = list(genr)
+                print(objs)
+                self.eq(objs[0][0], ('test:str', 'I am a message!'))
+
+                outp = self.getTestOutp()
+                cmdr = await s_cmdr.getItemCmdr(core, outp=outp)
                 await cmdr.runCmdLine('log --on --off')
                 await cmdr.fini()
                 self.true(outp.expect('log: error: argument --off: not allowed with argument --on'))


### PR DESCRIPTION
- Refactor ``log`` command to use ``synapse.lib.cmd``
- Add ``--nodes-only`` argument to ``log`` to capture only packed nodes to disk.