### PR TITLE
Convert Cortex.nodes from a direct call to a schedCoro based call.

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2765,7 +2765,10 @@ class Cortex(s_cell.Cell):
         '''
         A simple non-streaming way to return a list of nodes.
         '''
-        return [n async for n in self.eval(text, opts=opts, user=user)]
+        async def nodes():
+            return [n async for n in self.eval(text, opts=opts, user=user)]
+        task = self.schedCoro(nodes())
+        return await task
 
     @s_coro.genrhelp
     async def streamstorm(self, text, opts=None, user=None):


### PR DESCRIPTION
Prevents the current test task from being promoted to a Synapse Task