### PR TITLE
Feature synnodes stability

### DIFF
--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -754,21 +754,27 @@ class Snap(s_base.Base):
         '''
 
         for (formname, formvalu), forminfo in nodedefs:
+            try:
+                props = forminfo.get('props')
 
-            props = forminfo.get('props')
+                # remove any universal created props...
+                if props is not None:
+                    props.pop('.created', None)
 
-            # remove any universal created props...
-            if props is not None:
-                props.pop('.created', None)
+                node = await self.addNode(formname, formvalu, props=props)
+                if node is not None:
+                    tags = forminfo.get('tags')
+                    if tags is not None:
+                        for tag, asof in tags.items():
+                            await node.addTag(tag, valu=asof)
 
-            node = await self.addNode(formname, formvalu, props=props)
-            if node is not None:
-                tags = forminfo.get('tags')
-                if tags is not None:
-                    for tag, asof in tags.items():
-                        await node.addTag(tag, valu=asof)
+                yield node
 
-            yield node
+            except asyncio.CancelledError:  # pragma: no cover
+                raise
+
+            except Exception as e:
+                logger.exception(f'Error making node: [{formname}={formvalu}]')
 
     async def stor(self, sops, splices=None):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2660,6 +2660,12 @@ class CortexBasicTest(s_t_utils.SynTest):
             await core1.addFeedData('syn.nodes', podes)
             await self.agenlen(3, core1.eval('test:int'))
 
+            # Put bad data in
+            with self.getAsyncLoggerStream('synapse.lib.snap',
+                                           "Error making node: [test:str=newp]") as stream:
+                await core1.addFeedData('syn.nodes', [(('test:str', 'newp'), {'tags': {'test.newp': 'newp'}})])
+                self.true(await stream.wait(6))
+
     async def test_stat(self):
 
         async with self.getTestCoreAndProxy() as (realcore, core):


### PR DESCRIPTION
Originally in #1451 from `dev_unstable` branch.

* Make the syn.nodes ingest bulletproof
