### PR TITLE
Support YAML and JSON as an optsfile

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -1,3 +1,4 @@
+import os
 import json
 import queue
 import shlex
@@ -214,7 +215,7 @@ class StormCmd(s_cli.Cmd):
         --path: Get path information about returned nodes.
         --show <names>: Limit storm events (server-side) to the comma sep list)
         --file <path>: Run the storm query specified in the given file path.
-        --optsfile <path>: Run the query with the given options from a JSON file.
+        --optsfile <path>: Run the query with the given options from a JSON/YAML file.
         --spawn: (EXPERIMENTAL!) Run the query within a spawned sub-process runtime (read-only).
 
     Examples:
@@ -359,13 +360,10 @@ class StormCmd(s_cli.Cmd):
         stormopts = {}
         optsfile = opts.get('optsfile')
         if optsfile is not None:
-            try:
-                with open(optsfile) as fd:
-                    stormopts = json.loads(fd.read())
-
-            except FileNotFoundError as e:
+            if not os.path.isfile(optsfile):
                 self.printf('optsfile not found: %s' % (optsfile,))
                 return
+            stormopts = s_common.yamlload(optsfile)
 
         hide_unknown = opts.get('hide-unknown', self._cmd_cli.locs.get('storm:hide-unknown'))
         core = self.getCmdItem()

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -353,21 +353,27 @@ class CmdCoreTest(s_t_utils.SynTest):
 
         async with self.getTestCoreAndProxy() as (core, prox):
 
+            test_opts = {'vars': {'hehe': 'woot.com'}}
             dirn = s_common.gendir(core.dirn, 'junk')
 
             optsfile = os.path.join(dirn, 'woot.json')
+            optsfile_yaml = os.path.join(dirn, 'woot.yaml')
             stormfile = os.path.join(dirn, 'woot.storm')
 
             with s_common.genfile(stormfile) as fd:
                 fd.write(b'[ inet:fqdn=$hehe ]')
 
-            with s_common.genfile(optsfile) as fd:
-                fd.write(b'{"vars": {"hehe": "woot.com"}}')
+            s_common.jssave(test_opts, optsfile)
+            s_common.yamlsave(test_opts, optsfile_yaml)
 
             outp = self.getTestOutp()
             cmdr = await s_cmdr.getItemCmdr(prox, outp=outp)
-
             await cmdr.runCmdLine(f'storm --optsfile {optsfile} --file {stormfile}')
+            self.true(outp.expect('inet:fqdn=woot.com'))
+
+            outp = self.getTestOutp()
+            cmdr = await s_cmdr.getItemCmdr(prox, outp=outp)
+            await cmdr.runCmdLine(f'storm --optsfile {optsfile_yaml} --file {stormfile}')
             self.true(outp.expect('inet:fqdn=woot.com'))
 
             # Sad path cases


### PR DESCRIPTION
Allow opts to come in from yaml files.

Will have to forward port this to `master` branch.