### PR TITLE
Bug daemon share

### DIFF
--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -412,10 +412,8 @@ class Daemon(s_base.Base):
 
             if isinstance(valu, s_share.Share):
                 sess.onfini(valu)
-                iden = s_common.guid()
-                sess.setSessItem(iden, valu)
                 info = s_reflect.getShareInfo(valu)
-                await link.tx(('t2:share', {'iden': iden, 'sharinfo': info}))
+                await link.tx(('t2:share', {'iden': valu.iden, 'sharinfo': info}))
                 return
 
             await link.tx(('t2:fini', {'retn': (True, valu)}))

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -474,10 +474,16 @@ class TeleTest(s_t_utils.SynTest):
                 self.isinstance(sess.getSessItem(key), CustomShare)
 
                 # make another customeshare reference which will be tracked
+                evt = asyncio.Event()
                 async with await proxy.customshare() as _share:
                     self.len(3, sess.items)
+                    _key = [k for k in sess.items.keys() if k and k != key][0]
+                    _cshare = sess.getSessItem(_key)
+                    self.isinstance(_cshare, CustomShare)
+                    _cshare.onfini(evt.set)
                 # and that item is removed on the _share fini by the client
-                await asyncio.sleep(0.001)
+                # await asyncio.sleep(0.001)
+                self.true(await asyncio.wait_for(evt.wait(), 6))
                 self.len(2, sess.items)
                 self.nn(sess.getSessItem(key))
 

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -473,7 +473,8 @@ class TeleTest(s_t_utils.SynTest):
                 key = [k for k in sess.items.keys() if k][0]
                 self.isinstance(sess.getSessItem(key), CustomShare)
 
-                # make another customeshare reference which will be tracked
+                # make another customshare reference which will be
+                # tracked by the Sess object
                 evt = asyncio.Event()
                 async with await proxy.customshare() as _share:
                     self.len(3, sess.items)
@@ -481,8 +482,9 @@ class TeleTest(s_t_utils.SynTest):
                     _cshare = sess.getSessItem(_key)
                     self.isinstance(_cshare, CustomShare)
                     _cshare.onfini(evt.set)
-                # and that item is removed on the _share fini by the client
-                # await asyncio.sleep(0.001)
+
+                # and that item is removed from the sess on the
+                # _share fini by the client
                 self.true(await asyncio.wait_for(evt.wait(), 6))
                 self.len(2, sess.items)
                 self.nn(sess.getSessItem(key))

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -456,12 +456,32 @@ class TeleTest(s_t_utils.SynTest):
         async with self.getTestDmon() as dmon:
             dmon.share('woke', item)
             async with await self.getTestProxy(dmon, 'woke') as proxy:
+
+                # Ensure the session tracks the reference to the TeleApi object
+                sess = dmon.sessions[list(dmon.sessions.keys())[0]]
+                self.isinstance(sess.getSessItem(None), TeleApi)
+
                 self.eq(10, await proxy.getFooBar(20, 10))
 
                 # check a custom share works
                 obj = await proxy.customshare()
                 self.eq(999, await obj.boo(999))
 
+                # Ensure the Share object is placed into the
+                # session for the daemon.
+                self.len(2, sess.items)
+                key = [k for k in sess.items.keys() if k][0]
+                self.isinstance(sess.getSessItem(key), CustomShare)
+
+                # make another customeshare reference which will be tracked
+                async with await proxy.customshare() as _share:
+                    self.len(3, sess.items)
+                # and that item is removed on the _share fini by the client
+                await asyncio.sleep(0.001)
+                self.len(2, sess.items)
+                self.nn(sess.getSessItem(key))
+
+                # and we can still use the first obj we made
                 ret = await alist(obj.custgenr(3))
                 self.eq(ret, [0, 1, 2])
 


### PR DESCRIPTION
The ``__anit__`` constructor for the Share class automatically handles the iden generation and Sess management. Doing this twice is unnecessary.