### PR TITLE
scrape bug - nonstr reprs

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1392,13 +1392,14 @@ class ScrapeCmd(Cmd):
 
     Examples:
 
+        # Scrape properties from inbound nodes and create standalone nodes.
         inet:search:query | scrape
 
-        # Scrape inbound node properties and make edge:refs nodes to the new nodes.
+        # Scrape properties from inbound nodes and make edge:refs to the scraped nodes.
         inet:search:query | scrape --refs
 
-        # Scrape the :text prop from the inbound nodes.
-        inet:search:query | scrape --props text
+        # Scrape only the :engine and :text props from the inbound nodes.
+        inet:search:query | scrape --props text engine
     '''
 
     name = 'scrape'
@@ -1423,13 +1424,13 @@ class ScrapeCmd(Cmd):
             reprs = node.reprs()
 
             # make sure any provided props are valid
-            for fprop in self.opts.props:
+            proplist = [p.strip().lstrip(':') for p in self.opts.props]
+            for fprop in proplist:
                 if node.form.props.get(fprop, None) is None:
                     raise s_exc.BadOptValu(mesg=f'{fprop} not a valid prop for {node.ndef[1]}',
                                            name='props', valu=self.opts.props)
 
             # if a list of props haven't been specified, then default to ALL of them
-            proplist = self.opts.props
             if not proplist:
                 proplist = [k for k in node.props.keys()]
 
@@ -1441,6 +1442,7 @@ class ScrapeCmd(Cmd):
 
                 # use the repr val or the system mode val as appropriate
                 sval = reprs.get(prop, val)
+                sval = str(sval)
 
                 for form, valu in s_scrape.scrape(sval):
                     nnode = await node.snap.addNode(form, valu)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -467,7 +467,7 @@ class StormTest(s_t_utils.SynTest):
                                             })
                 bnode = await snap.addNode('inet:banner', ('tcp://2.4.6.8:80', 'this is a test foo@bar.com'))
 
-            q = 'inet:search:query | scrape -p text engine'
+            q = 'inet:search:query | scrape -p :text engine'
             nodes = await core.nodes(q)
             self.len(1, nodes)
             self.eq(nodes[0].ndef, ('inet:ipv4', 0x01020304))
@@ -500,6 +500,22 @@ class StormTest(s_t_utils.SynTest):
             await core.nodes('[inet:search:query="*"]')
             mesgs = await alist(core.streamstorm('inet:search:query | scrape --props text'))
             self.stormIsInPrint('No prop ":text" for', mesgs)
+
+            # make sure we handle .seen(i.e. non-str reprs)
+            qtxt = 'ns1.twiter-statics.info'
+            async with await core.snap() as snap:
+                guid = s_common.guid()
+                snode = await snap.addNode('inet:search:query', guid,
+                                          {'text': qtxt,
+                                           'time': '2019-04-04 17:03',
+                                           '.seen': ('2018/11/08 18:21:15.423', '2018/11/08 18:21:15.424'),
+                                           'engine': 'google',
+                                            })
+
+            q = f'inet:search:query:text={qtxt} | scrape'
+            nodes = await core.nodes(q)
+            self.len(1, nodes)
+            self.eq(nodes[0].ndef, ('inet:fqdn', qtxt))
 
     async def test_tee(self):
         async with self.getTestCore() as core:


### PR DESCRIPTION
- also added normalization of props option so that relative properties can be specified with or without a leading colon.