### PR TITLE
circleci config update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
               -F "${CODECOV_FLAG}" \
               -Z || echo 'Codecov upload failed'
 
-  do_venv_setupt:
+  do_venv_setup:
     description: "Setup venv for testing"
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@
 #
 version: 2.1
 
-orbs:
-  codecov: codecov/codecov@1.0.5
-
 commands:
   test_steps_doc:
     description: "Documentation test steps"
@@ -98,12 +95,18 @@ commands:
             . venv/bin/activate
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
-#            python -m coverage xml -i
 
-      -  codecov/upload:
-#           file: /home/circleci/repo/coverage.xml
-           upload_name: ${PYVERS}node${CIRCLE_NODE_INDEX}
-           flags: linux
+      - run:
+          name: Upload Coverage Results
+          command: |
+            # Activate the venv so that codecov bash uploader finds coverage
+            . venv/bin/activate
+            # Use the codecov call from the codecov orb..
+            curl -s https://codecov.io/bash | bash -s -- \
+              -t "${CODECOV_TOKEN}" \
+              -n "${PYVERS}node${CIRCLE_NODE_INDEX}" \
+              -F "linux" \
+              -Z || echo 'Codecov upload failed'
 
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,21 @@
 version: 2.1
 
 commands:
+  do_report_coverage:
+    description: "Codecov report upload"
+    steps:
+      - run:
+          name: Upload Coverage Results
+          command: |
+            # Activate the venv so that codecov bash uploader finds coverage
+            . venv/bin/activate
+            # Use the codecov call from the codecov orb..
+            curl -s https://codecov.io/bash | bash -s -- \
+              -t "${CODECOV_TOKEN}" \
+              -n "${PYVERS}node${CIRCLE_NODE_INDEX}" \
+              -F "${CODECOV_FLAG}" \
+              -Z || echo 'Codecov upload failed'
+
   test_steps_doc:
     description: "Documentation test steps"
     steps:
@@ -96,17 +111,7 @@ commands:
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
 
-      - run:
-          name: Upload Coverage Results
-          command: |
-            # Activate the venv so that codecov bash uploader finds coverage
-            . venv/bin/activate
-            # Use the codecov call from the codecov orb..
-            curl -s https://codecov.io/bash | bash -s -- \
-              -t "${CODECOV_TOKEN}" \
-              -n "${PYVERS}node${CIRCLE_NODE_INDEX}" \
-              -F "linux" \
-              -Z || echo 'Codecov upload failed'
+      - do_report_coverage
 
       - store_test_results:
           path: test-reports
@@ -149,10 +154,7 @@ commands:
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
             python -m coverage xml -i
 
-      -  codecov/upload:
-           file: /Users/distiller/repo/coverage.xml
-           upload_name: osx${PYVERS}node${CIRCLE_NODE_INDEX}
-           flags: osx
+      - do_report_coverage
 
       - store_test_results:
           path: test-reports
@@ -290,6 +292,7 @@ jobs:
     environment:
       COVERAGE_ARGS: --cov synapse --no-cov-on-fail
       PYVERS: 3.7
+      CODECOV_FLAG: osx
 
     working_directory: /Users/distiller/repo
 
@@ -303,6 +306,7 @@ jobs:
         environment:
           COVERAGE_ARGS: --cov synapse --no-cov-on-fail
           PYVERS: 3.7
+          CODECOV_FLAG: linux
           SYN_REGRESSION_REPO: ~/git/synapse-regression
 
     working_directory: ~/repo
@@ -351,19 +355,19 @@ workflows:
   version: 2
   run_tests:
     jobs:
-#      - doctests:
-#          filters:
-#            tags:
-#              only: /.*/
-#            branches:
-#              only: /.*/
-#
-#      - osx37:
-#          filters:
-#            tags:
-#              only: /.*/
-#            branches:
-#              only: /.*/
+      - doctests:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+
+      - osx37:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
 
       - python37:
           filters:
@@ -371,54 +375,54 @@ workflows:
               only: /.*/
             branches:
               only: /.*/
-#
-#      - deploy_pypi:
-#          requires:
-#            - doctests
-#            - python37
-#          filters:
-#            tags:
-#              only: /^v(0\.1\.[0-9]+)$/
-#            branches:
-#              ignore: /.*/
-#
-#      - docker_branches:
-#          requires:
-#            - doctests
-#            - python37
-#          filters:
-#            branches:
-#              only:
-#                - master
-#
-#      - docker_tags:
-#          requires:
-#            - doctests
-#            - python37
-#          filters:
-#            tags:
-#              only: /^v(0\.1\.[0-9]+)$/
-#            branches:
-#              ignore: /.*/
-#
-#      - docker_tags_01x:
-#          requires:
-#            - doctests
-#            - python37
-#          filters:
-#            tags:
-#              only: /^v0\.1\.[0-9.]+$/
-#            branches:
-#              ignore: /.*/
-#
-#  nightly:
-#    triggers:
-#      - schedule:
-#          cron: "0 12 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - master
-#    jobs:
-#      - doctests
-#      - python37
+
+      - deploy_pypi:
+          requires:
+            - doctests
+            - python37
+          filters:
+            tags:
+              only: /^v(0\.1\.[0-9]+)$/
+            branches:
+              ignore: /.*/
+
+      - docker_branches:
+          requires:
+            - doctests
+            - python37
+          filters:
+            branches:
+              only:
+                - master
+
+      - docker_tags:
+          requires:
+            - doctests
+            - python37
+          filters:
+            tags:
+              only: /^v(0\.1\.[0-9]+)$/
+            branches:
+              ignore: /.*/
+
+      - docker_tags_01x:
+          requires:
+            - doctests
+            - python37
+          filters:
+            tags:
+              only: /^v0\.1\.[0-9.]+$/
+            branches:
+              ignore: /.*/
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 12 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - doctests
+      - python37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
             # Use the codecov call from the codecov orb..
             curl -s https://codecov.io/bash | bash -s -- \
               -t "${CODECOV_TOKEN}" \
-              -n "${PYVERS}node${CIRCLE_NODE_INDEX}" \
+              -n "${CODECOV_PREFIX}${PYVERS}node${CIRCLE_NODE_INDEX}" \
               -F "${CODECOV_FLAG}" \
               -Z || echo 'Codecov upload failed'
 
@@ -281,9 +281,10 @@ jobs:
       xcode: "10.2.0"
 
     environment:
-      COVERAGE_ARGS: --cov synapse --no-cov-on-fail
       PYVERS: 3.7
       CODECOV_FLAG: osx
+      CODECOV_PREFIX: osx
+      COVERAGE_ARGS: --cov synapse --no-cov-on-fail
 
     working_directory: /Users/distiller/repo
 
@@ -295,10 +296,10 @@ jobs:
     docker:
       - image: circleci/python:3.7
         environment:
-          COVERAGE_ARGS: --cov synapse --no-cov-on-fail
           PYVERS: 3.7
           CODECOV_FLAG: linux
           SYN_REGRESSION_REPO: ~/git/synapse-regression
+          COVERAGE_ARGS: --cov synapse --no-cov-on-fail
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,10 +98,10 @@ commands:
             . venv/bin/activate
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
-            python -m coverage xml -i
+#            python -m coverage xml -i
 
       -  codecov/upload:
-           file: /home/circleci/repo/coverage.xml
+#           file: /home/circleci/repo/coverage.xml
            upload_name: ${PYVERS}node${CIRCLE_NODE_INDEX}
            flags: linux
 
@@ -348,19 +348,19 @@ workflows:
   version: 2
   run_tests:
     jobs:
-      - doctests:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: /.*/
-
-      - osx37:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: /.*/
+#      - doctests:
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              only: /.*/
+#
+#      - osx37:
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              only: /.*/
 
       - python37:
           filters:
@@ -368,54 +368,54 @@ workflows:
               only: /.*/
             branches:
               only: /.*/
-
-      - deploy_pypi:
-          requires:
-            - doctests
-            - python37
-          filters:
-            tags:
-              only: /^v(0\.1\.[0-9]+)$/
-            branches:
-              ignore: /.*/
-
-      - docker_branches:
-          requires:
-            - doctests
-            - python37
-          filters:
-            branches:
-              only:
-                - master
-
-      - docker_tags:
-          requires:
-            - doctests
-            - python37
-          filters:
-            tags:
-              only: /^v(0\.1\.[0-9]+)$/
-            branches:
-              ignore: /.*/
-
-      - docker_tags_01x:
-          requires:
-            - doctests
-            - python37
-          filters:
-            tags:
-              only: /^v0\.1\.[0-9.]+$/
-            branches:
-              ignore: /.*/
-
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 12 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - doctests
-      - python37
+#
+#      - deploy_pypi:
+#          requires:
+#            - doctests
+#            - python37
+#          filters:
+#            tags:
+#              only: /^v(0\.1\.[0-9]+)$/
+#            branches:
+#              ignore: /.*/
+#
+#      - docker_branches:
+#          requires:
+#            - doctests
+#            - python37
+#          filters:
+#            branches:
+#              only:
+#                - master
+#
+#      - docker_tags:
+#          requires:
+#            - doctests
+#            - python37
+#          filters:
+#            tags:
+#              only: /^v(0\.1\.[0-9]+)$/
+#            branches:
+#              ignore: /.*/
+#
+#      - docker_tags_01x:
+#          requires:
+#            - doctests
+#            - python37
+#          filters:
+#            tags:
+#              only: /^v0\.1\.[0-9.]+$/
+#            branches:
+#              ignore: /.*/
+#
+#  nightly:
+#    triggers:
+#      - schedule:
+#          cron: "0 12 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - master
+#    jobs:
+#      - doctests
+#      - python37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,32 @@ commands:
               -F "${CODECOV_FLAG}" \
               -Z || echo 'Codecov upload failed'
 
+  do_venv_setupt:
+    description: "Setup venv for testing"
+    steps:
+      - run:
+          name: setup venv
+          command: |
+            python3 -m venv --copies venv
+            . venv/bin/activate
+            python3 -m pip install -U wheel pip pytest pytest-cov pycodestyle
+
+      - run:
+          name: install synapse
+          command: |
+            . venv/bin/activate
+            python3 -m pip install -e .
+
+  do_test_execution:
+    description: "Execute unit tests via pytest"
+    steps:
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            mkdir test-reports
+            circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
+
   test_steps_doc:
     description: "Documentation test steps"
     steps:
@@ -79,18 +105,7 @@ commands:
           keys:
             - v1-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
 
-      - run:
-          name: setup venv
-          command: |
-            python3 -m venv --copies venv
-            . venv/bin/activate
-            python3 -m pip install -U wheel pip pytest pytest-cov pycodestyle
-
-      - run:
-          name: install synapse
-          command: |
-            . venv/bin/activate
-            python3 -m pip install -e .
+      - do_venv_setup
 
       - save_cache:
           paths:
@@ -104,13 +119,7 @@ commands:
             pycodestyle --max-line-length=120 --select E111,E101,E201,E202,E203,E221,E222,E223,E224,E225,E226,E227,E228,E231,E241,E242,E251,E303,E304,E502,E711,E712,E713,E714,E721,E741,E742,E743,W191,W291,W293,W292,W391,W602,W603 synapse
             pycodestyle --max-line-length=120 --select E111,E101,E201,E202,E203,E221,E222,E223,E224,E225,E226,E227,E228,E231,E241,E242,E251,E303,E304,E502,E711,E712,E713,E714,E721,E741,E742,E743,W191,W291,W293,W292,W391,W602,W603 scripts
 
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            mkdir test-reports
-            circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
-
+      - do_test_execution
       - do_report_coverage
 
       - store_test_results:
@@ -128,32 +137,14 @@ commands:
           keys:
             - v5-osx-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
 
-      - run:
-          name: setup venv
-          command: |
-            python3 -m venv --copies venv
-            . venv/bin/activate
-            python3 -m pip install -U wheel pip pytest pytest-cov pycodestyle
-
-      - run:
-          name: install synapse
-          command: |
-            . venv/bin/activate
-            python3 -m pip install -e .
+      - do_venv_setup
 
       - save_cache:
           paths:
             - ./venv
           key: v5-osx-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
 
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            mkdir test-reports
-            circleci tests glob synapse/tests/test_*.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
-            python -m coverage xml -i
-
+      - do_test_execution
       - do_report_coverage
 
       - store_test_results:


### PR DESCRIPTION
- streamline the venv setup and python test executions into their own commands
- drop the codecov orb uploader in favor of just using the bash uploader directly.