### PR TITLE
deprecate coreapi.stat

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -75,7 +75,7 @@ class CoreApi(s_cell.CellApi):
         return self.cell.getCoreMods()
 
     def stat(self):
-        self.user.confirm(('status',), gateiden='cortex')
+        self.user.confirm(('status',))
         s_common.deprecated('stat')
         return self.cell.stat()
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -74,8 +74,9 @@ class CoreApi(s_cell.CellApi):
     def getCoreMods(self):
         return self.cell.getCoreMods()
 
-    @s_cell.adminapi
     def stat(self):
+        self.user.confirm(('status',), gateiden='cortex')
+        s_common.deprecated('stat')
         return self.cell.stat()
 
     async def getModelDict(self):


### PR DESCRIPTION
Mark the coreApi() stat as deprecated and free his perm up to status so we can plumb a future cellapi gated on the status perm for the default cell, much like health checks.