### PR TITLE
Add config options to not store layer or cortex changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,25 +8,60 @@ v0.2.0 - 2020-xx-xx
 Features and Enhancements
 -------------------------
 - This release includes significant storage optimizations that require a data migration.
-  However, the 0.2.0 migration contains NO model migrations and is strictly limited to the internal
+  However, the 0.2.0 migration contains no *model* migrations and is strictly limited to the internal
   LMDB layer storage format.  The new format provides performance enhancements that significantly
   improve data ingest performance and reduce the memory footprint of the layer.
 
-- This release includes feature enhancments to the authorization subsystem to facilitate permissions
-  on a per-view and per-layer basis.  Additionally, APIs and tools for manipulating the auth subsystem
-  have been integrated into storm to allow user/role/rule editing from within storm queries.
+- This release includes feature enhancements to the authorization subsystem to facilitate permissions
+  on a per-view and per-layer basis.
+
+  FIXME:  words
+- Mirroring is fully featured, robust to communication drops
+
+- Spawn queries can run more things
+
+- SYNDEV_OMIT_FINI_WARNS
+
+- Provenance is disabled by default. Enable via SETTING
+
+- Added new graph cmd options
 
 Backward Compatibility Breaks
 -----------------------------
-- The splice message format has been optimized to be both smaller and to allow several atomic edits
-  to be contained in one message.  This speeds up performance of the runtime, minimizes bandwidth,
+- Pointer to migration process
 
-- The cellauth command has been removed as a stand alone tool.  Users should now use
-  the "auth" commands that are built into synapse.tools.cmdr or the commands / API built into the Storm
-  runtime.  This change was partially needed due to breaking API changes that eliminate ambiguity between
-  "user" manipulation APIs vs "role" manipulation APIs.
+- LMDB format changed
+
+- The change message format has been optimized to be both smaller and to allow several atomic edits
+  to be contained in one message.  This speeds up performance of the runtime, minimizes bandwidth,  The old change
+  format is called "splice".  The new message format is called "NodeEdits".  (Option to emit either in cmdr)
 
 - FIXME add one liners and/or additional bullets here and visi will explain them :D
+
+- Removed sudo
+
+- Cortex map_async is now default
+
+- Lots of remote API changes
+
+- Old clients can't talk to new (>=0.2.0) cortex.  New clients can't talk to < 0.2.0 cortex.
+
+- Remote layer removed
+
+- Deprecation of lots of methods
+
+- Removed cortex offset storage
+
+- Removed splices to cryotank, pushing splices, feed loop
+
+- Consolidated datamodel APIs
+
+- Triggers/cron/queues have creators and each may have admins
+
+- Removed #:score tagprop lift
+
+-Removed insecure mode
+
 
 v0.1.52 - 2019-02-27
 ====================

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -720,6 +720,11 @@ class Cortex(s_cell.Cell):  # type: ignore
             'description': 'Should new layers lock memory for performance by default.',
             'type': 'boolean'
         },
+        'layers:logedits': {
+            'default': True,
+            'description': 'Whether nodeedits are logged in each layer.',
+            'type': 'boolean'
+        },
         'provenance:en': {
             'default': False,
             'description': 'Enable provenance tracking for all writes',
@@ -734,11 +739,6 @@ class Cortex(s_cell.Cell):  # type: ignore
             'default': 8,
             'description': 'The max number of spare processes to keep around in the storm spawn pool.',
             'type': 'integer'
-        },
-        'splice:en': {
-            'default': True,
-            'description': 'Enable storing splices for layer changes.',
-            'type': 'boolean'
         },
         'storm:log': {
             'default': False,
@@ -2357,6 +2357,7 @@ class Cortex(s_cell.Cell):  # type: ignore
         ldef['iden'] = s_common.guid()
         ldef.setdefault('creator', self.auth.rootuser.iden)
         ldef.setdefault('lockmemory', self.conf.get('layers:lockmemory'))
+        ldef.setdefault('logedits', self.conf.get('layers:logedits'))
 
         s_layer.reqValidLdef(ldef)
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -404,6 +404,11 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             'description': 'Set to a Hive telepath URL.',
             'type': 'string'
         },
+        'logchanges': {
+            'default': False,
+            'description': 'Record all changes to the cell.  Required for mirroring.',
+            'type': 'boolean'
+        },
     }
 
     async def __anit__(self, dirn, conf=None, readonly=False, *args, **kwargs):
@@ -433,6 +438,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             conf = {}
 
         self.conf = self._initCellConf(conf)
+        self.dologging = self.conf.get('layers:logedits')
 
         await s_nexus.Pusher.__anit__(self, self.iden)
 
@@ -503,7 +509,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         }
 
     async def _initNexsRoot(self):
-        nexsroot = await s_nexus.NexsRoot.anit(self.dirn)
+        nexsroot = await s_nexus.NexsRoot.anit(self.dirn, dologging=self.dologging)
         self.onfini(nexsroot.fini)
         return nexsroot
 

--- a/synapse/lib/nexus.py
+++ b/synapse/lib/nexus.py
@@ -59,7 +59,7 @@ class ChangeDist(s_base.Base):
 
 class NexsRoot(s_base.Base):
 
-    async def __anit__(self, dirn: str):  # type: ignore
+    async def __anit__(self, dirn: str, dologging: bool = True):  # type: ignore
         await s_base.Base.__anit__(self)
 
         import synapse.lib.lmdbslab as s_lmdbslab  # avoid import cycle
@@ -69,17 +69,19 @@ class NexsRoot(s_base.Base):
         self._nexskids: Dict[str, 'Pusher'] = {}
 
         self.mirrors: List[ChangeDist] = []
+        self.dologging = dologging
 
-        path = s_common.genpath(self.dirn, 'slabs', 'nexus.lmdb')
-        self.nexusslab = await s_lmdbslab.Slab.anit(path, map_async=False)
+        if self.dologging:
+            path = s_common.genpath(self.dirn, 'slabs', 'nexus.lmdb')
+            self.nexusslab = await s_lmdbslab.Slab.anit(path, map_async=False)
+            self.nexuslog = s_slabseqn.SlabSeqn(self.nexusslab, 'nexuslog')
 
         async def fini():
-            await self.nexusslab.fini()
+            if self.dologging:
+                await self.nexusslab.fini()
             [(await dist.fini()) for dist in self.mirrors]
 
         self.onfini(fini)
-
-        self.nexuslog = s_slabseqn.SlabSeqn(self.nexusslab, 'nexuslog')
 
     async def issue(self, nexsiden: str, event: str, args: Any, kwargs: Any) -> Any:
         '''
@@ -87,7 +89,10 @@ class NexsRoot(s_base.Base):
         '''
         item = (nexsiden, event, args, kwargs)
 
-        indx = self.nexuslog.add(item)
+        if self.dologging:
+            indx = self.nexuslog.add(item)
+        else:
+            indx = 0
 
         [dist.update() for dist in tuple(self.mirrors)]
 
@@ -98,9 +103,7 @@ class NexsRoot(s_base.Base):
         nexsiden, event, args, kwargs = item
 
         nexus = self._nexskids[nexsiden]
-        func, passoff = nexus._nexshands[event]
-        if passoff:
-            return indx, await func(nexus, *args, nexsoff=indx, **kwargs)
+        func = nexus._nexshands[event]
 
         return indx, await func(nexus, *args, **kwargs)
 
@@ -115,12 +118,21 @@ class NexsRoot(s_base.Base):
         '''
         Returns the next offset that would be written
         '''
+        if not self.dologging:
+            return 0
+
         return self.nexuslog.index()
 
     async def waitForOffset(self, offs, timeout=None):
+        if not self.dologging:
+            return
+
         return await self.nexuslog.waitForOffset(offs, timeout=timeout)
 
     async def iter(self, offs: int):
+        if not self.dologging:
+            return
+
         maxoffs = offs
 
         for item in self.nexuslog.iter(offs):
@@ -149,12 +161,12 @@ class Pusher(s_base.Base, metaclass=RegMethType):
     '''
     A mixin-class to manage distributing changes where one might plug in mirroring or consensus protocols
     '''
-    _regclstupls: List[Tuple[str, Callable, bool]] = []
+    _regclstupls: List[Tuple[str, Callable]] = []
 
     async def __anit__(self, iden: str, nexsroot: NexsRoot = None):  # type: ignore
 
         await s_base.Base.__anit__(self)
-        self._nexshands: Dict[str, Tuple[Callable, bool]] = {}
+        self._nexshands: Dict[str, Callable] = {}
 
         self.nexsiden = iden
         self.nexsroot = None
@@ -162,8 +174,8 @@ class Pusher(s_base.Base, metaclass=RegMethType):
         if nexsroot is not None:
             self.setNexsRoot(nexsroot)
 
-        for event, func, passoff in self._regclstupls:  # type: ignore
-            self._nexshands[event] = func, passoff
+        for event, func in self._regclstupls:  # type: ignore
+            self._nexshands[event] = func
 
     def setNexsRoot(self, nexsroot):
 
@@ -178,7 +190,7 @@ class Pusher(s_base.Base, metaclass=RegMethType):
         self.nexsroot = nexsroot
 
     @classmethod
-    def onPush(cls, event: str, passoff=False) -> Callable:
+    def onPush(cls, event: str) -> Callable:
         '''
         Decorator that registers a method to be a handler for a named event
 
@@ -186,13 +198,13 @@ class Pusher(s_base.Base, metaclass=RegMethType):
         postcb:  whether to pass the log offset as the parameter "nexsoff" into the handler
         '''
         def decorator(func):
-            func._regme = (event, func, passoff)
+            func._regme = (event, func)
             return func
 
         return decorator
 
     @classmethod
-    def onPushAuto(cls, event: str, passoff=False) -> Callable:
+    def onPushAuto(cls, event: str) -> Callable:
         '''
         Decorator that does the same as onPush, except automatically creates the top half method
         '''
@@ -200,7 +212,7 @@ class Pusher(s_base.Base, metaclass=RegMethType):
             return await self._push(event, *args, **kwargs)
 
         def decorator(func):
-            pushfunc._regme = (event, func, passoff)
+            pushfunc._regme = (event, func)
             setattr(cls, '_hndl' + func.__name__, pushfunc)
             functools.update_wrapper(pushfunc, func)
             return pushfunc
@@ -221,4 +233,4 @@ class Pusher(s_base.Base, metaclass=RegMethType):
             return retn
 
         # There's no change distribution, so directly execute
-        return await self._nexshands[event][0](self, *args, **kwargs)
+        return await self._nexshands[event](self, *args, **kwargs)

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -52,7 +52,6 @@ class Snap(s_base.Base):
         self.core = view.core
         self.view = view
         self.user = user
-        self.store_splices = self.core.conf.get('splice:en')
 
         self.layers = list(reversed(view.layers))
         self.wlyr = self.layers[-1]

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2537,6 +2537,34 @@ class CortexBasicTest(s_t_utils.SynTest):
                 await self.agenlen(2, snap.eval('[test:str=foo test:str=bar]'))
             await self.agenlen(2, core.eval('test:str'))
 
+    async def test_cortex_logchanges_off(self):
+        '''
+        Everything still works when no nexus log is kept
+        '''
+        conf = {'layer:lmdb:map_async': True,
+                'provenance:en': True,
+                'logchanges': False,
+                'layers:logedits': True,
+                }
+        async with self.getTestCore(conf=conf) as core:
+            async with await core.snap() as snap:
+                await self.agenlen(2, snap.eval('[test:str=foo test:str=bar]'))
+            await self.agenlen(2, core.eval('test:str'))
+
+    async def test_cortex_logedits_off(self):
+        '''
+        Everything still works when no layer log is kept
+        '''
+        conf = {'layer:lmdb:map_async': True,
+                'provenance:en': True,
+                'logchanges': True,
+                'layers:logedits': False,
+                }
+        async with self.getTestCore(conf=conf) as core:
+            async with await core.snap() as snap:
+                await self.agenlen(2, snap.eval('[test:str=foo test:str=bar]'))
+            await self.agenlen(2, core.eval('test:str'))
+
     async def test_feed_syn_nodes(self):
         async with self.getTestCore() as core0:
             q = '[test:int=1 test:int=2 test:int=3]'

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2,7 +2,6 @@ import os
 
 import synapse.exc as s_exc
 import synapse.common as s_common
-import synapse.cortex as s_cortex
 import synapse.telepath as s_telepath
 
 import synapse.lib.cell as s_cell

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -956,7 +956,10 @@ class SynTest(unittest.TestCase):
         '''
         if conf is None:
             conf = {'layer:lmdb:map_async': True,
-                    'provenance:en': True}
+                    'provenance:en': True,
+                    'logchanges': True,
+                    'layers:logedits': True,
+                    }
 
         conf = copy.deepcopy(conf)
 


### PR DESCRIPTION
Also partially update changelog.

Remove splices:en conf option on cortex.

Add `layers:logedits` conf option on cortex to enable layer logging by default on all layers.

Add `logchanges` conf option on cell so that changes that go through the NexusRoot are not logged.

Remove passoffs option from nexus as it is no longer needed.