### PR TITLE
Disallow regular user from adding trigger or cron job.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,16 @@
 *****************
 Synapse Changelog
 *****************
+v0.1.28 - 2019-XXXX
+====================
+Features and Enhancements
+-------------------------
 
 
 v0.1.27 - 2019-09-18
 ====================
+- Require explicit permission for a user to add triggers or cron job.
+  (`#1379 <https://github.com/vertexproject/synapse/pull/1372>`_)
 
 Features and Enhancements
 -------------------------
@@ -18,8 +24,6 @@ Features and Enhancements
   (`#1373 <https://github.com/vertexproject/synapse/pull/1373>`_)
 - Add a ``scrape`` command to Storm to enable regex based scraping of node properties for easily identifiable forms.
   (`#1368 <https://github.com/vertexproject/synapse/pull/1368>`_)
-- Add explicit permissions for interacting with the trigger, cron and boss operations.
-  (`#1371 <https://github.com/vertexproject/synapse/pull/1371>`_)
 - Add explicit permissions for interacting with the trigger, cron and boss operations.
   (`#1371 <https://github.com/vertexproject/synapse/pull/1371>`_)
 - Add support for remote Telepath services in Storm.

--- a/synapse/cmds/cron.py
+++ b/synapse/cmds/cron.py
@@ -463,7 +463,7 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
             self.printf('No cron jobs found')
             return
         self.printf(
-                f'{"user":10} {"iden":10} {"en?":3} {"rpt?":4} {"now?":4} {"err?":4} '
+            f'{"user":10} {"iden":10} {"en?":3} {"rpt?":4} {"now?":4} {"err?":4} '
             f'{"# start":7} {"last start":16} {"last end":16} {"query"}')
 
         for iden, cron in cronlist:

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -102,6 +102,9 @@ class CoreApi(s_cell.CellApi):
         '''
         Adds a trigger to the cortex
         '''
+        if not self.user.admin and not self.user.allowed('trigger', 'add'):
+            mesg = 'User not authorized to create triggers.'
+            raise s_exc.AuthDeny(user=self.user.name, mesg=mesg)
         iden = await self.cell.addTrigger(condition, query, info, disabled,
                                           user=self.user)
         return iden
@@ -211,6 +214,9 @@ class CoreApi(s_cell.CellApi):
             reqs must have fields present or incunit must not be None (or both)
             The incunit if not None it must be larger in unit size than all the keys in all reqs elements.
         '''
+        if not self.user.admin and not self.user.allowed('cron', 'add'):
+            mesg = 'User not authorized to create cron job.'
+            raise s_exc.AuthDeny(user=self.user.name, mesg=mesg)
 
         def _convert_reqdict(reqdict):
             return {s_agenda.TimeUnit.fromString(k): v for (k, v) in reqdict.items()}

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -105,6 +105,7 @@ class CoreApi(s_cell.CellApi):
         if not self.user.admin and not self.user.allowed('trigger', 'add'):
             mesg = 'User not authorized to create triggers.'
             raise s_exc.AuthDeny(user=self.user.name, mesg=mesg)
+
         iden = await self.cell.addTrigger(condition, query, info, disabled,
                                           user=self.user)
         return iden

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -125,22 +125,26 @@ class TrigTest(s_t_utils.SynTest):
                 await self.agenlen(1, core.eval('test:int=8'))
 
                 # Bad trigger parms
-                await self.asyncraises(s_exc.BadOptValu, core.addTrigger('nocond', 'test:int=4',
-                                                                         info={'form': 'test:str'}))
-                await self.asyncraises(s_exc.BadSyntax,
-                                       core.addTrigger('node:add', ' | | badstorm ', info={'form': 'test:str'}))
-                await self.asyncraises(s_exc.BadOptValu,
-                                       core.addTrigger('node:add', 'test:int=4', info={'form': 'test:str', 'tag': 'foo'}))
-                await self.asyncraises(s_exc.BadOptValu,
-                                       core.addTrigger('prop:set', 'test:int=4',
-                                                       info={'form': 'test:str', 'prop': 'foo'}))
-                await self.asyncraises(s_exc.BadOptValu,
-                                       core.addTrigger('tag:add', '[ +#count test:str=$tag ]', info={}))
-                await self.asyncraises(s_exc.BadOptValu, core.addTrigger('tag:add', '[ +#count test:str=$tag ]',
-                                                                         info={'tag': 'foo', 'prop': 'test:str'}))
+                with self.raises(s_exc.BadOptValu):
+                    await core.addTrigger('nocond', 'test:int=4', info={'form': 'test:str'})
+
+                with self.raises(s_exc.BadSyntax):
+                    await core.addTrigger('node:add', ' | | badstorm ', info={'form': 'test:str'})
+
+                with self.raises(s_exc.BadOptValu):
+                    await core.addTrigger('node:add', 'test:int=4', info={'form': 'test:str', 'tag': 'foo'})
+
+                with self.raises(s_exc.BadOptValu):
+                    await core.addTrigger('prop:set', 'test:int=4', info={'form': 'test:str', 'prop': 'foo'})
+
+                with self.raises(s_exc.BadOptValu):
+                    await core.addTrigger('tag:add', '[ +#count test:str=$tag ]', info={})
+
+                with self.raises(s_exc.BadOptValu):
+                    await core.addTrigger('tag:add', '[ +#count test:str=$tag ]', info={'tag': 'foo', 'prop': 'test:str'})
                 # bad tagmatch
-                await self.asyncraises(s_exc.BadTag,
-                                       core.addTrigger('tag:add', '[ +#count test:str=$tag ]', info={'tag': 'foo&baz'}))
+                with self.raises(s_exc.BadTag):
+                    await core.addTrigger('tag:add', '[ +#count test:str=$tag ]', info={'tag': 'foo&baz'})
 
                 # Trigger list
                 triglist = await core.listTriggers()
@@ -187,8 +191,8 @@ class TrigTest(s_t_utils.SynTest):
                     # Trigger list other user
                     self.len(0, await fred.listTriggers())
 
-                    await self.asyncraises(
-                        s_exc.AuthDeny, fred.addTrigger('node:add', '[ test:int=1 ]', info={'form': 'test:str'}))
+                    with self.raises(s_exc.AuthDeny):
+                        await fred.addTrigger('node:add', '[ test:int=1 ]', info={'form': 'test:str'})
 
                     # Delete trigger auth failure
                     await self.asyncraises(s_exc.AuthDeny, fred.delTrigger(buid))

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -176,15 +176,19 @@ class TrigTest(s_t_utils.SynTest):
                 buid2 = [b for b, r in triglist if r['cond'] == 'tag:add' and r.get('form') is None][0]
                 await core.delTrigger(buid2)
 
+                # A rando user can't manipulate triggers
+
                 await core.addAuthUser('fred')
                 await core.setUserPasswd('fred', 'fred')
 
                 url = real.getLocalUrl()
 
                 async with await s_telepath.openurl(url, user='fred') as fred:
-
                     # Trigger list other user
                     self.len(0, await fred.listTriggers())
+
+                    await self.asyncraises(
+                        s_exc.AuthDeny, fred.addTrigger('node:add', '[ test:int=1 ]', info={'form': 'test:str'}))
 
                     # Delete trigger auth failure
                     await self.asyncraises(s_exc.AuthDeny, fred.delTrigger(buid))


### PR DESCRIPTION
Note: this is a behavior change. Before, regular users could create automation and manipulate their own automations. Now, they need specific permissions to create automation.