### PR TITLE
Do not use lark 0.7.4 as it is known buggy due to a pydot dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ regex>=2017.9.23
 PyYAML>=5.1,<6.0
 aiohttp>=3.5.4,<4.0
 prompt-toolkit>=2.0.7,<2.1.0
-lark-parser>=0.7.1,<0.8.0
+lark-parser>=0.7.1,<0.8.0,!=0.7.4
 Pygments>=2.3.0,<2.4.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'PyYAML>=5.1,<6.0',
         'aiohttp>=3.5.4,<4.0',
         'prompt-toolkit>=2.0.7,<2.1.0',
-        'lark-parser>=0.7.1,<0.8.0',
+        'lark-parser>=0.7.1,<0.8.0,!=0.7.4',
         'Pygments>=2.3.0,<2.4.0',
     ],
 


### PR DESCRIPTION
See https://github.com/lark-parser/lark/issues/443 for details