### PR TITLE
Allow underscores in org:alias values.

### DIFF
--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -15,7 +15,7 @@ class OuModule(s_module.CoreModule):
                 ('ou:org', ('guid', {}), {
                     'doc': 'A GUID for a human organization such as a company or military unit',
                 }),
-                ('ou:alias', ('str', {'lower': True, 'regex': r'^[0-9a-z]+$'}), {
+                ('ou:alias', ('str', {'lower': True, 'regex': r'^[0-9a-z_]+$'}), {
                     'doc': 'An alias for the org GUID',
                     'ex': 'vertexproject',
                 }),

--- a/synapse/tests/test_model_orgs.py
+++ b/synapse/tests/test_model_orgs.py
@@ -38,6 +38,8 @@ class OuModelTest(s_t_utils.SynTest):
             # ou:alias
             t = core.model.type('ou:alias')
             self.raises(s_exc.BadTypeValu, t.norm, 'asdf.asdf.asfd')
+            self.eq(t.norm('HAHA1')[0], 'haha1')
+            self.eq(t.norm('GOV_MFA')[0], 'gov_mfa')
 
             async with await core.snap() as snap:
                 guid0 = s_common.guid()


### PR DESCRIPTION
Closes #427 