### PR TITLE
link teardown change

### DIFF
--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -415,7 +415,7 @@ class Daemon(s_base.Base):
             if isinstance(item, s_telepath.Aware):
                 item = await s_coro.ornot(item.getTeleApi, link, mesg, path)
                 if isinstance(item, s_base.Base):
-                    link.onfini(item.fini)
+                    link.onfini(item)
 
             reply[1]['sharinfo'] = s_reflect.getShareInfo(item)
 


### PR DESCRIPTION
Make the link teardown the shared item created by a _onTeleSyn call via the todo list as opposed to the fini funcs list. Prevents a test race teardown.

Teardown is due to the potentially extended link teardown introduced here https://github.com/vertexproject/synapse/blame/v0.1.47/synapse/daemon.py#L415

Related to #1514 