### PR TITLE
Test fixes for migration tools

### DIFF
--- a/synapse/tests/test_tools_migrate020.py
+++ b/synapse/tests/test_tools_migrate020.py
@@ -607,7 +607,7 @@ class MigrationTest(s_t_utils.SynTest):
                         shutil.rmtree(os.path.join(root, dname))
 
             # check defaults
-            with self.getTestDir() as dest:
+            with self.getTestDir() as dest, self.withSetLoggingMock():
                 argv = [
                     '--src', src,
                     '--dest', dest,

--- a/synapse/tests/test_tools_migrate020.py
+++ b/synapse/tests/test_tools_migrate020.py
@@ -642,7 +642,7 @@ class MigrationTest(s_t_utils.SynTest):
         '''
         with self.getRegrDir('cortexes', REGR_VER) as src:
             # check user opts
-            with self.getTestDir() as destp:
+            with self.getTestDir() as destp, self.withSetLoggingMock():
                 dest = os.path.join(destp, 'woot')  # verify svc is creating dir if it doesn't exist
 
                 argv = [

--- a/synapse/tests/test_tools_sync020.py
+++ b/synapse/tests/test_tools_sync020.py
@@ -300,7 +300,7 @@ class SyncTest(s_t_utils.SynTest):
                 self.false(sync._queues[wlyr.iden].isfini)
 
     async def test_sync_assvr(self):
-        with self.getTestDir() as dirn:
+        with self.getTestDir() as dirn, self.withSetLoggingMock():
             argv = [
                 dirn,
                 '--src', 'tcp://foo:123',

--- a/synapse/tests/test_tools_sync020.py
+++ b/synapse/tests/test_tools_sync020.py
@@ -306,6 +306,8 @@ class SyncTest(s_t_utils.SynTest):
                 '--src', 'tcp://foo:123',
                 '--dest', 'tcp://bar:456',
                 '--offsfile', 'foo.yaml',
+                '--telepath', 'tcp://127.0.0.1:0',
+                '--https', 0,
             ]
 
             async with await s_sync.main(argv) as sync:


### PR DESCRIPTION
When starting up from main:
- Don't use default ports
- Use context manager to avoid logging.basicconfig