### PR TITLE
Fix a telepath method returning None on fini

### DIFF
--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -428,7 +428,7 @@ class Proxy(s_base.Base):
 
         mesg = await link.rx()
         if mesg is None:
-            return
+            raise s_exc.LinkShutDown(mesg='Remote peer disconnected')
 
         if mesg[0] == 't2:fini':
             await self._putPoolLink(link)

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -905,7 +905,7 @@ class TeleTest(s_t_utils.SynTest):
                 return retn
 
             task = dmon.schedCoro(doit())
-            await s_coro.event_wait(foo.simplesleep_evt, 2)
+            self.true(await s_coro.event_wait(foo.simplesleep_evt, 2))
             await prox.fini()
 
             await self.asyncraises(s_exc.LinkShutDown, task)

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -54,6 +54,7 @@ class Foo:
 
     def __init__(self):
         self.sleepg_evt = asyncio.Event()
+        self.simplesleep_evt = asyncio.Event()
 
     def bar(self, x, y):
         return x + y
@@ -78,7 +79,8 @@ class Foo:
         yield ('fini', {})
 
     async def simplesleep(self):
-        await asyncio.sleep(5)
+        self.simplesleep_evt.set()
+        await asyncio.sleep(10)
         return 42
 
     def genr(self):
@@ -903,7 +905,7 @@ class TeleTest(s_t_utils.SynTest):
                 return retn
 
             task = dmon.schedCoro(doit())
-            await asyncio.sleep(1)
+            await s_coro.event_wait(foo.simplesleep_evt, 2)
             await prox.fini()
 
             await self.asyncraises(s_exc.LinkShutDown, task)


### PR DESCRIPTION
Fix a bug where fini'ing a proxy when a method on that proxy is being awaited on another task returning None instead of raising an exception