### PR TITLE
Thesilence docs

### DIFF
--- a/docs/synapse/devguides/architecture.rst
+++ b/docs/synapse/devguides/architecture.rst
@@ -96,6 +96,7 @@ server for starting any cell, ``synapse.servers.cell``.  These servers will crea
 additional RPC or HTTP API listening servers as necessary.  Those are the preferred ways to run an application
 implemented via a ``Cell``.
 
+.. _arch-telepath:
 
 Telepath RPC
 ============

--- a/docs/synapse/glossary.rst
+++ b/docs/synapse/glossary.rst
@@ -46,7 +46,7 @@ See :ref:`gloss-buid`.
 BUID
 ----
 
-Short for Binary Unique Identifier. Within Synapse, a BUID is the globally unique (within a :ref:`gloss-cortex`) SHA256 digest of a node’s msgpack-encoded :ref:`gloss-ndef`.
+Short for Binary Unique Identifier. Within Synapse, a BUID is the globally unique (within a :ref:`gloss-cortex`) SHA-256 digest of a node’s msgpack-encoded :ref:`gloss-ndef`.
 
 
 C
@@ -85,7 +85,7 @@ The set of common operator symbols used to evaluate (compare) values in Storm. S
 Comparison Operator, Extended
 -----------------------------
 
-The set of Storm-specific operator symbols or expressions used to evaluate (compare) values in Storm based on custom or Storm-specific criteria. Extended comparison operators include regular expression (``~=``), time / interval (``@=``), set membership (``*in=``), tag (``#``), and so on.
+The set of Storm-specific operator symbols or expressions used to evaluate (compare) values in Storm based on custom or Storm-specific criteria. Extended comparison operators include regular expression (``~=``), time/interval (``@=``), set membership (``*in=``), tag (``#``), and so on.
 
 .. _gloss-comp-form:
 
@@ -109,7 +109,7 @@ Contrast with :ref:`gloss-variable`. See also :ref:`gloss-runtsafe` and :ref:`gl
 Constructor
 -----------
 
-Within Synapse, code that defines how a :ref:`gloss-prop` value of a given :ref:`gloss-type` can be constructed to ensure that the value is well-formed for its type. Also known as a :ref:`gloss-ctor` for short. Constructors support :ref:`gloss-type-norm` and :ref:`gloss-type-enforce`.
+Within Synapse, a constructor is code that defines how a :ref:`gloss-prop` value of a given :ref:`gloss-type` can be constructed to ensure that the value is well-formed for its type. Also known as a :ref:`gloss-ctor` for short. Constructors support :ref:`gloss-type-norm` and :ref:`gloss-type-enforce`.
 
 .. _gloss-cortex:
 
@@ -123,7 +123,7 @@ A Cortex is Synapse's implementation of an individual :ref:`gloss-hypergraph`. C
 Cron
 ----
 
-Within Synapse cron jobs are used to create scheduled tasks, similar to the Linux / Unix "cron" utility. The task to be executed by the cron job is specified using the :ref:`gloss-storm` query language.
+Within Synapse cron jobs are used to create scheduled tasks, similar to the Linux/Unix "cron" utility. The task to be executed by the cron job is specified using the :ref:`gloss-storm` query language.
 
 See the Storm command reference for the :ref:`storm-cron` command and the :ref:`storm-ref-automation` document for additional detail.
 
@@ -369,7 +369,7 @@ K
 Knowledge, Fused
 ----------------
 
-If a form within the Synapse data model has a "range" of time elements (i.e., an interval such as "first seen" / "last seen"), the form typically represents **fused knowledge** - a period of time during which an object, relationship, or event was known to exist. Forms representing fused knowledge can be thought of as combining *n* number of instance knowledge observations. ``inet:dns:query``, ``inet:dns:a``, and ``inet:whois:email`` forms are examples of fused knowledge.
+If a form within the Synapse data model has a "range" of time elements (i.e., an interval such as "first seen"/"last seen"), the form typically represents **fused knowledge** -- a period of time during which an object, relationship, or event was known to exist. Forms representing fused knowledge can be thought of as combining *n* number of instance knowledge observations. ``inet:dns:query``, ``inet:dns:a``, and ``inet:whois:email`` forms are examples of fused knowledge.
 
 See :ref:`instance-fused` for a more detailed discussion.
 
@@ -378,7 +378,7 @@ See :ref:`instance-fused` for a more detailed discussion.
 Knowledge, Instance
 -------------------
 
-If a form within the Synapse data model has a specific time element (i.e., a single date/time value), the form typically represents **instance knowledge** - a single instance or occurrence of an object, relationship, or event. ``inet:dns:request`` and ``inet:whois:rec`` forms are examples of instance knowledge.
+If a form within the Synapse data model has a specific time element (i.e., a single date/time value), the form typically represents **instance knowledge** -- a single instance or occurrence of an object, relationship, or event. ``inet:dns:request`` and ``inet:whois:rec`` forms are examples of instance knowledge.
 
 See :ref:`instance-fused` for a more detailed discussion.
 
@@ -390,9 +390,9 @@ L
 Layer
 -----
 
-Within Synapse, a layer is the substrate that contains node data and where permissions enforcement occurs. Viewed another way, a layer is a storage and write permission boundary. By default, a :ref:`gloss-cortex` has a single layer and a single :ref:`gloss-view`, meaning that by default all nodes are stored in one layer and all changes are written to that layer. However, multiple layers can be created for various purposes such as: separating data from different data sources (e.g., a read-only layer consisting of third-party data and associated tags can be created underneath a "working" layer, so that the third-party data is visible but cannot be modified); providing users with a personal "scratch space" where they can make changes in their layer without affecting the underlying main Cortex layer; or segregating data sets that should be visible / accessible to some users but not others.
+Within Synapse, a layer is the substrate that contains node data and where permissions enforcement occurs. Viewed another way, a layer is a storage and write permission boundary. By default, a :ref:`gloss-cortex` has a single layer and a single :ref:`gloss-view`, meaning that by default all nodes are stored in one layer and all changes are written to that layer. However, multiple layers can be created for various purposes such as: separating data from different data sources (e.g., a read-only layer consisting of third-party data and associated tags can be created underneath a "working" layer, so that the third-party data is visible but cannot be modified); providing users with a personal "scratch space" where they can make changes in their layer without affecting the underlying main Cortex layer; or segregating data sets that should be visible/accessible to some users but not others.
 
-Layers are closely related to views (see :ref:`gloss-view`). The order in which layers are instantiated within a view matters; in a multi-layer view, typically only the topmost layer is writeable by that view's users, with subsequent (lower) layers read-only. Permissions and implementation decisions will determine whether upper-layer writes are pushed downward (merged) into lower layers.
+Layers are closely related to views (see :ref:`gloss-view`). The order in which layers are instantiated within a view matters; in a multi-layer view, typically only the topmost layer is writeable by that view's users, with subsequent (lower) layers read-only. Explicit actions can push upper-layer writes downward (merge) into lower layers.
 
 .. _gloss-leaf-tag:
 
@@ -418,7 +418,7 @@ M
 Model
 -----
 
-Within Synapse, a system or systems used to represent data and / or assertions in a structured manner. A well-designed model allows efficient and meaningful exploration of the data to identify both known and potentially arbitrary or discoverable relationships.
+Within Synapse, a system or systems used to represent data and/or assertions in a structured manner. A well-designed model allows efficient and meaningful exploration of the data to identify both known and potentially arbitrary or discoverable relationships.
 
 .. _gloss-model-analytical:
 
@@ -530,7 +530,7 @@ Within Synapse, a derived property is one that can be extracted (derived) from a
 Property, Primary
 -----------------
 
-Within Synapse, a primary property is the property that defines a given :ref:`gloss-form` in the data model. The primary property of a form must be selected / defined such that the value of that property is unique across all possible instances of that form. Primary properties are always read-only (i.e., cannot be modified once set).
+Within Synapse, a primary property is the property that defines a given :ref:`gloss-form` in the data model. The primary property of a form must be defined such that the value of that property is unique across all possible instances of that form. Primary properties are always read-only (i.e., cannot be modified once set).
 
 .. _gloss-prop-relative:
 
@@ -564,7 +564,7 @@ Q
 Queue
 -----
 
-Within Synapse, a queue is a basic first-in, first-out (FIFO) data structure used to store and serve objects in a classic pub/sub (publish / subscribe) manner. Any primitive (such as a node iden) can be placed into a queue and then consumed from it. Queues can be used (for example) to support out-of-band processing by allowing non-critical tasks to be executed in the background. Queues are persistent; i.e., if a Cortex is restarted, the queue and any objects in the queue are retained.
+Within Synapse, a queue is a basic first-in, first-out (FIFO) data structure used to store and serve objects in a classic pub/sub (publish/subscribe) manner. Any primitive (such as a node iden) can be placed into a queue and then consumed from it. Queues can be used (for example) to support out-of-band processing by allowing non-critical tasks to be executed in the background. Queues are persistent; i.e., if a Cortex is restarted, the queue and any objects in the queue are retained.
 
 R
 =
@@ -629,7 +629,7 @@ See :ref:`gloss-prop-secondary`.
 Service
 -------
 
-A Storm service is a registerable remote component that can provide packages (:ref:`gloss-package`) and additional APIs to Storm and Storm commands. A service resides on a :ref:`gloss-telepath` API endpoint outside of the Cortex. When a service is loaded into a Cortex, the Cortex queries the endpoint to determine if the service is legitimate and, if so, loads the associated :ref:`gloss-package` to implement the service. An advantage of Storm services (over, say, additional Python modules) is that services can be restarted to reload their service definitions and packages while a Cortex is still running - thus allowing a service to be updated without having to restart the entire Cortex.
+A Storm service is a registerable remote component that can provide packages (:ref:`gloss-package`) and additional APIs to Storm and Storm commands. A service resides on a :ref:`gloss-telepath` API endpoint outside of the Cortex. When a service is loaded into a Cortex, the Cortex queries the endpoint to determine if the service is legitimate and, if so, loads the associated :ref:`gloss-package` to implement the service. An advantage of Storm services (over, say, additional Python modules) is that services can be restarted to reload their service definitions and packages while a Cortex is still running -- thus allowing a service to be updated without having to restart the entire Cortex.
 
 .. _gloss-simple-form:
 
@@ -650,7 +650,7 @@ TBD
 Splice
 ------
 
-A splice is an atomic change made to data within a Cortex, such as node creation or deletion, adding or removing a tag, or setting, modifying, or removing a property. All changes within a Cortex are recorded as individual splices within the Cortex's splice log.
+A splice is an atomic change made to data within a Cortex, such as node creation or deletion, adding or removing a tag, or setting, modifying, or removing a property. All changes within a Cortex may be retrieved as individual splices within the Cortex's splice log.
 
 .. _gloss-standard-comp-op:
 
@@ -664,7 +664,7 @@ See :ref:`gloss-comp-op-standard`.
 Storm
 -----
 
-The custom language used to interact with data in a Synapse :ref:`gloss-cortex`.
+The custom, domain-specific language used to interact with data in a Synapse :ref:`gloss-cortex`.
 
 See :ref:`storm-ref-intro` for additional detail.
 
@@ -729,7 +729,7 @@ See the Storm command reference for the :ref:`storm-trigger` command and the :re
 Type
 ----
 
-Within Synapse, a type is the definition of a data element within the data model. A type describes what the element is and enforces how it should look, including how it should be normalized, if necessary, for both storage (including indexing) and representation (display).
+Within Synapse, a type is the definition of a data element within the data model. A type describes what the element is and enforces how it should look, including how it should be normalized.
 
 See the :ref:`data-type` section in the :ref:`data-model-terms` document for additional detail.
 
@@ -745,7 +745,7 @@ Within Synapse, base types include standard types such as integers and strings, 
 Type, Model-Specific
 --------------------
 
-Within Synapse, knowledge domain-specific forms may themselves be specialized types. For example, an IPv4 address (``inet:ipv4``) is its own specialized type. While an IPv4 address is ultimately stored as an integer, the type has additional constraints (i.e., to ensure that IPv4 objects in the Cortex can only be created using integer values that fall within the allowable IPv4 address space).
+Within Synapse, knowledge-domain-specific forms may themselves be specialized types. For example, an IPv4 address (``inet:ipv4``) is its own specialized type. While an IPv4 address is ultimately stored as an integer, the type has additional constraints, e.g., IPv4 values must fall within the allowable IPv4 address space.
 
 .. _gloss-type-aware:
 
@@ -759,7 +759,7 @@ Type awareness is the feature of the :ref:`gloss-storm` query language that faci
 Type Enforcement
 ----------------
 
-Within Synapse, the process by which property values are required to conform to value and format constraints defined for that :ref:`gloss-type` within the data model before they can be set. Type enforcement helps to limit bad data being entered in to a Cortex by ensuring values entered make sense for the specified data type (i.e., that an IP address cannot be set as the value of a property defined as a domain (``inet:fqdn``) type, and that the integer value of the IP falls within the allowable set of values for IP address space).
+Within Synapse, the process by which property values are required to conform to value and format constraints defined for that :ref:`gloss-type` within the data model before they can be set. Type enforcement helps to limit bad data being entered in to a Cortex by ensuring values entered make sense for the specified data type (e.g., that an IP address cannot be set as the value of a property defined as a domain (``inet:fqdn``) type, and that the integer value of the IP falls within the allowable set of values for IP address space).
 
 .. _gloss-type-norm:
 
@@ -786,7 +786,7 @@ V
 Variable
 --------
 
-In Storm, a variable is an identifier with a value that can be defined and / or changed during normal execution, i.e., the value is variable.
+In Storm, a variable is an identifier with a value that can be defined and/or changed during normal execution, i.e., the value is variable.
 
 Contrast with :ref:`gloss-constant`. See also :ref:`gloss-runtsafe` and :ref:`gloss-non-runtsafe`.
 
@@ -795,6 +795,6 @@ Contrast with :ref:`gloss-constant`. See also :ref:`gloss-runtsafe` and :ref:`gl
 View
 ----
 
-Within Synapse, a view is a set of layers (see :ref:`gloss-layer`) and associated permissions that are used to synthesize nodes from the :ref:`gloss-cortex`, determining both the nodes that are visible to users via that view and where (i.e., in what layer) any changes made by a view's users are recorded. A default Cortex consists of a single layer and a single view, meaning that by default all nodes are stored in one layer and all changes are written to that layer.
+Within Synapse, a view is a ordered set of layers (see :ref:`gloss-layer`) and associated permissions that are used to synthesize nodes from the :ref:`gloss-cortex`, determining both the nodes that are visible to users via that view and where (i.e., in what layer) any changes made by a view's users are recorded. A default Cortex consists of a single layer and a single view, meaning that by default all nodes are stored in one layer and all changes are written to that layer.
 
-In multi-layer systems, a view consists of the set of layers that should be visible to users of that view, and the order in which the layers should be instantiated for that view.  Order matters because typically only the topmost layer is writeable by that view's users, with subsequent (lower) layers read-only. Permissions and implementation decisions will determine whether upper-layer writes are pushed downward (merged) into lower layers.
+In multi-layer systems, a view consists of the set of layers that should be visible to users of that view, and the order in which the layers should be instantiated for that view.  Order matters because typically only the topmost layer is writeable by that view's users, with subsequent (lower) layers read-only. Explicit actions can push upper-layer writes downward (merge) into lower layers.

--- a/docs/synapse/glossary.rst
+++ b/docs/synapse/glossary.rst
@@ -118,6 +118,14 @@ Cortex
 
 A Cortex is Synapse's implementation of an individual :ref:`gloss-hypergraph`. Cortex features include scalability, key/value-based node properties, and a :ref:`gloss-data-model` which facilitates normalization.
 
+.. _gloss-cron:
+
+Cron
+----
+
+Within Synapse cron jobs are used to create scheduled tasks, similar to the Linux / Unix "cron" utility. The task to be executed by the cron job is specified using the :ref:`gloss-storm` query language.
+
+See the Storm command reference for the :ref:`storm-cron` command and the :ref:`storm-ref-automation` document for additional detail.
 
 .. _gloss-ctor:
 
@@ -134,7 +142,7 @@ D
 Daemon
 ------
 
-TBD
+Similar to a traditional Linux or Unix daemon, a Synapse daemon is a long-running or recurring query or process that runs continuously in the background. A daemon is typically implemented by a Storm :ref:`gloss-service` and may be used for tasks such as processing elements from a :ref:`gloss-queue`. A daemon allows for non-blocking background processing of non-critical tasks. Daemons are persistent and will restart if they exit.
 
 .. _gloss-data-model:
 
@@ -173,6 +181,11 @@ Directed Graph
 
 See :ref:`gloss-graph-directed`.
 
+Dmon
+----
+
+Abbreviation for :ref:`gloss-daemon`.
+
 E
 =
 
@@ -205,7 +218,7 @@ F
 Feed
 ----
 
-TBD
+A feed is an ingest API consisting of a set of ingest formats (e.g., file formats, record formats) used to parse records directly into nodes. Feeds are typically used for bulk node creation, such as ingesting data from an external source or system.
 
 .. _gloss-filter:
 
@@ -377,7 +390,9 @@ L
 Layer
 -----
 
-TBD
+Within Synapse, a layer is the substrate that contains node data and where permissions enforcement occurs. Viewed another way, a layer is a storage and write permission boundary. By default, a :ref:`gloss-cortex` has a single layer and a single :ref:`gloss-view`, meaning that by default all nodes are stored in one layer and all changes are written to that layer. However, multiple layers can be created for various purposes such as: separating data from different data sources (e.g., a read-only layer consisting of third-party data and associated tags can be created underneath a "working" layer, so that the third-party data is visible but cannot be modified); providing users with a personal "scratch space" where they can make changes in their layer without affecting the underlying main Cortex layer; or segregating data sets that should be visible / accessible to some users but not others.
+
+Layers are closely related to views (see :ref:`gloss-view`). The order in which layers are instantiated within a view matters; in a multi-layer view, typically only the topmost layer is writeable by that view's users, with subsequent (lower) layers read-only. Permissions and implementation decisions will determine whether upper-layer writes are pushed downward (merged) into lower layers.
 
 .. _gloss-leaf-tag:
 
@@ -476,7 +491,7 @@ P
 Package
 -------
 
-TBD
+A package is a set of commands and library code used to implement a Storm :ref:`gloss-service`. When a new Storm service is loaded into a Cortex, the Cortex verifes that the service is legitimate and then requests the service's package in order to load any extended Storm commands associated with the service and any library code used to implement the service.
 
 .. _gloss-pivot:
 
@@ -549,7 +564,7 @@ Q
 Queue
 -----
 
-TBD
+Within Synapse, a queue is a basic first-in, first-out (FIFO) data structure used to store and serve objects in a classic pub/sub (publish / subscribe) manner. Any primitive (such as a node iden) can be placed into a queue and then consumed from it. Queues can be used (for example) to support out-of-band processing by allowing non-critical tasks to be executed in the background. Queues are persistent; i.e., if a Cortex is restarted, the queue and any objects in the queue are retained.
 
 R
 =
@@ -614,7 +629,7 @@ See :ref:`gloss-prop-secondary`.
 Service
 -------
 
-TBD
+A Storm service is a registerable remote component that can provide packages (:ref:`gloss-package`) and additional APIs to Storm and Storm commands. A service resides on a :ref:`gloss-telepath` API endpoint outside of the Cortex. When a service is loaded into a Cortex, the Cortex queries the endpoint to determine if the service is legitimate and, if so, loads the associated :ref:`gloss-package` to implement the service. An advantage of Storm services (over, say, additional Python modules) is that services can be restarted to reload their service definitions and packages while a Cortex is still running - thus allowing a service to be updated without having to restart the entire Cortex.
 
 .. _gloss-simple-form:
 
@@ -635,7 +650,7 @@ TBD
 Splice
 ------
 
-TBD
+A splice is an atomic change made to data within a Cortex, such as node creation or deletion, adding or removing a tag, or setting, modifying, or removing a property. All changes within a Cortex are recorded as individual splices within the Cortex's splice log.
 
 .. _gloss-standard-comp-op:
 
@@ -691,7 +706,7 @@ Within Synapse, the highest (leftmost) tag element in a tag hierarchy. For examp
 Telepath
 --------
 
-TBD
+Telepath is a lightweight remote procedure call (RPC) protocol used in Synapse. See :ref:`arch-telepath` in the :ref:`dev_architecture` guide for additional detail.
 
 .. _gloss-traverse:
 
@@ -707,7 +722,7 @@ Trigger
 
 Within Synapse, a trigger is a Storm query that is executed automatically upon the occurrence of a specified event within a Cortex (such as adding a node or applying a tag). "Trigger" refers collectively to the event and the query fired ("triggered") by the event.
 
-See the Synapse :ref:`syn-trigger` command and the Storm reference on :ref:`auto-triggers` for additional detail.
+See the Storm command reference for the :ref:`storm-trigger` command and the :ref:`storm-ref-automation` for additional detail.
 
 .. _gloss-type:
 
@@ -780,4 +795,6 @@ Contrast with :ref:`gloss-constant`. See also :ref:`gloss-runtsafe` and :ref:`gl
 View
 ----
 
-TBD
+Within Synapse, a view is a set of layers (see :ref:`gloss-layer`) and associated permissions that are used to synthesize nodes from the :ref:`gloss-cortex`, determining both the nodes that are visible to users via that view and where (i.e., in what layer) any changes made by a view's users are recorded. A default Cortex consists of a single layer and a single view, meaning that by default all nodes are stored in one layer and all changes are written to that layer.
+
+In multi-layer systems, a view consists of the set of layers that should be visible to users of that view, and the order in which the layers should be instantiated for that view.  Order matters because typically only the topmost layer is writeable by that view's users, with subsequent (lower) layers read-only. Permissions and implementation decisions will determine whether upper-layer writes are pushed downward (merged) into lower layers.

--- a/docs/synapse/userguide.rst
+++ b/docs/synapse/userguide.rst
@@ -32,8 +32,7 @@ The User Guide is a living document and will continue to be updated and expanded
     userguides/syn_tools_csvtool
 
     userguides/syn_ref_cmdr
-    userguides/syn_ref_automation
-
+    
     userguides/storm_ref_intro
     userguides/storm_ref_syntax
     userguides/storm_ref_lift
@@ -43,6 +42,7 @@ The User Guide is a living document and will continue to be updated and expanded
     userguides/storm_ref_model_introspect
     userguides/storm_ref_type_specific
     userguides/storm_ref_cmd
+    userguides/storm_ref_automation
 
     userguides/storm_adv_subquery
     userguides/storm_adv_vars

--- a/docs/synapse/userguides/storm_ref_automation.ipynb
+++ b/docs/synapse/userguides/storm_ref_automation.ipynb
@@ -6,10 +6,10 @@
    "source": [
     ".. highlight:: none\n",
     "\n",
-    ".. _syn-ref-automation:\n",
+    ".. _storm-ref-automation:\n",
     "\n",
-    "Synapse Reference - Automation\n",
-    "==============================\n",
+    "Storm Reference - Automation\n",
+    "============================\n",
     "\n",
     ".. _auto-triggers:\n",
     "\n",

--- a/docs/synapse/userguides/storm_ref_cmd.ipynb
+++ b/docs/synapse/userguides/storm_ref_cmd.ipynb
@@ -66,6 +66,17 @@
     "\n",
     "- `help`_\n",
     "- `count`_\n",
+    "- `cron`\n",
+    "\n",
+    "  - `cron.add`_\n",
+    "  - `cron.at`_\n",
+    "  - `cron.del`_\n",
+    "  - `cron.disable`_\n",
+    "  - `cron.enable`_\n",
+    "  - `cron.list`_\n",
+    "  - `cron.mod`_\n",
+    "  - `cron.stat`_\n",
+    "\n",
     "- `delnode`_\n",
     "- `dmon.list`_\n",
     "- `feed.list`_\n",
@@ -75,21 +86,52 @@
     "- `max`_\n",
     "- `min`_\n",
     "- `movetag`_\n",
-    "- `pkg.list`_\n",
-    "- `pkg.del`_\n",
-    "- `queue.add`_\n",
-    "- `queue.list`_\n",
-    "- `queue.del`_\n",
+    "- `packages`_\n",
+    "\n",
+    "  - `pkg.list`_\n",
+    "  - `pkg.del`_\n",
+    "\n",
+    "- `queues`_\n",
+    "\n",
+    "  - `queue.add`_\n",
+    "  - `queue.list`_\n",
+    "  - `queue.del`_\n",
+    "\n",
     "- `reindex`_\n",
     "- `scrape`_\n",
-    "- `service.add`_\n",
-    "- `service.list`_\n",
-    "- `service.del`_\n",
+    "- `services`_\n",
+    "\n",
+    "  - `service.add`_\n",
+    "  - `service.list`_\n",
+    "  - `service.del`_\n",
+    "\n",
     "- `sleep`_\n",
     "- `spin`_\n",
+    "- `splices`_\n",
+    "\n",
+    "  - `splice.list`_\n",
+    "  - `splice.undo`_\n",
+    "\n",
     "- `sudo`_\n",
     "- `tee`_\n",
+    "- `triggers`_\n",
+    "\n",
+    "  - `trigger.add`_\n",
+    "  - `trigger.del`_\n",
+    "  - `trigger.disable`_\n",
+    "  - `trigger.enable`_\n",
+    "  - `trigger.list`_\n",
+    "  - `trigger.mod`_\n",
+    "\n",
     "- `uniq`_\n",
+    "- `views`_\n",
+    "\n",
+    "  - `view.add`_\n",
+    "  - `view.del`_\n",
+    "  - `view.fork`_\n",
+    "  - `view.get`_\n",
+    "  - `view.list`_\n",
+    "  - `view.merge`_\n",
     "\n",
     "See :ref:`storm-ref-syntax` for an explanation of the syntax format used below.\n",
     "\n",
@@ -233,6 +275,95 @@
     "**Usage Notes:**\n",
     "\n",
     "- ``count`` does not consume nodes, so Storm will stream the nodes being counted to the CLI output while the command executes. To count nodes without streaming the output, ``count`` can be piped to the `spin`_ command (i.e., *<query>* | count | spin). ``Spin`` consumes nodes and so will prevent nodes processed by the ``count`` command from streaming."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron:\n",
+    "\n",
+    "cron\n",
+    "----"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-add:\n",
+    "\n",
+    "cron.add\n",
+    "++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-at:\n",
+    "\n",
+    "cron.at\n",
+    "+++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-del:\n",
+    "\n",
+    "cron.del\n",
+    "++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-disable:\n",
+    "\n",
+    "cron.disable\n",
+    "++++++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-enable:\n",
+    "\n",
+    "cron.enable\n",
+    "+++++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-list:\n",
+    "\n",
+    "cron.list\n",
+    "+++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-mod:\n",
+    "cron.mod\n",
+    "++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-stat:\n",
+    "\n",
+    "cron.stat\n",
+    "+++++++++"
    ]
   },
   {
@@ -964,10 +1095,20 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    ".. _storm-pkgs:\n",
+    "\n",
+    "packages\n",
+    "--------"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     ".. _storm-pkg-list:\n",
     "\n",
     "pkg.list\n",
-    "--------\n",
+    "++++++++\n",
     "\n",
     "The ``pkg.list`` command lists each Storm :ref:`gloss-package` loaded in the Cortex.\n",
     "\n",
@@ -994,7 +1135,7 @@
     ".. _storm-pkg-del:\n",
     "\n",
     "pkg.del\n",
-    "-------\n",
+    "+++++++\n",
     "\n",
     "The ``pkg.del`` command removes a Storm :ref:`gloss-package` from the Cortex.\n",
     "\n",
@@ -1018,10 +1159,20 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    ".. _storm-queues:\n",
+    "\n",
+    "queues\n",
+    "------"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     ".. _storm-queue-add:\n",
     "\n",
     "queue.add\n",
-    "---------\n",
+    "+++++++++\n",
     "\n",
     "The ``queue.add`` command adds a :ref:`gloss-queue` to the Cortex.\n",
     "\n",
@@ -1048,7 +1199,7 @@
     ".. _storm-queue-list:\n",
     "\n",
     "queue.list\n",
-    "----------\n",
+    "++++++++++\n",
     "\n",
     "The ``queue.list`` command lists each :ref:`gloss-queue` in the Cortex.\n",
     "\n",
@@ -1075,7 +1226,7 @@
     ".. _storm-queue-del:\n",
     "\n",
     "queue.del\n",
-    "---------\n",
+    "+++++++++\n",
     "\n",
     "The ``queue.del`` command removes a :ref:`gloss-queue` from the Cortex.\n",
     "\n",
@@ -1177,7 +1328,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "hideCode": false
+    "hideCode": true
    },
    "outputs": [],
    "source": [
@@ -1241,10 +1392,20 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    ".. _storm-services:\n",
+    "\n",
+    "services\n",
+    "--------"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     ".. _storm-service-add:\n",
     "\n",
     "service.add\n",
-    "-----------\n",
+    "+++++++++++\n",
     "\n",
     "The ``service.add`` command adds a Storm :ref:`gloss-service` to the Cortex.\n",
     "\n",
@@ -1271,7 +1432,7 @@
     ".. _storm-service-list:\n",
     "\n",
     "service.list\n",
-    "------------\n",
+    "++++++++++++\n",
     "\n",
     "The ``service.list`` command lists each Storm :ref:`gloss-service` in the Cortex.\n",
     "\n",
@@ -1298,7 +1459,7 @@
     ".. _storm-service-del:\n",
     "\n",
     "service.del\n",
-    "-----------\n",
+    "+++++++++++\n",
     "\n",
     "The ``service.del`` command removes a Storm :ref:`gloss-service` from the Cortex.\n",
     "\n",
@@ -1479,6 +1640,36 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    ".. _storm-splices:\n",
+    "\n",
+    "splices\n",
+    "-------"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-splice-list:\n",
+    "\n",
+    "splice.list\n",
+    "+++++++++++"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-splic-undo:\n",
+    "\n",
+    "splice.undo\n",
+    "+++++++++++"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     ".. _storm-sudo:\n",
     "\n",
     "sudo\n",
@@ -1644,6 +1835,78 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    ".. _storm-triggers:\n",
+    "\n",
+    "triggers\n",
+    "--------"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-trigger-add:\n",
+    "\n",
+    "trigger.add\n",
+    "+++++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-trigger-del:\n",
+    "\n",
+    "trigger.del\n",
+    "+++++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-trigger-disable:\n",
+    "\n",
+    "trigger.disable\n",
+    "+++++++++++++++\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-trigger-enable:\n",
+    "\n",
+    "trigger.enable\n",
+    "++++++++++++++\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-trigger-list:\n",
+    "\n",
+    "trigger.list\n",
+    "++++++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-trigger-mod:\n",
+    "\n",
+    "trigger.mod\n",
+    "+++++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     ".. _storm-uniq:\n",
     "\n",
     "uniq\n",
@@ -1708,6 +1971,81 @@
     "podes = await core.eval(q, num=4, cmdr=False)\n",
     "q = 'inet:fqdn#aka.threatconnect.thr.fancybear -> inet:dns:a -> inet:ipv4'\n",
     "podes = await core.eval(q, num=6, cmdr=False)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-views:\n",
+    "\n",
+    "views\n",
+    "-----"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-view-add:\n",
+    "\n",
+    "view.add\n",
+    "+++++++++\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-view-del:\n",
+    "\n",
+    "view.del\n",
+    "++++++++\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-view-fork:\n",
+    "\n",
+    "view.fork\n",
+    "+++++++++\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-view-get:\n",
+    "\n",
+    "view.get\n",
+    "++++++++\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-view-list:\n",
+    "\n",
+    "view.list\n",
+    "+++++++++\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-view-merge:\n",
+    "\n",
+    "view.merge\n",
+    "++++++++++"
    ]
   },
   {

--- a/docs/synapse/userguides/storm_ref_cmd.ipynb
+++ b/docs/synapse/userguides/storm_ref_cmd.ipynb
@@ -62,80 +62,67 @@
     "\n",
     "Help for a specific Storm command can be displayed with ``storm <command> --help``.\n",
     "\n",
-    "This section details the usage and syntax for built-in Storm commands:\n",
+    "This section details the usage and syntax for built-in Storm commands. Many of the commands below, such as ``count``, ``limit``, ``max`` / ``min``, or ``delnode``, directly support analyst tasks within Storm. Other commands, such as those used to manage daemons, queues, packages, or services, may be primarily of interest to Syanpse administrators or developers.\n",
     "\n",
     "- `help`_\n",
     "- `count`_\n",
-    "- `cron`\n",
-    "\n",
-    "  - `cron.add`_\n",
-    "  - `cron.at`_\n",
-    "  - `cron.del`_\n",
-    "  - `cron.disable`_\n",
-    "  - `cron.enable`_\n",
-    "  - `cron.list`_\n",
-    "  - `cron.mod`_\n",
-    "  - `cron.stat`_\n",
-    "\n",
+    "- `cron`_\n",
     "- `delnode`_\n",
-    "- `dmon.list`_\n",
-    "- `feed.list`_\n",
+    "- `dmon`_\n",
+    "- `feed`_\n",
     "- `graph`_\n",
     "- `iden`_\n",
     "- `limit`_\n",
     "- `max`_\n",
     "- `min`_\n",
     "- `movetag`_\n",
-    "- `packages`_\n",
-    "\n",
-    "  - `pkg.list`_\n",
-    "  - `pkg.del`_\n",
-    "\n",
-    "- `queues`_\n",
-    "\n",
-    "  - `queue.add`_\n",
-    "  - `queue.list`_\n",
-    "  - `queue.del`_\n",
-    "\n",
+    "- `package`_\n",
+    "- `queue`_\n",
     "- `reindex`_\n",
     "- `scrape`_\n",
-    "- `services`_\n",
-    "\n",
-    "  - `service.add`_\n",
-    "  - `service.list`_\n",
-    "  - `service.del`_\n",
-    "\n",
+    "- `service`_\n",
     "- `sleep`_\n",
     "- `spin`_\n",
-    "- `splices`_\n",
-    "\n",
-    "  - `splice.list`_\n",
-    "  - `splice.undo`_\n",
-    "\n",
+    "- `splice`_\n",
     "- `sudo`_\n",
     "- `tee`_\n",
-    "- `triggers`_\n",
-    "\n",
-    "  - `trigger.add`_\n",
-    "  - `trigger.del`_\n",
-    "  - `trigger.disable`_\n",
-    "  - `trigger.enable`_\n",
-    "  - `trigger.list`_\n",
-    "  - `trigger.mod`_\n",
-    "\n",
+    "- `trigger`_\n",
     "- `uniq`_\n",
-    "- `views`_\n",
-    "\n",
-    "  - `view.add`_\n",
-    "  - `view.del`_\n",
-    "  - `view.fork`_\n",
-    "  - `view.get`_\n",
-    "  - `view.list`_\n",
-    "  - `view.merge`_\n",
+    "- `view`_\n",
     "\n",
     "See :ref:`storm-ref-syntax` for an explanation of the syntax format used below.\n",
     "\n",
-    "The Storm query language is covered in detail starting with the :ref:`storm-ref-intro` section of the Synapse User Guide."
+    "The Storm query language is covered in detail starting with the :ref:`storm-ref-intro` section of the Synapse User Guide.\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  Storm commands, including custom commands, are added to the Cortex as **runtime nodes** (\"runt nodes\" - see :ref:`gloss-node-runt`) of the form ``syn:cmd``. These runt nodes can be lifted and filtered just like standard nodes in a Cortex.\n",
+    "\n",
+    "**Example**\n",
+    "\n",
+    "Lift the ``syn:cmd`` node for the Storm ``movetag`` command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'syn:cmd=movetag'\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. NOTE::\n",
+    "\n",
+    "  While the documentation for built-in Storm commands is relatively basic, the ``syn:cmd`` form within the data model includes additional secondary propeties that can be used to make commands (particularly custom commands) more \"self-documenting\" to users, because detail about the command can be introspected directly within the data model from within Storm. For example, the ``:input`` and ``:output`` properties can be used to specify a list (:ref:`type-array`) of forms that can be input (submitted) to the command and a list of forms that may be created by the command, respectively.\n"
    ]
   },
   {
@@ -284,7 +271,28 @@
     ".. _storm-cron:\n",
     "\n",
     "cron\n",
-    "----"
+    "----\n",
+    "\n",
+    "Storm includes ``cron.*`` commands that allow you to create scheduled :ref:`gloss-cron` jobs. Within Synapse, jobs are Storm queries that execute within a Cortex on a recurring or non-recurring (``cron.at``) basis.\n",
+    "\n",
+    "- `cron.add`_\n",
+    "- `cron.at`_\n",
+    "- `cron.list`_\n",
+    "- `cron.stat`_\n",
+    "- `cron.mod`_\n",
+    "- `cron.disable`_\n",
+    "- `cron.enable`_\n",
+    "- `cron.del`_\n",
+    "\n",
+    "Help for individual ``cron.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``\n",
+    "\n",
+    "Cron jobs (including jobs created with ``cron.at``) are added to the Cortex as **runtime nodes** (\"runt nodes\" - see :ref:`gloss-node-runt`) of the form ``syn:cron``. These runt nodes can be lifted and filtered just like standard nodes in a Cortex. See the :ref:`syn-ref-automation` document for additional information.\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  The Storm ``cron.*`` commands replace the Synapse cmdr-based :ref:`syn-cron` command, which is being deprecated."
    ]
   },
   {
@@ -294,7 +302,51 @@
     ".. _storm-cron-add:\n",
     "\n",
     "cron.add\n",
-    "++++++++\n"
+    "++++++++\n",
+    "\n",
+    "The ``cron.add`` command creates an individual cron job within a Cortex.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'cron.add --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "**Example**\n",
+    "\n",
+    "Add a cron job to run on the first day of every month to lift all IPv4 nodes with missing geolocation data (i.e., the ``:loc`` property is set to the string ``??``) and submit them to the maxmind service.\n",
+    "\n",
+    ".. NOTE::\n",
+    "  \n",
+    "  This example assumes a Storm service or other module has been implemented to interface with Maxmind; such a service is not included in Synpase by default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define query\n",
+    "q = 'cron.add --day 1 { inet:ipv4:loc=\"??\" | maxmind }'\n",
+    "# Execute the query\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -304,37 +356,47 @@
     ".. _storm-cron-at:\n",
     "\n",
     "cron.at\n",
-    "+++++++\n"
+    "+++++++\n",
+    "\n",
+    "The ``cron.at`` command creates a non-recurring cron job within a Cortex. Note that just like standard cron jobs, jobs created with ``cron.at`` will persist (remain in the list of cron jobs and as ``syn:cron`` runt nodes) until they are explicitly removed using ``cron.del``.\n",
+    "\n",
+    "**Syntax:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'cron.at --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-cron-del:\n",
+    "**Example**\n",
     "\n",
-    "cron.del\n",
-    "++++++++\n"
+    "Add a non-recurring cron job to run at 0200 UTC to create the set of IPv4 addresses in the 172.16.0.0/16 range."
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
    "source": [
-    ".. _storm-cron-disable:\n",
-    "\n",
-    "cron.disable\n",
-    "++++++++++++\n"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    ".. _storm-cron-enable:\n",
-    "\n",
-    "cron.enable\n",
-    "+++++++++++\n"
+    "# Define query\n",
+    "q = 'cron.at --hour 2 { [ inet:ipv4=172.16.0.0/16 ] }'\n",
+    "# Execute the query\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -344,16 +406,106 @@
     ".. _storm-cron-list:\n",
     "\n",
     "cron.list\n",
-    "+++++++++\n"
+    "+++++++++\n",
+    "\n",
+    "The ``cron.list`` command displays the set of cron jobs in the Cortex that the current user can view / modify based on their permissions.\n",
+    "\n",
+    "Cron jobs are displayed in alphanumeric order by job :ref:`gloss-iden`. Jobs are sorted upon Cortex initialization, so newly-created jobs will be displayed at the bottom of the list until the list is re-sorted the next time the Cortex is restarted.\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  Jobs can also be viewed in runt node form as ``syn:cron`` nodes.\n",
+    "\n",
+    "**Syntax:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'cron.list --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-cron-mod:\n",
-    "cron.mod\n",
-    "++++++++\n"
+    "**Examples**\n",
+    "\n",
+    "*cron.list*\n",
+    "\n",
+    "List cron jobs (including non-recurring jobs created with ``cron.at``)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define query\n",
+    "q = 'cron.list'\n",
+    "# Execute the query\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "**Notes:**\n",
+    "\n",
+    "The output of ``cron.list`` contains the following columns:\n",
+    "\n",
+    "- The username used to create the job.\n",
+    "- The first eight characters of the job's identifier (iden).\n",
+    "- Whether the job is currently enabled or disabled.\n",
+    "- Whether the job is scheduled to repeat.\n",
+    "- Whether the job is currently executing.\n",
+    "- Whether the last job execution encountered an error.\n",
+    "- The number of times the job has started.\n",
+    "- The date and time of the job's last start and last end.\n",
+    "- The query executed by the cron job."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "*cron jobs as runt nodes*\n",
+    "\n",
+    "List cron jobs whose Storm command contains the string \"maxmind\" by lifting ``syn:cron`` nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define query\n",
+    "q = 'syn:cron +:storm~=maxmind'\n",
+    "# Execute the query\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "**Notes:**\n",
+    "\n",
+    "While runt nodes (:ref:`gloss-node-runt`) are typically read-only, ``syn:cron`` nodes include ``:name`` and ``:doc`` secondary properties that can be set and modified via Storm. This allows management of cron jobs by providing them with meaningful names / categoreies and / or descriptions of their purpose. Changes to these properties will persist even after a Cortex restart."
    ]
   },
   {
@@ -363,7 +515,141 @@
     ".. _storm-cron-stat:\n",
     "\n",
     "cron.stat\n",
-    "+++++++++"
+    "+++++++++\n",
+    "\n",
+    "The ``cron.stat`` command displays statistics for an individual cron job and provides more detail on an individual job vs. ``cron.list``, including any errors and the interval at which the job executes. To view the stats for a job, you must provide the first portion of the job's iden (i.e., enough of the iden that the job can be uniquely identified), which can be obtained using ``cron.list`` or by lifting the appropriate ``syn:cron`` node.\n",
+    "\n",
+    "**Syntax:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'cron.stat --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-mod:\n",
+    "\n",
+    "cron.mod\n",
+    "++++++++\n",
+    "\n",
+    "The ``cron.mod`` command modifies the Storm query associated with a specific cron job. To modify a job, you must provide the first portion of the job's iden (i.e., enough of the iden that the job can be uniquely identified), which can be obtained using ``cron.list`` or by lifting the appropriate ``syn:cron`` node.\n",
+    "\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  Other aspects of the cron job, such as its schedule for execution, cannot be modified once the job has been created. To change these aspects you must delete and re-add the job.\n",
+    "\n",
+    "**Syntax:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'cron.mod --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-disable:\n",
+    "\n",
+    "cron.disable\n",
+    "++++++++++++\n",
+    "\n",
+    "The ``cron.disable`` command disables a job and prevents it from executing without removing it from the Cortex. To disable a job, you must provide the first portion of the job's iden (i.e., enough of the iden that the job can be uniquely identified), which can be obtained using ``cron.list`` or by lifting the appropriate ``syn:cron`` node.\n",
+    "\n",
+    "**Syntax:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'cron.disable --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-enable:\n",
+    "\n",
+    "cron.enable\n",
+    "+++++++++++\n",
+    "\n",
+    "The ``cron.enable`` command enables a disabled cron job. To enable a job, you must provide the first portion of the job's iden (i.e., enough of the iden that the job can be uniquely identified), which can be obtained using ``cron.list`` or by lifting the appropriate ``syn:cron`` node.\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  Cron jobs, including non-recurring jobs added with ``cron.at``, are enabled by default upon creation.\n",
+    "\n",
+    "**Syntax:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'cron.enable --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-cron-del:\n",
+    "\n",
+    "cron.del\n",
+    "++++++++\n",
+    "\n",
+    "The ``cron.del`` command permanently removes a cron job from the Cortex. To delete a job, you must provide the first portion of the job's iden (i.e., enough of the iden that the job can be uniquely identified), which can be obtained using ``cron.list`` or by lifting the appropriate ``syn:cron`` node.\n",
+    "\n",
+    "**Syntax:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'cron.del --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -493,12 +779,30 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    ".. _storm-dmon:\n",
+    "\n",
+    "dmon\n",
+    "----\n",
+    "\n",
+    "Storm includes ``dmon.*`` commands that allow you work with daemons (see :ref:`gloss-daemon`).\n",
+    "\n",
+    "- `dmon.list`_\n",
+    "\n",
+    "Help for individual ``queue.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     ".. _storm-dmon-list:\n",
     "\n",
     "dmon.list\n",
-    "---------\n",
+    "+++++++++\n",
     "\n",
-    "The ``dmon.list`` command displays the set of running daemon queries.\n",
+    "The ``dmon.list`` command displays the set of running dmon queries in the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -520,12 +824,30 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    ".. _storm-feed:\n",
+    "\n",
+    "feed\n",
+    "----\n",
+    "\n",
+    "Storm includes ``feed.*`` commands that allow you work with feeds (see :ref:`gloss-feed`).\n",
+    "\n",
+    "- `feed.list`_\n",
+    "\n",
+    "Help for individual ``queue.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
     ".. _storm-feed-list:\n",
     "\n",
     "feed.list\n",
-    "---------\n",
+    "+++++++++\n",
     "\n",
-    "The ``feed.list`` command displays available :ref:`gloss-feed` functions.\n",
+    "The ``feed.list`` command displays available feed functions in the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1095,10 +1417,21 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-pkgs:\n",
+    ".. _storm-pkg:\n",
     "\n",
-    "packages\n",
-    "--------"
+    "package\n",
+    "-------\n",
+    "\n",
+    "Storm includes ``pkg.*`` commands that allow you work with Storm packages (see :ref:`gloss-package`).\n",
+    "\n",
+    "- `pkg.list`_\n",
+    "- `pkg.del`_\n",
+    "\n",
+    "Help for individual ``pkg.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``\n",
+    "\n",
+    "Packages typically contain extended Storm commands and Storm library code used to implement a Storm :ref:`gloss-service`."
    ]
   },
   {
@@ -1110,7 +1443,7 @@
     "pkg.list\n",
     "++++++++\n",
     "\n",
-    "The ``pkg.list`` command lists each Storm :ref:`gloss-package` loaded in the Cortex.\n",
+    "The ``pkg.list`` command lists each Storm package loaded in the Cortex. Output is displayed in tabluar form and includes the package name and version information.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1137,7 +1470,7 @@
     "pkg.del\n",
     "+++++++\n",
     "\n",
-    "The ``pkg.del`` command removes a Storm :ref:`gloss-package` from the Cortex.\n",
+    "The ``pkg.del`` command removes a Storm package from the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1159,10 +1492,20 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-queues:\n",
+    ".. _storm-queue:\n",
     "\n",
-    "queues\n",
-    "------"
+    "queue\n",
+    "-----\n",
+    "\n",
+    "Storm includes ``queue.*`` commands that allow you work with queues (see :ref:`gloss-queue`).\n",
+    "\n",
+    "- `queue.add`_\n",
+    "- `queue.list`_\n",
+    "- `queue.del`_\n",
+    "\n",
+    "Help for individual ``queue.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``"
    ]
   },
   {
@@ -1174,7 +1517,7 @@
     "queue.add\n",
     "+++++++++\n",
     "\n",
-    "The ``queue.add`` command adds a :ref:`gloss-queue` to the Cortex.\n",
+    "The ``queue.add`` command adds a queue to the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1201,7 +1544,7 @@
     "queue.list\n",
     "++++++++++\n",
     "\n",
-    "The ``queue.list`` command lists each :ref:`gloss-queue` in the Cortex.\n",
+    "The ``queue.list`` command lists each queue in the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1228,7 +1571,7 @@
     "queue.del\n",
     "+++++++++\n",
     "\n",
-    "The ``queue.del`` command removes a :ref:`gloss-queue` from the Cortex.\n",
+    "The ``queue.del`` command removes a queue from the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1392,10 +1735,20 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-services:\n",
+    ".. _storm-service:\n",
     "\n",
-    "services\n",
-    "--------"
+    "service\n",
+    "-------\n",
+    "\n",
+    "Storm includes ``service.*`` commands that allow you work with Storm services (see :ref:`gloss-service`).\n",
+    "\n",
+    "- `service.add`_\n",
+    "- `service.list`_\n",
+    "- `service.del`_\n",
+    "\n",
+    "Help for individual ``service.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``"
    ]
   },
   {
@@ -1407,7 +1760,7 @@
     "service.add\n",
     "+++++++++++\n",
     "\n",
-    "The ``service.add`` command adds a Storm :ref:`gloss-service` to the Cortex.\n",
+    "The ``service.add`` command adds a Storm service to the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1434,7 +1787,7 @@
     "service.list\n",
     "++++++++++++\n",
     "\n",
-    "The ``service.list`` command lists each Storm :ref:`gloss-service` in the Cortex.\n",
+    "The ``service.list`` command lists each Storm service in the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1461,7 +1814,7 @@
     "service.del\n",
     "+++++++++++\n",
     "\n",
-    "The ``service.del`` command removes a Storm :ref:`gloss-service` from the Cortex.\n",
+    "The ``service.del`` command removes a Storm service from the Cortex.\n",
     "\n",
     "**Syntax:**"
    ]
@@ -1556,7 +1909,7 @@
     "\n",
     "The ``spin`` command is used to suppress the output of a Storm query. ``Spin`` simply consumes all nodes sent to the command, so no nodes are output to the CLI. This allows you to execute a Storm query and view messages and results without displaying the associated nodes.\n",
     "\n",
-    "**Syntax:**\n"
+    "**Syntax:**"
    ]
   },
   {
@@ -1640,10 +1993,21 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-splices:\n",
+    ".. _storm-splice:\n",
     "\n",
-    "splices\n",
-    "-------"
+    "splice\n",
+    "------\n",
+    "\n",
+    "Storm includes ``splice.*`` commands that allow you work with splices (see :ref:`gloss-splice`).\n",
+    "\n",
+    "- `splice.list`_\n",
+    "- `splice.undo`_\n",
+    "\n",
+    "Splices are represented as **runtime nodes** (\"runt nodes\" - see :ref:`gloss-node-runt`) of the form ``syn:splice``. These runt nodes can be lifted and filtered just like standard nodes in a Cortex.\n",
+    "\n",
+    "Help for individual ``splice.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``"
    ]
   },
   {
@@ -1653,17 +2017,51 @@
     ".. _storm-splice-list:\n",
     "\n",
     "splice.list\n",
-    "+++++++++++"
+    "+++++++++++\n",
+    "\n",
+    "The ``splice.list`` command allows you to list (view) splices in the splice log. By default, splices are displayed starting with the most recent and working backwards through the log.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'splice.list --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-splic-undo:\n",
+    ".. _storm-splice-undo:\n",
     "\n",
     "splice.undo\n",
-    "+++++++++++"
+    "+++++++++++\n",
+    "\n",
+    "The ``splice.undo`` command allows a user with appropriate permissions to roll back or undo the specified set of splices (changes).\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'splice.undo --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -1677,7 +2075,7 @@
     "\n",
     "The ``sudo`` command executes a Storm query with administrator privileges.\n",
     "\n",
-    "**Syntax:**\n"
+    "**Syntax:**"
    ]
   },
   {
@@ -1835,10 +2233,29 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-triggers:\n",
+    ".. _storm-trigger:\n",
     "\n",
-    "triggers\n",
-    "--------"
+    "trigger\n",
+    "-------\n",
+    "\n",
+    "Storm includes ``trigger.*`` commands that allow you to create automated event-driven triggers (see :ref:`gloss-trigger`) using the Storm query syntax.\n",
+    "\n",
+    "- `trigger.add`_\n",
+    "- `trigger.list`_\n",
+    "- `trigger.mod`_\n",
+    "- `trigger.disable`_\n",
+    "- `trigger.enable`_\n",
+    "- `trigger.del`_\n",
+    "\n",
+    "Help for individual ``trigger.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``\n",
+    "\n",
+    "Triggers are added to the Cortex as **runtime nodes** (\"runt nodes\" - see :ref:`gloss-node-runt`) of the form ``syn:trigger``. These runt nodes can be lifted and filtered just like standard nodes in a Cortex. See the :ref:`syn-ref-automation` document for additional information.\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  The Storm ``trigger.*`` commands replace the Synapse cmdr-based :ref:`syn-trigger` command, which is being deprecated."
    ]
   },
   {
@@ -1848,17 +2265,185 @@
     ".. _storm-trigger-add:\n",
     "\n",
     "trigger.add\n",
-    "+++++++++++\n"
+    "+++++++++++\n",
+    "\n",
+    "The ``trigger.add`` command adds a trigger to a Cortex.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'trigger.add --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-trigger-del:\n",
+    "**Example**\n",
     "\n",
-    "trigger.del\n",
-    "+++++++++++\n"
+    "Create a trigger so that when the tag ``#foo`` is added to an ``inet:fqdn`` node, the tag ``#bar`` is added as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define query\n",
+    "q = 'trigger.add tag:add --form inet:fqdn --tag #foo --query { [ +#bar ] }'\n",
+    "# Execute the query\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-trigger-list:\n",
+    "\n",
+    "trigger.list\n",
+    "++++++++++++\n",
+    "\n",
+    "The ``trigger-list`` command displays the set of triggers in the Cortex that the current user can view / modify based on their permissions. Triggers are displayed at the cmdr CLI in tabular format, with columns including the user who created the trigger, the :ref:`gloss-iden` of the trigger, the condition that fires the trigger (i.e., ``node:add``), and the Storm query associated with the trigger.\n",
+    "\n",
+    "Triggers are displayed in alphanumeric order by iden. Triggers are sorted upon Cortex initialization, so newly-created triggers will be displayed at the bottom of the list until the list is re-sorted the next time the Cortex is restarted.\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  Triggers can also be viewed in runt node form as ``syn:trigger`` nodes.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'trigger.list --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "**Examples**\n",
+    "\n",
+    "*trigger.list*\n",
+    "\n",
+    "List triggers in a Cortex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define query\n",
+    "q = 'trigger.list'\n",
+    "# Execute the query\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "**Notes:**\n",
+    "\n",
+    "The output of ``trigger.list`` contains the following columns:\n",
+    "\n",
+    "- The username used to create the trigger.\n",
+    "- The first eight characters of the trigger's identifier (iden).\n",
+    "- Whether the trigger is currently enabled or disabled.\n",
+    "- The condition that causes the trigger to fire.\n",
+    "- The object that the condition operates on, if any.\n",
+    "- The tag or tag expression used by the condition (for ``tag:add`` or ``tag:del`` conditions).\n",
+    "- The query to be executed when the trigger fires."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "*triggers as runt nodes*\n",
+    "\n",
+    "List triggers that fire on ``tag:add`` events by lifting ``syn:trigger`` nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define query\n",
+    "q = 'syn:trigger:cond=tag:add'\n",
+    "# Execute the query\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "**Notes:**\n",
+    "\n",
+    "While runt nodes (:ref:`gloss-node-runt`) are typically read-only, ``syn:trigger`` nodes include ``:name`` and ``:doc`` secondary properties that can be set and modified via Storm. This allows management of triggers by providing them with meaningful names / categoreies and / or descriptions of their purpose. Changes to these properties will persist even after a Cortex restart."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-trigger-mod:\n",
+    "\n",
+    "trigger.mod\n",
+    "+++++++++++\n",
+    "\n",
+    "The ``trigger.mod`` command modifies the Storm query associated with a specific trigger. To modify a trigger, you must provide the first portion of the trigger's iden (i.e., enough of the iden that the trigger can be uniquely identified), which can be obtained using ``trigger.list`` or by lifting the appropriate ``syn:trigger`` node.\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  Other aspects of the trigger, such as the condition used to fire the trigger or the tag or property associated with the trigger, cannot be modified once the trigger has been created. To change these aspects, you must delete and re-add the trigger.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'trigger.mod --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -1869,7 +2454,23 @@
     "\n",
     "trigger.disable\n",
     "+++++++++++++++\n",
-    "\n"
+    "\n",
+    "The ``trigger.disable`` command disables a trigger and prevents it from firing without removing it from the Cortex. To disable a trigger, you must provide the first portion of the trigger's iden (i.e., enough of the iden that the trigger can be uniquely identified), which can be obtained using ``trigger.list`` or by lifting the appropriate ``syn:trigger`` node.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'trigger.disable --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -1880,27 +2481,54 @@
     "\n",
     "trigger.enable\n",
     "++++++++++++++\n",
-    "\n"
+    "\n",
+    "The ``trigger-enable`` command enables a disabled trigger. To enable a trigger, you must provide the first portion of the trigger's iden (i.e., enough of the iden that the trigger can be uniquely identified), which can be obtained using ``trigger.list`` or by lifting the appropriate ``syn:trigger`` node.\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  Triggers are enabled by default upon creation.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'trigger.enable --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-trigger-list:\n",
+    ".. _storm-trigger-del:\n",
     "\n",
-    "trigger.list\n",
-    "++++++++++++\n"
+    "trigger.del\n",
+    "+++++++++++\n",
+    "\n",
+    "The ``trigger.del`` command permanently removes a trigger from the Cortex. To delete a trigger, you must provide the first portion of the trigger's iden (i.e., enough of the iden that the trigger can be uniquely identified), which can be obtained using ``trigger.list`` or by lifting the appropriate ``syn:trigger`` node.\n",
+    "\n",
+    "**Syntax**"
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
    "source": [
-    ".. _storm-trigger-mod:\n",
-    "\n",
-    "trigger.mod\n",
-    "+++++++++++\n"
+    "# Run the command and display output\n",
+    "q = 'trigger.del --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -1977,10 +2605,23 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. _storm-views:\n",
+    ".. _storm-view:\n",
     "\n",
-    "views\n",
-    "-----"
+    "view\n",
+    "----\n",
+    "\n",
+    "Storm includes ``view.*`` commands that allow you work with views (see :ref:`gloss-view`).\n",
+    "\n",
+    "- `view.add`_\n",
+    "- `view.fork`_\n",
+    "- `view.get`_\n",
+    "- `view.list`_\n",
+    "- `view.merge`_\n",
+    "- `view.del`_\n",
+    "\n",
+    "Help for individual ``view.*`` commands can be displayed using:\n",
+    "\n",
+    "  ``storm <command> --help | -h``"
    ]
   },
   {
@@ -1990,18 +2631,24 @@
     ".. _storm-view-add:\n",
     "\n",
     "view.add\n",
-    "+++++++++\n"
+    "++++++++\n",
+    "\n",
+    "The ``view.add`` command adds a view to the Cortex.\n",
+    "\n",
+    "**Syntax**"
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
    "source": [
-    ".. _storm-view-del:\n",
-    "\n",
-    "view.del\n",
-    "++++++++\n",
-    "\n"
+    "# Run the command and display output\n",
+    "q = 'view.add --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -2012,7 +2659,23 @@
     "\n",
     "view.fork\n",
     "+++++++++\n",
-    "\n"
+    "\n",
+    "The ``view.fork`` command forks an existing view from the Cortex. Forking a view creates a new view with a new writeable layer on top of the set of layers from the previous (forked) view.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'view.fork --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -2023,7 +2686,23 @@
     "\n",
     "view.get\n",
     "++++++++\n",
-    "\n"
+    "\n",
+    "The ``view.get`` command retrieves an existing view from the Cortex.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'view.get --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -2035,7 +2714,22 @@
     "view.list\n",
     "+++++++++\n",
     "\n",
-    "\n"
+    "The ``view.list`` command lists the views in the Cortex.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'view.list --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {
@@ -2045,7 +2739,51 @@
     ".. _storm-view-merge:\n",
     "\n",
     "view.merge\n",
-    "++++++++++"
+    "++++++++++\n",
+    "\n",
+    "The ``view.merge`` command merges data from a forked view into its parent view.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'view.merge --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _storm-view-del:\n",
+    "\n",
+    "view.del\n",
+    "++++++++\n",
+    "\n",
+    "The ``view.del`` command permanently deletes a view from the Cortex.\n",
+    "\n",
+    "**Syntax**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the command and display output\n",
+    "q = 'view.del --help'\n",
+    "podes = await core.eval(q, cmdr=True)"
    ]
   },
   {

--- a/docs/synapse/userguides/syn_ref_cmdr.ipynb
+++ b/docs/synapse/userguides/syn_ref_cmdr.ipynb
@@ -132,6 +132,10 @@
     "- `cron enable`_\n",
     "- `cron del`_\n",
     "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  The cmdr ``cron`` command is being deprecated in favor of the equivalent Storm ``cron.*`` commands (e.g., ``cron.add``, ``cron.list``, etc.) See the :ref:`storm-cron` section of the :ref:`storm-ref-cmd` document for details.\n",
+    "\n",
     "**Syntax:**\n"
    ]
   },
@@ -783,6 +787,10 @@
     "- `trigger disable`_\n",
     "- `trigger enable`_\n",
     "- `trigger del`_\n",
+    "\n",
+    ".. NOTE::\n",
+    "\n",
+    "  The cmdr ``trigger`` command is being deprecated in favor of the equivalent Storm ``trigger.*`` commands (e.g., ``trigger.add``, ``trigger.list``, etc.) See the :ref:`storm-triggers` section of the :ref:`storm-ref-cmd` document for details.\n",
     "\n",
     "**Syntax:**\n"
    ]

--- a/docs/synapse/userguides/syn_ref_cmdr.ipynb
+++ b/docs/synapse/userguides/syn_ref_cmdr.ipynb
@@ -134,7 +134,7 @@
     "\n",
     ".. NOTE::\n",
     "\n",
-    "  The cmdr ``cron`` command is being deprecated in favor of the equivalent Storm ``cron.*`` commands (e.g., ``cron.add``, ``cron.list``, etc.) See the :ref:`storm-cron` section of the :ref:`storm-ref-cmd` document for details.\n",
+    "  The cmdr ``cron`` command is being deprecated in favor of the equivalent Storm ``cron.*`` commands (e.g., ``cron.add``, ``cron.list``, etc.). Users are stronlgy encouraged to use the Storm-based equivalents instead. See the :ref:`storm-cron` section of the :ref:`storm-ref-cmd` document for details.\n",
     "\n",
     "**Syntax:**\n"
    ]
@@ -211,7 +211,7 @@
     "\n",
     "``cron list`` lists existing cron jobs in a Cortex that the current user can view / modify based on their permissions.\n",
     "\n",
-    "**Syntax:**\n"
+    "**Syntax:**"
    ]
   },
   {
@@ -225,66 +225,6 @@
     "# Run the command and display output\n",
     "q = 'cron list -h'\n",
     "podes = await core.runCmdLine(q)"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "**Example**\n",
-    "\n",
-    "- List all cron jobs in a Cortex (including jobs scheculed with both ``cron`` and ``at``):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hideCode": true,
-    "hideOutput": true,
-    "hidePrompt": false
-   },
-   "outputs": [],
-   "source": [
-    "# Add some cron jobs\n",
-    "q = 'cron add -d 1 { inet:ipv4:loc=\"??\" | maxmind }'\n",
-    "q1 = 'cron add -H 12 { inet:fqdn=woot.com | nslookup }'\n",
-    "q2 = 'at +2 minutes { inet:ipv4=127.0.0.1 }'\n",
-    "podes = await core.runCmdLine(q)\n",
-    "podes = await core.runCmdLine(q1)\n",
-    "podes = await core.runCmdLine(q2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hideCode": true
-   },
-   "outputs": [],
-   "source": [
-    "# Run the command and display output\n",
-    "q = 'cron list'\n",
-    "podes = await core.runCmdLine(q)"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "**Notes:**\n",
-    "\n",
-    "The output contains the following columns:\n",
-    "\n",
-    "- The username used to create the job.\n",
-    "- The first eight characters of the job's identifier (iden). When referencing a job's iden (such as for ``cron mod`` or ``cron stat``), you only need to specify enough characters to uniquely identify the job among all jobs currently in the Cortex. For example, if only a single job exists, it can be referenced by the first character of its iden alone.\n",
-    "- Whether the job is currently enabled or disabled.\n",
-    "- Whether the job is scheduled to repeat.\n",
-    "- Whether the job is currently executing.\n",
-    "- Whether the last job execution encountered an error.\n",
-    "- The number of times the job has started.\n",
-    "- The date and time of the job's last start and last end.\n",
-    "- The query executed by the cron job."
    ]
   },
   {
@@ -790,7 +730,7 @@
     "\n",
     ".. NOTE::\n",
     "\n",
-    "  The cmdr ``trigger`` command is being deprecated in favor of the equivalent Storm ``trigger.*`` commands (e.g., ``trigger.add``, ``trigger.list``, etc.) See the :ref:`storm-triggers` section of the :ref:`storm-ref-cmd` document for details.\n",
+    "  The cmdr ``trigger`` command is being deprecated in favor of the equivalent Storm ``trigger.*`` commands (e.g., ``trigger.add``, ``trigger.list``, etc.). Users are stronlgy encouraged to use the Storm-based equivalents instead. See the :ref:`storm-trigger` section of the :ref:`storm-ref-cmd` document for details.\n",
     "\n",
     "**Syntax:**\n"
    ]
@@ -862,28 +802,6 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "**Example:**\n",
-    "\n",
-    " - Add a trigger so that when the tag ``#foo`` is added to an ``inet:fqdn`` node, the tag ``#bar`` is also added."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hideCode": true
-   },
-   "outputs": [],
-   "source": [
-    "# Run the command and display output\n",
-    "q = 'trigger add tag:add inet:fqdn #foo { [ +#bar ] }'\n",
-    "podes = await core.runCmdLine(q)"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
     "trigger list\n",
     "++++++++++++\n",
     "\n",
@@ -903,44 +821,6 @@
     "# Run the command and display output\n",
     "q = 'trigger list -h'\n",
     "podes = await core.runCmdLine(q)"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "**Example:**\n",
-    "\n",
-    "- List current triggers in a Cortex."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hideCode": true
-   },
-   "outputs": [],
-   "source": [
-    "# Run the command and display output\n",
-    "q = 'trigger list'\n",
-    "podes = await core.runCmdLine(q)"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "**Notes:**\n",
-    "\n",
-    "The output contains the following columns:\n",
-    "\n",
-    " - The username used to create the trigger.\n",
-    " - The first eight characters of the trigger's identifier (iden). When referencing a trigger's iden (such as for ``trigger mod``), you only need to specify enough characters to uniquely identify the trigger among all triggers currently in the Cortex. For example, if only a single trigger exists, it can be referenced by the first character of its iden alone.\n",
-    " - Whether the trigger is enabled or disabled.\n",
-    " - The condition that fires the trigger.\n",
-    " - The object associated with the condition (form for ``node:add`` or ``node:del``, property for ``prop:set``, tag (potentially preceded by an optional form) for ``tag:add`` or ``tag:del``).\n",
-    " - The storm query executed by the trigger."
    ]
   },
   {


### PR DESCRIPTION
- Update Storm command reference with new commands, including cron / trigger
- Update Synapse command reference, note cron / trigger deprecated, remove examples
- Update glossary
- Move "automation" placeholder from Synapse to Storm