### PR TITLE
Docs: Convert from conda to docker image for RTD 

### DIFF
--- a/environment_docs.yml
+++ b/environment_docs.yml
@@ -1,9 +1,0 @@
-# Environment file for conda for readthedocs
-# This is to be used until rtd supports python 3.7 natively
-name: synapse-docs
-dependencies:
-  - python=3.7
-  - pip:
-    - sphinx
-    - jupyter
-    - sphinx-rtd-theme

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,12 +1,12 @@
 # .readthedocs.yml
 
-conda:
-    file: environment_docs.yml
+#conda:
+#    file: environment_docs.yml
 
 # Replace the build process with native cpython 3.7
 # once is is available from RTD
-#python:
-#  version: 3.7
-#  pip_install: true
-#  extra_requirements:
-#    - docs
+python:
+  version: 3.7
+  pip_install: true
+  extra_requirements:
+    - docs

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,10 +1,5 @@
 # .readthedocs.yml
 
-#conda:
-#    file: environment_docs.yml
-
-# Replace the build process with native cpython 3.7
-# once is is available from RTD
 python:
   version: 3.7
   pip_install: true


### PR DESCRIPTION
Recommended practice in https://docs.readthedocs.io/en/stable/guides/build-using-too-many-resources.html now that python 3.7 is supported in RTD.