### PR TITLE
Bump circleci cache for linux ci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,14 +103,14 @@ commands:
 
       - restore_cache:
           keys:
-            - v1-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
+            - v2-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - do_venv_setup
 
       - save_cache:
           paths:
             - ./venv
-          key: v1-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: v2-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
           name: syntax


### PR DESCRIPTION
Cached builds using multidict 4.7.0 fail.  4.7.1 is working for us now.

related:
https://github.com/aio-libs/multidict/issues/418