### PR TITLE
Add default optional arguments to get() and pop() methods for persistent vars.

### DIFF
--- a/synapse/lib/hive.py
+++ b/synapse/lib/hive.py
@@ -615,10 +615,10 @@ class HiveDict(s_base.Base):
         for key, node in iter(self.node):
             yield key, node.valu
 
-    async def pop(self, name):
+    async def pop(self, name, default=None):
         node = self.node.get(name)
         if node is None:
-            return self.defs.get(name)
+            return self.defs.get(name, default)
 
         retn = node.valu
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -295,13 +295,13 @@ class StormHiveDict(Prim):
             mesg = 'The name of a persistent variable must be a string.'
             raise s_exc.StormRuntimeError(mesg=mesg, name=name)
 
-    async def _methGet(self, name):
+    async def _methGet(self, name, default=None):
         self._reqStr(name)
-        return self.valu.get(name)
+        return self.valu.get(name, default=default)
 
-    async def _methPop(self, name):
+    async def _methPop(self, name, default=None):
         self._reqStr(name)
-        return await self.valu.pop(name)
+        return await self.valu.pop(name, default=default)
 
     async def _methSet(self, name, valu):
         self._reqStr(name)
@@ -345,15 +345,15 @@ class LibGlobals(Lib):
             mesg = 'The name of a persistent variable must be a string.'
             raise s_exc.StormRuntimeError(mesg=mesg, name=name)
 
-    async def _methGet(self, name):
+    async def _methGet(self, name, default=None):
         self._reqStr(name)
         self._reqAllowed('storm:globals:get', name)
-        return self._stormvars.get(name)
+        return self._stormvars.get(name, default=default)
 
-    async def _methPop(self, name):
+    async def _methPop(self, name, default=None):
         self._reqStr(name)
         self._reqAllowed('storm:globals:pop', name)
-        return await self._stormvars.pop(name)
+        return await self._stormvars.pop(name, default=default)
 
     async def _methSet(self, name, valu):
         self._reqStr(name)

--- a/synapse/tests/test_lib_hive.py
+++ b/synapse/tests/test_lib_hive.py
@@ -87,6 +87,7 @@ class HiveTest(s_test.SynTest):
                     self.eq(None, hivedict.get('nope'))
 
                     self.eq(s_common.novalu, hivedict.get('nope', default=s_common.novalu))
+                    self.eq(s_common.novalu, await hivedict.pop('nope', default=s_common.novalu))
 
             async with self.getTestHiveFromDirn(dirn) as hive:
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -368,6 +368,19 @@ class StormTypesTest(s_test.SynTest):
                     mesgs = await s_test.alist(prox.storm(popq))
                     self.stormIsInPrint('pop valu is beep', mesgs)
 
+                    # get and pop take a secondary default value which may be returned
+                    q = '''$valu = $lib.globals.get(throwaway, $(0))
+                    $lib.print("get valu is {valu}", valu=$valu)
+                    '''
+                    mesgs = await s_test.alist(prox.storm(q))
+                    self.stormIsInPrint('get valu is 0', mesgs)
+
+                    q = '''$valu = $lib.globals.pop(throwaway, $(0))
+                    $lib.print("pop valu is {valu}", valu=$valu)
+                    '''
+                    mesgs = await s_test.alist(prox.storm(q))
+                    self.stormIsInPrint('pop valu is 0', mesgs)
+
                     listq = '''for ($key, $valu) in $lib.globals.list() {
                     $string = $lib.str.format("{key} is {valu}", key=$key, valu=$valu)
                     $lib.print($string)
@@ -438,6 +451,19 @@ class StormTypesTest(s_test.SynTest):
                     mesgs = await s_test.alist(uprox.storm(listq))
                     self.len(1, [m for m in mesgs if m[0] == 'print'])
                     self.stormIsInPrint('somekey is hehe', mesgs)
+
+                    # get and pop take a secondary default value which may be returned
+                    q = '''$valu = $lib.user.vars.get(newp, $(0))
+                    $lib.print("get valu is {valu}", valu=$valu)
+                    '''
+                    mesgs = await s_test.alist(prox.storm(q))
+                    self.stormIsInPrint('get valu is 0', mesgs)
+
+                    q = '''$valu = $lib.user.vars.pop(newp, $(0))
+                    $lib.print("pop valu is {valu}", valu=$valu)
+                    '''
+                    mesgs = await s_test.alist(prox.storm(q))
+                    self.stormIsInPrint('pop valu is 0', mesgs)
 
                     # the user can access the specific core.vars key
                     # that they have access too but not the admin key


### PR DESCRIPTION
missing feature from #1287 