### PR TITLE
Toggle migration mode in sync service

### DIFF
--- a/docs/synapse/devops.rst
+++ b/docs/synapse/devops.rst
@@ -81,6 +81,10 @@ After migration, the ``sync_020`` service can be used to push post-backup change
 and keep it updated until cut-over. ``sync_020`` uses splices to translate the changes, and therefore they must
 be enabled on the source Cortex. In order to control and monitor synchronization, ``sync_020`` can be added as a Storm service.
 
+When synchronization is started the service will enable "migration mode" on the destination ``0.2.x`` Cortex, which
+prevents cron jobs and triggers from running.  Migration mode will then be disabled when the synchronization is
+stopped or when the Cortex is restarted.
+
 #. Complete migration, including starting up the ``0.2.x`` Cortex.
 #. Locate the saved splice offset file from migration at ``<new_02x_dirn>/migration/lyroffs.yaml``.
 #. Start the ``sync_020`` service (shown with the optional ``--auth-passwd`` to bootstrap the root user)::
@@ -90,6 +94,7 @@ be enabled on the source Cortex. In order to control and monitor synchronization
         --src <01x_telepath_url> --dest <02x_telepath_url>
 
 #. Add the Storm service to the Cortex and use the available commands to start synchronization.
+#. When ready to cutover, and the synchronization status is up-to-date, stop the service.
 
 Axon
 ====

--- a/docs/synapse/devops.rst
+++ b/docs/synapse/devops.rst
@@ -94,7 +94,7 @@ stopped or when the Cortex is restarted.
         --src <01x_telepath_url> --dest <02x_telepath_url>
 
 #. Add the Storm service to the Cortex and use the available commands to start synchronization.
-#. When ready to cutover, and the synchronization status is up-to-date, stop the service.
+#. When ready to cut-over, and the read status is up-to-date, stop the synchronization using the ``stopsync`` command.
 
 Axon
 ====

--- a/synapse/tests/test_tools_sync020.py
+++ b/synapse/tests/test_tools_sync020.py
@@ -329,6 +329,11 @@ class SyncTest(s_t_utils.SynTest):
 
                 self.eq('queue_fini', sync._pull_status[wlyr.iden])
 
+                # run stopsync with a prx exception
+                sync.dest = 'foobar'
+                stopres = await syncprx.stopSync()
+                self.len(2, stopres)  # returns the two layers stopped
+
     async def test_startSyncFromLast(self):
         conf_sync = {
             'poll_s': 1,

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -498,9 +498,6 @@ class Migrator(s_base.Base):
         if self.addmode not in ADD_MODES:
             raise Exception(f'addmode {self.addmode} is not valid')
 
-        if self.addmode != 'nexus':
-            logger.warning('Add mode is bypassing nexus - no migration splices will exist in 0.2.x cortex')
-
         self.editbatchsize = conf.get('editbatchsize')
         if self.editbatchsize is None:
             self.editbatchsize = 100

--- a/synapse/tools/sync_020.py
+++ b/synapse/tools/sync_020.py
@@ -5,19 +5,15 @@ import os
 import sys
 import asyncio
 import logging
-import argparse
 
 import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.telepath as s_telepath
 
 import synapse.lib.cell as s_cell
-import synapse.lib.base as s_base
 import synapse.lib.time as s_time
 import synapse.lib.queue as s_queue
 import synapse.lib.layer as s_layer
-import synapse.lib.config as s_config
-import synapse.lib.output as s_output
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.version as s_version
 import synapse.lib.lmdbslab as s_lmdbslab

--- a/synapse/tools/sync_020.py
+++ b/synapse/tools/sync_020.py
@@ -334,7 +334,7 @@ class SyncMigrator(s_cell.Cell):
     async def _startLyrSync(self, lyriden, nextoffs):
         '''
         Starts up the sync process for a given layer and starting offset.
-        Always retrieves a fresh datamodel.
+        Always retrieves a fresh datamodel and sets migration mode.
         Creates layer queue and fires layer push/pull tasks if they do not already exist.
 
         Args:
@@ -344,7 +344,10 @@ class SyncMigrator(s_cell.Cell):
         await self.layers.set(lyriden, nextoffs)
         self.pull_offs.set(lyriden, nextoffs)
 
-        await self._loadDatamodel()
+        async with await s_telepath.openurl(self.dest) as prx:
+            model = await prx.getModelDict()
+            self.model.update(model)
+            await prx.enableMigrationMode()
 
         queue = self._queues.get(lyriden)
         if queue is None or queue.isfini:
@@ -364,7 +367,7 @@ class SyncMigrator(s_cell.Cell):
 
     async def stopSync(self):
         '''
-        Cancel all tasks and fini queues.
+        Cancel all tasks and fini queues. Also disable migration mode on dest cortex.
 
         Returns:
             (list): Of layer idens that were stopped
@@ -385,6 +388,15 @@ class SyncMigrator(s_cell.Cell):
             logger.warning(f'Fini\'ing {lyriden} queue')
             await queue.fini()
             retn.add(lyriden)
+
+        try:
+            async with await s_telepath.openurl(self.dest) as prx:
+                await prx.disableMigrationMode()
+        except asyncio.CancelledError:  # pragma: no cover
+            raise
+        except Exception as e:
+            logger.exception(f'Unable to disable migration mode on dest cortex: {e}')
+            pass
 
         logger.info('stopSync complete')
         return list(retn)
@@ -408,14 +420,6 @@ class SyncMigrator(s_cell.Cell):
             errs.append((offset, err))
 
         return errs
-
-    async def _loadDatamodel(self):
-        '''
-        Retrieve the datamodel (with stortypes) from the destination cortex.
-        '''
-        async with await s_telepath.openurl(self.dest) as prx:
-            model = await prx.getModelDict()
-            self.model.update(model)
 
     def _getLayerUrl(self, tbase, lyriden):
         '''


### PR DESCRIPTION
- Enabled whenever a layer sync is started
- Disabled when the sync service is stopped
- Disabled (by default) when Cortex is restarted
- Updated migration docs