### PR TITLE
Implement merge method on view

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2250,6 +2250,8 @@ class Cortex(s_cell.Cell):
         if iden == self.view.iden:
             raise s_exc.SynErr(mesg='cannot delete the main view')
 
+        # FIXME: verify that there are no children views
+
         view = self.views.pop(iden, None)
         if view is None:
             raise s_exc.NoSuchView(iden=iden)

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2248,9 +2248,11 @@ class Cortex(s_cell.Cell):
             This does not delete any of the view's layers
         '''
         if iden == self.view.iden:
-            raise s_exc.SynErr(mesg='cannot delete the main view')
+            raise s_exc.SynErr(mesg='Cannot delete the main view')
 
-        # FIXME: verify that there are no children views
+        for view in self.views.values():
+            if view.parent is not None and view.parent.iden == iden:
+                raise s_exc.SynErr(mesg='Cannot delete a view that has children')
 
         view = self.views.pop(iden, None)
         if view is None:

--- a/synapse/lib/lmdblayer.py
+++ b/synapse/lib/lmdblayer.py
@@ -74,7 +74,8 @@ class LmdbLayer(s_layer.Layer):
 
         self.layrslab = await s_lmdbslab.Slab.anit(path, max_dbs=128, map_size=mapsize, maxsize=maxsize,
                                                    growsize=growsize, writemap=True, readahead=readahead,
-                                                   lockmemory=self.lockmemory, map_async=map_async, readonly=self.readonly)
+                                                   lockmemory=self.lockmemory, map_async=map_async,
+                                                   readonly=self.readonly)
         self.onfini(self.layrslab.fini)
 
         self.spliceslab = await s_lmdbslab.Slab.anit(splicepath, max_dbs=128, map_size=mapsize, maxsize=maxsize,
@@ -638,7 +639,7 @@ class LmdbLayer(s_layer.Layer):
                     yield (buid,)
                 continue
 
-            #pragma: no cover
+            # pragma: no cover
             mesg = f'No such index function for tag props: {iopr[0]}'
             raise s_exc.NoSuchName(name=iopr[0], mesg=mesg)
 

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -81,6 +81,10 @@ class Snap(s_base.Base):
         self.onfini(self.stack.close)
         self.changelog = []
         self.tagtype = self.core.model.type('ival')
+        self.trigson = True
+
+    def disableTriggers(self):
+        self.trigson = False
 
     # APIs that wrap cortex APIs to provide a boundary for the storm runtime
     # ( in many instances a sub-process snap will override )

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -279,7 +279,7 @@ class View(s_hive.AuthGater):
 
     async def fork(self, **layrinfo):
         '''
-        Makes a new view inheriting from this view with the same layers and a new write layer on top
+        Make a new view inheriting from this view with the same layers and a new write layer on top
 
         Args:
             Passed through to cortex.addLayer
@@ -299,6 +299,43 @@ class View(s_hive.AuthGater):
         view.parent = self
 
         return view
+
+    async def merge(self, user=None):
+        '''
+        Merge this view into its parent.  All changes made to this view will be applied to the parent.
+
+        When complete, delete this view.
+        '''
+        fromlayr = self.layers[0]
+        if self.parent is None:
+            raise s_exc.CannotMerge()
+
+        # TODO:  verify parent is not readonly
+
+        # TODO:  mark this view/write layer as readonly
+
+        CHUNKSIZE = 1000
+        fromoff = 0
+
+        if user is None:
+            user = self.core.auth.getUserByName('root')
+
+        await self.core.boss.promote('storm', user=user, info={'merging': self.iden})
+        async with await self.parent.snap(user=user) as snap:
+            snap.disableTriggers()
+            snap.strict = False
+            while True:
+                splicechunk = [x async for x in fromlayr.splices(fromoff, CHUNKSIZE)]
+
+                await snap.addFeedData('syn.splice', splicechunk)
+
+                if len(splicechunk) < CHUNKSIZE:
+                    break
+
+                fromoff += CHUNKSIZE
+                await asyncio.sleep(0)
+
+        await self.core.delView(self.iden)
 
     async def runTagAdd(self, node, tag, valu):
 
@@ -329,16 +366,27 @@ class View(s_hive.AuthGater):
         await self.triggers.runTagDel(node, tag)
 
     async def runNodeAdd(self, node):
+        if not node.snap.trigson:
+            return
+
         await self.triggers.runNodeAdd(node)
+
         if self.parent is not None:
             await self.parent.runNodeAdd(node)
 
     async def runNodeDel(self, node):
+        if not node.snap.trigson:
+            return
+
         await self.triggers.runNodeDel(node)
+
         if self.parent is not None:
             await self.parent.runNodeDel(node)
 
     async def runPropSet(self, node, prop, oldv):
+        if not node.snap.trigson:
+            return
+
         await self.triggers.runPropSet(node, prop, oldv)
 
         if self.parent is not None:

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -308,7 +308,7 @@ class View(s_hive.AuthGater):
         '''
         fromlayr = self.layers[0]
         if self.parent is None:
-            raise s_exc.CannotMerge()
+            raise s_exc.SynErr('Cannot merge a view than has not been forked')
 
         if self.parent.layers[0].readonly:
             raise s_exc.ReadOnlyLayer(mesg="May not merge if the parent's write layer is read-only")

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -310,9 +310,12 @@ class View(s_hive.AuthGater):
         if self.parent is None:
             raise s_exc.CannotMerge()
 
-        # FIXME:  verify parent is not readonly
+        if self.parent.layers[0].readonly:
+            raise s_exc.ReadOnlyLayer(mesg="May not merge if the parent's write layer is read-only")
 
-        # FIXME:  mark this view/write layer as readonly
+        for view in self.core.views.values():
+            if view.parent is not None and view.parent == self:
+                raise s_exc.SynErr(mesg='Cannot merge a view that has children itself')
 
         CHUNKSIZE = 1000
         fromoff = 0

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -310,9 +310,9 @@ class View(s_hive.AuthGater):
         if self.parent is None:
             raise s_exc.CannotMerge()
 
-        # TODO:  verify parent is not readonly
+        # FIXME:  verify parent is not readonly
 
-        # TODO:  mark this view/write layer as readonly
+        # FIXME:  mark this view/write layer as readonly
 
         CHUNKSIZE = 1000
         fromoff = 0

--- a/synapse/tests/test_lib_view.py
+++ b/synapse/tests/test_lib_view.py
@@ -46,7 +46,12 @@ class ViewTest(s_t_utils.SynTest):
             await self.asyncraises(s_exc.ReadOnlyLayer, core.view.setLayers([tmplayr]))
             await self.asyncraises(s_exc.ReadOnlyLayer, view2.setLayers([tmplayr]))
 
-            await core.delView(view2.iden)
+            # Merge the child back into the parent
+            await view2.merge()
+
+            # Now, the node added to the child is seen in the parent
+            nodes = await core.nodes('test:int=12')
+            self.len(1, nodes)
 
     async def test_view_trigger(self):
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_view.py
+++ b/synapse/tests/test_lib_view.py
@@ -4,7 +4,7 @@ import synapse.tests.utils as s_t_utils
 from synapse.tests.utils import alist
 
 class ViewTest(s_t_utils.SynTest):
-    async def test_view_fork(self):
+    async def test_view_fork_merge(self):
         async with self.getTestCore() as core:
             await core.nodes('[ test:int=10 ]')
             nodes = await alist(core.eval('test:int=10'))
@@ -36,8 +36,13 @@ class ViewTest(s_t_utils.SynTest):
             # Deleting nodes from the child view should not affect the main
             await alist(view2.eval('test:int | delnode'))
             self.eq(2, core.counts.get('test:int'))
-            nodes = await alist(view2.eval('test:int=10'))
-            self.len(1, nodes)
+            await self.agenlen(0, view2.eval('test:int=12'))
+
+            # Until we get tombstoning, the child view can't delete a node in the lower layer
+            await self.agenlen(1, view2.eval('test:int=10'))
+
+            # Add a node back
+            await self.agenlen(1, view2.eval('[ test:int=12 ]'))
 
             # Forker and forkee have their layer configuration frozen
             tmplayr = await core.addLayer()
@@ -45,6 +50,17 @@ class ViewTest(s_t_utils.SynTest):
             await self.asyncraises(s_exc.ReadOnlyLayer, view2.addLayer(tmplayr))
             await self.asyncraises(s_exc.ReadOnlyLayer, core.view.setLayers([tmplayr]))
             await self.asyncraises(s_exc.ReadOnlyLayer, view2.setLayers([tmplayr]))
+
+            # You can't merge if the parent's write layer is readonly
+            view2.parent.layers[0].readonly = True
+            await self.asyncraises(s_exc.ReadOnlyLayer, view2.setLayers([tmplayr]))
+            view2.parent.layers[0].readonly = False
+
+            # You can't delete a view or merge it if it has children
+            view3 = await view2.fork()
+            await self.asyncraises(s_exc.SynErr, view2.merge())
+            await self.asyncraises(s_exc.SynErr, view2.core.delView(view2.iden))
+            await view3.core.delView(view3.iden)
 
             # Merge the child back into the parent
             await view2.merge()

--- a/synapse/tests/test_lib_view.py
+++ b/synapse/tests/test_lib_view.py
@@ -44,6 +44,10 @@ class ViewTest(s_t_utils.SynTest):
             # Add a node back
             await self.agenlen(1, view2.eval('[ test:int=12 ]'))
 
+            # Add a bunch of nodes to require chunking of splices when merging
+            for i in range(1000):
+                await self.agenlen(1, view2.eval('[test:int=$val]', opts={'vars': {'val': i + 1000}}))
+
             # Forker and forkee have their layer configuration frozen
             tmplayr = await core.addLayer()
             await self.asyncraises(s_exc.ReadOnlyLayer, core.view.addLayer(tmplayr))

--- a/synapse/tests/test_lib_view.py
+++ b/synapse/tests/test_lib_view.py
@@ -51,9 +51,12 @@ class ViewTest(s_t_utils.SynTest):
             await self.asyncraises(s_exc.ReadOnlyLayer, core.view.setLayers([tmplayr]))
             await self.asyncraises(s_exc.ReadOnlyLayer, view2.setLayers([tmplayr]))
 
+            # You can't merge a non-forked view
+            await self.asyncraises(s_exc.SynErr, view2.core.view.merge())
+
             # You can't merge if the parent's write layer is readonly
             view2.parent.layers[0].readonly = True
-            await self.asyncraises(s_exc.ReadOnlyLayer, view2.setLayers([tmplayr]))
+            await self.asyncraises(s_exc.ReadOnlyLayer, view2.merge())
             view2.parent.layers[0].readonly = False
 
             # You can't delete a view or merge it if it has children


### PR DESCRIPTION
A new view that was forked from another view can now be merged back into the view it was forked on.

All changes from the child view are incorporated in its parent view and it is destroyed. As triggers were fired when they were applied to the child view, triggers do not fire when merged into the parent.

Limitation: a view can't merge into its parent if it has any existing forked children.