### PR TITLE
Bug: Telepath synchronous generator teardown

### DIFF
--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -369,6 +369,11 @@ class Base:
 
         if __debug__:
             import synapse.lib.threads as s_threads  # avoid import cycle
+            if s_threads.iden() != self.tid:
+                thr = s_threads.current()
+                m = f'Fini called on {self} outside the loop thread!: {self.tid} / {s_threads.iden()} is {thr.name}'
+                logger.error(m)
+                # print(m)
             assert s_threads.iden() == self.tid
 
         self._syn_refs -= 1

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -369,11 +369,6 @@ class Base:
 
         if __debug__:
             import synapse.lib.threads as s_threads  # avoid import cycle
-            if s_threads.iden() != self.tid:
-                thr = s_threads.current()
-                m = f'Fini called on {self} outside the loop thread!: {self.tid} / {s_threads.iden()} is {thr.name}'
-                logger.error(m)
-                # print(m)
             assert s_threads.iden() == self.tid
 
         self._syn_refs -= 1

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -98,6 +98,12 @@ class GenrHelp:
         except StopAsyncIteration:
             return
 
+        except GeneratorExit:
+            # Raised if a synchronous consumer exiting a iterator early,
+            # we need to signal the generator to close down.
+            s_glob.sync(self.genr.aclose())
+            raise
+
     async def spin(self):
         async for x in self.genr:
             pass

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -8,6 +8,7 @@ import threading
 logger = logging.getLogger(__name__)
 
 import synapse.exc as s_exc
+import synapse.glob as s_glob
 import synapse.common as s_common
 import synapse.telepath as s_telepath
 
@@ -235,10 +236,6 @@ class TeleTest(s_t_utils.SynTest):
 
     def test_telepath_sync_genr_break(self):
 
-        import time
-        import threading
-        import synapse.glob as s_glob
-
         try:
             acm = self.getTestCoreAndProxy()
             core, proxy = s_glob.sync(acm.__aenter__())
@@ -262,8 +259,11 @@ class TeleTest(s_t_utils.SynTest):
 
             # Break from the generator right away, causing a
             # GeneratorExit in the GenrHelp object __iter__ method.
+            pode = None
             for pode in proxy.eval(q):
                 break
+            # Ensure the query did yield an object
+            self.nn(pode)
 
             # Ensure the link we have a reference too was torn down
             self.true(evt.wait(4))

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -233,6 +233,40 @@ class TeleTest(s_t_utils.SynTest):
             async with await s_telepath.openurl('tcp://127.0.0.1/foo', port=addr[1]) as prox:
                 self.eq((10, 20, 30), await s_coro.executor(sync))
 
+    def test_telepath_sync_genr_break(self):
+
+        import time
+        import threading
+        import synapse.glob as s_glob
+
+        try:
+            acm = self.getTestCoreAndProxy()
+            core, proxy = s_glob.sync(acm.__aenter__())
+
+            logger.info(core)
+            logger.info(proxy)
+
+            form = 'test:int'
+
+            q = '[' + ' '.join([f'{form}={i}' for i in range(20)]) + ' ]'
+            logger.info(q)
+
+            podes = list(proxy.eval(q))
+            self.len(20, podes)
+
+            evt = threading.Event()
+            evt.clear()
+
+            q = f'{form} | sleep 1'
+
+            for pode in proxy.eval(q):
+                print(pode)
+                break
+            time.sleep(0.1)
+
+        finally:
+            s_glob.sync(acm.__aexit__(None, None, None))
+
     async def test_telepath_no_sess(self):
 
         foo = Foo()


### PR DESCRIPTION
Fix an issue where the telepath link could get torn down on the mainthread instead of the ioloop during a generator exit from synchronous code.