### PR TITLE
In cmdr, emit the time the query execution started on the server

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -366,8 +366,6 @@ class StormCmd(s_cli.Cmd):
         if showtext is not None:
             stormopts['show'] = showtext.split(',')
 
-        # self.printf('')
-
         nodesfd = None
         if opts.get('save-nodes'):
             nodesfd = s_common.genfile(opts.get('save-nodes'))

--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -281,7 +281,10 @@ class StormCmd(s_cli.Cmd):
                     self.printf(f'        #{tag}')
 
     def _onInit(self, mesg):
-        pass
+        tick = mesg[1].get('tick')
+        if tick is not None:
+            tick = s_time.repr(tick)
+            self.printf(f'Executing query at {tick}')
 
     def _onFini(self, mesg):
         took = mesg[1].get('took')
@@ -363,7 +366,7 @@ class StormCmd(s_cli.Cmd):
         if showtext is not None:
             stormopts['show'] = showtext.split(',')
 
-        self.printf('')
+        # self.printf('')
 
         nodesfd = None
         if opts.get('save-nodes'):


### PR DESCRIPTION
update cmdr to emit the init time on the cortex. Turns the output of a query from:

```
cli> storm .created | limit 1

inet:fqdn=com
        .created = 2019/06/12 16:40:46.045
        :host = com
        :issuffix = True
        :iszone = False
limit reached: 1
complete. 1 nodes in 4 ms (250/sec).
```

to the following:

```
cli> storm .created | limit 1
Executing query at 2019/07/09 23:25:51.063
inet:fqdn=com
        .created = 2019/06/12 16:40:46.045
        :host = com
        :issuffix = True
        :iszone = False
limit reached: 1
complete. 1 nodes in 4 ms (250/sec).
```
