### PR TITLE
020: Always send an init message in streamstorm

### DIFF
--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -183,12 +183,13 @@ class View(s_nexus.Pusher):  # type: ignore
             tick = s_common.now()
             count = 0
             try:
-                # First, try text parsing. If this fails, we won't be able to get
-                # a storm runtime in the snap, so catch and pass the `err` message
-                # before handing a `fini` message along.
-                self.core.getStormQuery(text)
 
+                # Always start with an init message.
                 await chan.put(('init', {'tick': tick, 'text': text, 'task': synt.iden}))
+
+                # Try text parsing. If this fails, we won't be able to get a storm
+                # runtime in the snap, so catch and pass the `err` message
+                self.core.getStormQuery(text)
 
                 shownode = (show is None or 'node' in show)
                 async with await self.snap(user=user) as snap:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1731,12 +1731,12 @@ class CortexBasicTest(s_t_utils.SynTest):
                 self.true(await stream.wait(4))
             # Bad syntax
             mesgs = await alist(core.storm(' | | | '))
-            self.len(0, [mesg for mesg in mesgs if mesg[0] == 'init'])
+            self.len(1, [mesg for mesg in mesgs if mesg[0] == 'init'])
             self.len(1, [mesg for mesg in mesgs if mesg[0] == 'fini'])
-            mesgs = [mesg for mesg in mesgs if mesg[0] == 'err']
-            self.len(1, mesgs)
-            enfo = mesgs[0][1]
-            self.eq(enfo[0], 'BadSyntax')
+            # Lark sensitive test
+            self.stormIsInErr("No terminal defined for '|'", mesgs)
+            errs = [mesg[1] for mesg in mesgs if mesg[0] == 'err']
+            self.eq(errs[0][0], 'BadSyntax')
 
     async def test_strict(self):
 


### PR DESCRIPTION
This avoids the ambiguity of what the first message a remote caller may get is by always making it ``init``.