### PR TITLE
Ci gitlab codecov orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
             ls -ltha coverage
 
       -  codecov/upload:
-           file: /home/circleci/repo/coverage.xml
+           file: /home/circleci/repo/.coverage
 
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
           command: |
             python3 -m venv --copies venv
             . venv/bin/activate
-            python3 -m pip install -U wheel pip pytest pytest-cov pycodestyle codecov
+            python3 -m pip install -U wheel pip pytest pytest-cov pycodestyle
 
       - run:
           name: install synapse
@@ -122,7 +122,7 @@ commands:
           command: |
             python3 -m venv --copies venv
             . venv/bin/activate
-            python3 -m pip install -U wheel pip pytest pytest-cov pycodestyle codecov
+            python3 -m pip install -U wheel pip pytest pytest-cov pycodestyle
 
       - run:
           name: install synapse
@@ -142,11 +142,8 @@ commands:
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
 
-      - run:
-          name: report coverage
-          command: |
-            . venv/bin/activate
-            if [ -n "${COVERAGE_ARGS}" ]; then codecov --name ${PYVERS}node${CIRCLE_NODE_INDEX} ${CODECOV_ARGS}; fi;
+      -  codecov/upload:
+           file: /home/circleci/repo/coverage.xml
 
       - store_test_results:
           path: test-reports
@@ -282,7 +279,7 @@ jobs:
       xcode: "10.2.0"
 
     environment:
-      COVERAGE_ARGS: --cov synapse --no-cov-on-fail
+      COVERAGE_ARGS:  --cov synapse --no-cov-on-fail --cov-report=xml
       PYVERS: 3.7
 
     working_directory: ~/repo
@@ -295,7 +292,6 @@ jobs:
     docker:
       - image: circleci/python:3.7
         environment:
-          CODECOV_ARGS: --required
           COVERAGE_ARGS: --cov synapse --no-cov-on-fail --cov-report=xml
           PYVERS: 3.7
           SYN_REGRESSION_REPO: ~/git/synapse-regression
@@ -358,8 +354,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only:
-                - master
+              only: /.*/
 
       - python37:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@
 #
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@1.0.2
+
 commands:
   test_steps_doc:
     description: "Documentation test steps"
@@ -96,7 +99,8 @@ commands:
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
 
-      - run:
+      -  codecov/upload:
+
           name: report coverage
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,8 @@ commands:
             . venv/bin/activate
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
+            ls -ltha .
+            ls -ltha coverage
 
       -  codecov/upload:
            file: /home/circleci/repo/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,11 +98,9 @@ commands:
             . venv/bin/activate
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
-            ls -ltha .
-            ls -ltha test-reports
 
       -  codecov/upload:
-           file: /home/circleci/repo/.coverage
+           file: /home/circleci/repo/coverage.xml
 
       - store_test_results:
           path: test-reports
@@ -298,7 +296,7 @@ jobs:
       - image: circleci/python:3.7
         environment:
           CODECOV_ARGS: --required
-          COVERAGE_ARGS: --cov synapse --no-cov-on-fail
+          COVERAGE_ARGS: --cov synapse --no-cov-on-fail --cov-report=xml
           PYVERS: 3.7
           SYN_REGRESSION_REPO: ~/git/synapse-regression
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ jobs:
       xcode: "10.2.0"
 
     environment:
-      COVERAGE_ARGS:  --cov synapse --no-cov-on-fail --cov-report=xml
+      COVERAGE_ARGS: --cov synapse --no-cov-on-fail --cov-report=xml
       PYVERS: 3.7
 
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,8 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: /.*/
+              only:
+                - master
 
       - python37:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.0.2
+  codecov: codecov/codecov@1.0.5
 
 commands:
   test_steps_doc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,7 @@ commands:
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
 
       -  codecov/upload:
-
-          name: report coverage
-          command: |
-            . venv/bin/activate
-            if [ -n "${COVERAGE_ARGS}" ]; then codecov --name ${PYVERS}node${CIRCLE_NODE_INDEX} ${CODECOV_ARGS}; fi;
+           file: /home/circleci/repo/coverage.xml
 
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ commands:
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
             ls -ltha .
-            ls -ltha coverage
+            ls -ltha test-reports
 
       -  codecov/upload:
            file: /home/circleci/repo/.coverage

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1161,8 +1161,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                     waiter = src_core.waiter(1, 'core:splice:cryotank:sent')
                     # Form a node and make sure that it exists
                     async with await src_core.snap() as snap:
-                        await snap.addNode('test:str', 'teehee')
-                        # self.nn(await snap.getNodeByNdef(('test:str', 'teehee')))
+                        self.nn(await snap.addNode('test:str', 'teehee'))
 
                     self.true(await waiter.wait(timeout=10))
                 await src_core.waitfini()

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1158,15 +1158,14 @@ class CortexBasicTest(s_t_utils.SynTest):
                 }
                 async with self.getTestCore(dirn=dirn, conf=conf) as src_core:
 
-                    waiter = src_core.waiter(2, 'core:splice:cryotank:sent')
+                    waiter = src_core.waiter(1, 'core:splice:cryotank:sent')
                     # Form a node and make sure that it exists
                     async with await src_core.snap() as snap:
                         await snap.addNode('test:str', 'teehee')
-                        self.nn(await snap.getNodeByNdef(('test:str', 'teehee')))
+                        # self.nn(await snap.getNodeByNdef(('test:str', 'teehee')))
 
-                    await waiter.wait(timeout=10)
-                    await src_core.fini()
-                    await src_core.waitfini()
+                    self.true(await waiter.wait(timeout=10))
+                await src_core.waitfini()
 
             # Now that the src core is closed, make sure that the splice exists in the tank
             tank = cryo.tanks.get('blahblah')


### PR DESCRIPTION
- Don't use the codecov python package; use the orb instead. While its code repository has been updated in the past year, they haven't had a pypi release in over a year.
- Fix a cortex unit test which ran slow (but runs fast now due to editatom).