### PR TITLE
auth model elements, spooled storage, subgraph carving features

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -4,6 +4,7 @@ import fnmatch
 import logging
 import binascii
 import itertools
+import contextlib
 import collections
 
 import synapse.exc as s_exc
@@ -14,6 +15,7 @@ import synapse.lib.coro as s_coro
 import synapse.lib.node as s_node
 import synapse.lib.cache as s_cache
 import synapse.lib.types as s_types
+import synapse.lib.spooled as s_spooled
 import synapse.lib.provenance as s_provenance
 import synapse.lib.stormtypes as s_stormtypes
 
@@ -205,6 +207,9 @@ class SubGraph:
 
                     'degrees': 1,
 
+                    'filterinput': True,
+                    'yieldfiltered': False,
+
                     'filters': [
                         '-(#foo or #bar)',
                         '-(foo:bar or baz:faz)',
@@ -246,6 +251,9 @@ class SubGraph:
 
         self.rules.setdefault('refs', False)
         self.rules.setdefault('degrees', 1)
+
+        self.rules.setdefault('filterinput', True)
+        self.rules.setdefault('yieldfiltered', False)
 
     async def omit(self, node):
 
@@ -303,52 +311,70 @@ class SubGraph:
 
     async def run(self, runt, genr):
 
-        done = {}
         degrees = self.rules.get('degrees')
+        filterinput = self.rules.get('filterinput')
+        yieldfiltered = self.rules.get('yieldfiltered')
 
         self.user = runt.user
 
-        async for node, path in genr:
+        todo = collections.deque()
 
-            if await self.omit(node):
-                continue
+        async with contextlib.AsyncExitStack() as stack:
 
-            path.meta('graph:seed', True)
+            done = await stack.enter_async_context(s_spooled.Set.ctx())
+            intodo = await stack.enter_async_context(s_spooled.Set.ctx())
 
-            todo = collections.deque([(node, path, 0)])
+            async def todogenr():
 
-            while todo:
+                async for node, path in genr:
+                    path.meta('graph:seed', True)
+                    yield node, path, 0
 
-                tnode, tpath, tdist = todo.popleft()
+                while todo:
+                    yield todo.popleft()
 
-                # filter out nodes that we've already done at
-                # the given distance or less... (best possible)
-                donedist = done.get(tnode.buid)
-                if donedist is not None and donedist <= tdist:
+            async for node, path, dist in todogenr():
+
+                if node.buid in done:
                     continue
 
-                done[tnode.buid] = tdist
+                await done.add(node.buid)
+                intodo.discard(node.buid)
+
+                omitted = False
+                if dist > 0 or filterinput:
+                    omitted = await self.omit(node)
+
+                if omitted and not yieldfiltered:
+                    continue
+
+                # we must traverse the pivots for the node *regardless* of degrees
+                # due to needing to tie any leaf nodes to nodes that were already yielded
 
                 edges = set()
-                ndist = tdist + 1
-
-                async for pivn, pivp in self.pivots(runt, tnode, tpath):
-
-                    if await self.omit(pivn):
-                        continue
+                async for pivn, pivp in self.pivots(runt, node, path):
 
                     edges.add(pivn.iden())
 
-                    if degrees is not None and ndist > degrees:
+                    # we dont pivot from omitted nodes
+                    if omitted:
                         continue
 
-                    todo.append((pivn, pivp, ndist))
+                    # no need to pivot to nodes we already did
+                    if pivn.buid in done:
+                        continue
 
-                edgelist = [(iden, {}) for iden in edges]
-                tpath.meta('edges', edgelist)
+                    # no need to queue up todos that are already in todo
+                    if pivn.buid in intodo:
+                        continue
 
-                if donedist is None:
-                    yield tnode, tpath
+                    # do we have room to go another degree out?
+                    if degrees is None or dist < degrees:
+                        todo.append((pivn, pivp, dist + 1))
+                        await intodo.add(pivn.buid)
+
+                path.meta('edges', [(iden, {}) for iden in edges])
+                yield node, path
 
 class Oper(AstNode):
     pass

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -104,6 +104,13 @@ class Base:
 
         return self
 
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def ctx(cls, *args, **kwargs):
+        item = await cls.anit(*args, **kwargs)
+        yield item
+        await item.fini()
+
     async def __anit__(self):
 
         self.loop = asyncio.get_running_loop()

--- a/synapse/lib/modules.py
+++ b/synapse/lib/modules.py
@@ -5,6 +5,7 @@ coremods = (
     'synapse.models.dns.DnsModule',
     'synapse.models.orgs.OuModule',
     'synapse.models.syn.SynModule',
+    'synapse.models.auth.AuthModule',
     'synapse.models.base.BaseModule',
     'synapse.models.person.PsModule',
     'synapse.models.files.FileModule',

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -165,8 +165,9 @@ class Snap(s_base.Base):
     async def printf(self, mesg):
         await self.fire('print', mesg=mesg)
 
-    async def warn(self, mesg, **info):
-        logger.warning(mesg)
+    async def warn(self, mesg, log=True, **info):
+        if log:
+            logger.warning(mesg)
         await self.fire('warn', mesg=mesg, **info)
 
     async def getNodeByBuid(self, buid):

--- a/synapse/lib/spooled.py
+++ b/synapse/lib/spooled.py
@@ -64,39 +64,3 @@ class Set(Spooled):
             return
 
         self.realset.discard(valu)
-
-class Dict(Spooled):
-
-    async def __anit__(self, size=10000):
-        await Spooled.__anit__(self, size=size)
-        self.info = {}
-
-    async def set(self, name, valu):
-
-        if self.fallback:
-            self._set_fallback(name, valu)
-            return
-
-        self.info[name] = valu
-
-        if len(self.info) >= self.size:
-            await self._initFallBack()
-            [self._set_fallback(k, v) for (k, v) in self.info.items()]
-            self.info.clear()
-
-    def get(self, name, defv=None):
-
-        if self.fallback:
-            return self._get_fallback(name, defv=defv)
-
-        return self.info.get(name, defv)
-
-    def _set_fallback(self, name, valu):
-        self.slab.put(s_msgpack.en(name), s_msgpack.en(valu))
-
-    def _get_fallback(self, name, defv=None):
-        byts = self.slab.get(s_msgpack.en(name))
-        if byts is None:
-            return defv
-
-        return s_msgpack.un(byts)

--- a/synapse/lib/spooled.py
+++ b/synapse/lib/spooled.py
@@ -10,7 +10,7 @@ class Spooled(s_base.Base):
     '''
     A Base class that can be used to implement objects which fallback to lmdb.
 
-    These objects are intended to fallback from Python to lmbd slabs, which alligns them
+    These objects are intended to fallback from Python to lmbd slabs, which aligns them
     together. Under memory pressure, these objects have a better shot of getting paged out.
     '''
 

--- a/synapse/lib/spooled.py
+++ b/synapse/lib/spooled.py
@@ -1,0 +1,99 @@
+import shutil
+import tempfile
+
+import synapse.lib.base as s_base
+import synapse.lib.msgpack as s_msgpack
+import synapse.lib.lmdbslab as s_lmdbslab
+
+class Spooled(s_base.Base):
+
+    async def __anit__(self, size=10000):
+
+        await s_base.Base.__anit__(self)
+
+        self.size = size
+        self.slab = None
+        self.slabpath = None
+        self.fallback = False
+
+        async def fini():
+
+            if self.slab is not None:
+                await self.slab.fini()
+
+            if self.slabpath is not None:
+                shutil.rmtree(self.slabpath, ignore_errors=True)
+
+        self.onfini(fini)
+
+    async def _initFallBack(self):
+        self.fallback = True
+        self.slabpath = tempfile.mkdtemp()
+        self.slab = await s_lmdbslab.Slab.anit(self.slabpath)
+
+class Set(Spooled):
+    '''
+    A minimal set-like implementation that will spool to a slab on large growth.
+    '''
+    async def __anit__(self, size=10000):
+        await Spooled.__anit__(self, size=size)
+        self.realset = set()
+
+    def __contains__(self, valu):
+        if self.fallback:
+            return self.slab.get(s_msgpack.en(valu)) != None
+        return valu in self.realset
+
+    async def add(self, valu):
+
+        if self.fallback:
+            return self.slab.put(s_msgpack.en(valu), b'\x01')
+
+        self.realset.add(valu)
+        if len(self.realset) >= self.size:
+            await self._initFallBack()
+            [self.slab.put(s_msgpack.en(valu), b'\x01') for valu in self.realset]
+            self.realset.clear()
+
+    def discard(self, valu):
+
+        if self.fallback:
+            self.slab.pop(s_msgpack.en(valu))
+            return
+
+        self.realset.discard(valu)
+
+class Dict(Spooled):
+
+    async def __anit__(self, size=10000):
+        await Spooled.__anit__(self, size=size)
+        self.info = {}
+
+    async def set(self, name, valu):
+
+        if self.fallback:
+            return self._set_fallback(name, valu)
+
+        self.info[name] = valu
+
+        if len(self.info) >= self.size:
+            await self._initFallBack()
+            [ self._set_fallback(k, v) for (k, v) in self.info.items() ]
+            self.info.clear()
+
+    def get(self, name, defv=None):
+
+        if self.fallback:
+            return self._get_fallback(name, defv=defv)
+
+        return self.info.get(name, defv)
+
+    def _set_fallback(self, name, valu):
+        self.slab.put(s_msgpack.en(name), s_msgpack.en(valu))
+
+    def _get_fallback(self, name, defv=None):
+        byts = self.slab.get(s_msgpack.en(name))
+        if byts is None:
+            return defv
+
+        return s_msgpack.un(byts)

--- a/synapse/lib/spooled.py
+++ b/synapse/lib/spooled.py
@@ -47,9 +47,11 @@ class Set(Spooled):
     async def add(self, valu):
 
         if self.fallback:
-            return self.slab.put(s_msgpack.en(valu), b'\x01')
+            self.slab.put(s_msgpack.en(valu), b'\x01')
+            return
 
         self.realset.add(valu)
+
         if len(self.realset) >= self.size:
             await self._initFallBack()
             [self.slab.put(s_msgpack.en(valu), b'\x01') for valu in self.realset]
@@ -72,7 +74,8 @@ class Dict(Spooled):
     async def set(self, name, valu):
 
         if self.fallback:
-            return self._set_fallback(name, valu)
+            self._set_fallback(name, valu)
+            return
 
         self.info[name] = valu
 

--- a/synapse/lib/spooled.py
+++ b/synapse/lib/spooled.py
@@ -2,10 +2,17 @@ import shutil
 import tempfile
 
 import synapse.lib.base as s_base
+import synapse.lib.const as s_const
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.lmdbslab as s_lmdbslab
 
 class Spooled(s_base.Base):
+    '''
+    A Base class that can be used to implement objects which fallback to lmdb.
+
+    These objects are intended to fallback from Python to lmbd slabs, which alligns them
+    together. Under memory pressure, these objects have a better shot of getting paged out.
+    '''
 
     async def __anit__(self, size=10000):
 
@@ -29,25 +36,34 @@ class Spooled(s_base.Base):
     async def _initFallBack(self):
         self.fallback = True
         self.slabpath = tempfile.mkdtemp()
-        self.slab = await s_lmdbslab.Slab.anit(self.slabpath)
+        self.slab = await s_lmdbslab.Slab.anit(self.slabpath,
+                                               map_size=s_const.mebibyte * 32)
 
 class Set(Spooled):
     '''
     A minimal set-like implementation that will spool to a slab on large growth.
     '''
+
     async def __anit__(self, size=10000):
         await Spooled.__anit__(self, size=size)
         self.realset = set()
+        self.len = 0
 
     def __contains__(self, valu):
         if self.fallback:
             return self.slab.get(s_msgpack.en(valu)) is not None
         return valu in self.realset
 
+    def __len__(self):
+        if self.fallback:
+            return self.len
+        return len(self.realset)
+
     async def add(self, valu):
 
         if self.fallback:
             self.slab.put(s_msgpack.en(valu), b'\x01')
+            self.len += 1
             return
 
         self.realset.add(valu)
@@ -55,12 +71,16 @@ class Set(Spooled):
         if len(self.realset) >= self.size:
             await self._initFallBack()
             [self.slab.put(s_msgpack.en(valu), b'\x01') for valu in self.realset]
+            self.len = len(self.realset)
             self.realset.clear()
 
     def discard(self, valu):
 
         if self.fallback:
-            self.slab.pop(s_msgpack.en(valu))
+            ret = self.slab.pop(s_msgpack.en(valu))
+            if ret is None:
+                return
+            self.len -= 1
             return
 
         self.realset.discard(valu)

--- a/synapse/lib/spooled.py
+++ b/synapse/lib/spooled.py
@@ -41,7 +41,7 @@ class Set(Spooled):
 
     def __contains__(self, valu):
         if self.fallback:
-            return self.slab.get(s_msgpack.en(valu)) != None
+            return self.slab.get(s_msgpack.en(valu)) is not None
         return valu in self.realset
 
     async def add(self, valu):
@@ -81,7 +81,7 @@ class Dict(Spooled):
 
         if len(self.info) >= self.size:
             await self._initFallBack()
-            [ self._set_fallback(k, v) for (k, v) in self.info.items() ]
+            [self._set_fallback(k, v) for (k, v) in self.info.items()]
             self.info.clear()
 
     def get(self, name, defv=None):

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2005,8 +2005,6 @@ class GraphCmd(Cmd):
 
         subg = s_ast.SubGraph(rules)
 
-        genr = subg.run(runt, genr)
-
         async for node, path in subg.run(runt, genr):
             yield node, path
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1966,6 +1966,14 @@ class GraphCmd(Cmd):
         pars.add_argument('--form-filter', default=[], nargs=2, action='append',
                           help='Specify a <form> <filter> form specific filter.')
 
+        pars.add_argument('--refs', default=False, action='store_true',
+                          help='Do automatic in-model pivoting with node.getNodeRefs().')
+        pars.add_argument('--yield-filtered', default=False, action='store_true', dest='yieldfiltered',
+                          help='Yield nodes which would be filtered. This still performs pivots to collect edge data,'
+                               'but does not yield pivoted nodes.')
+        pars.add_argument('--no-filter-input', default=True, action='store_false', dest='filterinput',
+                          help='Do not drop input nodes if they would match a filter.')
+
         return pars
 
     async def execStormCmd(self, runt, genr):
@@ -1977,6 +1985,11 @@ class GraphCmd(Cmd):
             'filters': [],
 
             'forms': {},
+
+            'refs': self.opts.refs,
+            'filterinput': self.opts.filterinput,
+            'yieldfiltered': self.opts.yieldfiltered,
+
         }
 
         for pivo in self.opts.pivot:

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -263,6 +263,7 @@ class LibBase(Lib):
             'true': True,
             'false': False,
             'text': self._text,
+            'warn': self._warn,
             'print': self._print,
             'sorted': self._sorted,
             'import': self._libBaseImport,
@@ -336,12 +337,21 @@ class LibBase(Lib):
         ints = [intify(x) for x in vals]
         return max(*ints)
 
-    async def _print(self, mesg, **kwargs):
+    @staticmethod
+    def _get_mesg(mesg, **kwargs):
         if not isinstance(mesg, str):
             mesg = repr(mesg)
         elif kwargs:
             mesg = kwarg_format(mesg, **kwargs)
+        return mesg
+
+    async def _print(self, mesg, **kwargs):
+        mesg = self._get_mesg(mesg, **kwargs)
         await self.runt.printf(mesg)
+
+    async def _warn(self, mesg, **kwargs):
+        mesg = self._get_mesg(mesg, **kwargs)
+        await self.runt.warn(mesg, log=False)
 
     async def _dict(self, **kwargs):
         return Dict(kwargs)

--- a/synapse/models/auth.py
+++ b/synapse/models/auth.py
@@ -1,0 +1,62 @@
+import synapse.lib.module as s_module
+
+class AuthModule(s_module.CoreModule):
+
+    def getModelDefs(self):
+
+        modl = {
+            'types': (
+                ('auth:creds', ('guid', {}), {
+                    'doc': 'A unique set of credentials used to authenticate to a system.',
+                }),
+                ('auth:access', ('guid', {}), {
+                    'doc': 'An instance of using a creds to access a resource.',
+                }),
+            ),
+            'forms': (
+                ('auth:creds', {}, (
+                    ('email', ('inet:email', {}), {
+                        'doc': 'The email address used to identify the user.',
+                    }),
+                    ('user', ('inet:user', {}), {
+                        'doc': 'The user name used to identify the user.',
+                    }),
+                    ('phone', ('tel:phone', {}), {
+                        'doc': 'The phone number used to identify the user.',
+                    }),
+                    ('passwd', ('inet:passwd', {}), {
+                        'doc': 'The password used to authenticate.',
+                    }),
+                    ('passwdhash', ('it:auth:passwdhash', {}), {
+                        'doc': 'The password hash used to authenticate.',
+                    }),
+                    ('website', ('inet:url', {}), {
+                        'doc': 'The base URL of the website that the credentials allow access to.',
+                    }),
+                    ('host', ('it:host', {}), {
+                        'doc': 'The host that the credentials allow access to.',
+                    }),
+                    ('wifi:ssid', ('inet:wifi:ssid', {}), {
+                        'doc': 'The WiFi SSID that the credentials allow access to.',
+                    }),
+                    # TODO x509, rfid, mat:item locks/keys
+                )),
+
+                ('auth:access', {}, (
+                    ('creds',  ('auth:creds', {}), {
+                        'doc': 'The credentials used to attempt access.',
+                    }),
+                    ('time', ('time', {}), {
+                        'doc': 'The time of the access attempt.',
+                    }),
+                    ('success', ('bool', {}), {
+                        'doc': 'Set to true if the access was successful.',
+                    }),
+                    ('person', ('ps:person', {}), {
+                        'doc': 'The person who attempted access.',
+                    }),
+                )),
+            ),
+        }
+        name = 'auth'
+        return ((name, modl), )

--- a/synapse/models/auth.py
+++ b/synapse/models/auth.py
@@ -10,7 +10,7 @@ class AuthModule(s_module.CoreModule):
                     'doc': 'A unique set of credentials used to access a resource.',
                 }),
                 ('auth:access', ('guid', {}), {
-                    'doc': 'An instance of using a creds to access a resource.',
+                    'doc': 'An instance of using creds to access a resource.',
                 }),
             ),
             'forms': (
@@ -43,7 +43,7 @@ class AuthModule(s_module.CoreModule):
                 )),
 
                 ('auth:access', {}, (
-                    ('creds',  ('auth:creds', {}), {
+                    ('creds', ('auth:creds', {}), {
                         'doc': 'The credentials used to attempt access.',
                     }),
                     ('time', ('time', {}), {

--- a/synapse/models/auth.py
+++ b/synapse/models/auth.py
@@ -7,7 +7,7 @@ class AuthModule(s_module.CoreModule):
         modl = {
             'types': (
                 ('auth:creds', ('guid', {}), {
-                    'doc': 'A unique set of credentials used to authenticate to a system.',
+                    'doc': 'A unique set of credentials used to access a resource.',
                 }),
                 ('auth:access', ('guid', {}), {
                     'doc': 'An instance of using a creds to access a resource.',

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2026,7 +2026,6 @@ class CortexBasicTest(s_t_utils.SynTest):
             alldefs = {}
 
             async with await core.snap() as snap:
-
                 async for node, path in snap.storm('inet:fqdn', opts={'graph': rules}):
 
                     if path.metadata.get('graph:seed'):

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2152,6 +2152,18 @@ class CortexBasicTest(s_t_utils.SynTest):
                      ('inet:fqdn', 'com'),
                      ('inet:asn', 20)}, set(alldefs.keys()))
 
+            # Construct a test that encounters nodes which are already
+            # in the to-do queue. This is mainly a coverage test.
+            q = '[inet:ipv4=0 inet:ipv4=1 inet:ipv4=2 :asn=1138 +#deathstar]'
+            await core.nodes(q)
+
+            q = '#deathstar | graph --degree 2 --refs'
+            ndefs = set()
+            async with await core.snap() as snap:
+                async for node, path in snap.storm(q):
+                    ndefs.add(node.ndef)
+            self.isin(('inet:asn', 1138), ndefs)
+
     async def test_storm_two_level_assignment(self):
         async with self.getTestCore() as core:
             q = '$foo=baz $bar=$foo [test:str=$bar]'

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2026,6 +2026,7 @@ class CortexBasicTest(s_t_utils.SynTest):
             alldefs = {}
 
             async with await core.snap() as snap:
+
                 async for node, path in snap.storm('inet:fqdn', opts={'graph': rules}):
 
                     if path.metadata.get('graph:seed'):

--- a/synapse/tests/test_lib_base.py
+++ b/synapse/tests/test_lib_base.py
@@ -440,3 +440,11 @@ class BaseTest(s_t_utils.SynTest):
 
         self.true(mixed.m1fini.is_set())
         self.true(mixed.m2fini.is_set())
+
+    async def test_ctx(self):
+
+        async with Hehe.ctx(1138) as hehe:
+            self.eq(1138, hehe.foo)
+            self.eq(1148, hehe.bar)
+            self.false(hehe.isfini)
+        self.true(hehe.isfini)

--- a/synapse/tests/test_lib_spooled.py
+++ b/synapse/tests/test_lib_spooled.py
@@ -1,0 +1,34 @@
+import os
+
+import synapse.tests.utils as s_test
+
+import synapse.lib.spooled as s_spooled
+
+class SpooledTest(s_test.SynTest):
+
+    async def test_spooled_set(self):
+
+        sset = await s_spooled.Set.anit(size=2)
+
+        await sset.add(10)
+        self.true(10 in sset)
+        sset.discard(10)
+        self.false(10 in sset)
+
+        self.false(sset.fallback)
+
+        await sset.add(10)
+        await sset.add(20)
+        await sset.add(30)
+
+        self.nn(sset.slab)
+        self.nn(sset.slabpath)
+        self.true(sset.fallback)
+
+        self.true(10 in sset)
+        sset.discard(10)
+        self.false(10 in sset)
+
+        self.true(os.path.isdir(sset.slabpath))
+        await sset.fini()
+        self.false(os.path.isdir(sset.slabpath))

--- a/synapse/tests/test_lib_spooled.py
+++ b/synapse/tests/test_lib_spooled.py
@@ -21,6 +21,8 @@ class SpooledTest(s_test.SynTest):
         await sset.add(20)
         await sset.add(30)
 
+        await sset.add(None)
+
         self.nn(sset.slab)
         self.nn(sset.slabpath)
         self.true(sset.fallback)
@@ -28,6 +30,8 @@ class SpooledTest(s_test.SynTest):
         self.true(10 in sset)
         sset.discard(10)
         self.false(10 in sset)
+
+        self.true(None in sset)
 
         self.true(os.path.isdir(sset.slabpath))
         await sset.fini()

--- a/synapse/tests/test_lib_spooled.py
+++ b/synapse/tests/test_lib_spooled.py
@@ -9,19 +9,25 @@ class SpooledTest(s_test.SynTest):
     async def test_spooled_set(self):
 
         sset = await s_spooled.Set.anit(size=2)
+        self.len(0, sset)
 
         await sset.add(10)
         self.true(10 in sset)
+        self.len(1, sset)
         sset.discard(10)
         self.false(10 in sset)
 
+        self.len(0, sset)
         self.false(sset.fallback)
 
         await sset.add(10)
+
+        # Trigger fallback
         await sset.add(20)
         await sset.add(30)
-
         await sset.add(None)
+
+        self.len(4, sset)
 
         self.nn(sset.slab)
         self.nn(sset.slabpath)
@@ -30,6 +36,10 @@ class SpooledTest(s_test.SynTest):
         self.true(10 in sset)
         sset.discard(10)
         self.false(10 in sset)
+        self.len(3, sset)
+
+        sset.discard(10)
+        self.len(3, sset)
 
         self.true(None in sset)
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -2875,3 +2875,17 @@ class StormTypesTest(s_test.SynTest):
             self.eq(('foo', 'bar'), await core.callStorm('$list = $lib.list() $list.append(foo) $list.append(bar) return($list)'))
             self.eq({'foo': 'bar'}, await core.callStorm('$dict = $lib.dict() $dict.foo = bar return($dict)'))
             self.eq({'foo': 2}, await core.callStorm('$tally = $lib.stats.tally() $tally.inc(foo) $tally.inc(foo) return($tally)'))
+
+    async def test_print_warn(self):
+        async with self.getTestCore() as core:
+            q = '$lib.print(hello)'
+            msgs = await core.stormlist(q)
+            self.stormIsInPrint('hello', msgs)
+
+            q = '$name="moto" $lib.print("hello {name}", name=$name)'
+            msgs = await core.stormlist(q)
+            self.stormIsInPrint('hello moto', msgs)
+
+            q = '$name="moto" $lib.warn("hello {name}", name=$name)'
+            msgs = await core.stormlist(q)
+            self.stormIsInWarn('hello moto', msgs)

--- a/synapse/tests/test_model_auth.py
+++ b/synapse/tests/test_model_auth.py
@@ -1,0 +1,55 @@
+#import copy
+import logging
+
+import synapse.exc as s_exc
+import synapse.common as s_common
+import synapse.tests.utils as s_t_utils
+#from synapse.tests.utils import alist
+
+logger = logging.getLogger(__name__)
+
+class AuthModelTest(s_t_utils.SynTest):
+
+    async def test_model_auth(self):
+
+        async with self.getTestCore() as core:
+
+            cred = s_common.guid()
+            nodes = await core.nodes(f'''
+                [ auth:creds={cred}
+                    :email=visi@vertex.link
+                    :user=lolz
+                    :phone=12028675309
+                    :passwd=secret
+                    :passwdhash="*"
+                    :website=https://www.vertex.link
+                    :host="*"
+                    :wifi:ssid=vertexproject
+                ]
+            ''')
+
+            self.len(1, nodes)
+            self.nn(nodes[0].props['host'])
+            self.nn(nodes[0].props['passwdhash'])
+
+            self.eq('lolz', nodes[0].props['user'])
+            self.eq('12028675309', nodes[0].props['phone'])
+            self.eq('secret', nodes[0].props['passwd'])
+            self.eq('visi@vertex.link', nodes[0].props['email'])
+            self.eq('https://www.vertex.link', nodes[0].props['website'])
+            self.eq('vertexproject', nodes[0].props['wifi:ssid'])
+
+            accs = s_common.guid()
+            nodes = await core.nodes(f'''
+                [ auth:access={accs}
+                    :person="*"
+                    :creds={cred}
+                    :time=20200202
+                    :success=true
+                ]
+            ''')
+            self.nn(nodes[0].props['creds'])
+            self.nn(nodes[0].props['person'])
+
+            self.eq(True, nodes[0].props['success'])
+            self.eq(1580601600000, nodes[0].props['time'])

--- a/synapse/tests/test_model_auth.py
+++ b/synapse/tests/test_model_auth.py
@@ -1,10 +1,7 @@
-#import copy
 import logging
 
-import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.tests.utils as s_t_utils
-#from synapse.tests.utils import alist
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Initial auth model
- Add ``filterinput`` and ``yieldfiltered`` flags to the graph rules.
- Add ``$lib.warn()`` to stormtypes
- Add ``synapse.lib.spool``
- Add ``synapse.lib.base.Base.ctx()`` helper.
