### PR TITLE
Dressing for visi-storm-funcs

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1072,7 +1072,9 @@ class Cortex(s_cell.Cell):
 
         mods = pkgdef.get('modules', ())
         cmds = pkgdef.get('commands', ())
+        svciden = pkgdef.get('svciden')
 
+        # Validate storm contents from modules and commands
         for mdef in mods:
 
             modname = mdef.get('name')
@@ -1083,6 +1085,9 @@ class Cortex(s_cell.Cell):
             self.getStormQuery(modtext)
 
         for cdef in cmds:
+            cdef.setdefault('cmdconf', {})
+            if svciden:
+                cdef['cmdconf']['svciden'] = svciden
             await self._reqStormCmd(cdef)
 
         # now actually load...
@@ -1156,7 +1161,6 @@ class Cortex(s_cell.Cell):
             mesg = f'No storm service with iden: {iden}'
             raise s_exc.NoSuchStormSvc(mesg=mesg)
 
-        await self._delStormSvcCmds(iden)
         await self._delStormSvcPkgs(iden)
 
         name = sdef.get('name')
@@ -1181,20 +1185,6 @@ class Cortex(s_cell.Cell):
             name = pkg.get('name')
             if name:
                 await self.delStormPkg(name)
-
-    async def _delStormSvcCmds(self, iden):
-        '''
-        Delete a storm service's commands from the cortex.
-        '''
-
-        oldcmds = []
-        for name, cdef in self.cmdhive.items():
-            cmdiden = cdef.get('cmdconf', {}).get('svciden')
-            if cmdiden and cmdiden == iden:
-                oldcmds.append(cdef.get('name'))
-
-        for name in oldcmds:
-            await self.delStormCmd(name)
 
     async def setStormSvcEvents(self, iden, edef):
         '''
@@ -1605,6 +1595,7 @@ class Cortex(s_cell.Cell):
                 await self._trySetStormCmd(name, cdef)
 
         for name in oldcmds:
+            logger.warning(f'Removing old command: [{name}]')
             await self.cmdhive.pop(name)
 
         for name, pkgdef in self.pkghive.items():

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1157,6 +1157,7 @@ class Cortex(s_cell.Cell):
             raise s_exc.NoSuchStormSvc(mesg=mesg)
 
         await self._delStormSvcCmds(iden)
+        await self._delStormSvcPkgs(iden)
 
         name = sdef.get('name')
         if name is not None:
@@ -1166,6 +1167,21 @@ class Cortex(s_cell.Cell):
         if ssvc is not None:
             await ssvc.fini()
 
+    async def _delStormSvcPkgs(self, iden):
+        '''
+        Delete storm packages associated with a service.
+        '''
+        oldpkgs = []
+        for name, pdef in self.pkghive.items():
+            pkgiden = pdef.get('svciden')
+            if pkgiden and pkgiden == iden:
+                oldpkgs.append(pdef)
+
+        for pkg in oldpkgs:
+            name = pkg.get('name')
+            if name:
+                await self.delStormPkg(name)
+
     async def _delStormSvcCmds(self, iden):
         '''
         Delete a storm service's commands from the cortex.
@@ -1174,7 +1190,7 @@ class Cortex(s_cell.Cell):
         oldcmds = []
         for name, cdef in self.cmdhive.items():
             cmdiden = cdef.get('cmdconf', {}).get('svciden')
-            if cmdiden == iden:
+            if cmdiden and cmdiden == iden:
                 oldcmds.append(cdef.get('name'))
 
         for name in oldcmds:

--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import collections
 
@@ -796,9 +797,11 @@ class Path:
         return path
 
     def clone(self):
-        path = Path(self.runt, self.vars, self.nodes)
+        path = Path(self.runt,
+                    copy.copy(self.vars),
+                    copy.copy(self.nodes),)
         path.traces = list(self.traces)
-        path.frames = list(self.frames)
+        path.frames = [(copy.copy(vars), runt) for (vars, runt) in self.frames]
         return path
 
     def initframe(self, initvars=None, initrunt=None):

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -708,6 +708,44 @@ class AstTest(s_test.SynTest):
             self.eq(erfo[1][1].get('name'), 'pprint')
             self.eq(erfo[1][1].get('valu'), 'newp')
 
+    async def test_ast_function_scope(self):
+
+        async with self.getTestCore() as core:
+
+            nodes = await core.nodes('''
+
+                function foo (x) {
+                    [ test:str=$x ]
+                }
+
+                yield $foo(asdf)
+
+            ''')
+
+            self.len(1, nodes)
+            self.eq(nodes[0].ndef, ('test:str', 'asdf'))
+
+            scmd = {
+                'name': 'foocmd',
+                'storm': '''
+
+                    function lulz (lulztag) {
+                        [ test:str=$lulztag ]
+                    }
+
+                    for $tag in $node.tags() {
+                        yield $lulz($tag)
+                    }
+
+                ''',
+            }
+
+            await core.setStormCmd(scmd)
+
+            nodes = await core.nodes('[ inet:ipv4=1.2.3.4 +#visi ] | foocmd')
+            self.eq(nodes[0].ndef, ('test:str', 'visi'))
+            self.eq(nodes[1].ndef, ('inet:ipv4', 0x01020304))
+
     async def test_ast_setitem(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -524,6 +524,11 @@ class AstTest(s_test.SynTest):
             'version': (0, 0, 1),
         }
 
+        stormpkg = {
+            'name': 'stormpkg',
+            'version': (1, 2, 3)
+        }
+
         async with self.getTestCore() as core:
 
             await core.addStormPkg(foo_stormpkg)
@@ -556,6 +561,12 @@ class AstTest(s_test.SynTest):
 
             msgs = await core.streamstorm(f'pkg.del foo').list()
             self.stormIsInPrint('Removing package: foo', msgs)
+
+            # Direct add via stormtypes
+            await core.streamstorm('$lib.pkg.add($pkg)',
+                                   opts={'vars': {'pkg': stormpkg}}).list()
+            msgs = await core.streamstorm('pkg.list').list()
+            self.stormIsInPrint('stormpkg', msgs)
 
             with self.raises(s_exc.NoSuchName):
                 nodes = await core.nodes('test.nodes')

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -300,7 +300,7 @@ class StormSvcTest(s_test.SynTest):
                 await core.nodes('[ inet:ipv4=6.6.6.6 ] | ohhai')
 
     async def test_storm_cmd_scope(self):
-
+        # TODO - Fix me / move me - what is this tests purpose in life?
         async with self.getTestCore() as core:
 
             cdef = {

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -310,44 +310,6 @@ class StormSvcTest(s_test.SynTest):
 
             nodes = await core.nodes('[ test:str=asdf ] | lulz')
 
-    async def test_storm_func_scope(self):
-
-        async with self.getTestCore() as core:
-
-            nodes = await core.nodes('''
-
-                function foo (x) {
-                    [ test:str=$x ]
-                }
-
-                yield $foo(asdf)
-
-            ''')
-
-            self.len(1, nodes)
-            self.eq(nodes[0].ndef, ('test:str', 'asdf'))
-
-            scmd = {
-                'name': 'foocmd',
-                'storm': '''
-
-                    function lulz (lulztag) {
-                        [ test:str=$lulztag ]
-                    }
-
-                    for $tag in $node.tags() {
-                        yield $lulz($tag)
-                    }
-
-                ''',
-            }
-
-            await core.setStormCmd(scmd)
-
-            nodes = await core.nodes('[ inet:ipv4=1.2.3.4 +#visi ] | foocmd')
-            self.eq(nodes[0].ndef, ('test:str', 'visi'))
-            self.eq(nodes[1].ndef, ('inet:ipv4', 0x01020304))
-
     async def test_storm_pkg_persist(self):
 
         pkg = {


### PR DESCRIPTION
Follow-up work for #1419 

- Enforce that Path clone() var changes don't affect parent path
- Add ``$lib.pkg.add()`` example
- Add service package re-registration on reconnect
- Move storm svc commadns into svc svc packages