### PR TITLE
Migrate splices to nodeedits

### DIFF
--- a/synapse/tests/test_tools_migrate020.py
+++ b/synapse/tests/test_tools_migrate020.py
@@ -1115,9 +1115,6 @@ class MigrationTest(s_t_utils.SynTest):
                 # even though there were splice migration errors, nodes and nodedata are still intact
                 await self._checkCore(core, tdata)
 
-    async def test_migr_migrsplices(self):
-        pass
-
     async def test_migr_cell(self):
         conf = {
             'src': None,

--- a/synapse/tests/test_tools_migrate020.py
+++ b/synapse/tests/test_tools_migrate020.py
@@ -116,6 +116,8 @@ class MigrationTest(s_t_utils.SynTest):
         with self.getRegrDir('assets', REGR_VER) as assetdir:
             podesj = getAssetJson(assetdir, 'podes.json')
             ndj = getAssetJson(assetdir, 'nodedata.json')
+            splicej = getAssetJson(assetdir, 'splices.json')
+            splicepodesj = getAssetJson(assetdir, 'splicepodes.json')
 
         # strip out data we don't expect to migrate
         podesj = [p for p in podesj if p[0] not in NOMIGR_NDEF]
@@ -123,6 +125,9 @@ class MigrationTest(s_t_utils.SynTest):
 
         tdata['podes'] = tupleize(podesj)
         tdata['nodedata'] = tupleize(ndj)
+
+        tdata['splices'] = splicej
+        tdata['splicepodes'] = splicepodesj
 
         # initialize migration tool
         with self.getRegrDir('cortexes', REGR_VER) as src:
@@ -187,7 +192,7 @@ class MigrationTest(s_t_utils.SynTest):
 
         self.eq(nodedata_cnt, totnodedata_migr)
 
-    async def _checkCore(self, core, tdata):
+    async def _checkCore(self, core, tdata, nodesonly=False):
         '''
         Verify data in the migrated to 0.2.x cortex.
         '''
@@ -208,39 +213,78 @@ class MigrationTest(s_t_utils.SynTest):
         except AssertionError:
             # print a more useful diff on error
             notincore = list(itertools.filterfalse(lambda x: x in podes, tpodes))
-            self.eq([], notincore)
             notintest = list(itertools.filterfalse(lambda x: x in tpodes, podes))
+            self.eq([], notincore)
             self.eq([], notintest)
             raise
 
-        nodedata = []
-        for n in nodes:
-            nodedata.append([n.ndef, [nd async for nd in n.iterData()]])
-        nodedata = tupleize(nodedata)
-        try:
-            self.eq(nodedata, tnodedata)
-        except AssertionError:
-            # print a more useful diff on error
-            notincore = list(itertools.filterfalse(lambda x: x in nodedata, tnodedata))
-            self.eq([], notincore)
-            notintest = list(itertools.filterfalse(lambda x: x in tnodedata, nodedata))
-            self.eq([], notintest)
-            raise
+        if not nodesonly:
+            nodedata = []
+            for n in nodes:
+                nodedata.append([n.ndef, [nd async for nd in n.iterData()]])
+            nodedata = tupleize(nodedata)
+            try:
+                self.eq(nodedata, tnodedata)
+            except AssertionError:
+                # print a more useful diff on error
+                notincore = list(itertools.filterfalse(lambda x: x in nodedata, tnodedata))
+                notintest = list(itertools.filterfalse(lambda x: x in tnodedata, nodedata))
+                self.eq([], notincore)
+                self.eq([], notintest)
+                raise
 
         # manually check node subset
         self.len(1, await core.nodes('inet:ipv4=1.2.3.4'))
         self.len(2, await core.nodes('inet:dns:a:ipv4=1.2.3.4'))
 
-        # check that triggers are active
-        await core.auth.getUserByName('root')
-        self.len(5, await core.nodes('syn:trigger'))
-        self.len(5, await core.callStorm('return ($lib.trigger.list())'))
-        tnodes = await core.nodes('[ inet:ipv4=9.9.9.9 ]')
-        self.nn(tnodes[0].tags.get('trgtag'))
+        if not nodesonly:
+            # check that triggers are active
+            await core.auth.getUserByName('root')
+            self.len(5, await core.nodes('syn:trigger'))
+            self.len(5, await core.callStorm('return ($lib.trigger.list())'))
+            tnodes = await core.nodes('[ inet:ipv4=9.9.9.9 ]')
+            self.nn(tnodes[0].tags.get('trgtag'))
 
-        # make sure trigger conditions don't exist with a None value
-        trigs = await core.view.listTriggers()
-        self.true(all([trig[1].pack().get(x, 'empty') is not None for trig in trigs for x in ['form', 'prop', 'tag']]))
+            # make sure trigger conditions don't exist with a None value
+            conds = ['form', 'prop', 'tag']
+            trigs = await core.view.listTriggers()
+            self.true(all([trig[1].pack().get(x, 'empty') is not None for trig in trigs for x in conds]))
+
+    async def _checkSplices(self, core0, tdata):
+        '''
+        Validate splices by feeding into a fresh cortex and evaluating as if it was the original migrated cortex
+        '''
+        with self.getTestDir() as dirn:
+            conf = {
+                'layer:lmdb:map_async': True,
+                'provenance:en': False,
+                'nexslog:en': False,
+                'layers:logedits': False,
+            }
+            async with self.getTestCore(dirn=dirn) as core1:
+                # give the new core the same hive for datamodel, triggers, etc.
+                tree0 = await core0.hive.saveHiveTree()
+                await core1.loadHiveTree(copy.deepcopy(tree0))
+
+            async with self.getTestCore(dirn=dirn, conf=conf) as core1:
+                # primary layer
+                lyr00 = core0.getLayer()
+                lyr01 = core1.getLayer()
+
+                nes0 = [nodeedits for offs, nodeedits in lyr00.nodeeditlog.iter(0)]
+                sodes0 = [await lyr01.storNodeEdits(nes[0], None) for nes in nes0]
+                self.lt(len(nes0), tdata['splices'][lyr00.iden]['nextoffs'])
+
+                # secondary layer
+                lyr10 = [lyr for lyr in core0.listLayers() if lyr.iden != lyr00.iden][0]
+                lyr11def = await core1.addLayer()
+                lyr11 = core1.getLayer(lyr11def['iden'])
+
+                nes1 = [nodeedits for offs, nodeedits in lyr10.nodeeditlog.iter(0)]
+                sodes1 = [await lyr11.storNodeEdits(nes[0], None) for nes in nes1]
+                self.lt(len(nes1), tdata['splices'][lyr10.iden]['nextoffs'])
+
+                await self._checkCore(core1, tdata, nodesonly=True)
 
     async def _checkAuth(self, core):
         defview = await core.hive.get(('cellinfo', 'defaultview'))
@@ -466,6 +510,7 @@ class MigrationTest(s_t_utils.SynTest):
                 self.gt(core.nexsroot._nexuslog.index(), 1)
 
                 # check core data
+                await self._checkSplices(core, tdata)
                 await self._checkCore(core, tdata)
                 await self._checkAuth(core)
 
@@ -505,6 +550,7 @@ class MigrationTest(s_t_utils.SynTest):
                 self.eq(core.nexsroot._nexuslog.index(), 0)
 
                 # check core data
+                await self._checkSplices(core, tdata)
                 await self._checkCore(core, tdata)
                 await self._checkAuth(core)
 
@@ -530,6 +576,7 @@ class MigrationTest(s_t_utils.SynTest):
                 self.eq(core.nexsroot._nexuslog.index(), 0)
 
                 # check core data
+                await self._checkSplices(core, tdata)
                 await self._checkCore(core, tdata)
                 await self._checkAuth(core)
 
@@ -577,6 +624,7 @@ class MigrationTest(s_t_utils.SynTest):
                 # startup 0.2.0 core
                 async with await s_cortex.Cortex.anit(dest, conf=None) as core:
                     # check core data
+                    await self._checkSplices(core, tdata)
                     await self._checkCore(core, tdata)
                     await self._checkAuth(core)
 
@@ -671,6 +719,7 @@ class MigrationTest(s_t_utils.SynTest):
                 # startup 0.2.0 core
                 async with await s_cortex.Cortex.anit(dest, conf=None) as core:
                     # check core data
+                    await self._checkSplices(core, tdata)
                     await self._checkCore(core, tdata)
                     await self._checkAuth(core)
 
@@ -970,14 +1019,6 @@ class MigrationTest(s_t_utils.SynTest):
                     await self.asyncraises(Exception, migr.migrate())
 
     async def test_migr_splices(self):
-        '''
-        TODO:
-            - Progress reporting
-            - Error limit
-            - Restart
-            - Start back from 0 on an already partially migrated layer
-            - More splices than queue len to check pausing/restart behavior
-        '''
         conf = {
             'src': None,
             'dest': None,
@@ -989,13 +1030,14 @@ class MigrationTest(s_t_utils.SynTest):
 
             path = os.path.join(migr.dest, migr.migrdir, 'splices')
             conf = {
-                'queue_size': 5,  # make artificially small to simulate read waiting
+                'queue_size': 15,  # make artificially small to simulate read waiting
             }
-            migr.migrsplices = await s_migr.MigrSplices.anit(path, conf={})
+            migr.migrsplices = await s_migr.MigrSplices.anit(path, conf=conf)
             migr.onfini(migr.migrsplices)
 
             migr.migrsplices.model.update(migr.model.getModelDict())
-            await migr._migrSplices('9f3e63d5242cf60779a7f46be2e86a4f')
+            await migr._migrSplices(locallyrs[0])
+            await migr._migrSplices(locallyrs[1])
 
             await migr.fini()
 
@@ -1003,16 +1045,53 @@ class MigrationTest(s_t_utils.SynTest):
             async with await s_cortex.Cortex.anit(dest, conf=None) as core:
                 # we should be able to iterate over the nodeedits, store them,
                 # and bring the cortex to the same state as a node migration
+                # this will generate a duplicate set of nodeedits in the layer
                 self.len(0, await core.nodes('.created -meta:source:name=test'))
+                self.eq(0, await core.count('.created'))
 
                 lyr0 = core.layers[locallyrs[0]]
-                nes0 = []
-                for offs, nodeedits in lyr0.nodeeditlog.iter(0):
-                    nes0.append(nodeedits)
+                nes0 = [nodeedits for offs, nodeedits in lyr0.nodeeditlog.iter(0)]
+                sodes0 = [await lyr0.storNodeEdits(nes[0], None) for nes in nes0]
 
-                for nes in nes0:
-                    await lyr0.storNodeEdits(nes[0], None)  # generates a duplicate set of nodeedits
+                lyr1 = core.layers[locallyrs[1]]
+                nes1 = [nodeedits for offs, nodeedits in lyr1.nodeeditlog.iter(0)]
+                sodes1 = [await lyr1.storNodeEdits(nes[0], None) for nes in nes1]
 
+                await self._checkCore(core, tdata)
+
+    async def test_migr_splice_errs(self):
+        conf = {
+            'src': None,
+            'dest': None,
+            'migrops': [op for op in s_migr.ALL_MIGROPS if op != 'splices'],
+        }
+
+        async with self._getTestMigrCore(conf) as (tdata, dest, locallyrs, migr):
+            await migr.migrate()
+
+            path = os.path.join(migr.dest, migr.migrdir, 'splices')
+            conf = {
+                'queue_size': 15,
+                'err_lim': 5,
+            }
+            migr.migrsplices = await s_migr.MigrSplices.anit(path, conf=conf)
+            migr.onfini(migr.migrsplices)
+
+            # datamodel is not loaded, which will generate errors
+            await migr._migrSplices(locallyrs[0])
+            await migr._migrSplices(locallyrs[1])
+
+            await migr.fini()
+
+            # startup 0.2.0 core and check there are no nodeedits stored
+            async with await s_cortex.Cortex.anit(dest, conf=None) as core:
+                offs0 = core.layers[locallyrs[0]].getNodeEditOffset()
+                offs1 = core.layers[locallyrs[1]].getNodeEditOffset()
+
+                self.eq(0, offs0)
+                self.eq(0, offs1)
+
+                # even though there were splice migration errors, nodes and nodedata are still in tact
                 await self._checkCore(core, tdata)
 
     async def test_migr_cell(self):

--- a/synapse/tests/test_tools_migrate020.py
+++ b/synapse/tests/test_tools_migrate020.py
@@ -682,7 +682,7 @@ class MigrationTest(s_t_utils.SynTest):
                 self.true(os.path.exists(lyrslab))
 
                 # add a boot.yaml file
-                s_common.yamlsave({'auth:admin': 'root:root'}, migr0.src, 'boot.yaml')
+                s_common.yamlsave({'auth:admin': 'root:root'}, migr.src, 'boot.yaml')
 
                 await migr.migrate()
 

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -68,15 +68,13 @@ OLDMODEL_FORMS = (
     'cluster',
     'graph:link',
     'graph:timelink',
-    'inet:whois:regmail',  # commit 6b864d4
-    # commit 5422fb39
+    'inet:whois:regmail',
     'inet:web:actref', 'inet:web:postref',
     'file:ref',
 )
 
 OLDMODEL_PROPS = (
     'ou:org:disolved',
-    # commit 5422fb39
     'it:exec:reg:get:reg:key', 'it:exec:reg:get:reg:int', 'it:exec:reg:get:reg:str', 'it:exec:reg:get:reg:bytes',
     'it:exec:reg:set:reg:key', 'it:exec:reg:set:reg:int', 'it:exec:reg:set:reg:str', 'it:exec:reg:set:reg:bytes',
     'it:exec:reg:del:reg:key', 'it:exec:reg:del:reg:int', 'it:exec:reg:del:reg:str', 'it:exec:reg:del:reg:bytes',

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -653,7 +653,7 @@ class Migrator(s_base.Base):
 
         self.migrsplices = None
         self.spliceconf = {
-            'err_lim': 100000,
+            'err_lim': -1,
             'queue_size': 100000,
             'offs_logging': 1000000,
         }

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -625,7 +625,7 @@ class Migrator(s_base.Base):
 
         self.migrsplices = None
         self.spliceconf = {
-            'err_lim': 10,
+            'err_lim': 100000,
             'queue_size': 100000,
             'offs_logging': 1000000,
         }

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -1635,6 +1635,7 @@ class Migrator(s_base.Base):
         async def genr(offs):
             for indx, valu in splicelog.iter(offs):
                 yield valu
+            return
 
         self.migrsplices.src_genrs[iden] = genr
 
@@ -1666,6 +1667,7 @@ class Migrator(s_base.Base):
 
         # start the migration and wait for the tasks to complete
         await synccoro
+        await asyncio.sleep(0)
 
         pulltask = self.migrsplices.pull_tasks[iden]
         await asyncio.wait_for(pulltask, timeout=None)

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -69,6 +69,8 @@ OLDMODEL_FORMS = (
     'graph:link',
     'graph:timelink',
     'inet:whois:regmail',  # commit 6b864d4
+    # commit 5422fb39
+    'inet:web:actref', 'inet:web:postref',
 )
 
 OLDMODEL_PROPS = (
@@ -77,6 +79,8 @@ OLDMODEL_PROPS = (
     'it:exec:reg:get:reg:key', 'it:exec:reg:get:reg:int', 'it:exec:reg:get:reg:str', 'it:exec:reg:get:reg:bytes',
     'it:exec:reg:set:reg:key', 'it:exec:reg:set:reg:int', 'it:exec:reg:set:reg:str', 'it:exec:reg:set:reg:bytes',
     'it:exec:reg:del:reg:key', 'it:exec:reg:del:reg:int', 'it:exec:reg:del:reg:str', 'it:exec:reg:del:reg:bytes',
+    'inet:fqdn:created', 'inet:fqdn:expires', 'inet:fqdn:updated',
+    'file:ref',
 )
 
 MAX_01X_VERS = (0, 1, 3)
@@ -101,7 +105,7 @@ class MigrSplices(s_sync.SyncMigrator):
         '''
         pass
 
-    async def _disableMigrationMode(self):
+    async def _disableMigrationMode(self):  # pragma: no cover
         pass
 
     async def _initCellDmon(self):

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -62,6 +62,7 @@ OLDMODEL_FORMS = (
     'seen',
     'source',
     'has',
+    'refs',
     'wentto',
     'event',
     'cluster',

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -71,6 +71,7 @@ OLDMODEL_FORMS = (
     'inet:whois:regmail',  # commit 6b864d4
     # commit 5422fb39
     'inet:web:actref', 'inet:web:postref',
+    'file:ref',
 )
 
 OLDMODEL_PROPS = (
@@ -80,7 +81,6 @@ OLDMODEL_PROPS = (
     'it:exec:reg:set:reg:key', 'it:exec:reg:set:reg:int', 'it:exec:reg:set:reg:str', 'it:exec:reg:set:reg:bytes',
     'it:exec:reg:del:reg:key', 'it:exec:reg:del:reg:int', 'it:exec:reg:del:reg:str', 'it:exec:reg:del:reg:bytes',
     'inet:fqdn:created', 'inet:fqdn:expires', 'inet:fqdn:updated',
-    'file:ref',
 )
 
 MAX_01X_VERS = (0, 1, 3)

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -1065,6 +1065,9 @@ class Migrator(s_base.Base):
                 await self._migrlogAdd(migrop, 'error', 'bootyaml_authadmin', s_common.now())
 
             # move to migration dir as backup
+            bubootpath = os.path.join(self.dest, self.migrdir, 'boot.yaml')
+            if os.path.exists(bubootpath):
+                os.remove(bubootpath)
             shutil.move(bootpath, os.path.join(self.dest, self.migrdir))
 
         # confdefs

--- a/synapse/tools/sync_020.py
+++ b/synapse/tools/sync_020.py
@@ -796,7 +796,7 @@ class SyncMigrator(s_cell.Cell):
                 if err is not None:
                     errs += 1
                     await self._setLyrErr(lyriden, offs, err)
-                    if errs >= err_lim:
+                    if err_lim != -1 and errs >= err_lim:
                         logger.error(f'Error limit reached')
                         raise SyncErrLimReached(mesg='Error limit reached - correct or increase err_lim to continue')
 
@@ -814,7 +814,7 @@ class SyncMigrator(s_cell.Cell):
                 logger.debug(f'{lyriden} queue reader status: read={cnt}, errs={errs}, size={queuelen}')
 
             if offs % offs_logging == 0 and offs != 0:
-                logger.info(f'Destination layer splice push at offset {offs}')
+                logger.info(f'Destination layer splice push at offset {offs} with {errs} errors')
 
             if queuelen == 0:
                 evnt.set()

--- a/synapse/tools/sync_020.py
+++ b/synapse/tools/sync_020.py
@@ -274,8 +274,6 @@ class SyncMigrator(s_cell.Cell):
             status = 'active'
 
             if done:
-                retn['result'] = task.result()
-
                 cancelled = task.cancelled()
                 retn['cancelled'] = cancelled
                 status = 'cancelled' if cancelled else 'done'
@@ -286,6 +284,7 @@ class SyncMigrator(s_cell.Cell):
                         retn['exc'] = str(exc)
                         status = 'exception'
                     else:
+                        retn['result'] = task.result()
                         status = 'finished'
 
             retn['status'] = status

--- a/synapse/tools/sync_020.py
+++ b/synapse/tools/sync_020.py
@@ -273,10 +273,12 @@ class SyncMigrator(s_cell.Cell):
                 status = 'cancelled' if cancelled else 'done'
 
                 if not cancelled:
-                    exc = str(task.exception())
-                    retn['exc'] = exc
-                    if exc:
+                    exc = task.exception()
+                    if exc is not None:
+                        retn['exc'] = str(exc)
                         status = 'exception'
+                    else:
+                        status = 'finished'
 
             retn['status'] = status
 

--- a/synapse/tools/sync_020.py
+++ b/synapse/tools/sync_020.py
@@ -352,6 +352,7 @@ class SyncMigrator(s_cell.Cell):
         '''
         await self.layers.set(lyriden, nextoffs)
         self.pull_offs.set(lyriden, nextoffs)
+        self.push_offs.set(lyriden, nextoffs)
 
         await self._loadDatamodel()
 
@@ -810,10 +811,10 @@ class SyncMigrator(s_cell.Cell):
 
             cnt += 1
 
-            if queuelen != 0 and queuelen % 10000 == 0:
+            if queuelen != 0 and queuelen % 10000 == 0:  # pragma: no cover
                 logger.debug(f'{lyriden} queue reader status: read={cnt}, errs={errs}, size={queuelen}')
 
-            if offs % offs_logging == 0 and offs != 0:
+            if offs % offs_logging == 0 and offs != 0:  # pragma: no cover
                 logger.info(f'Destination layer splice push at offset {offs} with {errs} errors')
 
             if queuelen == 0:


### PR DESCRIPTION
- Abstract SyncMigrator so that it can be used as a one-pass splice migration step
- Add constants for known deprecated model elements to limit log spam
- Fixes issue where re-migrating the main directory when boot.yaml was already copied would cause an error