### PR TITLE
Save migration cortex and model versions

### DIFF
--- a/synapse/tests/test_tools_migrate020.py
+++ b/synapse/tests/test_tools_migrate020.py
@@ -14,6 +14,7 @@ import synapse.tests.utils as s_t_utils
 
 import synapse.lib.cell as s_cell
 import synapse.lib.msgpack as s_msgpack
+import synapse.lib.version as s_version
 import synapse.lib.stormsvc as s_stormsvc
 
 import synapse.tools.migrate_020 as s_migr
@@ -516,10 +517,17 @@ class MigrationTest(s_t_utils.SynTest):
             self.gt(offslogs0[0]['val'][0], 0)
             self.gt(offslogs0[1]['val'][0], 0)
 
-            # check the saved file
+            # check the saved offset file
             offsyaml = s_common.yamlload(dest0, 'migration', 'lyroffs.yaml')
             offslogdict = {x['key']: {'nextoffs': x['val'][0], 'created': x['val'][1]} for x in offslogs0}
             self.eq(offsyaml, offslogdict)
+
+            # check the saved version file
+            # note that forked view layer does not have model vers set in 0.1.x
+            versyaml = s_common.yamlload(dest0, 'migration', 'migrvers.yaml')
+            self.sorteq([(-1, -1, -1), (0, 1, 2)], [tuple(v) for v in versyaml.get('src:model', {}).values()])
+            self.eq((-1, -1, -1), versyaml.get('src:cortex'))  # unknown with regr repo at 0.1.51
+            self.eq({s_version.version}, {tuple(versyaml.get('dest:cortex').get(op)) for op in migr0.migrops})
 
             await migr0.fini()
 
@@ -553,9 +561,15 @@ class MigrationTest(s_t_utils.SynTest):
                 self.gt(offslogs[0]['val'][1], offslogs0[0]['val'][1])  # timestamp should be updated
                 self.gt(offslogs[1]['val'][1], offslogs0[1]['val'][1])
 
-                # check the saved file
+                # check the saved offset file
                 offsyaml = s_common.yamlload(dest, 'migration', 'lyroffs.yaml')
                 self.eq(offsyaml, {x['key']: {'nextoffs': x['val'][0], 'created': x['val'][1]} for x in offslogs})
+
+                # check the saved version file
+                versyaml = s_common.yamlload(dest, 'migration', 'migrvers.yaml')
+                self.sorteq([(-1, -1, -1), (0, 1, 2)], [tuple(v) for v in versyaml.get('src:model', {}).values()])
+                self.eq((-1, -1, -1), versyaml.get('src:cortex'))  # unknown with regr repo at 0.1.51
+                self.eq({s_version.version}, {tuple(versyaml.get('dest:cortex').get(op)) for op in migr.migrops})
 
                 await migr.fini()
 
@@ -595,7 +609,7 @@ class MigrationTest(s_t_utils.SynTest):
                     self.false(migr.srcdedicated)
                     self.false(migr.destdedicated)
 
-                    # check the saved file
+                    # check the saved offset file
                     offsyaml = s_common.yamlload(dest, 'migration', 'lyroffs.yaml')
                     self.true(all(v['nextoffs'] == 0 for v in offsyaml.values()))
 


### PR DESCRIPTION
- Dumps versions to yaml file at the end of migration
- Also close src slabs when done an individual migration step for better resource management in srcdedicated=True multilayer case