### PR TITLE
Fix bug where removal of tag prop wouldn't update Node

### DIFF
--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -7,8 +7,6 @@ import synapse.common as s_common
 
 import synapse.lib.chop as s_chop
 import synapse.lib.time as s_time
-import synapse.lib.types as s_types
-import synapse.lib.storm as s_storm
 
 import synapse.lib.editatom as s_editatom
 
@@ -554,6 +552,8 @@ class Node:
         info = {'univ': True}
         sops = [('prop:del', (self.buid, self.form.name, '#' + t, info)) for (t, v) in removed]
         sops.extend([('tag:prop:del', (self.buid, self.form.name, tag, prop, {})) for (tag, prop) in tagprops])
+
+        [self.tagprops.pop(tp) for tp in tagprops]
 
         # fire all the splices
         splices = [self.snap.splice('tag:del', ndef=self.ndef, tag=t, valu=v) for (t, v) in removed]

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -96,7 +96,6 @@ class CortexTest(s_t_utils.SynTest):
                 self.len(1, await core.nodes('test:int +#foo.bar'))
                 self.len(1, await core.nodes('test:int +#foo.bar:score'))
                 self.len(1, await core.nodes('test:int +#foo.bar:score=20'))
-                # self.len(1, await core.nodes('test:int +#foo.bar:score?=20'))
                 self.len(1, await core.nodes('test:int +#foo.bar:score<=30'))
                 self.len(1, await core.nodes('test:int +#foo.bar:score>=10'))
                 self.len(1, await core.nodes('test:int +#foo.bar:score*range=(10, 30)'))
@@ -131,18 +130,24 @@ class CortexTest(s_t_utils.SynTest):
                 self.len(1, await core.nodes('#foo.bar:score>=90'))
                 self.len(1, await core.nodes('#foo.bar:score*range=(90, 110)'))
 
-                # test that removing it explicitly behaves as intended
+                # remove the tag
                 await core.nodes('test:int=10 [ -#foo.bar ]')
                 self.len(0, await core.nodes('#foo.bar:score'))
                 self.len(0, await core.nodes('#foo.bar:score=100'))
                 self.len(1, await core.nodes('test:int=10 -#foo.bar:score'))
 
-                # add it back in to remove by whole tag...
+                # remove just the tagprop
                 await core.nodes('test:int=10 [ +#foo.bar:score=100 ]')
-                self.len(1, await core.nodes('#foo.bar:score=100'))
+                await core.nodes('test:int=10 [ -#foo.bar:score ]')
+                self.len(0, await core.nodes('#foo.bar:score'))
+                self.len(0, await core.nodes('#foo.bar:score=100'))
+                self.len(1, await core.nodes('test:int=10 -#foo.bar:score'))
 
-                # test that removing the tag removes all props indexes
-                await core.nodes('test:int=10 [ -#foo.bar ]')
+                # remove a higher-level tag
+                await core.nodes('test:int=10 [ +#foo.bar:score=100 ]')
+                nodes = await core.nodes('test:int=10 [ -#foo ]')
+                self.len(0, nodes[0].tagprops)
+                self.len(0, await core.nodes('#foo'))
                 self.len(0, await core.nodes('#foo.bar:score'))
                 self.len(0, await core.nodes('#foo.bar:score=100'))
                 self.len(1, await core.nodes('test:int=10 -#foo.bar:score'))


### PR DESCRIPTION
Fix issue where removing a tag prop e.g. `[ -#foo:score ]` would still have the tagprop returned in the Node.