### PR TITLE
Fix grammar issue that disallowed `$(1 and 1 and 0)`

### DIFF
--- a/synapse/lib/storm.lark
+++ b/synapse/lib/storm.lark
@@ -276,10 +276,10 @@ OR: "or"
 AND: "and"
 
 // Expression rules in increasing order of precedence (modeled on Python's order)
-?expror: exprand | exprand _WSCOMM? OR _WSCOMM? exprand
-?exprand: exprnot | exprnot _WSCOMM? AND _WSCOMM? exprnot
+?expror: exprand | expror _WSCOMM? OR _WSCOMM? exprand
+?exprand: exprnot | exprand _WSCOMM? AND _WSCOMM? exprnot
 ?exprnot: exprcmp | NOT _WSCOMM? exprcmp
-?exprcmp: exprsum | exprsum _WSCOMM? (EXPRCMPR) _WSCOMM? exprsum
+?exprcmp: exprsum | exprcmp _WSCOMM? EXPRCMPR _WSCOMM? exprsum
 ?exprsum: exprproduct | exprsum _WSCOMM? (EXPRPLUS | EXPRMINUS) _WSCOMM? exprproduct
 ?exprproduct: _expratom | exprproduct _WSCOMM? (EXPRTIMES | EXPRDIVIDE) _WSCOMM? _expratom
 _expratom: _exprvalu | "(" exprsum ")"

--- a/synapse/tests/test_lib_grammar.py
+++ b/synapse/tests/test_lib_grammar.py
@@ -13,6 +13,8 @@ import synapse.tests.utils as s_t_utils
 # flake8: noqa: E501
 
 _Queries = [
+    '$foo=$(1 or 1 or 0)',
+    '$foo=$(1 and 1 and 0)',
     '$var=tag1 #base.$var',
     'test:str $var=tag1 +#base.$var@=2014',
     'test:str $var=tag1 -> #base.$var',
@@ -557,6 +559,8 @@ _Queries = [
 
 # Generated with print_parse_list below
 _ParseResults = [
+    'Query: [SetVarOper: [Const: foo, DollarExpr: [ExprNode: [ExprNode: [Const: 1, Const: or, Const: 1], Const: or, Const: 0]]]]',
+    'Query: [SetVarOper: [Const: foo, DollarExpr: [ExprNode: [ExprNode: [Const: 1, Const: and, Const: 1], Const: and, Const: 0]]]]',
     'Query: [SetVarOper: [Const: var, Const: tag1], LiftTag: [TagName: [Const: base, VarValue: [Const: var]]]]',
     'Query: [LiftProp: [Const: test:str], SetVarOper: [Const: var, Const: tag1], FiltOper: [Const: +, TagValuCond: [TagMatch: [Const: base, VarValue: [Const: var]], Const: @=, Const: 2014]]]',
     'Query: [LiftProp: [Const: test:str], SetVarOper: [Const: var, Const: tag1], PivotToTags: [TagMatch: [Const: base, VarValue: [Const: var]]], isjoin=False]',


### PR DESCRIPTION
It also disallowed `$(1 or 1 or 0)`