### PR TITLE
Fix bug where abrv offset would be off by 1 on restart

### DIFF
--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -170,7 +170,7 @@ class SlabAbrv:
 
         item = self.slab.last(db=self.abrv2name)
         if item is not None:
-            self.offs = s_common.int64un(item[0])
+            self.offs = s_common.int64un(item[0]) + 1
 
     @s_cache.memoize(10000)
     def abrvToName(self, abrv):

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -631,6 +631,12 @@ class LmdbSlabTest(s_t_utils.SynTest):
                 # And we still have no valu for 02
                 self.none(abrv.abrvToName(b'\x00\x00\x00\x00\x00\x00\x00\x02'))
 
+                # And we don't overwrite existing values on restart
+                valu = abrv.nameToAbrv('hoho')
+                self.eq(valu, b'\x00\x00\x00\x00\x00\x00\x00\x02')
+
+                valu = abrv.nameToAbrv('haha')
+                self.eq(valu, b'\x00\x00\x00\x00\x00\x00\x00\x01')
 class LmdbSlabMemLockTest(s_t_utils.SynTest):
 
     async def test_lmdbslabmemlock(self):

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -637,6 +637,7 @@ class LmdbSlabTest(s_t_utils.SynTest):
 
                 valu = abrv.nameToAbrv('haha')
                 self.eq(valu, b'\x00\x00\x00\x00\x00\x00\x00\x01')
+
 class LmdbSlabMemLockTest(s_t_utils.SynTest):
 
     async def test_lmdbslabmemlock(self):


### PR DESCRIPTION
This would affect tagprops currently.