### PR TITLE
Move nodedata back into its own slab.

### DIFF
--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -893,14 +893,9 @@ class Layer(s_nexus.Pusher):
 
     async def truncate(self):
 
-        await self.layrslab.fini()
-        await self.nodeeditslab.fini()
-
-        path = s_common.genpath(self.dirn, 'layer_v2.lmdb')
-        shutil.rmtree(path, ignore_errors=True)
-
-        path = s_common.genpath(self.dirn, 'nodeedits.lmdb')
-        shutil.rmtree(path, ignore_errors=True)
+        await self.layrslab.trash()
+        await self.nodeeditslab.trash()
+        await self.dataslab.trash()
 
         await self._initLayerStorage()
 
@@ -916,8 +911,12 @@ class Layer(s_nexus.Pusher):
         }
 
         path = s_common.genpath(self.dirn, 'layer_v2.lmdb')
+        nodedatapath = s_common.genpath(self.dirn, 'nodedata.lmdb')
 
         self.layrslab = await s_lmdbslab.Slab.anit(path, **slabopts)
+        self.dataslab = await s_lmdbslab.Slab.anit(nodedatapath, map_async=True,
+                                                   readahead=False, readonly=self.readonly)
+
         self.formcounts = await self.layrslab.getHotCount('count:forms')
 
         path = s_common.genpath(self.dirn, 'nodeedits.lmdb')
@@ -930,6 +929,7 @@ class Layer(s_nexus.Pusher):
 
         self.onfini(self.layrslab)
         self.onfini(self.nodeeditslab)
+        self.onfini(self.dataslab)
 
         self.bybuid = self.layrslab.initdb('bybuid')
 
@@ -939,7 +939,7 @@ class Layer(s_nexus.Pusher):
         self.bytagprop = self.layrslab.initdb('bytagprop', dupsort=True)
 
         self.countdb = self.layrslab.initdb('counters')
-        self.nodedata = self.layrslab.initdb('nodedata')
+        self.nodedata = self.dataslab.initdb('nodedata')
 
         self.nodeeditlog = s_slabseqn.SlabSeqn(self.nodeeditslab, 'nodeedits')
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1481,7 +1481,7 @@ class Layer(s_nexus.Pusher):
         name, valu, oldv = edit[1]
         abrv = self.getPropAbrv(name, None)
 
-        oldb = self.layrslab.replace(buid + abrv, s_msgpack.en(valu), db=self.nodedata)
+        oldb = self.dataslab.replace(buid + abrv, s_msgpack.en(valu), db=self.nodedata)
 
         if oldb is not None:
             oldv = s_msgpack.un(oldb)
@@ -1497,7 +1497,7 @@ class Layer(s_nexus.Pusher):
         name, valu = edit[1]
         abrv = self.getPropAbrv(name, None)
 
-        oldb = self.layrslab.pop(buid + abrv, db=self.nodedata)
+        oldb = self.dataslab.pop(buid + abrv, db=self.nodedata)
         if oldb is None:
             return None
 
@@ -1578,16 +1578,17 @@ class Layer(s_nexus.Pusher):
         '''
         abrv = self.getPropAbrv(name, None)
 
-        byts = self.layrslab.get(buid + abrv, db=self.nodedata)
+        byts = self.dataslab.get(buid + abrv, db=self.nodedata)
         if byts is None:
             return False, None
+
         return True, s_msgpack.un(byts)
 
     async def iterNodeData(self, buid):
         '''
         Return a generator of all a buid's node data
         '''
-        for lkey, byts in self.layrslab.scanByPref(buid, db=self.nodedata):
+        for lkey, byts in self.dataslab.scanByPref(buid, db=self.nodedata):
             abrv = lkey[32:]
 
             valu = s_msgpack.un(byts)
@@ -1748,8 +1749,8 @@ class Layer(s_nexus.Pusher):
         '''
         Remove all node data for a buid
         '''
-        for lkey, _ in self.layrslab.scanByPref(buid, db=self.nodedata):
-            self.layrslab.delete(lkey, db=self.nodedata)
+        for lkey, _ in self.dataslab.scanByPref(buid, db=self.nodedata):
+            self.dataslab.delete(lkey, db=self.nodedata)
 
     # TODO: Hack until we get interval trees pushed all the way through
     def _cmprIval(self, item, othr):

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -33,13 +33,6 @@ MAX_DOUBLE_SIZE = 100 * s_const.gibibyte
 int64min = s_common.int64en(0)
 int64max = s_common.int64en(0xffffffffffffffff)
 
-class LmdbDatabase():
-    def __init__(self, db, dupsort):
-        self.db = db
-        self.dupsort = dupsort
-
-_DefaultDB = LmdbDatabase(None, False)
-
 class Hist:
     '''
     A class for storing items in a slab by time.
@@ -551,10 +544,12 @@ class Slab(s_base.Base):
     def __repr__(self):
         return 'Slab: %r' % (self.path,)
 
-    def trash(self):
+    async def trash(self):
         '''
         Deletes underlying storage
         '''
+        await self.fini()
+
         try:
             os.unlink(self.optspath)
         except FileNotFoundError:  # pragma: no cover

--- a/synapse/lib/slaboffs.py
+++ b/synapse/lib/slaboffs.py
@@ -8,15 +8,15 @@ class SlabOffs:
 
     As with all slab objects, this is meant for single-thread async loop use.
     '''
-    def __init__(self, slab: s_lmdbslab.Slab, db) -> None:
-        self.db = db
-        self.lenv = slab
+    def __init__(self, slab: s_lmdbslab.Slab, db: str) -> None:
+        self.db = slab.initdb(db)
+        self.slab = slab
 
     def get(self, iden):
 
         buid = s_common.uhex(iden)
 
-        byts = self.lenv.get(buid, db=self.db)
+        byts = self.slab.get(buid, db=self.db)
         if byts is None:
             return 0
 
@@ -25,8 +25,8 @@ class SlabOffs:
     def set(self, iden, offs):
         buid = s_common.uhex(iden)
         byts = s_common.int64en(offs)
-        self.lenv.put(buid, byts, db=self.db)
+        self.slab.put(buid, byts, db=self.db)
 
     def delete(self, iden):
         buid = s_common.uhex(iden)
-        self.lenv.delete(buid, db=self.db)
+        self.slab.delete(buid, db=self.db)

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -360,8 +360,6 @@ class View(s_nexus.Pusher):  # type: ignore
         await self.core.boss.promote('storm', user=user, info={'merging': self.iden})
 
         async with await self.parent.snap(user=user) as snap:
-            snap.disableTriggers()
-            snap.strict = False
 
             with snap.getStormRuntime(user=user):
                 meta = await snap.getSnapMeta()

--- a/synapse/tests/test_lib_view.py
+++ b/synapse/tests/test_lib_view.py
@@ -91,8 +91,6 @@ class ViewTest(s_t_utils.SynTest):
     async def test_view_trigger(self):
         async with self.getTestCore() as core:
 
-            root = await core.auth.getUserByName('root')
-
             # Fork the main view
             vdef2 = await core.view.fork()
             view2_iden = vdef2.get('iden')


### PR DESCRIPTION
This prevents large node data from being locked into memory