### PR TITLE
bug: move color awareness for cli printing to the cli instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ Features and Enhancements
 
 - Add an optional facility to lmdbslab to prevent its data from being swapped out of memory. Add a Cortex configuration option (in the cell.yaml file) named ``dedicated`` to enable this for the lmdb slabs that store the graph data in a Cortex. This is currently only supported on Linux. (`#1254 <https://github.com/vertexproject/synapse/pull/1254>`_)
 
+Bugfixes
+--------
+
+- Fix an issue where the Cmdr color awareness for error highlighting was preventing documentation from building properly. (`#1261 <https://github.com/vertexproject/synapse/pull/1261>`_)
+
 
 v0.1.10 - 2019-06-04
 ====================

--- a/synapse/lib/cli.py
+++ b/synapse/lib/cli.py
@@ -25,8 +25,6 @@ import synapse.lib.version as s_version
 
 logger = logging.getLogger(__name__)
 
-# Set to False for testing or unsupported terminals
-ColorsEnabled = True
 
 class Cmd:
     '''
@@ -252,6 +250,7 @@ class Cli(s_base.Base):
         self.item = item    # whatever object we are commanding
 
         self.echoline = False
+        self.colorsenabled = False
 
         if isinstance(self.item, s_base.Base):
             self.item.onfini(self._onItemFini)
@@ -315,7 +314,7 @@ class Cli(s_base.Base):
             return retn
 
     def printf(self, mesg, addnl=True, color=None):
-        if not ColorsEnabled:
+        if not self.colorsenabled:
             return self.outp.printf(mesg, addnl=addnl)
 
         if color is not None:

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -155,18 +155,16 @@ class CmdCoreTest(s_t_utils.SynTest):
             call_args = [args[0][0] for args in p.call_args_list if isinstance(args[0][0], FormattedText)]
             unpacked_args = []
             for arg in call_args:
-                unpacked_args.append(*arg)
+                (color, text) = arg[0]
+                if text.startswith('Syntax Error:'):
+                    text = 'Syntax Error'
+                unpacked_args.append((color, text))
             self.isin(('#6faef2', '[#foo]'), unpacked_args)
             self.isin(('#6faef2', ' ^'), unpacked_args)
-            self.isin(('#ff0066', "Syntax Error: No terminal defined for '#' at line 1 col 2.  Expecting one of: "
-                                  "absolute property, -, +, relative property, }, universal property, whitespace"),
-                      unpacked_args)
+            self.isin(('#ff0066', 'Syntax Error'), unpacked_args)
             self.isin(('#6faef2', 'test:str ->'), unpacked_args)
             self.isin(('#6faef2', '           ^'), unpacked_args)
-            self.isin(('#ff0066', 'Syntax Error: Unexpected end of input.  Expecting one of: '
-                                  '#, break, continue, $, + or -, for, if, [, (, {, relative '
-                                  'property, switch, |, <+-, <-, -+>, ->, whitespace or comment'),
-                      unpacked_args)
+            self.isin(('#ff0066', 'Syntax Error'), unpacked_args)
 
     async def test_log(self):
 

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -1,8 +1,9 @@
 import os
 import regex
 import asyncio
-import prompt_toolkit
-from unittest.mock import patch
+import unittest.mock as mock
+
+from prompt_toolkit.formatted_text import FormattedText
 
 import synapse.exc as s_exc
 import synapse.common as s_common
@@ -144,11 +145,28 @@ class CmdCoreTest(s_t_utils.SynTest):
             outp.expect('Syntax Error')
 
             outp.clear()
-            s_cli.ColorsEnabled = True
-            cmdr = await s_cmdr.getItemCmdr(core, outp=outp)
-            await cmdr.runCmdLine('storm [#foo]')
-            await cmdr.runCmdLine('storm test:str ->')
-            # TODO: figure out how to evaluate whether these made it to the screen
+            with mock.patch('synapse.lib.cli.print_formatted_text',
+                            mock.MagicMock(return_value=None)) as p:  # type: mock.MagicMock
+                cmdr = await s_cmdr.getItemCmdr(core, outp=outp)
+                cmdr.colorsenabled = True
+                await cmdr.runCmdLine('storm [#foo]')
+                await cmdr.runCmdLine('storm test:str ->')
+            self.true(p.called)
+            call_args = [args[0][0] for args in p.call_args_list if isinstance(args[0][0], FormattedText)]
+            unpacked_args = []
+            for arg in call_args:
+                unpacked_args.append(*arg)
+            self.isin(('#6faef2', '[#foo]'), unpacked_args)
+            self.isin(('#6faef2', ' ^'), unpacked_args)
+            self.isin(('#ff0066', "Syntax Error: No terminal defined for '#' at line 1 col 2.  Expecting one of: "
+                                  "absolute property, -, +, relative property, }, universal property, whitespace"),
+                      unpacked_args)
+            self.isin(('#6faef2', 'test:str ->'), unpacked_args)
+            self.isin(('#6faef2', '           ^'), unpacked_args)
+            self.isin(('#ff0066', 'Syntax Error: Unexpected end of input.  Expecting one of: '
+                                  '#, break, continue, $, + or -, for, if, [, (, {, relative '
+                                  'property, switch, |, <+-, <-, -+>, ->, whitespace or comment'),
+                      unpacked_args)
 
     async def test_log(self):
 

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -164,7 +164,6 @@ class CmdCoreTest(s_t_utils.SynTest):
             self.isin(('#ff0066', 'Syntax Error'), unpacked_args)
             self.isin(('#6faef2', 'test:str ->'), unpacked_args)
             self.isin(('#6faef2', '           ^'), unpacked_args)
-            self.isin(('#ff0066', 'Syntax Error'), unpacked_args)
 
     async def test_log(self):
 

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -46,7 +46,6 @@ import synapse.cryotank as s_cryotank
 import synapse.telepath as s_telepath
 
 import synapse.lib.coro as s_coro
-import synapse.lib.cli as s_cli
 import synapse.lib.cmdr as s_cmdr
 import synapse.lib.const as s_const
 import synapse.lib.storm as s_storm
@@ -655,7 +654,6 @@ class SynTest(unittest.TestCase):
     '''
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        s_cli.ColorsEnabled = False
         for s in dir(self):
             attr = getattr(self, s, None)
             # If s is an instance method and starts with 'test_', synchelp wrap it

--- a/synapse/tools/cmdr.py
+++ b/synapse/tools/cmdr.py
@@ -21,6 +21,8 @@ async def main(argv):  # pragma: no cover
 
         cmdr = await s_cmdr.getItemCmdr(item)
         await cmdr.addSignalHandlers()
+        # Enable colors for users
+        cmdr.colorsenabled = True
 
         if len(argv) == 2:
             await cmdr.runCmdLine(argv[1])


### PR DESCRIPTION
Refactor color handling for printing to a instance local value, instead of a module global. Add mock test to ensure it is calling the colorized functions on errors.