### PR TITLE
More debug awareness.

### DIFF
--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -78,7 +78,8 @@ class Base:
     '''
     def __init__(self):
         self.anitted = False
-        assert inspect.stack()[1].function == 'anit', 'Objects from Base must be constructed solely via "anit"'
+        if __debug__:
+            assert inspect.stack()[1].function == 'anit', 'Objects from Base must be constructed solely via "anit"'
 
     @classmethod
     async def anit(cls, *args, **kwargs):


### PR DESCRIPTION
Only perform the anit assertion if __debug__ is true. Allows for this optimization to be compiled away at interpreter startup.