### PR TITLE
Eager CI upgrades. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
           name: install synapse
           command: |
             . venv/bin/activate
-            python3 -m pip install -e .
+            python3 -m pip install -U --upgrade-strategy=eager -e .
 
   do_test_execution:
     description: "Execute unit tests via pytest"
@@ -73,7 +73,7 @@ commands:
             . venv/bin/activate
             python3 setup.py egg_info
             grep -v -E "^\[" synapse.egg-info/requires.txt > _requirements.txt
-            python3 -m pip install -r _requirements.txt
+            python3 -m pip install -U -r _requirements.txt
 
       - save_cache:
           paths:


### PR DESCRIPTION
Prevent us from having to do cache-key rolling to pick up new versions of third-party libs in the event that a broken package is released and then a fix is published.