### PR TITLE
Allow expressions to deal with None values

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -2308,11 +2308,11 @@ class DollarExpr(RunValue, Cond):
     '''
     async def compute(self, path):
         assert len(self.kids) == 1
-        return s_stormtypes.intify(await self.kids[0].compute(path))
+        return s_stormtypes.intOrNoneify(await self.kids[0].compute(path))
 
     async def runtval(self, runt):
         assert len(self.kids) == 1
-        return s_stormtypes.intify(await self.kids[0].runtval(runt))
+        return s_stormtypes.intOrNoneify(await self.kids[0].runtval(runt))
 
     async def getCondEval(self, runt):
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -31,6 +31,11 @@ def intify(x):
 
     return int(x)
 
+def intOrNoneify(x):
+    if x is None:
+        return None
+    return intify(x)
+
 def kwarg_format(text, **kwargs):
     '''
     Replaces instances curly-braced argument names in text with their values

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -3076,6 +3076,20 @@ class CortexBasicTest(s_t_utils.SynTest):
             await _test('$(not 1 and 1)', 0)  # not > and
             await _test('$(not 1 > 1)', 1)  # cmp > not
 
+            opts = {'vars': {'none': None}}
+            # runtsafe
+            nodes = await core.nodes('if $($none) {[test:str=yep]}', opts=opts)
+            self.len(0, nodes)
+
+            # non-runtsafe
+            nodes = await core.nodes('[test:int=42] if $($none) {[test:str=$node]} else {spin}', opts=opts)
+            self.len(0, nodes)
+
+            nodes = await core.nodes('if $(not $none) {[test:str=yep]}', opts=opts)
+            self.len(1, nodes)
+            nodes = await core.nodes('[test:int=42] if $(not $none) {[test:str=yep]} else {spin}', opts=opts)
+            self.len(2, nodes)
+
             # TODO:  implement move-along mechanism
             # await _test('$(1 / 0)', 0)
 


### PR DESCRIPTION
This is very narrowly scoped: allow $($var) and $(not $var) where var is None.

Eventually, we're going to need a type system.