### PR TITLE
Add .time.format() to allow formatting a Synapse timestamp into a string

### DIFF
--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -202,8 +202,21 @@ class LibTime(Lib):
         '''
         Format a Synapse timestamp into a string value using strftime.
         '''
+        timetype = self.runt.snap.model.type('time')
+        # Give a times string a shot at being normed prior to formating.
         try:
-            dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=valu)
+            norm, _ = timetype.norm(valu)
+        except s_exc.BadTypeValu as e:
+            mesg = f'Failed to norm a time value prior to formatting - {str(e)}'
+            raise s_exc.StormRuntimeError(mesg=mesg, valu=valu,
+                                          format=format) from None
+
+        if norm == timetype.futsize:
+            mesg = 'Cannot format a timestamp for ongoing/future time.'
+            raise s_exc.StormRuntimeError(mesg=mesg, valu=valu, format=format)
+
+        try:
+            dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=norm)
             ret = dt.strftime(format)
         except Exception as e:
             mesg = f'Error during time format - {str(e)}'

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -193,9 +193,23 @@ class LibTime(Lib):
             'now': s_common.now,
             'fromunix': self.fromunix,
             'parse': self.parse,
+            'format': self.format,
         })
 
     # TODO from other iso formats!
+
+    async def format(self, valu, format):
+        '''
+        Format a Synapse timestamp into a string value using strftime.
+        '''
+        try:
+            dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=valu)
+            ret = dt.strftime(format)
+        except Exception as e:
+            mesg = f'Error during time format - {str(e)}'
+            raise s_exc.StormRuntimeError(mesg=mesg, valu=valu,
+                                          format=format) from None
+        return ret
 
     async def parse(self, valu, format):
         '''

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -679,6 +679,21 @@ class StormTypesTest(s_test.SynTest):
             self.len(1, ernfos)
             self.isin('Error during time parsing', ernfos[0][1].get('mesg'))
 
+            query = '''[test:str=1234 :tick=20190917]
+            $lib.print($lib.time.format(:tick, "%Y-%d-%m"))
+            '''
+            mesgs = await alist(core.streamstorm(query))
+            self.stormIsInPrint('2019-17-09', mesgs)
+            # strftime fail - taken from
+            # https://github.com/python/cpython/blob/3.7/Lib/test/datetimetester.py#L1404
+            query = r'''[test:str=1234 :tick=20190917]
+            $lib.print($lib.time.format(:tick, "%y\ud800%m"))
+            '''
+            mesgs = await alist(core.streamstorm(query))
+            ernfos = [m[1] for m in mesgs if m[0] == 'err']
+            self.len(1, ernfos)
+            self.isin('Error during time format', ernfos[0][1].get('mesg'))
+
     async def test_storm_node_data(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
Adds ``$lib.time.format()``