### PR TITLE
Prevent downgrading to before layer reidening

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Bugfixes
   (`#1455 <https://github.com/vertexproject/synapse/pull/1455>`_)
 - Bump CircleCI cache keys due to a bad multidict release poisoning build caches.
   (`#1463 <https://github.com/vertexproject/synapse/pull/1463>`_)
+- Added an empty layer migration to prevent Cortex downgrading prior to v0.1.41. This is to prevent a user from running
+  a Cortex on older code, as reverting a Cortex created/used with a Synapse version greater than or equal to v0.1.33 and
+  v0.1.34 can result in apparent data loss. Data is not actually lost but would require non-trivial effort to recover.
+  (`#1458 <https://github.com/vertexproject/synapse/pull/1458>`_)
 
 Improved Documentation
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,8 @@ Bugfixes
   (`#1463 <https://github.com/vertexproject/synapse/pull/1463>`_)
 - Added an empty layer migration to prevent Cortex downgrading prior to v0.1.41. This is to prevent a user from running
   a Cortex on older code, as reverting a Cortex created/used with a Synapse version greater than or equal to v0.1.33 and
-  v0.1.34 can result in apparent data loss. Data is not actually lost but would require non-trivial effort to recover.
+  v0.1.34, to a version prior than those, can result in apparent data loss. Data is not actually lost but would require
+  non-trivial effort to recover.
   (`#1458 <https://github.com/vertexproject/synapse/pull/1458>`_)
 
 Improved Documentation

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -816,6 +816,7 @@ class Cortex(s_cell.Cell):
         await self._migrateViewsLayers()
         await self._initCoreLayers()
         await self._initCoreViews()
+        self.onfini(self._finiStor)
         await self._migrateLayerOffset()
         await self._checkLayerModels()
         await self._initCoreQueues()
@@ -826,12 +827,10 @@ class Cortex(s_cell.Cell):
 
         self.addHealthFunc(self._cortexHealth)
 
-        async def fini():
-            await asyncio.gather(*[view.fini() for view in self.views.values()])
-            await asyncio.gather(*[layr.fini() for layr in self.layers.values()])
+        async def finidmon():
             await asyncio.gather(*[dmon.fini() for dmon in self.stormdmons.values()])
 
-        self.onfini(fini)
+        self.onfini(finidmon)
 
         self.trigstor = s_trigger.TriggerStorage(self)
         self.agenda = await s_agenda.Agenda.anit(self)
@@ -859,6 +858,10 @@ class Cortex(s_cell.Cell):
         self._initCryoLoop()
         self._initPushLoop()
         self._initFeedLoops()
+
+    async def _finiStor(self):
+        await asyncio.gather(*[view.fini() for view in self.views.values()])
+        await asyncio.gather(*[layr.fini() for layr in self.layers.values()])
 
     async def _initRuntFuncs(self):
 

--- a/synapse/lib/modelrev.py
+++ b/synapse/lib/modelrev.py
@@ -6,7 +6,7 @@ import synapse.lib.migrate as s_migrate
 
 logger = logging.getLogger(__name__)
 
-maxvers = (0, 1, 1)
+maxvers = (0, 1, 2)
 
 class ModelRev:
 
@@ -16,6 +16,7 @@ class ModelRev:
             ((0, 0, 0), self._addModelVers),
             ((0, 1, 0), self._addFormNameSpaces),
             ((0, 1, 1), self._normContactAddress),
+            ((0, 1, 2), self._afterUniqueIdens),
         )
 
     async def revCoreLayers(self):
@@ -95,3 +96,10 @@ class ModelRev:
     async def _normContactAddress(self, layers):
         async with self.getCoreMigr(layers) as migr:
             await migr.normPropValu('ps:contact:address')
+
+    async def _afterUniqueIdens(self, layers):
+        '''
+        Nothing to do.  Merely acts as a barrier against running a version before we went to the scheme where cortex,
+        views, and layers had unique idens.  (The migration actually occurs in cortex._migrateViewLayers)
+        '''
+        pass

--- a/synapse/lib/modelrev.py
+++ b/synapse/lib/modelrev.py
@@ -39,11 +39,11 @@ class ModelRev:
 
             if not layr.canrev and vers != version:
                 mesg = f'layer {layr.__class__.__name__} {layr.iden} ({layr.dirn}) can not be updated.'
-                raise s_exc.CantRevLayer(layer=layr.iden, mesg=mesg)
+                raise s_exc.CantRevLayer(layer=layr.iden, mesg=mesg, curv=version, layv=vers)
 
             if vers > version:
                 mesg = f'layer {layr.__class__.__name__} {layr.iden} ({layr.dirn}) is from the future!'
-                raise s_exc.CantRevLayer(layer=layr.iden, mesg=mesg)
+                raise s_exc.CantRevLayer(layer=layr.iden, mesg=mesg, curv=version, layv=vers)
 
             # realistically all layers are probably at the same version... but...
             layers.append(layr)


### PR DESCRIPTION
Add a fake empty model migration.