### PR TITLE
Remove unnecessary view merge perm checks

### DIFF
--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1833,7 +1833,6 @@ class Layer(s_nexus.Pusher):
 
                     yield splice
 
-
     async def splicesBack(self, offs=None, size=None):
 
         if not self.logedits:

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1810,18 +1810,29 @@ class Layer(s_nexus.Pusher):
         if offs is None:
             offs = (0, 0, 0)
 
-        count = 0
-        for offset, (nodeedits, meta) in self.nodeeditlog.slice(offs[0], size):
-            async for splice in self.makeSplices(offset, nodeedits, meta):
+        if size:
 
-                if splice[0] < offs:
-                    continue
+            count = 0
+            for offset, (nodeedits, meta) in self.nodeeditlog.iter(offs[0]):
+                async for splice in self.makeSplices(offset, nodeedits, meta):
 
-                if count >= size:
-                    return
+                    if splice[0] < offs:
+                        continue
 
-                yield splice
-                count = count + 1
+                    if count >= size:
+                        return
+
+                    yield splice
+                    count = count + 1
+        else:
+            for offset, (nodeedits, meta) in self.nodeeditlog.iter(offs[0]):
+                async for splice in self.makeSplices(offset, nodeedits, meta):
+
+                    if splice[0] < offs:
+                        continue
+
+                    yield splice
+
 
     async def splicesBack(self, offs=None, size=None):
 
@@ -1834,7 +1845,7 @@ class Layer(s_nexus.Pusher):
         if size:
 
             count = 0
-            for offset, (nodeedits, meta) in self.nodeeditlog.sliceBack(offs[0], size):
+            for offset, (nodeedits, meta) in self.nodeeditlog.iterBack(offs[0]):
                 async for splice in self.makeSplices(offset, nodeedits, meta, reverse=True):
 
                     if splice[0] > offs:

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1810,7 +1810,7 @@ class Layer(s_nexus.Pusher):
         if offs is None:
             offs = (0, 0, 0)
 
-        if size:
+        if size is not None:
 
             count = 0
             for offset, (nodeedits, meta) in self.nodeeditlog.iter(offs[0]):
@@ -1841,7 +1841,7 @@ class Layer(s_nexus.Pusher):
         if offs is None:
             offs = (self.nodeeditlog.index(), 0, 0)
 
-        if size:
+        if size is not None:
 
             count = 0
             for offset, (nodeedits, meta) in self.nodeeditlog.iterBack(offs[0]):

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -74,13 +74,9 @@ class View(s_nexus.Pusher):  # type: ignore
 
         self.permCheck = {
             'node:add': self._nodeAddConfirm,
-            'node:del': self._nodeDelConfirm,
             'prop:set': self._propSetConfirm,
-            'prop:del': self._propDelConfirm,
             'tag:add': self._tagAddConfirm,
-            'tag:del': self._tagDelConfirm,
             'tag:prop:set': self._tagPropSetConfirm,
-            'tag:prop:del': self._tagPropDelConfirm,
         }
 
         # isolate some initialization to easily override for SpawnView.
@@ -382,18 +378,6 @@ class View(s_nexus.Pusher):  # type: ignore
         perms = ('node', 'add', splice['ndef'][0])
         self.parent._confirm(user, perms)
 
-    async def _nodeDelConfirm(self, user, snap, splice):
-        buid = s_common.buid(splice['ndef'])
-        node = await snap.getNodeByBuid(buid)
-
-        if node is not None:
-            for tag in node.tags.keys():
-                perms = ('node', 'tag', 'del', *tag.split('.'))
-                self.parent._confirm(user, perms)
-
-            perms = ('node', 'del', splice['ndef'][0])
-            self.parent._confirm(user, perms)
-
     async def _propSetConfirm(self, user, snap, splice):
         ndef = splice.get('ndef')
         prop = splice.get('prop')
@@ -401,31 +385,14 @@ class View(s_nexus.Pusher):  # type: ignore
         perms = ('node', 'prop', 'set', full)
         self.parent._confirm(user, perms)
 
-    async def _propDelConfirm(self, user, snap, splice):
-        ndef = splice.get('ndef')
-        prop = splice.get('prop')
-        full = f'{ndef[0]}:{prop}'
-        perms = ('node', 'prop', 'del', full)
-        self.parent._confirm(user, perms)
-
     async def _tagAddConfirm(self, user, snap, splice):
         tag = splice.get('tag')
         perms = ('node', 'tag', 'add', *tag.split('.'))
         self.parent._confirm(user, perms)
 
-    async def _tagDelConfirm(self, user, snap, splice):
-        tag = splice.get('tag')
-        perms = ('node', 'tag', 'del', *tag.split('.'))
-        self.parent._confirm(user, perms)
-
     async def _tagPropSetConfirm(self, user, snap, splice):
         tag = splice.get('tag')
         perms = ('node', 'tag', 'add', *tag.split('.'))
-        self.parent._confirm(user, perms)
-
-    async def _tagPropDelConfirm(self, user, snap, splice):
-        tag = splice.get('tag')
-        perms = ('node', 'tag', 'del', *tag.split('.'))
         self.parent._confirm(user, perms)
 
     async def mergeAllowed(self, user=None):
@@ -449,13 +416,11 @@ class View(s_nexus.Pusher):  # type: ignore
 
         CHUNKSIZE = 1000
         fromoff = (0, 0, 0)
-
         async with await self.parent.snap(user=user) as snap:
             while True:
 
                 splicecount = 0
                 async for offs, splice in fromlayr.splices(fromoff, CHUNKSIZE):
-
                     check = self.permCheck.get(splice[0])
                     if check is None:
                         raise s_exc.SynErr(mesg='Unknown splice type, cannot safely merge',

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -420,6 +420,9 @@ class LayerTest(s_t_utils.SynTest):
             # Get all the splices
             await self.agenlen(26, layr.splices())
 
+            # Get all but the first splice
+            await self.agenlen(25, layr.splices((0, 0, 1)))
+
             # Make sure we still get two splices when
             # offset is not at the beginning of a nodeedit
             await self.agenlen(2, layr.splices((1, 0, 200), 2))

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -417,6 +417,9 @@ class LayerTest(s_t_utils.SynTest):
             self.eq(splice[1]['user'], root.iden)
             self.nn(splice[1].get('time'))
 
+            # Get all the splices
+            await self.agenlen(26, layr.splices())
+
             # Make sure we still get two splices when
             # offset is not at the beginning of a nodeedit
             await self.agenlen(2, layr.splices((1, 0, 200), 2))

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -417,6 +417,11 @@ class LayerTest(s_t_utils.SynTest):
             self.eq(splice[1]['user'], root.iden)
             self.nn(splice[1].get('time'))
 
+            # Make sure we still get two splices when
+            # offset is not at the beginning of a nodeedit
+            await self.agenlen(2, layr.splices((1, 0, 200), 2))
+            await self.agenlen(2, layr.splicesBack((3, 0, -1), 2))
+
     async def test_layer_stortype_float(self):
         async with self.getTestCore() as core:
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -1788,6 +1788,11 @@ class StormTypesTest(s_test.SynTest):
                 await alist(forkview.eval('test:int=12 [-#tag.proptest:risk]'))
                 await alist(forkview.eval('test:int=12 | delnode'))
 
+                # Make a bunch of nodes so we chunk the permission check
+                for i in range(1000):
+                    opts = {'vars': {'val': i + 1000}}
+                    await self.agenlen(1, forkview.eval('[test:int=$val]', opts=opts))
+
                 # Merge the view forked by the user
                 # Will need perms for all the ops required to merge
 


### PR DESCRIPTION
Also adjust splices/splicesBack methods to correctly handle size param with mid-nodeedit offsets.