### PR TITLE
Bug minor task kill

### DIFF
--- a/synapse/cmds/boss.py
+++ b/synapse/cmds/boss.py
@@ -65,10 +65,6 @@ class KillCmd(s_cli.Cmd):
         core = self.getCmdItem()
 
         match = opts.iden
-        if not match:
-            self.printf('no iden given to kill.')
-            return
-
         idens = []
         for task in await core.ps():
             iden = task.get('iden')

--- a/synapse/cmds/boss.py
+++ b/synapse/cmds/boss.py
@@ -1,3 +1,7 @@
+import shlex
+import synapse.exc as s_exc
+
+import synapse.lib.cmd as s_cmd
 import synapse.lib.cli as s_cli
 import synapse.lib.time as s_time
 
@@ -38,14 +42,29 @@ class KillCmd(s_cli.Cmd):
     '''
     _cmd_name = 'kill'
     _cmd_syntax = (
-        ('iden', {}),
+        ('line', {'type': 'glob'}),
     )
+
+    def _make_argparser(self):
+        parser = s_cmd.Parser(prog='kill', outp=self, description=self.__doc__)
+        parser.add_argument('iden', help='Task iden to kill.', type=str)
+        return parser
 
     async def runCmdOpts(self, opts):
 
+        line = opts.get('line')
+        if line is None:
+            self.printf(self.__doc__)
+            return
+
+        try:
+            opts = self._make_argparser().parse_args(shlex.split(line))
+        except s_exc.ParserExit:
+            return
+
         core = self.getCmdItem()
 
-        match = opts.get('iden')
+        match = opts.iden
         if not match:
             self.printf('no iden given to kill.')
             return
@@ -57,7 +76,7 @@ class KillCmd(s_cli.Cmd):
                 idens.append(iden)
 
         if len(idens) == 0:
-            self.printf('no matching process found. aborting.')
+            self.printf('no matching process found.')
             return
 
         if len(idens) > 1:  # pragma: no cover

--- a/synapse/cmds/hive.py
+++ b/synapse/cmds/hive.py
@@ -78,7 +78,7 @@ A Hive is a hierarchy persistent storage mechanism typically used for configurat
                                            parser_class=functools.partial(s_cmd.Parser, outp=self))
 
         parser_ls = subparsers.add_parser('list', aliases=['ls'], help="List entries in the hive", usage=ListHelp)
-        parser_ls .add_argument('path', nargs='?', help='Hive path')
+        parser_ls.add_argument('path', nargs='?', help='Hive path')
 
         parser_get = subparsers.add_parser('get', help="Get any entry in the hive", usage=GetHelp)
         parser_get.add_argument('path', help='Hive path')

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -154,7 +154,7 @@ class CellApi(s_base.Base):
 
         admin = self.user.admin
 
-        logger.info(f'User [{str(self.user)}] Requesting task kill: {iden}')
+        logger.info(f'User [{self.user.name}] Requesting task kill: {iden}')
         task = self.cell.boss.get(iden)
         if task is None:
             logger.info(f'Task does not exist: {iden}')

--- a/synapse/tests/test_cmds_boss.py
+++ b/synapse/tests/test_cmds_boss.py
@@ -98,6 +98,11 @@ class CmdBossTest(s_t_utils.SynTest):
                 await cmdr.runCmdLine('kill 123412341234')
                 self.true(outp.expect('no matching process found', False))
 
+                # Specify the iden arg multiple times
+                outp.clear()
+                await cmdr.runCmdLine('kill 123412341234 deadb33f')
+                self.true(outp.expect('unrecognized arguments', False))
+
                 # Tear down the task as a real user
                 outp.clear()
                 await cmdr.runCmdLine('kill %s' % (iden,))

--- a/synapse/tests/test_cmds_boss.py
+++ b/synapse/tests/test_cmds_boss.py
@@ -42,7 +42,7 @@ class CmdBossTest(s_t_utils.SynTest):
 
             outp.clear()
             await cmdr.runCmdLine('kill')
-            outp.expect('no iden given to kill')
+            outp.expect('Kill a running task/query within the cortex.')
 
             outp.clear()
             await cmdr.runCmdLine('kill %s' % (iden,))
@@ -91,7 +91,12 @@ class CmdBossTest(s_t_utils.SynTest):
                 await self.asyncraises(s_exc.AuthDeny, tcore.kill(iden))
                 toutp.clear()
                 await tcmdr.runCmdLine('kill %s' % (iden,))
-                self.true(toutp.expect('no matching process found. aborting.'))
+                self.true(toutp.expect('no matching process found.'))
+
+                # Try a kill with a numeric identifier - this won't match
+                outp.clear()
+                await cmdr.runCmdLine('kill 123412341234')
+                self.true(outp.expect('no matching process found', False))
 
                 # Tear down the task as a real user
                 outp.clear()


### PR DESCRIPTION
- fix error in logging a user name when killing task
- fix `kill` command to allow killing a task with a numeric identifier