### PR TITLE
Bug cryotank anit

### DIFF
--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -247,13 +247,11 @@ class CryoCell(s_cell.Cell):
 
     confdefs = ()
 
-    async def __anit__(self, dirn):
+    async def __anit__(self, dirn, conf=None, readonly=False):
 
         await s_cell.Cell.__anit__(self, dirn)
 
         self.dmon.share('cryotank', self)
-
-        path = s_common.gendir(self.dirn, 'cryo.lmdb')
 
         self.names = await self.hive.open(('cryo', 'names'))
 
@@ -275,7 +273,7 @@ class CryoCell(s_cell.Cell):
     async def getCellApi(self, link, user, path):
 
         if not path:
-            return await CryoApi.anit(self, link, user)
+            return await self.cellapi.anit(self, link, user)
 
         if len(path) == 1:
             tank = await self.init(path[0])

--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -244,6 +244,7 @@ class CryoApi(s_cell.CellApi):
 class CryoCell(s_cell.Cell):
 
     cellapi = CryoApi
+    tankapi = TankApi
 
     confdefs = ()
 
@@ -277,7 +278,7 @@ class CryoCell(s_cell.Cell):
 
         if len(path) == 1:
             tank = await self.init(path[0])
-            return await TankApi.anit(tank, link, user)
+            return await self.tankapi.anit(tank, link, user)
 
         raise s_exc.NoSuchPath(path=path)
 

--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -250,7 +250,7 @@ class CryoCell(s_cell.Cell):
 
     async def __anit__(self, dirn, conf=None, readonly=False):
 
-        await s_cell.Cell.__anit__(self, dirn)
+        await s_cell.Cell.__anit__(self, dirn, conf)
 
         self.dmon.share('cryotank', self)
 


### PR DESCRIPTION
- Fix cryocell __anit__ to inherit the correct signature from Cell.
- Remove unused path variable.
- Fix getCellApi to use Class defined ctors instead of hardcoded ctors.