### PR TITLE
Fix leap day agenda bug

### DIFF
--- a/synapse/lib/agenda.py
+++ b/synapse/lib/agenda.py
@@ -208,20 +208,29 @@ class ApptRec:
         # Truncate the seconds part
         newdt = lastdt.replace(second=0)
 
+        # Note: self.reqdict is sorted from largest unit to smallest
         for unit, newval in self.reqdict.items():
             dtkey = _TimeunitToDatetime[unit]
+
             if unit is TimeUnit.DAYOFWEEK:
                 newdt = newdt.replace(**newvals)
                 newvals = {}
                 newval = newdt.day + (6 + newval - newdt.weekday()) % 7 + 1
                 if newval > calendar.monthrange(newdt.year, newdt.month)[1]:
                     newval -= 7
+
+            elif unit is TimeUnit.YEAR:
+                # As we change the year, clamp the day of the month to a valid value (only matters on leap day)
+                dayval = _dayofmonth(newdt.day, newdt.month, newval)
+                newvals['day'] = dayval
+
             elif unit is TimeUnit.MONTH:
                 # As we change the month, clamp the day of the month to a valid value
                 newdt = newdt.replace(**newvals)
                 newvals = {}
                 dayval = _dayofmonth(newdt.day, newval, newdt.year)
                 newvals['day'] = dayval
+
             elif unit is TimeUnit.DAYOFMONTH:
                 newdt = newdt.replace(**newvals)
                 newvals = {}

--- a/synapse/tests/test_lib_agenda.py
+++ b/synapse/tests/test_lib_agenda.py
@@ -42,6 +42,18 @@ class AgendaTest(s_t_utils.SynTest):
         newts = ar.nexttime(now)
         self.eq(newts, datetime.datetime(year=2019, month=12, day=3, hour=2, minute=2, tzinfo=tz.utc).timestamp())
 
+        # It is leap day 2020, one shot next year
+        now = datetime.datetime(year=2020, month=2, day=29, hour=2, minute=2, tzinfo=tz.utc).timestamp()  # Monday
+        ar = s_agenda.ApptRec({s_tu.YEAR: 2021})
+        newts = ar.nexttime(now)
+        self.eq(newts, datetime.datetime(year=2021, month=2, day=28, hour=2, minute=2, tzinfo=tz.utc).timestamp())
+
+        # It is leap day 2020, one shot next year, Halloween
+        now = datetime.datetime(year=2020, month=2, day=29, hour=2, minute=2, tzinfo=tz.utc).timestamp()  # Monday
+        ar = s_agenda.ApptRec({s_tu.DAYOFMONTH: 31, s_tu.YEAR: 2021, s_tu.MONTH: 10})
+        newts = ar.nexttime(now)
+        self.eq(newts, datetime.datetime(year=2021, month=10, day=31, hour=2, minute=2, tzinfo=tz.utc).timestamp())
+
         # No inc, month req: One shot in July
         ar = s_agenda.ApptRec({s_tu.MONTH: 7})
         now = datetime.datetime(year=2018, month=12, day=3, hour=2, minute=2, tzinfo=tz.utc).timestamp()  # Monday


### PR DESCRIPTION
Handle next time of appointment when today is leap day.

Symptom was: `ValueError: day is out of range for month` when the appointment crossed years.