### PR TITLE
Bug log cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,18 +2,18 @@
 Synapse Changelog
 *****************
 
-<git tag> - YYYY-MM-DD
+v0.1.9 - TDB
 ======================
 
 Features and Enhancements
 -------------------------
 
-- Add new features (`#XXX <https://github.com/vertexproject/synapse/pull/XXX>`_)
+- Add colored error reporting in Cmdr when a BadSyntax exception is sent to the user. (`#1248 <https://github.com/vertexproject/synapse/pull/1248>`_)
 
 Bugfixes
 --------
 
-- Fix old bugs (`#XXX <https://github.com/vertexproject/synapse/pull/XXX>`_)
+- Fix an issue where the Cmdr ``log`` command did not clean up all of its settings. (`#1249 <https://github.com/vertexproject/synapse/pull/1249>`_)
 
 Improved Documentation
 ----------------------

--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -143,8 +143,9 @@ Examples:
             thr.join(2)
         fp = self.locs.pop('log:fp', None)
         fd = self.locs.pop('log:fd', None)
-        self.locs.pop('log:fmt', None)
-        self.locs.pop('log:splicesonly', None)
+        for key in list(self.locs.keys()):
+            if key.startswith('log:'):
+                self.locs.pop(key, None)
         if fd:
             try:
                 self.printf(f'Closing logfile: [{fp}]')

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -152,6 +152,12 @@ class CmdCoreTest(s_t_utils.SynTest):
 
     async def test_log(self):
 
+        def check_locs_cleanup(cobj):
+            keys = list(cobj.locs.keys())
+            for key in keys:
+                if key.startswith('log:'):
+                    self.fail(f'Key with "log:" prefix found. [{key}]')
+
         async with self.getTestCoreAndProxy() as (realcore, core):
 
             with self.getTestSynDir() as dirn:
@@ -163,6 +169,7 @@ class CmdCoreTest(s_t_utils.SynTest):
                 await cmdr.runCmdLine('storm [test:str=hi :tick=2018 +#haha.hehe]')
                 await cmdr.runCmdLine('log --off')
                 await cmdr.fini()
+                check_locs_cleanup(cmdr)
 
                 self.true(outp.expect('Starting logfile'))
                 self.true(outp.expect('Closing logfile'))
@@ -183,6 +190,7 @@ class CmdCoreTest(s_t_utils.SynTest):
                 await cmdr.runCmdLine('storm [test:str="I am a message!" :tick=1999 +#oh.my] ')
                 await cmdr.runCmdLine('log --off')
                 await cmdr.fini()
+                check_locs_cleanup(cmdr)
 
                 self.true(os.path.isfile(fp))
                 with s_common.genfile(fp) as fd:
@@ -199,6 +207,7 @@ class CmdCoreTest(s_t_utils.SynTest):
                 await cmdr.runCmdLine('storm [test:str="I am a message!" :tick=1999 +#oh.my] ')
                 await cmdr.runCmdLine('log --off')
                 await cmdr.fini()
+                check_locs_cleanup(cmdr)
 
                 self.true(os.path.isfile(fp))
                 with s_common.genfile(fp) as fd:


### PR DESCRIPTION
The storm log command did not always clean up its locs data.