### PR TITLE
Feature telepath synver

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ v0.1.7 - TBD
 Features and Enhancements
 -------------------------
 
-- Add new features (`#XXX <https://github.com/vertexproject/synapse/pull/XXX>`_)
+- Add the Synapse version information in the Telepath handshake.  Expose this with the ``Proxy._getSynVers()`` API and in the Cmdr CLI via the ``locs`` command.  (`#1238 <https://github.com/vertexproject/synapse/pull/1238>`_)
 
 Bugfixes
 --------

--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -24,3 +24,5 @@ if tuple([int(x) for x in lmdb.__version__.split('.')]) < (0, 94): # pragma: no 
     raise Exception('synapse is only supported on version >= 0.94 of the lmdb python module')
 
 from synapse.lib.version import version, verstring
+# Friendly __version__ string alias
+__version__ = verstring

--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -254,7 +254,11 @@ class Cli(s_base.Base):
         if isinstance(self.item, s_telepath.Proxy):
             # Technically, the :version is a tuple and :verstring is a string
             # but for human UX the verstring is easier to read at first glance.
-            self.locs['syn:version'] = self.item.sharinfo.get('syn:verstring', 'Synapse version unavailable')
+            version = self.item.sharinfo.get('syn:version')
+            if version is None:  # pragma: no cover
+                self.locs['syn:version'] = 'Synapse version unavailable'
+            else:
+                self.locs['syn:version'] = '.'.join([str(v) for v in version])
 
         self.cmds = {}
         self.cmdprompt = 'cli> '

--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -252,9 +252,7 @@ class Cli(s_base.Base):
             self.item.onfini(self._onItemFini)
 
         if isinstance(self.item, s_telepath.Proxy):
-            # Technically, the :version is a tuple and :verstring is a string
-            # but for human UX the verstring is easier to read at first glance.
-            version = self.item.sharinfo.get('syn:version')
+            version = self.item._getSynVers()
             if version is None:  # pragma: no cover
                 self.locs['syn:version'] = 'Synapse version unavailable'
             else:

--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -15,6 +15,7 @@ from prompt_toolkit.eventloop.defaults import use_asyncio_event_loop
 
 import synapse.exc as s_exc
 import synapse.common as s_common
+import synapse.telepath as s_telepath
 
 import synapse.lib.base as s_base
 import synapse.lib.output as s_output
@@ -249,6 +250,11 @@ class Cli(s_base.Base):
 
         if isinstance(self.item, s_base.Base):
             self.item.onfini(self._onItemFini)
+
+        if isinstance(self.item, s_telepath.Proxy):
+            # Technically, the :version is a tuple and :verstring is a string
+            # but for human UX the verstring is easier to read at first glance.
+            self.locs['syn:version'] = self.item.sharinfo.get('syn:verstring', 'Synapse version unavailable')
 
         self.cmds = {}
         self.cmdprompt = 'cli> '
@@ -491,6 +497,9 @@ class CmdLocals(Cmd):
     async def runCmdOpts(self, opts):
         ret = {}
         for k, v in self._cmd_cli.locs.items():
-            ret[k] = repr(v)
+            if isinstance(v, (int, str)):
+                ret[k] = v
+            else:
+                ret[k] = repr(v)
         mesg = json.dumps(ret, indent=2, sort_keys=True)
         self.printf(mesg)

--- a/synapse/lib/reflect.py
+++ b/synapse/lib/reflect.py
@@ -74,6 +74,7 @@ def getShareInfo(item):
     meths = {}
     info = {'meths': meths,
             'syn:version': s_version.version,
+            'syn:verstring': s_version.verstring,
             }
 
     for name in dir(item):

--- a/synapse/lib/reflect.py
+++ b/synapse/lib/reflect.py
@@ -74,7 +74,6 @@ def getShareInfo(item):
     meths = {}
     info = {'meths': meths,
             'syn:version': s_version.version,
-            'syn:verstring': s_version.verstring,
             }
 
     for name in dir(item):

--- a/synapse/lib/reflect.py
+++ b/synapse/lib/reflect.py
@@ -2,6 +2,8 @@ import inspect
 
 import logging
 
+import synapse.lib.version as s_version
+
 logger = logging.getLogger(__name__)
 
 clsskip = set([object])
@@ -70,7 +72,9 @@ def getShareInfo(item):
         return info
 
     meths = {}
-    info = {'meths': meths}
+    info = {'meths': meths,
+            'syn:version': s_version.version,
+            }
 
     for name in dir(item):
 

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -276,6 +276,20 @@ class Proxy(s_base.Base):
         self.onfini(fini)
         self.link.onfini(self.fini)
 
+    def _getSynVers(self):
+        '''
+        Helper method to retrieve the remote Synapse version from Proxy.
+
+        Notes:
+            This will return None if the synapse version was not supplied
+            during the Telepath handshake.
+
+        Returns:
+            tuple: A tuple of major, minor, patch information as integers.
+        '''
+        version = self.sharinfo.get('syn:version')
+        return version
+
     async def getPoolLink(self):
 
         while self.links and not self.isfini:

--- a/synapse/tests/test_lib_cli.py
+++ b/synapse/tests/test_lib_cli.py
@@ -1,7 +1,10 @@
 import asyncio
 
 import synapse.exc as s_exc
+
 import synapse.lib.cli as s_cli
+import synapse.lib.version as s_version
+
 import synapse.tests.utils as s_t_utils
 
 class TstThrowCmd(s_cli.Cmd):
@@ -44,6 +47,13 @@ class CliTest(s_t_utils.SynTest):
             self.true(outp.expect('haha'))
             self.true(outp.expect('foo'))
             self.true(outp.expect('bar'))
+
+        outp = self.getTestOutp()
+        async with self.getTestCoreAndProxy() as (core, proxy):
+            async with await s_cli.Cli.anit(proxy, outp=outp) as cli:
+                cli.echoline = True
+                await cli.runCmdLine('locs')
+                self.true(outp.expect(s_version.verstring))
 
     async def test_cli_quit(self):
         outp = self.getTestOutp()

--- a/synapse/tests/test_lib_reflect.py
+++ b/synapse/tests/test_lib_reflect.py
@@ -44,3 +44,4 @@ class ReflectTest(s_t_utils.SynTest):
 
             sharinfo = getattr(echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo')
             self.eq(sharinfo.get('syn:version'), s_version.version)
+            self.eq(sharinfo.get('syn:verstring'), s_version.verstring)

--- a/synapse/tests/test_lib_reflect.py
+++ b/synapse/tests/test_lib_reflect.py
@@ -44,4 +44,3 @@ class ReflectTest(s_t_utils.SynTest):
 
             sharinfo = getattr(echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo')
             self.eq(sharinfo.get('syn:version'), s_version.version)
-            self.eq(sharinfo.get('syn:verstring'), s_version.verstring)

--- a/synapse/tests/test_lib_reflect.py
+++ b/synapse/tests/test_lib_reflect.py
@@ -1,5 +1,6 @@
 import synapse.lib.base as s_base
 import synapse.lib.reflect as s_reflect
+import synapse.lib.version as s_version
 
 import synapse.tests.utils as s_t_utils
 
@@ -40,3 +41,6 @@ class ReflectTest(s_t_utils.SynTest):
                 pass
             self.isinstance(getattr(echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo', None), dict)
             self.isinstance(getattr(Echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo', None), dict)
+
+            sharinfo = getattr(echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo')
+            self.eq(sharinfo.get('syn:version'), s_version.version)

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -14,6 +14,7 @@ import synapse.telepath as s_telepath
 import synapse.lib.cell as s_cell
 import synapse.lib.coro as s_coro
 import synapse.lib.share as s_share
+import synapse.lib.version as s_version
 
 import synapse.tests.utils as s_t_utils
 from synapse.tests.utils import alist
@@ -175,6 +176,9 @@ class TeleTest(s_t_utils.SynTest):
             await self.asyncraises(s_exc.BadUrl, s_telepath.openurl('noscheme/foo'))
 
             prox = await s_telepath.openurl('tcp://127.0.0.1/foo', port=addr[1])
+
+            # Prox exposes remote synapse version
+            self.eq(prox._getSynVers(), s_version.version)
 
             # Add an additional prox.fini handler.
             prox.onfini(evt.set)


### PR DESCRIPTION
- Plumb synapse version through telepath in a backwards-compatible manner
- In cmdr, expose the version if the item being command is a telepath proxy