### PR TITLE
Version cmd

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Features and Enhancements
 -------------------------
 
 - Add colored error reporting in Cmdr when a BadSyntax exception is sent to the user. (`#1248 <https://github.com/vertexproject/synapse/pull/1248>`_)
+- Expose the local Synapse version information in Cmdr via the ``locs`` command. (`#1250 <https://github.com/vertexproject/synapse/pull/1250>`_)
+- Add reflected class names to the Telepath shareinfo. Expose this with the ``Proxy._getClasses:|()`` API. (`#1250 <https://github.com/vertexproject/synapse/pull/1250>`_)
 
 Bugfixes
 --------

--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -21,6 +21,7 @@ import synapse.telepath as s_telepath
 import synapse.lib.base as s_base
 import synapse.lib.output as s_output
 import synapse.lib.grammar as s_grammar
+import synapse.lib.version as s_version
 
 logger = logging.getLogger(__name__)
 
@@ -255,12 +256,14 @@ class Cli(s_base.Base):
         if isinstance(self.item, s_base.Base):
             self.item.onfini(self._onItemFini)
 
+        self.locs['syn:local:version'] = s_version.verstring
+
         if isinstance(self.item, s_telepath.Proxy):
             version = self.item._getSynVers()
             if version is None:  # pragma: no cover
-                self.locs['syn:version'] = 'Synapse version unavailable'
+                self.locs['syn:remote:version'] = 'Remote Synapse version unavailable'
             else:
-                self.locs['syn:version'] = '.'.join([str(v) for v in version])
+                self.locs['syn:remote:version'] = '.'.join([str(v) for v in version])
 
         self.cmds = {}
         self.cmdprompt = 'cli> '

--- a/synapse/lib/reflect.py
+++ b/synapse/lib/reflect.py
@@ -74,6 +74,7 @@ def getShareInfo(item):
     meths = {}
     info = {'meths': meths,
             'syn:version': s_version.version,
+            'classes': getClsNames(item),
             }
 
     for name in dir(item):

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -290,6 +290,20 @@ class Proxy(s_base.Base):
         version = self.sharinfo.get('syn:version')
         return version
 
+    def _getClasses(self):
+        '''
+        Helper method to retrieve the classes that comprise the remote object.
+
+        Notes:
+            This will return None if the class version was not supplied
+            during the Telepath handshake.
+
+        Returns:
+            tuple: A tuple of strings containing the class paths for the remote object.
+        '''
+        classes = self.sharinfo.get('classes')
+        return classes
+
     async def getPoolLink(self):
 
         while self.links and not self.isfini:

--- a/synapse/tests/test_lib_cli.py
+++ b/synapse/tests/test_lib_cli.py
@@ -53,6 +53,8 @@ class CliTest(s_t_utils.SynTest):
             async with await s_cli.Cli.anit(proxy, outp=outp) as cli:
                 cli.echoline = True
                 await cli.runCmdLine('locs')
+                self.true(outp.expect('syn:local:version'))
+                self.true(outp.expect('syn:remote:version'))
                 self.true(outp.expect(s_version.verstring))
 
     async def test_cli_quit(self):
@@ -252,7 +254,8 @@ class CliTest(s_t_utils.SynTest):
             await cli.runCmdLoop()
 
             self.true(outp.expect('o/'))
-            self.true(outp.expect('{}'))
+            self.true(outp.expect('"syn:local:version"'))
+            self.true(outp.expect(f'"{s_version.verstring}"'))
             self.true(outp.expect('ZeroDivisionError'))
             self.true(outp.expect('Cmd cancelled'))
             self.true(cli.isfini)

--- a/synapse/tests/test_lib_reflect.py
+++ b/synapse/tests/test_lib_reflect.py
@@ -44,3 +44,5 @@ class ReflectTest(s_t_utils.SynTest):
 
             sharinfo = getattr(echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo')
             self.eq(sharinfo.get('syn:version'), s_version.version)
+            self.eq(sharinfo.get('classes'),
+                    ['synapse.tests.test_lib_reflect.Echo', 'synapse.lib.base.Base'])

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -180,6 +180,10 @@ class TeleTest(s_t_utils.SynTest):
             # Prox exposes remote synapse version
             self.eq(prox._getSynVers(), s_version.version)
 
+            # Prox exposes reflected classes
+            self.eq(prox._getClasses(),
+                    ('synapse.tests.test_telepath.Foo',))
+
             # Add an additional prox.fini handler.
             prox.onfini(evt.set)
 


### PR DESCRIPTION
- Expose local synapse version in cli locs

- Update remote synapse version in cli locs to distinguish it from the local version

- Add reflected class information to a telepath proxy (for possible future use)

In the Cmdr CLI this looks like 

```
cli> locs                                                                                                                                                                                                     
{
  "syn:local:version": "0.1.8",
  "syn:remote:version": "0.1.8"
}

```
