### PR TITLE
Bug: Telepath remote layers fail to work when the default does not use the default layer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Bugfixes
 - Fix an issue where the Cmdr ``log`` command did not clean up all of its settings. (`#1249 <https://github.com/vertexproject/synapse/pull/1249>`_)
 - Fix an issue with the Storm ``switch`` statement handling of non-runtsafe values. (`#1251 <https://github.com/vertexproject/synapse/pull/1251>`_)
 - Fix an issue with the Storm ``if`` statement handling of non-runtsafe values. (`#1253 <https://github.com/vertexproject/synapse/pull/1253>`_)
+- Fix an issue with when connecting to a Cortex via Telepath for the default remote layer, which previously could have pointed to a layer which was not the correct layer for the default view. (`#1255 <https://github.com/vertexproject/synapse/pull/1255>`_)
 
 Improved Documentation
 ----------------------

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -931,8 +931,9 @@ class Cortex(s_cell.Cell):
         if path[0] == 'layer':
 
             if len(path) == 1:
-                # get the main layer...
-                layr = self.layers.get(self.iden)
+                # get the top layer for the default view
+                view = self.getView(self.iden)  # type: View
+                layr = view.layers[0]
                 return await s_layer.LayerApi.anit(self, link, user, layr)
 
             if len(path) == 2:

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -932,7 +932,7 @@ class Cortex(s_cell.Cell):
 
             if len(path) == 1:
                 # get the top layer for the default view
-                view = self.getView(self.iden)  # type: View
+                view = self.getView()
                 layr = view.layers[0]
                 return await s_layer.LayerApi.anit(self, link, user, layr)
 
@@ -1230,6 +1230,15 @@ class Cortex(s_cell.Cell):
         return self.layers.get(iden)
 
     def getView(self, iden=None):
+        '''
+        Get a View object.
+
+        Args:
+            iden (str): The View iden to retrieve.
+
+        Returns:
+            View: A View object.
+        '''
         if iden is None:
             iden = self.iden
         return self.views.get(iden)


### PR DESCRIPTION
When connecting to a cortex via telepath for remote layers, and using the default /layer, use the default view's write layer and not the self.iden layer.