### PR TITLE
Feature persistent stormvars

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -896,9 +896,9 @@ class Cortex(s_cell.Cell):
         '''
         self.addStormLib(('csv',), s_stormtypes.LibCsv)
         self.addStormLib(('str',), s_stormtypes.LibStr)
-        self.addStormLib(('core',), s_stormtypes.LibCore)
         self.addStormLib(('time',), s_stormtypes.LibTime)
         self.addStormLib(('user',), s_stormtypes.LibUser)
+        self.addStormLib(('globals',), s_stormtypes.LibGlobals)
         self.addStormLib(('inet', 'http'), s_stormhttp.LibHttp)
 
     def _initSplicers(self):

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -705,6 +705,7 @@ class Cortex(s_cell.Cell):
         self.layrctors = {}
         self.feedfuncs = {}
         self.stormcmds = {}
+        self.stormvars = None  # type: s_hive.HiveDict
         self.stormrunts = {}
 
         self._runtLiftFuncs = {}
@@ -719,6 +720,10 @@ class Cortex(s_cell.Cell):
         self.libroot = (None, {}, {})
         self.bldgbuids = {} # buid -> (Node, Event)  Nodes under construction
 
+        # async inits
+        await self._initCoreHive()
+
+        # sync inits
         self._initSplicers()
         self._initStormCmds()
         self._initStormLibs()
@@ -862,6 +867,10 @@ class Cortex(s_cell.Cell):
         form = self.model.form(name)
         return form.getWaitFor(valu)
 
+    async def _initCoreHive(self):
+        stormvars = await self.hive.open(('cortex', 'storm', 'vars'))
+        self.stormvars = await stormvars.dict()
+
     def _initStormCmds(self):
         '''
         Registration for built-in Storm commands.
@@ -887,7 +896,9 @@ class Cortex(s_cell.Cell):
         '''
         self.addStormLib(('csv',), s_stormtypes.LibCsv)
         self.addStormLib(('str',), s_stormtypes.LibStr)
+        self.addStormLib(('core',), s_stormtypes.LibCore)
         self.addStormLib(('time',), s_stormtypes.LibTime)
+        self.addStormLib(('user',), s_stormtypes.LibUser)
         self.addStormLib(('inet', 'http'), s_stormhttp.LibHttp)
 
     def _initSplicers(self):

--- a/synapse/lib/hive.py
+++ b/synapse/lib/hive.py
@@ -590,7 +590,7 @@ class HiveDict(s_base.Base):
 
         self.node.onfini(self)
 
-    def get(self, name, onedit=None):
+    def get(self, name, onedit=None, default=None):
 
         # use hive.onedit() here to register for
         # paths which potentially dont exist yet
@@ -600,7 +600,7 @@ class HiveDict(s_base.Base):
 
         node = self.node.get(name)
         if node is None:
-            return self.defs.get(name)
+            return self.defs.get(name, default)
 
         return node.valu
 

--- a/synapse/lib/hive.py
+++ b/synapse/lib/hive.py
@@ -865,7 +865,7 @@ class HiveUser(HiveIden):
         self.profile = await prof.dict()
 
         # vars cache for persistent user level data storage
-        # TODO: max size check?
+        # TODO: max size check / max count check?
         pvars = await self.node.open(('vars',))
         self.pvars = await pvars.dict()
 
@@ -873,12 +873,6 @@ class HiveUser(HiveIden):
         self.permcache = s_cache.FixedCache(self._calcPermAllow)
 
         self._initFullRules()
-
-        # user needs to get hive:get / hive:set / hive:pop permissions to their stormvars tree
-        for baseperm in ('hive:get', 'hive:set', 'hive:pop'):
-            rule = (True, (baseperm,) + pvars.full)
-            if rule not in self.fullrules:
-                await self.addRule(rule)
 
     def pack(self):
         return {

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -145,7 +145,8 @@ class Runtime:
 
         # fails will not be cached...
         perm = '.'.join(args)
-        raise s_exc.AuthDeny(perm=perm, user=self.user.name)
+        mesg = f'User must have permission {perm}'
+        raise s_exc.AuthDeny(mesg=mesg, perm=perm, user=self.user.name)
 
     async def iterStormQuery(self, query):
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -290,14 +290,21 @@ class StormHiveDict(Prim):
             'list': self._methList,
         })
 
+    def _reqStr(self, name):
+        if not isinstance(name, str):
+            mesg = 'The name of a persistent variable must be a string.'
+            raise s_exc.StormRuntimeError(mesg=mesg, name=name)
+
     async def _methGet(self, name):
+        self._reqStr(name)
         return self.valu.get(name)
 
     async def _methPop(self, name):
+        self._reqStr(name)
         return await self.valu.pop(name)
 
     async def _methSet(self, name, valu):
-        # prevent nest key/hive node creation here
+        self._reqStr(name)
         await self.valu.set(name, valu)
 
     async def _methList(self):
@@ -333,17 +340,24 @@ class LibGlobals(Lib):
     def _reqAllowed(self, perm, name):
         self.runt.allowed(perm, name)
 
+    def _reqStr(self, name):
+        if not isinstance(name, str):
+            mesg = 'The name of a persistent variable must be a string.'
+            raise s_exc.StormRuntimeError(mesg=mesg, name=name)
+
     async def _methGet(self, name):
+        self._reqStr(name)
         self._reqAllowed('storm:globals:get', name)
         return self._stormvars.get(name)
 
     async def _methPop(self, name):
+        self._reqStr(name)
         self._reqAllowed('storm:globals:pop', name)
         return await self._stormvars.pop(name)
 
     async def _methSet(self, name, valu):
+        self._reqStr(name)
         self._reqAllowed('storm:globals:set', name)
-        # prevent nest key/hive node creation here
         await self._stormvars.set(name, valu)
 
     async def _methList(self):

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -48,15 +48,12 @@ class CellTest(s_t_utils.SynTest):
 
                 root_url = f'tcp://root:secretsauce@127.0.0.1:{port}/echo00'
                 async with await s_telepath.openurl(root_url) as proxy:
-                    root_user = await proxy.getCellUser()
-                    root_iden = root_user.get('iden')
                     self.true(await proxy.isadmin())
                     self.true(await proxy.allowed('hehe', 'haha'))
 
                 user = await echo.auth.addUser('visi')
                 await user.setPasswd('foo')
                 await user.addRule((True, ('foo', 'bar')))
-                visi_iden = user.iden
 
                 visi_url = f'tcp://visi:foo@127.0.0.1:{port}/echo00'
                 async with await s_telepath.openurl(visi_url) as proxy:  # type: EchoAuthApi
@@ -75,7 +72,6 @@ class CellTest(s_t_utils.SynTest):
                     # happy path perms
                     await user.addRule((True, ('hive:set', 'foo', 'bar')))
                     await user.addRule((True, ('hive:get', 'foo', 'bar')))
-                    # await user.addRule((True, ('hive:list', 'foo', 'bar')))
                     await user.addRule((True, ('hive:pop', 'foo', 'bar')))
 
                     val = await proxy.setHiveKey(('foo', 'bar'), 'thefirstval')
@@ -110,12 +106,6 @@ class CellTest(s_t_utils.SynTest):
                     self.false(info[1].get('locked'))
                     async with await s_telepath.openurl(visi_url) as visi_proxy:
                         self.false(await visi_proxy.isadmin())
-
-                    # Admin user, as expected, can acess all user persistent storage
-                    _path = ('auth', 'users', root_iden, 'vars')
-                    self.eq(await proxy.listHiveKey(_path), ())
-                    _path = ('auth', 'users', visi_iden, 'vars')
-                    self.eq(await proxy.listHiveKey(_path), ())
 
                 async with await s_telepath.openurl(root_url) as proxy:  # type: EchoAuthApi
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -48,15 +48,18 @@ class CellTest(s_t_utils.SynTest):
 
                 root_url = f'tcp://root:secretsauce@127.0.0.1:{port}/echo00'
                 async with await s_telepath.openurl(root_url) as proxy:
+                    root_user = await proxy.getCellUser()
+                    root_iden = root_user.get('iden')
                     self.true(await proxy.isadmin())
                     self.true(await proxy.allowed('hehe', 'haha'))
 
                 user = await echo.auth.addUser('visi')
                 await user.setPasswd('foo')
                 await user.addRule((True, ('foo', 'bar')))
+                visi_iden = user.iden
 
                 visi_url = f'tcp://visi:foo@127.0.0.1:{port}/echo00'
-                async with await s_telepath.openurl(visi_url) as proxy:
+                async with await s_telepath.openurl(visi_url) as proxy:  # type: EchoAuthApi
                     self.true(await proxy.allowed('foo', 'bar'))
                     self.false(await proxy.isadmin())
                     self.false(await proxy.allowed('hehe', 'haha'))
@@ -72,7 +75,7 @@ class CellTest(s_t_utils.SynTest):
                     # happy path perms
                     await user.addRule((True, ('hive:set', 'foo', 'bar')))
                     await user.addRule((True, ('hive:get', 'foo', 'bar')))
-                    await user.addRule((True, ('hive:list', 'foo', 'bar')))
+                    # await user.addRule((True, ('hive:list', 'foo', 'bar')))
                     await user.addRule((True, ('hive:pop', 'foo', 'bar')))
 
                     val = await proxy.setHiveKey(('foo', 'bar'), 'thefirstval')
@@ -94,7 +97,24 @@ class CellTest(s_t_utils.SynTest):
                     val = await proxy.listHiveKey(('foo', 'bar'))
                     self.eq(('baz', 'faz', 'haz'), val)
 
-                async with await s_telepath.openurl(root_url) as proxy:
+                    # The default persistent user-specific hive storage is accessible
+                    # to the user and they can list/add/pop data from it.
+                    path = ('auth', 'users', visi_iden, 'vars')
+                    self.eq(await proxy.listHiveKey(path), ())
+                    self.eq(await proxy.setHiveKey(path + ('hehe',), 'haha'), None)
+                    self.eq(await proxy.listHiveKey(path), ('hehe',))
+                    self.eq(await proxy.getHiveKey(path + ('hehe',)), 'haha')
+                    self.eq(await proxy.popHiveKey(path + ('hehe',)), 'haha')
+                    self.eq(await proxy.listHiveKey(path), ())
+
+                    # Default perm does not give access to arbitrary hive keys :)
+                    _path = ('auth', 'users')
+                    await self.asyncraises(s_exc.AuthDeny, proxy.listHiveKey(_path))
+                    # Can't cross over to other users storage
+                    _path = ('auth', 'users', root_iden, 'vars')
+                    await self.asyncraises(s_exc.AuthDeny, proxy.listHiveKey(_path))
+
+                async with await s_telepath.openurl(root_url) as proxy:  # type: EchoAuthApi
 
                     await proxy.setUserLocked('visi', True)
                     info = await proxy.getAuthInfo('visi')
@@ -108,7 +128,13 @@ class CellTest(s_t_utils.SynTest):
                     async with await s_telepath.openurl(visi_url) as visi_proxy:
                         self.false(await visi_proxy.isadmin())
 
-                async with await s_telepath.openurl(root_url) as proxy:
+                    # Admin user, as expected, can acess all user persistent storage
+                    _path = ('auth', 'users', root_iden, 'vars')
+                    self.eq(await proxy.listHiveKey(_path), ())
+                    _path = ('auth', 'users', visi_iden, 'vars')
+                    self.eq(await proxy.listHiveKey(_path), ())
+
+                async with await s_telepath.openurl(root_url) as proxy:  # type: EchoAuthApi
 
                     await self.asyncraises(s_exc.NoSuchUser,
                                            proxy.setUserArchived('newp', True))
@@ -133,7 +159,7 @@ class CellTest(s_t_utils.SynTest):
                     await self.asyncraises(s_exc.AuthDeny,
                                            s_telepath.openurl(visi_url))
 
-                async with echo.getLocalProxy() as proxy:
+                async with echo.getLocalProxy() as proxy:  # type: EchoAuthApi
 
                     await proxy.setHiveKey(('foo', 'bar'), [1, 2, 3, 4])
                     self.eq([1, 2, 3, 4], await proxy.getHiveKey(('foo', 'bar')))

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -97,23 +97,6 @@ class CellTest(s_t_utils.SynTest):
                     val = await proxy.listHiveKey(('foo', 'bar'))
                     self.eq(('baz', 'faz', 'haz'), val)
 
-                    # The default persistent user-specific hive storage is accessible
-                    # to the user and they can list/add/pop data from it.
-                    path = ('auth', 'users', visi_iden, 'vars')
-                    self.eq(await proxy.listHiveKey(path), ())
-                    self.eq(await proxy.setHiveKey(path + ('hehe',), 'haha'), None)
-                    self.eq(await proxy.listHiveKey(path), ('hehe',))
-                    self.eq(await proxy.getHiveKey(path + ('hehe',)), 'haha')
-                    self.eq(await proxy.popHiveKey(path + ('hehe',)), 'haha')
-                    self.eq(await proxy.listHiveKey(path), ())
-
-                    # Default perm does not give access to arbitrary hive keys :)
-                    _path = ('auth', 'users')
-                    await self.asyncraises(s_exc.AuthDeny, proxy.listHiveKey(_path))
-                    # Can't cross over to other users storage
-                    _path = ('auth', 'users', root_iden, 'vars')
-                    await self.asyncraises(s_exc.AuthDeny, proxy.listHiveKey(_path))
-
                 async with await s_telepath.openurl(root_url) as proxy:  # type: EchoAuthApi
 
                     await proxy.setUserLocked('visi', True)

--- a/synapse/tests/test_lib_hive.py
+++ b/synapse/tests/test_lib_hive.py
@@ -157,7 +157,6 @@ class HiveTest(s_test.SynTest):
                 self.nn(user)
 
                 self.false(user.admin)
-                # User has rules to access their persistent data store
                 self.len(0, user.rules)
                 self.len(0, user.roles)
 

--- a/synapse/tests/test_lib_hive.py
+++ b/synapse/tests/test_lib_hive.py
@@ -155,7 +155,7 @@ class HiveTest(s_test.SynTest):
 
                 self.false(user.admin)
                 # User has rules to access their persistent data store
-                self.len(3, user.rules)
+                self.len(0, user.rules)
                 self.len(0, user.roles)
 
                 await user.info.set('admin', True)

--- a/synapse/tests/test_lib_hive.py
+++ b/synapse/tests/test_lib_hive.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 
 import synapse.exc as s_exc
+import synapse.common as s_common
 
 import synapse.tests.utils as s_test
 
@@ -84,6 +85,8 @@ class HiveTest(s_test.SynTest):
                     self.eq(31337, await hivedict.pop('lulz'))
 
                     self.eq(None, hivedict.get('nope'))
+
+                    self.eq(s_common.novalu, hivedict.get('nope', default=s_common.novalu))
 
             async with self.getTestHiveFromDirn(dirn) as hive:
 

--- a/synapse/tests/test_lib_hive.py
+++ b/synapse/tests/test_lib_hive.py
@@ -154,7 +154,8 @@ class HiveTest(s_test.SynTest):
                 self.nn(user)
 
                 self.false(user.admin)
-                self.len(0, user.rules)
+                # User has rules to access their persistent data store
+                self.len(3, user.rules)
                 self.len(0, user.roles)
 
                 await user.info.set('admin', True)

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -389,6 +389,22 @@ class StormTypesTest(s_test.SynTest):
                     self.len(1, errs)
                     self.eq(errs[0][1][1].get('mesg'), err)
 
+                    # Sad path - names must be strings.
+                    q = '$lib.user.vars.set((my, nested, valu), haha)'
+                    mesgs = await s_test.alist(prox.storm(q))
+                    err = 'The name of a persistent variable must be a string.'
+                    errs = [m for m in mesgs if m[0] == 'err']
+                    self.len(1, errs)
+                    self.eq(errs[0][1][1].get('mesg'), err)
+
+                    # Sad path - names must be strings.
+                    q = '$lib.globals.set((my, nested, valu), haha)'
+                    mesgs = await s_test.alist(prox.storm(q))
+                    err = 'The name of a persistent variable must be a string.'
+                    errs = [m for m in mesgs if m[0] == 'err']
+                    self.len(1, errs)
+                    self.eq(errs[0][1][1].get('mesg'), err)
+
                 async with core.getLocalProxy() as uprox:  # type: s_cortex.CoreApi
                     self.true(await uprox.setCellUser(iden1))
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -491,3 +491,13 @@ class StormTypesTest(s_test.SynTest):
                     '''
                     mesgs = await s_test.alist(uprox.storm(q))
                     self.stormIsInPrint('lessThanSekrit', mesgs)
+
+                    # The StormHiveDict is safe when computing things
+                    q = '''[test:int=1234]
+                    $lib.user.vars.set(someint, $node.value())
+                    [test:str=$lib.user.vars.get(someint)]
+                    '''
+                    podes = await s_test.alist(uprox.eval(q))
+                    self.len(2, podes)
+                    self.eq({('test:str', '1234'), ('test:int', 1234)},
+                            {pode[0] for pode in podes})

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -351,26 +351,26 @@ class StormTypesTest(s_test.SynTest):
                     await prox.addAuthRule('user1', (True, ('node:add',)))
                     await prox.addAuthRule('user1', (True, ('prop:set',)))
                     await prox.addAuthRule('user1', (True,
-                                                     ('storm:globals', 'get', 'userkey',)))
+                                                     ('storm:globals:get', 'userkey',)))
 
-                    # Basic tests as root for $lib.core.vars
+                    # Basic tests as root for $lib.globals
 
-                    q = '''$lib.core.vars.set(adminkey, sekrit)
-                    $lib.core.vars.set(userkey, lessThanSekrit)
-                    $lib.core.vars.set(throwaway, beep)
-                    $valu=$lib.core.vars.get(adminkey)
+                    q = '''$lib.globals.set(adminkey, sekrit)
+                    $lib.globals.set(userkey, lessThanSekrit)
+                    $lib.globals.set(throwaway, beep)
+                    $valu=$lib.globals.get(adminkey)
                     $lib.print($valu)
                     '''
                     mesgs = await s_test.alist(prox.storm(q))
                     self.stormIsInPrint('sekrit', mesgs)
 
-                    popq = '''$valu = $lib.core.vars.pop(throwaway)
+                    popq = '''$valu = $lib.globals.pop(throwaway)
                     $lib.print("pop valu is {valu}", valu=$valu)
                     '''
                     mesgs = await s_test.alist(prox.storm(popq))
                     self.stormIsInPrint('pop valu is beep', mesgs)
 
-                    listq = '''for ($key, $valu) in $lib.core.vars.list() {
+                    listq = '''for ($key, $valu) in $lib.globals.list() {
                     $string = $lib.str.format("{key} is {valu}", key=$key, valu=$valu)
                     $lib.print($string)
                     }
@@ -427,7 +427,7 @@ class StormTypesTest(s_test.SynTest):
 
                     # the user can access the specific core.vars key
                     # that they have access too but not the admin key
-                    q = '''$valu=$lib.core.vars.get(userkey)
+                    q = '''$valu=$lib.globals.get(userkey)
                         $lib.print($valu)
                         '''
                     mesgs = await s_test.alist(uprox.storm(q))
@@ -435,7 +435,7 @@ class StormTypesTest(s_test.SynTest):
 
                     # While the user has get perm, they do not have set or pop
                     # permission
-                    q = '''$valu=$lib.core.vars.pop(userkey)
+                    q = '''$valu=$lib.globals.pop(userkey)
                     $lib.print($valu)
                     '''
                     mesgs = await s_test.alist(uprox.storm(q))
@@ -444,7 +444,7 @@ class StormTypesTest(s_test.SynTest):
                     self.len(1, errs)
                     self.eq(errs[0][1][0], 'AuthDeny')
 
-                    q = '''$valu=$lib.core.vars.set(userkey, newSekritValu)
+                    q = '''$valu=$lib.globals.set(userkey, newSekritValu)
                     $lib.print($valu)
                     '''
                     mesgs = await s_test.alist(uprox.storm(q))
@@ -454,7 +454,7 @@ class StormTypesTest(s_test.SynTest):
                     self.eq(errs[0][1][0], 'AuthDeny')
 
                     # Attempting to access the adminkey fails
-                    q = '''$valu=$lib.core.vars.get(adminkey)
+                    q = '''$valu=$lib.globals.get(adminkey)
                     $lib.print($valu)
                     '''
                     mesgs = await s_test.alist(uprox.storm(q))
@@ -466,7 +466,7 @@ class StormTypesTest(s_test.SynTest):
                     # if the user attempts to list the values in
                     # core.vars, they only get the values they can read.
                     corelistq = '''
-                    for ($key, $valu) in $lib.core.vars.list() {
+                    for ($key, $valu) in $lib.globals.list() {
                         $string = $lib.str.format("{key} is {valu}", key=$key, valu=$valu)
                         $lib.print($string)
                     }
@@ -485,7 +485,7 @@ class StormTypesTest(s_test.SynTest):
                     self.len(1, [m for m in mesgs if m[0] == 'print'])
                     self.stormIsInPrint('somekey is hehe', mesgs)
 
-                    q = '''$valu=$lib.core.vars.get(userkey)
+                    q = '''$valu=$lib.globals.get(userkey)
                     $lib.print($valu)
                     '''
                     mesgs = await s_test.alist(uprox.storm(q))

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -351,8 +351,7 @@ class StormTypesTest(s_test.SynTest):
                     await prox.addAuthRule('user1', (True, ('node:add',)))
                     await prox.addAuthRule('user1', (True, ('prop:set',)))
                     await prox.addAuthRule('user1', (True,
-                                                     ('hive:get', 'cortex', 'storm',
-                                                      'vars', 'userkey')))
+                                                     ('storm:globals', 'get', 'userkey',)))
 
                     # Basic tests as root for $lib.core.vars
 


### PR DESCRIPTION
- Add default hive storage for users to the HiveUser class.
- Add ``$lib.user.vars`` to access the per-user storage.
- Add ``$lib.core.vars`` to access global storage.