### PR TITLE
Speed up unit tests

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2745,7 +2745,7 @@ class Cortex(s_cell.Cell):
         '''
         Parse storm query text and return a Query object.
         '''
-        query = s_grammar.Parser(text).query()
+        query = s_grammar.parseQuery(text)
         query.init(self)
         return query
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import logging
+import copy
 import contextlib
 import collections
 
@@ -2745,7 +2746,7 @@ class Cortex(s_cell.Cell):
         '''
         Parse storm query text and return a Query object.
         '''
-        query = s_grammar.parseQuery(text)
+        query = copy.deepcopy(s_grammar.parseQuery(text))
         query.init(self)
         return query
 

--- a/synapse/lib/grammar.py
+++ b/synapse/lib/grammar.py
@@ -5,6 +5,7 @@ import regex  # type: ignore
 import synapse.exc as s_exc
 
 import synapse.lib.ast as s_ast
+import synapse.lib.cache as s_cache
 import synapse.lib.datfile as s_datfile
 
 # TL;DR:  *rules* are the internal nodes of an abstract syntax tree (AST), *terminals* are the leaves
@@ -335,6 +336,13 @@ class Parser:
         newtree = AstConverter(self.text).transform(tree)
         assert isinstance(newtree, s_ast.Const)
         return newtree.valu
+
+@s_cache.memoize(size=100)
+def parseQuery(text):
+    '''
+    Parse a storm query and return the Lark AST.  Cached here to speed up unit tests
+    '''
+    return Parser(text).query()
 
 # TODO:  commonize with storm.lark
 scmdre = regex.compile('[a-z][a-z0-9.]+')


### PR DESCRIPTION
Most of the time was taken parsing and reparsing the same storm code. In real life, a cortex isn't taken up and down 1000 times, but for unit tests it happens.

Add system-wide cache for parsing queries. This take parallel running of unit tests from 200 s to 75 s (on my machine).