### PR TITLE
Add a default share name for the axon.

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -114,6 +114,10 @@ class Axon(s_cell.Cell):
 
         await s_cell.Cell.__anit__(self, dirn)
 
+        # share ourself via the cell dmon as "axon"
+        # for potential default remote use
+        self.dmon.share('axon', self)
+
         path = s_common.gendir(self.dirn, 'axon.lmdb')
         self.axonslab = await s_lmdbslab.Slab.anit(path)
         self.sizes = self.axonslab.initdb('sizes')

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -79,6 +79,7 @@ class AxonTest(s_t_utils.SynTest):
 
     async def test_axon_base(self):
         async with self.getTestAxon() as axon:
+            self.isin('axon', axon.dmon.shared)
             await self.runAxonTestBase(axon)
 
     async def test_axon_proxy(self):


### PR DESCRIPTION
Missing default share name.