### PR TITLE
Feature - cron information in tasks

### DIFF
--- a/synapse/lib/agenda.py
+++ b/synapse/lib/agenda.py
@@ -608,7 +608,10 @@ class Agenda(s_base.Base):
             logger.warning('Unknown user %s in stored appointment', appt.useriden)
             await self._markfailed(appt)
             return
-        await self.core.boss.execute(self._runJob(user, appt), f'Agenda {appt.iden}', user)
+        await self.core.boss.execute(self._runJob(user, appt), f'Cron {appt.iden}', user,
+                                     info={'iden': appt.iden,
+                                           'query': appt.query,
+                                           })
 
     async def _markfailed(self, appt):
         appt.lastfinishtime = appt.laststarttime = time.time()

--- a/synapse/tests/test_lib_agenda.py
+++ b/synapse/tests/test_lib_agenda.py
@@ -292,6 +292,8 @@ class AgendaTest(s_t_utils.SynTest):
                 sync.clear()
                 self.len(1, core.boss.tasks)
                 task = next(iter(core.boss.tasks.values()))
+                self.eq(task.info.get('query'), 'inet:ipv4=1 | sleep 120')
+                self.eq(task.info.get('iden'), guid)
                 appt_info = [info for g, info in agenda.list() if g == guid][0]
                 self.eq(appt_info['isrunning'], True)
                 await task.kill()


### PR DESCRIPTION
- Rename agenda tasks as Cron tasks
- Push the iden and Storm query into the task info dictionary so it is accessible via API.

This looks like

```
cli> ps                                                                                                                                                                                                       
task iden: b34b76ffcbcc4e12bbe6120de777bc5c
    name: Cron 74e129f9bc2ef80ac281c4f48ff67cb4
    user: 'root'
    status: None
    metadata: {'query': '.created | sleep 3', 'iden': '74e129f9bc2ef80ac281c4f48ff67cb4'}
    start time: 2019/06/27 13:24:00.171
1 tasks found.
````
