### PR TITLE
Allow inet:fqdn filtering to start with a * wildcard.

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -210,8 +210,11 @@ class Fqdn(s_types.Type):
 
     def _ctorCmprEq(self, text):
         if text == '':
-            raise s_exc.BadCmprValu(valu=text, name=self.name, cmpr='=',
-                                    mesg='Cannot generate fqdn comparator for a empty string')
+            # Asking if a +inet:fqdn='' is a odd filter, but
+            # the intuitive answer for that filter is to return False
+            def cmpr(valu):
+                return False
+            return cmpr
 
         if text[0] == '*':
             cval = text[1:]
@@ -538,6 +541,21 @@ class Url(s_types.StrBase):
     def postTypeInit(self):
         s_types.StrBase.postTypeInit(self)
         self.setNormFunc(str, self._normPyStr)
+
+    def _ctorCmprEq(self, text):
+        if text == '':
+            # Asking if a +inet:url='' is a odd filter, but
+            # the intuitive answer for that filter is to return False
+            def cmpr(valu):
+                return False
+            return cmpr
+
+        norm, info = self.norm(text)
+
+        def cmpr(valu):
+            return norm == valu
+
+        return cmpr
 
     def _normPyStr(self, valu):
         orig = valu

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -208,6 +208,23 @@ class Fqdn(s_types.Type):
     def postTypeInit(self):
         self.setNormFunc(str, self._normPyStr)
 
+    def _ctorCmprEq(self, text):
+        if text == '':
+            raise s_exc.BadCmprValu(valu=text, name=self.name, cmpr='=',
+                                    mesg='Cannot generate fqdn comparator for a empty string')
+
+        if text[0] == '*':
+            cval = text[1:]
+            def cmpr(valu):
+                return valu.endswith(cval)
+            return cmpr
+
+        norm, info = self.norm(text)
+
+        def cmpr(valu):
+            return norm == valu
+        return cmpr
+
     def _normPyStr(self, valu):
 
         valu = valu.replace('[.]', '.')

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -414,9 +414,19 @@ class InetModelTest(s_t_utils.SynTest):
             # Demonstrate wildcard
             async with await core.snap() as snap:
                 await self.agenlen(3, snap.getNodesBy(formname, '*'))
+                await self.agenlen(3, snap.getNodesBy(formname, '*link'))
                 await self.agenlen(2, snap.getNodesBy(formname, '*.link'))
                 await self.agenlen(1, snap.getNodesBy(formname, '*.vertex.link'))
                 await self.agenraises(s_exc.BadLiftValu, snap.getNodesBy(formname, 'api.*.link'))
+
+            q = 'inet:fqdn="*.link" +inet:fqdn="*vertex.link"'
+            nodes = await core.nodes(q)
+            self.len(2, nodes)
+            self.eq({'vertex.link', 'api.vertex.link'}, {n.ndef[1] for n in nodes})
+
+            # Cannot filter on a empty string
+            q = 'inet:fqdn="*.link" +inet:fqdn=""'
+            await self.asyncraises(s_exc.BadCmprValu, core.nodes(q))
 
     async def test_fqdn_suffix(self):
         # Demonstrate FQDN suffix/zone behavior

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -426,7 +426,8 @@ class InetModelTest(s_t_utils.SynTest):
 
             # Cannot filter on a empty string
             q = 'inet:fqdn="*.link" +inet:fqdn=""'
-            await self.asyncraises(s_exc.BadCmprValu, core.nodes(q))
+            nodes = await core.nodes(q)
+            self.len(0, nodes)
 
     async def test_fqdn_suffix(self):
         # Demonstrate FQDN suffix/zone behavior
@@ -987,6 +988,16 @@ class InetModelTest(s_t_utils.SynTest):
                 self.eq(node.ndef, expected_ndef)
                 self.eq(node.get('fqdn'), 'vertex.link')
                 self.eq(node.get('path'), '')
+
+            # equality comparator behavior
+            valu = 'https://vertex.link?a=1'
+            q = f'inet:url +inet:url="{valu}"'
+            nodes = await core.nodes(q)
+            self.len(1, nodes)
+
+            q = 'inet:url +inet:url=""'
+            nodes = await core.nodes(q)
+            self.len(0, nodes)
 
     async def test_url_fqdn(self):
 


### PR DESCRIPTION
Brings equality between ``inet:fqdn=`` lifts and ``+inet:fqdn=`` filters.