### PR TITLE
Feature: Simplify storm tag globbing

### DIFF
--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -158,7 +158,7 @@ def regexizeTagGlob(tag):
 
         The returned string does not contain a starting '^' or trailing '$'.
     '''
-    return ReRegex.sub(lambda m: r'[^.]+?' if m.group(1) is None else r'.+', regex.escape(tag))
+    return ReRegex.sub(lambda m: r'([^.]+?)' if m.group(1) is None else r'(.+)', regex.escape(tag))
 
 @memoize()
 def getTagGlobRegx(name):

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -298,7 +298,6 @@ class Node(Prim):
 
     async def _methNodeTags(self, glob=None):
         tags = list(self.valu.tags.keys())
-        tags.sort()
         if glob is not None:
             regx = s_cache.getTagGlobRegx(glob)
             tags = [t for t in tags if regx.fullmatch(t)]
@@ -306,7 +305,6 @@ class Node(Prim):
 
     async def _methNodeGlobTags(self, glob):
         tags = list(self.valu.tags.keys())
-        tags.sort()
         regx = s_cache.getTagGlobRegx(glob)
         ret = []
         for tag in tags:

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -267,7 +267,11 @@ class List(Prim):
         Return a single field from the list by index.
         '''
         indx = intify(valu)
-        return self.valu[indx]
+        try:
+            return self.valu[indx]
+        except IndexError as e:
+            raise s_exc.StormRuntimeError(mesg=str(e),
+                                          len=len(self.valu), indx=indx) from None
 
     async def _methListLength(self):
         '''

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -270,7 +270,7 @@ class List(Prim):
         try:
             return self.valu[indx]
         except IndexError as e:
-            raise s_exc.StormRuntimeError(mesg=str(e),
+            raise s_exc.StormRuntimeError(mesg=str(e), valurepr=repr(self.valu),
                                           len=len(self.valu), indx=indx) from None
 
     async def _methListLength(self):
@@ -295,11 +295,25 @@ class Node(Prim):
             'value': self._methNodeValue,
         })
 
-    async def _methNodeTags(self, glob=None):
+    async def _methNodeTags(self, glob=None, index=None):
         tags = list(self.valu.tags.keys())
+        tags.sort()
         if glob is not None:
             regx = s_cache.getTagGlobRegx(glob)
             tags = [t for t in tags if regx.fullmatch(t)]
+            if index is not None:
+                ret = []
+                indx = intify(index)
+                for tag in tags:
+                    parts = tag.split('.')
+                    try:
+                        ret.append(parts[indx])
+                    except IndexError as e:
+                        raise s_exc.StormRuntimeError(mesg=str(e),
+                                                      valurepr=repr(parts),
+                                                      len=len(parts),
+                                                      indx=indx) from None
+                tags = ret
         return tags
 
     async def _methNodeValue(self):

--- a/synapse/tests/test_lib_cache.py
+++ b/synapse/tests/test_lib_cache.py
@@ -38,21 +38,21 @@ class CacheTest(s_t_utils.SynTest):
 
     def test_regexize(self):
         restr = s_cache.regexizeTagGlob('foo*')
-        self.eq(restr, r'foo[^.]+?')
+        self.eq(restr, r'foo([^.]+?)')
         re = regex.compile(restr)
         self.nn(re.fullmatch('foot'))
         self.none(re.fullmatch('foo'))
         self.none(re.fullmatch('foo.bar'))
 
         restr = s_cache.regexizeTagGlob('foo**')
-        self.eq(restr, r'foo.+')
+        self.eq(restr, r'foo(.+)')
         re = regex.compile(restr)
         self.nn(re.fullmatch('foot'))
         self.none(re.fullmatch('foo'))
         self.nn(re.fullmatch('foo.bar'))
 
         restr = s_cache.regexizeTagGlob('foo.b*.b**z')
-        self.eq(restr, r'foo\.b[^.]+?\.b.+z')
+        self.eq(restr, r'foo\.b([^.]+?)\.b(.+)z')
         re = regex.compile(restr)
         self.none(re.fullmatch('foot'))
         self.none(re.fullmatch('foo'))
@@ -64,7 +64,7 @@ class CacheTest(s_t_utils.SynTest):
         self.nn(re.fullmatch('foo.bar.burma.shave.workz'))
 
         restr = s_cache.regexizeTagGlob('*.bar')
-        self.eq(restr, r'[^.]+?\.bar')
+        self.eq(restr, r'([^.]+?)\.bar')
         re = regex.compile(restr)
         self.none(re.fullmatch('foo'))
         self.none(re.fullmatch('.bar'))
@@ -73,7 +73,7 @@ class CacheTest(s_t_utils.SynTest):
         self.none(re.fullmatch('foo.bar.blah'))
 
         restr = s_cache.regexizeTagGlob('*bar')
-        self.eq(restr, r'[^.]+?bar')
+        self.eq(restr, r'([^.]+?)bar')
         re = regex.compile(restr)
         self.nn(re.fullmatch('bbar'))
         self.none(re.fullmatch('foo'))
@@ -83,7 +83,7 @@ class CacheTest(s_t_utils.SynTest):
         self.none(re.fullmatch('foo.bart'))
 
         restr = s_cache.regexizeTagGlob('**.bar')
-        self.eq(restr, r'.+\.bar')
+        self.eq(restr, r'(.+)\.bar')
         re = regex.compile(restr)
         self.none(re.fullmatch('foo'))
         self.none(re.fullmatch('.bar'))
@@ -93,7 +93,7 @@ class CacheTest(s_t_utils.SynTest):
         self.none(re.fullmatch('foo.duck.zanzibar'))
 
         restr = s_cache.regexizeTagGlob('**bar')
-        self.eq(restr, r'.+bar')
+        self.eq(restr, r'(.+)bar')
         re = regex.compile(restr)
         self.nn(re.fullmatch('.bar'))
         self.none(re.fullmatch('foo'))
@@ -103,7 +103,7 @@ class CacheTest(s_t_utils.SynTest):
         self.nn(re.fullmatch('foo.duck.zanzibar'))
 
         restr = s_cache.regexizeTagGlob('foo.b*b')
-        self.eq(restr, r'foo\.b[^.]+?b')
+        self.eq(restr, r'foo\.b([^.]+?)b')
         re = regex.compile(restr)
         self.none(re.fullmatch('foo.bb'))
         self.none(re.fullmatch('foo.bar'))
@@ -111,7 +111,7 @@ class CacheTest(s_t_utils.SynTest):
         self.none(re.fullmatch('foo.bar.rab'))
 
         restr = s_cache.regexizeTagGlob('foo.b**b')
-        self.eq(restr, r'foo\.b.+b')
+        self.eq(restr, r'foo\.b(.+)b')
         re = regex.compile(restr)
         self.none(re.fullmatch('foo.bb'))
         self.none(re.fullmatch('foo.bar'))
@@ -121,7 +121,7 @@ class CacheTest(s_t_utils.SynTest):
         self.none(re.fullmatch('foo.baaaaab.baaad'))
 
         restr = s_cache.regexizeTagGlob('foo.**.bar')
-        self.eq(restr, r'foo\..+\.bar')
+        self.eq(restr, r'foo\.(.+)\.bar')
         re = regex.compile(restr)
         self.none(re.fullmatch('foo.bar'))
         self.nn(re.fullmatch('foo.a.bar'))

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -36,7 +36,8 @@ class StormTypesTest(s_test.SynTest):
         def check_fire_mesgs(storm_mesgs, expected_data):
             tmesgs = [m[1] for m in storm_mesgs if m[0] == 'storm:fire']
             self.len(1, tmesgs)
-            self.eq(tmesgs[0].get('data', {}).get('globs'), expected_data)
+            test_data = set(tmesgs[0].get('data', {}).get('globs'))
+            self.eq(test_data, expected_data)
 
         async with self.getTestCore() as core:
             q = '''[test:str=woot
@@ -49,27 +50,27 @@ class StormTypesTest(s_test.SynTest):
             # explicit behavior tests
             q = 'test:str=woot $globs=$node.globtags("foo.*.*.faz") $lib.fire(test, globs=$globs) -test:str'
             mesgs = await core.streamstorm(q).list()
-            e = [('bar', 'baz'), ('bar', 'jaz'), ('knight', 'day')]
+            e = {('bar', 'baz'), ('bar', 'jaz'), ('knight', 'day')}
             check_fire_mesgs(mesgs, e)
 
             q = 'test:str=woot $globs=$node.globtags("foo.bar.*") $lib.fire(test, globs=$globs) -test:str'
             mesgs = await core.streamstorm(q).list()
-            e = ['baz', 'jaz']
+            e = {'baz', 'jaz'}
             check_fire_mesgs(mesgs, e)
 
             q = 'test:str=woot $globs=$node.globtags("foo.bar.*.*") $lib.fire(test, globs=$globs) -test:str'
             mesgs = await core.streamstorm(q).list()
-            e = [('baz', 'faz'), ('jaz', 'faz')]
+            e = {('baz', 'faz'), ('jaz', 'faz')}
             check_fire_mesgs(mesgs, e)
 
             q = 'test:str=woot $globs=$node.globtags("foo.bar.**") $lib.fire(test, globs=$globs) -test:str'
             mesgs = await core.streamstorm(q).list()
-            e = ['baz', 'baz.faz', 'jaz', 'jaz.faz']
+            e = {'baz', 'baz.faz', 'jaz', 'jaz.faz'}
             check_fire_mesgs(mesgs, e)
 
             q = 'test:str=woot $globs=$node.globtags("foo.bar.*.*.*") $lib.fire(test, globs=$globs) -test:str'
             mesgs = await core.streamstorm(q).list()
-            e = []
+            e = set()
             check_fire_mesgs(mesgs, e)
 
             # For loop example for a single-match case


### PR DESCRIPTION
- Simplify a common ``$node.tags()`` access pattern.
- Catch IndexError on Storm list types and convert it into a StormRuntimeError