### PR TITLE
020 miscellaneous cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,25 +10,40 @@ Features and Enhancements
 
 - Refactored Layer Storage Format
 
-This release includes significant storage optimizations for both performance and size.  However, the `0.2.0` migration contains no *model* migrations and is strictly limited to the internal LMDB layer storage format.  The new format provides performance enhancements that significantly improve data ingest performance and reduce the memory footprint of the layer.  See :ref:`020_migration` for details on migrating your `0.1.x` Cortex to `0.2.0`.
+This release includes significant storage optimizations for both performance and size.  However, the `0.2.0` migration
+contains no *model* migrations and is strictly limited to the internal LMDB layer storage format.  The new format
+provides performance enhancements that significantly improve data ingest performance and reduce the memory footprint of
+the layer.  See :ref:`020_migration` for details on migrating your `0.1.x` Cortex to `0.2.0`.
 
 - View/Layer Management
 
-Views and layers may now be managed via simple storm commands or manipulated by the storm API.  Additionally, permissions may be assigned on a per-view or per-layer basis allowing granular control of users and roles.
-With proper permission, a view may now be easily forked to create an analyst owned "sandbox" where their edits are written to a separate layer which can later be merged by someone with appropriate permissions.  A user
+Views and layers may now be managed via simple storm commands or manipulated by the storm API.  Additionally,
+permissions may be assigned on a per-view or per-layer basis allowing granular control of users and roles.
+With proper permission, a view may now be easily forked to create an analyst owned "sandbox" where their edits are
+written to a separate layer which can later be merged by someone with appropriate permissions.  A user
 may now set a "default view" profile option to specify the view to be used when they issue a default storm query.
 
 - Mirrors Are Now A Fully Operational Battle Station
 
-Previous support for Cortex "mirrors" has been limited to mirroring data from a single layer.  The mechanism for change control and distribution within a Cortex has been updated to facilitate true mirroring of all changes within a Cortex.  Each change within a Cortex is assigned a sequential identifier which allows mirrors to be taken offline and catch-up once they are returned to operation.  Additionally, mirrors have been updated to facilitate "write-back" edits which propagate changes via their upstream mirror, making the mirror appear writable.  With this new mechanism, a set of mirrors may be configured to handle read offloading as well as write consolidation.
+Previous support for Cortex "mirrors" has been limited to mirroring data from a single layer.  The mechanism for change
+control and distribution within a Cortex has been updated to facilitate true mirroring of all changes within a Cortex.
+Each change within a Cortex is assigned a sequential identifier which allows mirrors to be taken offline and catch-up
+once they are returned to operation.  Additionally, mirrors have been updated to facilitate "write-back" edits which
+propagate changes via their upstream mirror, making the mirror appear writable.  With this new mechanism, a set of
+mirrors may be configured to handle read offloading as well as write consolidation.
 
 - Cron/Trigger Management
 
-Cron jobs and triggers may now be managed via simple storm commands or manipulated by the storm API.  Additionally, permissions are now enforced on a per-object basis.
+Cron jobs and triggers may now be managed via simple storm commands or manipulated by the storm API.  Additionally,
+permissions are now enforced on a per-object basis.
 
 - Experimental Spawn Runtime Improvements
 
-The (still experimental) ``spawn: True`` option to the storm runtime, which facilitates execution of a storm query in a sub-process, has made progress toward feature parity.  Specifically, a number of storm library APIs have been updated to facilitate access from within a spawned sub-process transparently.  While the spawn option is still considered experimental, it has reached a level of maturity which may warrant review due to the powerful performance benefit for large or long running read queries.
+The (still experimental) ``spawn: True`` option to the storm runtime, which facilitates execution of a storm query in a
+sub-process, has made progress toward feature parity.  Specifically, a number of storm library APIs have been updated to
+facilitate access from within a spawned sub-process transparently.  While the spawn option is still considered
+experimental, it has reached a level of maturity which may warrant review due to the powerful performance benefit for
+large or long running read queries.
 
 Backward Compatibility Breaks
 -----------------------------
@@ -37,7 +52,8 @@ Modified Node Permission Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 What changed
-    Node permissions were modified to allow all basic node edits to fall within a single hierarchy in order to facilitate easily granting permissions for all node edits.
+    Node permissions were modified to allow all basic node edits to fall within a single hierarchy in order to
+    facilitate easily granting permissions for all node edits.
 
     The following permission table provides translation:
 
@@ -53,16 +69,25 @@ What changed
     ============== ==============
 
 Why make the change
-    By placing all node edit permissions under a single hierarchy, administrators may easily grant access to all node modifications by adding the permission ``node``.  As previously, more granular versions of the given permissions are available to individually control access.
+    By placing all node edit permissions under a single hierarchy, administrators may easily grant access to all node
+    modifications by adding the permission ``node``.  As previously, more granular versions of the given permissions are
+    available to individually control access.
 
 What you need to do
-    The Synpase ``0.2.x`` migration tool should take care of translating all relevant permissions changes within a migrated Cortex.  However, any 3rd party code that modifies permissions should be updated to the new naming convention.
+    The Synpase ``0.2.x`` migration tool should take care of translating all relevant permissions changes within a
+    migrated Cortex.  However, any 3rd party code that modifies permissions should be updated to the new naming
+    convention.
 
 Node Edits vs Splices
 ~~~~~~~~~~~~~~~~~~~~~
 
 What changed
-    The various splice events provided by the storm runtime have been consolidated and streamlined into a single ``node:edits`` event type.  The new ``node:edits`` events contain a more compressed and aggregated representation of node changes and include changes that were previous unreported.  Callers may now specify the format for the node edits reported by the storm runtime by using the ``editformat`` optional parameter to the storm runtime, but the default output will now be ``node:edits`` rather than splices.  The following table enumerates the options for the ``editformat`` parameter:
+    The various splice events provided by the storm runtime have been consolidated and streamlined into a single
+    ``node:edits`` event type.  The new ``node:edits`` events contain a more compressed and aggregated representation of
+    node changes and include changes that were previous unreported.  Callers may now specify the format for the node
+    edits reported by the storm runtime by using the ``editformat`` optional parameter to the storm runtime, but the
+    default output will now be ``node:edits`` rather than splices.  The following table enumerates the options for the
+    ``editformat`` parameter:
 
     ========== =========================================================
     editformat Storm runtime behavior
@@ -74,10 +99,16 @@ What changed
     ========== =========================================================
 
 Why make the change
-    The splice format was originally designed to facilitate a single atomic edit per-splice.  As such, it required the potentially large primary property value to be embedded in each splice.  When making multiple edits, this representation is inefficient and causes the retransmission, and potential storage, of duplicate data.  Additionally, the key-value structure of the splice format provided unnecessary extensibility at the cost of transmission/storage size.
+    The splice format was originally designed to facilitate a single atomic edit per-splice.  As such, it required the
+    potentially large primary property value to be embedded in each splice.  When making multiple edits, this
+    representation is inefficient and causes the retransmission, and potential storage, of duplicate data.
+    Additionally, the key-value structure of the splice format provided unnecessary extensibility at the cost of
+    transmission/storage size.
 
 What you need to do
-    Update any code that consumes/indexes the various splice events to handle the new ``node:edits`` format.  Additionally, callers may specify ``editformat: "splices"`` within their storm runtime options to enable backward-compatible splice generation.
+    Update any code that consumes/indexes the various splice events to handle the new ``node:edits`` format.
+    Additionally, callers may specify ``editformat: "splices"`` within their storm runtime options to enable
+    backward-compatible splice generation.
 
 Removed Remote Layers
 ~~~~~~~~~~~~~~~~~~~~~
@@ -86,10 +117,14 @@ What changed
     Support for remote layers has been removed.
 
 Why make the change
-    The performance characteristics and stability of remote layers has never reached what we consider production deployable status.  Additionally, complexities with model versions, migrations, and model synchronization have made the use of remote layers highly fragile.  While we may eventually design a new remote layer capability, the current implementation is being removed due to being unsupportable.
+    The performance characteristics and stability of remote layers has never reached what we consider production
+    deployable status.  Additionally, complexities with model versions, migrations, and model synchronization have made
+    the use of remote layers highly fragile.  While we may eventually design a new remote layer capability, the current
+    implementation is being removed due to being unsupportable.
 
 What you need to do
-    If you have remote layers deployed in production, you should update the view configuration to contain an "upstream" layer.  This will create a copy of the remote layer data to the local Cortex and keep it in sync.
+    If you have remote layers deployed in production, you should update the view configuration to contain an "upstream"
+    layer.  This will create a copy of the remote layer data to the local Cortex and keep it in sync.
 
 Removed Pushing Splices
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -98,7 +133,10 @@ What changed
     The configuration options to enable pushing splices to a cryotank or to another cortex have been removed.
 
 Why make the change
-    The archival of splices to a cryotank and the responsibility of a Cortex to "push" changes to another Cortex have long been essentially vestigial.  Additionally, these options required a Cortex reboot to take effect and were not runtime configurable.  The current mechanisms for mirroring and upstream layers allow for a more scalable and dynamic configuration.
+    The archival of splices to a cryotank and the responsibility of a Cortex to "push" changes to another Cortex have
+    long been essentially vestigial.  Additionally, these options required a Cortex reboot to take effect and were not
+    runtime configurable.  The current mechanisms for mirroring and upstream layers allow for a more scalable and
+    dynamic configuration.
 
 What you need to do
     It is unlikely that this change will effect any known deployments.
@@ -110,7 +148,9 @@ What changed
     The monolithic configuration option for pulling "feed" data from a Cryotank has been removed.
 
 Why make the change
-    The ability to feed a Cortex directly from a Cryotank represents a very early approach to automate data ingest into a Cortex.  This capability has been superseded by Storm Services which provide a dynamically configurable way to integrate services and data.
+    The ability to feed a Cortex directly from a Cryotank represents a very early approach to automate data ingest into
+    a Cortex.  This capability has been superseded by Storm Services which provide a dynamically configurable way to
+    integrate services and data.
 
 What you need to do
     It is unlikely that this change will effect any known deployments.
@@ -119,10 +159,14 @@ Removed Tag Prop Lifting Without Tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 What changed
-    The ability to lift nodes by the presence of a tag property *without* specifying the tag name has been removed.  Given a tag property of "confidence", the ``#:confidence`` and ``#:confidence>90`` style syntax are no longer valid.  However, lifting by tag property *with* the tag, such as ``#foo.bar:confidence`` and ``#foo.bar:confidence>90`` remain valid.
+    The ability to lift nodes by the presence of a tag property *without* specifying the tag name has been removed.
+    Given a tag property of "confidence", the ``#:confidence`` and ``#:confidence>90`` style syntax are no longer valid.
+    However, lifting by tag property *with* the tag, such as ``#foo.bar:confidence`` and ``#foo.bar:confidence>90``
+    remain valid.
 
 Why make the change
-    The necessary indexing to provide a performant way to lift nodes by the tag property without the tag is too expensive for the analytically dubious use case.
+    The necessary indexing to provide a performant way to lift nodes by the tag property without the tag is too
+    expensive for the analytically dubious use case.
 
 What you need to do
     Any instances of lifting nodes by tag property without the tag will need to be updated to include the tag name.
@@ -134,7 +178,10 @@ What changed
     The "insecure" option in cell.yaml has been removed.
 
 Why make the change
-    Insecure mode of operation was a vestigial option originally designed to aid in bootstrapping and setting up initial admin users.  Telepath now allows for ``cell://`` and ``unix://`` connection schemes that can bypass authentication for local users making insecure mode unnecessary.  Additionally, it is currently possible to bootstrap a root password directly using command line arguments, environment variables, or configuration files.
+    Insecure mode of operation was a vestigial option originally designed to aid in bootstrapping and setting up initial
+    admin users.  Telepath now allows for ``cell://`` and ``unix://`` connection schemes that can bypass authentication
+    for local users making insecure mode unnecessary.  Additionally, it is currently possible to bootstrap a root
+    password directly using command line arguments, environment variables, or configuration files.
 
 What you need to do
     If you have services deployed in insecure mode, they will need to be transitioned to using proper authentication.
@@ -146,10 +193,18 @@ What changed
     Model properties may no longer have default values.
 
 Why make the change
-    The root reason for this change is a complex cascade of requirements which hinge on the simple concept of populating a default value.  In Synapse ``0.2.x``, nodes may be created and edited without lifting them.  This means that ingest speeds can be significantly increased by taking an "upsert" approach.  However, it also has the side effect of making it very difficult to know if a given node already has a value specified in another layer without lifting and fusing the node from all the properties in all the layers within the view.  Ultimately, by removing the expectation of default values for a given property, we have been able to allow the Cortex to create nodes without needing to lift them, creating a large performance benefit.
+    The root reason for this change is a complex cascade of requirements which hinge on the simple concept of populating
+    a default value.  In Synapse ``0.2.x``, nodes may be created and edited without lifting them.  This means that
+    ingest speeds can be significantly increased by taking an "upsert" approach.  However, it also has the side effect
+    of making it very difficult to know if a given node already has a value specified in another layer without lifting
+    and fusing the node from all the properties in all the layers within the view.  Ultimately, by removing the
+    expectation of default values for a given property, we have been able to allow the Cortex to create nodes without
+    needing to lift them, creating a large performance benefit.
 
 What you need to do
-    If you have custom model elements that have default values, they will no longer be populated by default.  As a work around, you may create a trigger which populates the property when the node is added, but use caution when merging properties from multiple layers when populating defaults.
+    If you have custom model elements that have default values, they will no longer be populated by default.  As a work
+    around, you may create a trigger which populates the property when the node is added, but use caution when merging
+    properties from multiple layers when populating defaults.
 
 Node Data Fields Must Be JSON Compatible
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -158,10 +213,14 @@ What changed
     Node properties of type ``data`` as well as untyped ``node data`` must be JSON serializable.
 
 Why make the change
-    Node properties of type ``data`` are stored using msgpack serialization, however many of our externally facing APIs use JSON serialization.  By adding the requirement that these fields are JSON compatible, we prevent issues which would preclude nodes from being returned via HTTP APIs.
+    Node properties of type ``data`` are stored using msgpack serialization, however many of our externally facing APIs
+    use JSON serialization.  By adding the requirement that these fields are JSON compatible, we prevent issues which
+    would preclude nodes from being returned via HTTP APIs.
 
 What you need to do
-    If you're using ``data`` fields or ``node data`` to store raw bytes or other data structures that are incompatible with JSON serialization, you will need to migrate these values to JSON compatible structures prior to running your ``0.2.0`` migration.
+    If you're using ``data`` fields or ``node data`` to store raw bytes or other data structures that are incompatible
+    with JSON serialization, you will need to migrate these values to JSON compatible structures prior to running your
+    ``0.2.0`` migration.
 
 Additional Changes
 ------------------
@@ -175,7 +234,6 @@ Additional Changes
 - Removed cortex offset storage.
 - SYNDEV_OMIT_FINI_WARNS was added to silence tear down warnings.
 - Provenance is disabled by default. Enable by setting ``provenance:en: True`` in ``cell.yaml``.
-- nodedata and ``data`` type must now be json-serializable.  Previously, these accepted binary data.
 - The CellApi ``@adminapi`` decorator now must be called as a function, ``@adminapi()``.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -168,7 +168,9 @@ Additional Changes
 
 - ``map_async`` is now enabled by default for all slabs.
 - Synapse tools may not be used to connect to services of a different minor version.
-- Deprecated annotations added to APIs that will be removed in ``0.3.0``.
+- Storm API methods now support user-impersonation by providing a user iden in the ``opts`` dictionary. This ability is
+  permission enforced.
+- Deprecated annotations added to APIs that will be removed in ``0.3.0``.  This includes the Cortex ``.eval()`` API.
 - The ``sudo`` command has been deprecated and does nothing.
 - Removed cortex offset storage.
 - SYNDEV_OMIT_FINI_WARNS was added to silence tear down warnings.

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1557,10 +1557,6 @@ class Cortex(s_cell.Cell):  # type: ignore
             mesg = 'ext univ name must start with "_"'
             raise s_exc.BadPropDef(name=name, mesg=mesg)
 
-        if info.get('defval', s_common.novalu) is not s_common.novalu:
-            mesg = 'Ext univ may not (yet) have a default value.'
-            raise s_exc.BadPropDef(name=name, mesg=mesg)
-
         self.model.addUnivProp(name, tdef, info)
 
         await self.extunivs.set(name, (name, tdef, info))
@@ -1570,10 +1566,6 @@ class Cortex(s_cell.Cell):  # type: ignore
     async def addFormProp(self, form, prop, tdef, info):
         if not prop.startswith('_'):
             mesg = 'ext prop must begin with "_"'
-            raise s_exc.BadPropDef(prop=prop, mesg=mesg)
-
-        if info.get('defval', s_common.novalu) is not s_common.novalu:
-            mesg = 'Ext prop may not (yet) have a default value.'
             raise s_exc.BadPropDef(prop=prop, mesg=mesg)
 
         self.model.addFormProp(form, prop, tdef, info)

--- a/synapse/lib/spawn.py
+++ b/synapse/lib/spawn.py
@@ -355,7 +355,6 @@ class SpawnCore(s_base.Base):
         self.hive = await s_hive.openurl(f'cell://{self.dirn}', name='*/hive')
         self.onfini(self.hive)
 
-        # TODO cortex configured for remote auth...
         node = await self.hive.open(('auth',))
         self.auth = await s_hiveauth.Auth.anit(node)
         self.onfini(self.auth.fini)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -836,6 +836,7 @@ class StormDmon(s_base.Base):
 
         self.count = 0
         self.status = 'initializing'
+        self.err_evnt = asyncio.Event()
 
         async def fini():
             if self.task is not None:
@@ -852,6 +853,7 @@ class StormDmon(s_base.Base):
         retn = dict(self.ddef)
         retn['count'] = self.count
         retn['status'] = self.status
+        retn['err'] = self.err_evnt.is_set()
         return retn
 
     async def _run(self):
@@ -881,6 +883,7 @@ class StormDmon(s_base.Base):
                 if self.loop_task:
                     self.loop_task.cancel()
                 self.status = f'fatal error: Dmon main cancelled'
+                self.err_evnt.set()
                 logger.warning(f'Dmon main cancelled ({self.iden})')
                 raise
             except s_exc.NoSuchView as e:
@@ -891,6 +894,7 @@ class StormDmon(s_base.Base):
                 raise
             except Exception as e:  # pragma: no cover
                 self.status = f'error: {e}'
+                self.err_evnt.set()
                 logger.exception(f'Dmon error during loop task execution ({self.iden})')
                 await self.waitfini(timeout=1)
 
@@ -922,6 +926,7 @@ class StormDmon(s_base.Base):
 
                     snap.on('warn', dmonWarn)
                     snap.on('print', dmonPrint)
+                    self.err_evnt.clear()
 
                     async for nodepath in snap.storm(text, opts=opts, user=self.user):
                         # all storm tasks yield often to prevent latency
@@ -940,6 +945,7 @@ class StormDmon(s_base.Base):
             except Exception as e:
                 logger.exception(f'Dmon error ({self.iden})')
                 self.status = f'error: {e}'
+                self.err_evnt.set()
                 await self.waitfini(timeout=1)
 
 class Runtime:

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -958,7 +958,7 @@ class List(Prim):
         '''
         Return the length of the list.
         '''
-        # TODO - Remove this v0.3.0
+        s_common.deprecated('StormType List.length()')
         return len(self)
 
     async def _methListSize(self):

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -270,7 +270,6 @@ class FileModule(s_module.CoreModule):
                         'doc': 'The best known base name for the file.'}),
 
                     ('mime', ('file:mime', {}), {
-                        'defval': '??',
                         'doc': 'The "best" mime type name for the file.'}),
 
                     ('mime:x509:cn', ('str', {}), {

--- a/synapse/models/geopol.py
+++ b/synapse/models/geopol.py
@@ -34,12 +34,12 @@ class PolModule(s_module.CoreModule):
 
                     ('pol:country', {}, (
                         ('flag', ('file:bytes', {}), {}),
-                        ('founded', ('time', {}), {'defval': 0}),
+                        ('founded', ('time', {}), {}),
                         ('iso2', ('pol:iso2', {}), {}),
                         ('iso3', ('pol:iso3', {}), {}),
                         ('isonum', ('pol:isonum', {}), {}),
                         ('name', ('str', {'lower': True}), {}),
-                        ('pop', ('int', {}), {'defval': 0}),
+                        ('pop', ('int', {}), {}),
                         ('tld', ('inet:fqdn', {}), {}),
                     )),
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -1146,7 +1146,6 @@ class InetModule(s_module.CoreModule):
 
                     ('inet:asn', {}, (
                         ('name', ('str', {'lower': True}), {
-                            'defval': '??',
                             'doc': 'The name of the organization currently responsible for the ASN.'
                         }),
                         ('owner', ('ou:org', {}), {
@@ -1376,11 +1375,9 @@ class InetModule(s_module.CoreModule):
                         }),
                         ('issuffix', ('bool', {}), {
                             'doc': 'True if the FQDN is considered a suffix.',
-                            'defval': 0,
                         }),
                         ('iszone', ('bool', {}), {
                             'doc': 'True if the FQDN is considered a zone.',
-                            'defval': 0,
                         }),
                         ('zone', ('inet:fqdn', {}), {
                             'doc': 'The zone level parent for this FQDN.',
@@ -1494,19 +1491,19 @@ class InetModule(s_module.CoreModule):
 
                     ('inet:ipv4', {}, (
 
-                        ('asn', ('inet:asn', {}), {'defval': 0,  # TODO replace with nullval
+                        ('asn', ('inet:asn', {}), {
                             'doc': 'The ASN to which the IPv4 address is currently assigned.'}),
 
                         ('latlong', ('geo:latlong', {}), {
                             'doc': 'The best known latitude/longitude for the node'}),
 
-                        ('loc', ('loc', {}), {'defval': '??',
+                        ('loc', ('loc', {}), {
                             'doc': 'The geo-political location string for the IPv4.'}),
 
                         ('place', ('geo:place', {}), {
                             'doc': 'The geo:place assocated with the latlong property.'}),
 
-                        ('type', ('str', {}), {'defval': '??',
+                        ('type', ('str', {}), {
                             'doc': 'The type of IP address (e.g., private, multicast, etc.).'}),
 
                         ('dns:rev', ('inet:fqdn', {}), {
@@ -1516,7 +1513,6 @@ class InetModule(s_module.CoreModule):
                     ('inet:ipv6', {}, (
 
                         ('asn', ('inet:asn', {}), {
-                            'defval': 0,  # TODO replace with nullval
                             'doc': 'The ASN to which the IPv6 address is currently assigned.'}),
 
                         ('ipv4', ('inet:ipv4', {}), {
@@ -1532,13 +1528,11 @@ class InetModule(s_module.CoreModule):
                             'doc': 'The most current DNS reverse lookup for the IPv6.'}),
 
                         ('loc', ('loc', {}), {
-                            'defval': '??',
                             'doc': 'The geo-political location string for the IPv6.'}),
                     )),
 
                     ('inet:mac', {}, (
                         ('vendor', ('str', {}), {
-                            'defval': '??',
                             'doc': 'The vendor associated with the 24-bit prefix of a MAC address.'
                         }),
                     )),
@@ -2223,11 +2217,9 @@ class InetModule(s_module.CoreModule):
                             'doc': 'The "expires" time from the whois record.'
                         }),
                         ('registrar', ('inet:whois:rar', {}), {
-                            'defval': '??',
                             'doc': 'The registrar name from the whois record.'
                         }),
                         ('registrant', ('inet:whois:reg', {}), {
-                            'defval': '??',
                             'doc': 'The registrant name from the whois record.'
                         }),
                     )),
@@ -2405,7 +2397,7 @@ class InetModule(s_module.CoreModule):
                         ('place', ('geo:place', {}), {
                             'doc': 'The geo:place assocated with the latlong property.'}),
 
-                        ('loc', ('loc', {}), {'defval': '??',
+                        ('loc', ('loc', {}), {
                             'doc': 'The geo-political location string for the wireless access point.'}),
                     )),
 

--- a/synapse/models/media.py
+++ b/synapse/models/media.py
@@ -22,17 +22,14 @@ class MediaModule(s_module.CoreModule):
                     'doc': 'The (optional) file blob containing or published as the news',
                 }),
                 ('title', ('str', {'lower': True}), {
-                    'defval': '??',
                     'doc': 'Title/Headline for the news',
                     'ex': 'mars lander reaches mars',
                 }),
                 ('summary', ('str', {}), {
-                    'defval': '??',
                     'doc': 'A brief summary of the news item',
                     'ex': 'lorum ipsum',
                 }),
                 ('published', ('time', {}), {
-                    'defval': 0,
                     'doc': 'The date the news item was published',
                     'ex': '20161201180433',
                 }),
@@ -41,7 +38,6 @@ class MediaModule(s_module.CoreModule):
                     'ex': 'microsoft',
                 }),
                 ('author', ('ps:name', {}), {
-                    'defval': '?,?',
                     'doc': 'The free-form author of the news',
                     'ex': 'stark,anthony'
                 }),

--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -141,14 +141,12 @@ class SynModule(s_module.CoreModule):
                     ('isnow', ('syn:tag', {}), {
                         'doc': 'Set to an updated tag if the tag has been renamed.'}),
 
-                    ('doc', ('str', {}), {'defval': '',
-                        'doc': 'A short definition for the tag.'}),
+                    ('doc', ('str', {}), {'doc': 'A short definition for the tag.'}),
 
                     ('depth', ('int', {}), {'ro': 1,
                         'doc': 'How deep the tag is in the hierarchy.'}),
 
-                    ('title', ('str', {}), {'defval': '',
-                        'doc': 'A display title for the tag.'}),
+                    ('title', ('str', {}), {'doc': 'A display title for the tag.'}),
 
                     ('base', ('str', {}), {'ro': 1,
                         'doc': 'The tag base name. Eg baz for foo.bar.baz'}),

--- a/synapse/models/telco.py
+++ b/synapse/models/telco.py
@@ -195,7 +195,6 @@ class TelcoModule(s_module.CoreModule):
                 ('tel:phone', {}, (
                     ('loc', ('loc', {}), {
                         'doc': 'The location associated with the number.',
-                        'defval': '??',
                     }),
                 )),
                 ('tel:call', {}, (
@@ -250,15 +249,12 @@ class TelcoModule(s_module.CoreModule):
                     }),
                     ('manu', ('str', {'lower': 1}), {
                         'doc': 'The TAC manufacturer name',
-                        'defval': '??',
                     }),
                     ('model', ('str', {'lower': 1}), {
                         'doc': 'The TAC model name',
-                        'defval': '??',
                     }),
                     ('internal', ('str', {'lower': 1}), {
                         'doc': 'The TAC internal model name',
-                        'defval': '??',
                     }),
                 )),
                 ('tel:mob:imei', {}, (

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -3847,13 +3847,6 @@ class CortexBasicTest(s_t_utils.SynTest):
                 with self.raises(s_exc.BadPropDef):
                     await core.addUnivProp('woot', ('str', {'lower': True}), {})
 
-                # blowup for defvals
-                with self.raises(s_exc.BadPropDef):
-                    await core.addFormProp('inet:ipv4', '_visi', ('int', {}), {'defval': 20})
-
-                with self.raises(s_exc.BadPropDef):
-                    await core.addUnivProp('_woot', ('str', {'lower': True}), {'defval': 'asdf'})
-
                 with self.raises(s_exc.NoSuchForm):
                     await core.addFormProp('inet:newp', '_visi', ('int', {}), {})
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -10,6 +10,7 @@ import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.cortex as s_cortex
 
+import synapse.lib.coro as s_coro
 import synapse.lib.node as s_node
 import synapse.lib.version as s_version
 
@@ -3791,14 +3792,15 @@ class CortexBasicTest(s_t_utils.SynTest):
             msgs = await core.stormlist('dmon.list')
             self.stormIsInPrint('(wootdmon            ): running', msgs)
 
+            dmon = list(core.stormdmons.values())[0]
+
             # make the dmon blow up
             await core.nodes('''
                 $lib.queue.get(boom).put(hehe)
                 for ($offs, $item) in $q.gets(size=1) { $q.cull($offs) }
             ''')
 
-            # TODO figure out a way to fix this
-            await asyncio.sleep(0.1)
+            self.true(await s_coro.event_wait(dmon.err_evnt, 6))
 
             msgs = await core.stormlist('dmon.list')
             self.stormIsInPrint('(wootdmon            ): error', msgs)

--- a/synapse/tests/test_model_syn.py
+++ b/synapse/tests/test_model_syn.py
@@ -176,7 +176,6 @@ class SynModelTest(s_t_utils.SynTest):
             self.len(1, nodes)
             node = nodes[0]
             self.eq(('syn:prop', 'test:edge:n1:form'), node.ndef)
-            self.none(node.get('defval'))
             self.eq('form', node.get('base'))
             self.eq('n1:form', node.get('relname'))
 

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 poptsToWords = {
         'ex': 'Example',
         'ro': 'Read Only',
-        'defval': 'Default Value',
     }
 
 raw_back_slash_colon = r'\:'
@@ -244,8 +243,6 @@ def processFormsProps(rst, dochelp, forms, univ_names):
                              ''
                              )
                 for k, v in popts.items():
-                    if k == 'defval' and v == '':
-                        v = "''"
                     k = poptsToWords.get(k, k.replace(':', raw_back_slash_colon))
                     rst.addLines('  ' + f'* {k}: ``{v}``')
 
@@ -294,8 +291,6 @@ def processUnivs(rst, dochelp, univs):
                          ''
                          )
             for k, v in info.items():
-                if k == 'defval' and v == '':
-                    v = "''"
                 k = poptsToWords.get(k, k.replace(':', raw_back_slash_colon))
                 rst.addLines('  ' + f'* {k}: ``{v}``')
 


### PR DESCRIPTION
- Bump changelog to include data from #1633 and remove long lines from the raw file. Let RST do its job.
- Fix dmon test todo by adding an error-status event to the storm dmon. This status is also exposed in the pack method of the StormDmon. 
- Remove references to setting ``defval`` values in the model.
- Fix some generic todos