### PR TITLE
LMDB bug fixes

### DIFF
--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -889,7 +889,7 @@ class Slab(s_base.Base):
 
     def scanByDups(self, lkey, db=None):
 
-        with Scan(self, db) as scan:
+        with Scan(self, db, singlekey=True) as scan:
 
             if not scan.set_key(lkey):
                 return
@@ -898,7 +898,7 @@ class Slab(s_base.Base):
 
     def scanByDupsBack(self, lkey, db=None):
 
-        with ScanBack(self, db) as scan:
+        with ScanBack(self, db, singlekey=True) as scan:
 
             if not scan.set_key(lkey):
                 return
@@ -981,8 +981,7 @@ class Slab(s_base.Base):
             if not scan.first():
                 return
 
-            for lkey, lval in scan.iternext():
-                yield lkey, lval
+            yield from scan.iternext()
 
     def scanByFullBack(self, db=None):
 
@@ -991,8 +990,7 @@ class Slab(s_base.Base):
             if not scan.first():
                 return
 
-            for lkey, lval in scan.iternext():
-                yield lkey, lval
+            yield from scan.iternext()
 
     # def keysByRange():
     # def valsByRange():
@@ -1161,14 +1159,28 @@ class Slab(s_base.Base):
 class Scan:
     '''
     A state-object used by Slab.  Not to be instantiated directly.
+
+    Args:
+
+        slab (Slab):  which slab the scan is over
+        db (str):  name of open database on the slab
+        singlekey(bool):  whether the scan should iterate over the values in a single key
     '''
-    def __init__(self, slab, db):
+    def __init__(self, slab, db, singlekey=False):
         self.slab = slab
         self.db, self.dupsort = slab.dbnames[db]
 
+        assert not singlekey or self.dupsort  # singlekey doesn't make sense with non dupsort db
+
+        self.singlekey = singlekey
+
+        if self.singlekey:
+            self.iterfunc = functools.partial(lmdb.Cursor.iternext_dup, keys=True)
+        else:
+            self.iterfunc = lmdb.Cursor.iternext
+
         self.atitem = None
         self.bumped = False
-        self.iterfunc = None
         self.curs = None
 
     def __enter__(self):
@@ -1197,11 +1209,6 @@ class Scan:
         if not self.curs.first():
             return False
 
-        if self.dupsort:
-            self.iterfunc = functools.partial(lmdb.Cursor.iternext_dup, keys=True)
-        else:
-            self.iterfunc = lmdb.Cursor.iternext
-
         self.genr = self.curs.iternext()
         self.atitem = next(self.genr)
         return True
@@ -1211,22 +1218,17 @@ class Scan:
         if not self.curs.set_key(lkey):
             return False
 
-        # set_key for a scan is only logical if it's a dup scan
-        if self.dupsort:
-            self.iterfunc = functools.partial(lmdb.Cursor.iternext_dup, keys=True)
-        else:
-            self.iterfunc = lmdb.Cursor.iternext
-
         self.genr = self.iterfunc(self.curs)
         self.atitem = next(self.genr)
         return True
 
     def set_range(self, lkey):
 
+        assert not self.singlekey
+
         if not self.curs.set_range(lkey):
             return False
 
-        self.iterfunc = lmdb.Cursor.iternext
         self.genr = self.iterfunc(self.curs)
         self.atitem = next(self.genr)
 
@@ -1248,11 +1250,22 @@ class Scan:
                     self.bumped = False
 
                     self.curs = self.slab.xact.cursor(db=self.db)
+
                     if self.dupsort:
+
                         ret = self.curs.set_range_dup(*self.atitem)
+                        if not ret:
+                            if self.singlekey:
+                                raise StopIteration
+                            key = self.atitem[0]
+                            ret = self.curs.set_range(key)
+                            if ret and self.curs.key() == key:
+                                ret = self.curs.next_nodup()
+
                     else:
                         ret = self.curs.set_range(self.atitem[0])
-                    if ret is False:
+
+                    if not ret:
                         raise StopIteration
 
                     self.genr = self.iterfunc(self.curs)
@@ -1276,15 +1289,17 @@ class ScanBack(Scan):
 
     Scans backwards.
     '''
+    def __init__(self, slab, db, singlekey=False):
+        Scan.__init__(self, slab, db, singlekey)
+        if self.singlekey:
+            self.iterfunc = functools.partial(lmdb.Cursor.iterprev_dup, keys=True)
+        else:
+            self.iterfunc = lmdb.Cursor.iterprev
+
     def first(self):
 
         if not self.curs.last():
             return False
-
-        if self.dupsort:
-            self.iterfunc = functools.partial(lmdb.Cursor.iterprev_dup, keys=True)
-        else:
-            self.iterfunc = lmdb.Cursor.iterprev
 
         self.genr = self.curs.iterprev()
 
@@ -1301,21 +1316,17 @@ class ScanBack(Scan):
             if not self.curs.last_dup():
                 return False # pragma: no cover
 
-            self.iterfunc = functools.partial(lmdb.Cursor.iterprev_dup, keys=True)
-        else:
-            self.iterfunc = lmdb.Cursor.iterprev
-
         self.genr = self.iterfunc(self.curs)
         self.atitem = next(self.genr)
         return True
 
     def set_range(self, lkey):
 
+        assert not self.singlekey
+
         if not self.curs.set_range(lkey):
             if not self.curs.last():
                 return False
-
-        self.iterfunc = lmdb.Cursor.iterprev
 
         self.genr = self.iterfunc(self.curs)
         self.atitem = next(self.genr)
@@ -1330,31 +1341,49 @@ class ScanBack(Scan):
         try:
 
             while True:
-
                 yield self.atitem
 
-                if self.bumped:
+                if self.slab.isfini:
+                    raise s_exc.IsFini()
 
-                    if self.slab.isfini:
-                        raise s_exc.IsFini()
+                if not self.bumped:
+                    self.atitem = next(self.genr)
+                    continue
 
-                    self.bumped = False
+                self.bumped = False
+                advance = True
 
-                    self.curs = self.slab.xact.cursor(db=self.db)
-                    if self.dupsort:
-                        ret = self.curs.set_range_dup(*self.atitem)
-                        if ret is False:
-                            if not self.curs.last():
-                                raise StopIteration
-                    else:
-                        ret = self.curs.set_range(self.atitem[0])
-                        if ret is False:
-                            if not self.curs.last():
-                                raise StopIteration
+                self.curs = self.slab.xact.cursor(db=self.db)
 
-                    self.genr = self.iterfunc(self.curs)
-                    if ret is not False:
-                        next(self.genr)
+                if self.dupsort:
+
+                    # Grab the >= val with the exact key
+                    ret = self.curs.set_range_dup(*self.atitem)
+                    if not ret:
+                        # Grab >= key
+                        key = self.atitem[0]
+                        ret = self.curs.set_range(key)
+
+                        # If we got the same key, advance to the last val
+                        if ret and self.curs.key() == key:
+                            self.curs.last_dup()
+
+                            # We're already guaranteed to be < self.atitem because set_range_dup returned False
+                            advance = False
+
+                        elif self.singlekey:  # if set_range failed or we didn't get the same key, we're done
+                            raise StopIteration
+
+                else:
+                    ret = self.curs.set_range(self.atitem[0])
+
+                if not ret:
+                    if not self.curs.last():
+                        raise StopIteration
+
+                self.genr = self.iterfunc(self.curs)
+                if ret and advance:
+                    next(self.genr)
 
                 self.atitem = next(self.genr)
 

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -758,3 +758,13 @@ class LayerTest(s_t_utils.SynTest):
             await core.nodes('[test:str=foo .seen=(2015, 2016)]')
             lafter = len(await alist(layr.splices()))
             self.eq(lbefore, lafter)
+
+    async def test_layer_del_then_lift(self):
+        '''
+        Regression test
+        '''
+        async with self.getTestCore() as core:
+            await core.nodes('$x = 0 while $($x < 2000) { [file:bytes="*"] [ou:org="*"] $x = $($x + 1)}')
+            await core.nodes('.created | delnode --force')
+            nodes = await core.nodes('.created')
+            self.len(0, nodes)

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -71,6 +71,9 @@ class LmdbSlabTest(s_t_utils.SynTest):
             items = list(slab.scanByDups(b'\x00\x02', db=bar))
             self.eq(items, ((b'\x00\x02', b'haha'), (b'\x00\x02', b'visi'), (b'\x00\x02', b'zomg')))
 
+            items = list(slab.scanByDups(b'\x00\x04', db=bar))
+            self.eq(items, ())
+
             # backwards scan tests
 
             items = list(slab.scanByPrefBack(b'\x00', db=foo))
@@ -96,7 +99,6 @@ class LmdbSlabTest(s_t_utils.SynTest):
 
             items = list(slab.scanByDupsBack(b'\x00\x02', db=bar))
             self.eq(items, ((b'\x00\x02', b'zomg'), (b'\x00\x02', b'visi'), (b'\x00\x02', b'haha')))
-
             items = list(slab.scanByDupsBack(b'\x00\x04', db=bar))
             self.eq(items, ())
 
@@ -284,6 +286,178 @@ class LmdbSlabTest(s_t_utils.SynTest):
 
                 self.raises(StopIteration, next, iterback5)
                 self.raises(StopIteration, next, iterback6)
+
+    async def test_lmdbslab_scanbump2(self):
+
+        with self.getTestDir() as dirn:
+
+            path = os.path.join(dirn, 'test.lmdb')
+
+            async with await s_lmdbslab.Slab.anit(path, map_size=100000, growsize=10000) as slab:
+
+                dupydb = slab.initdb('dup', dupsort=True)
+                dupndb = slab.initdb('ndup', dupsort=False)
+
+                for db in (dupndb, dupydb):
+                    slab.put(b'1', b'', db=db)
+                    slab.put(b'2', b'', db=db)
+                    slab.put(b'3', b'', db=db)
+
+                    # forwards, bump after 2nd entry
+                    it = slab.scanByFull(db=db)
+                    self.eq((b'1', b''), next(it))
+                    self.eq((b'2', b''), next(it))
+                    slab.forcecommit()
+                    self.eq((b'3', b''), next(it))
+                    self.raises(StopIteration, next, it)
+
+                    # backwards, bump after 2nd entry
+                    it = slab.scanByFullBack(db=db)
+                    self.eq((b'3', b''), next(it))
+                    self.eq((b'2', b''), next(it))
+                    slab.forcecommit()
+                    self.eq((b'1', b''), next(it))
+                    self.raises(StopIteration, next, it)
+
+                    # forwards, bump/delete after 2nd entry
+                    it = slab.scanByFull(db=db)
+                    self.eq((b'1', b''), next(it))
+                    self.eq((b'2', b''), next(it))
+                    slab.forcecommit()
+                    slab.delete(b'2', db=db)
+                    self.eq((b'3', b''), next(it))
+                    self.raises(StopIteration, next, it)
+
+                    it = slab.scanByFull(db=db)
+                    self.eq((b'1', b''), next(it))
+                    slab.forcecommit()
+                    slab.delete(b'3', db=db)
+                    self.raises(StopIteration, next, it)
+
+                    slab.put(b'2', b'', db=db)
+                    slab.put(b'3', b'', db=db)
+
+                    # backwards, bump/delete after 2nd entry
+                    it = slab.scanByFullBack(db=db)
+                    self.eq((b'3', b''), next(it))
+                    self.eq((b'2', b''), next(it))
+                    slab.forcecommit()
+                    slab.delete(b'2', db=db)
+                    self.eq((b'1', b''), next(it))
+                    self.raises(StopIteration, next, it)
+
+                    it = slab.scanByFullBack(db=db)
+                    slab.forcecommit()
+                    slab.delete(b'3', db=db)
+                    self.eq((b'1', b''), next(it))
+                    self.raises(StopIteration, next, it)
+
+                slab.delete(b'1', db=dupydb)
+                slab.delete(b'2', db=dupydb)
+                slab.delete(b'3', db=dupydb)
+                slab.put(b'0', b'', db=dupydb)
+                slab.put(b'1', b'1', db=dupydb)
+                slab.put(b'1', b'2', db=dupydb)
+                slab.put(b'1', b'3', db=dupydb)
+                slab.put(b'2', b'', db=dupydb)
+
+                # dupsort=yes, forwards, same keys, bump after 2nd entry
+                it = slab.scanByFull(db=dupydb)
+                self.eq((b'0', b''), next(it))
+                self.eq((b'1', b'1'), next(it))
+                self.eq((b'1', b'2'), next(it))
+                slab.forcecommit()
+                self.eq((b'1', b'3'), next(it))
+                self.eq((b'2', b''), next(it))
+                self.raises(StopIteration, next, it)
+
+                # forwards, bump/delete after 2nd entry
+                it = slab.scanByFull(db=dupydb)
+                self.eq((b'0', b''), next(it))
+                self.eq((b'1', b'1'), next(it))
+                slab.forcecommit()
+                slab.delete(b'1', val=b'2', db=dupydb)
+                self.eq((b'1', b'3'), next(it))
+                self.eq((b'2', b''), next(it))
+                self.raises(StopIteration, next, it)
+
+                it = slab.scanByFull(db=dupydb)
+                self.eq((b'0', b''), next(it))
+                self.eq((b'1', b'1'), next(it))
+                self.eq((b'1', b'3'), next(it))
+                slab.forcecommit()
+                slab.delete(b'1', val=b'3', db=dupydb)
+                self.eq((b'2', b''), next(it))
+                self.raises(StopIteration, next, it)
+
+                slab.put(b'1', b'2', db=dupydb)
+                slab.put(b'1', b'3', db=dupydb)
+
+                # dupsort=yes, backwards, same keys, bump after 2nd entry
+                it = slab.scanByFullBack(db=dupydb)
+                self.eq((b'2', b''), next(it))
+                self.eq((b'1', b'3'), next(it))
+                self.eq((b'1', b'2'), next(it))
+                slab.forcecommit()
+                self.eq((b'1', b'1'), next(it))
+                self.eq((b'0', b''), next(it))
+                self.raises(StopIteration, next, it)
+
+                # dupsort=yes, backwards, same keys, bump/delete after 2nd entry
+                it = slab.scanByFullBack(db=dupydb)
+                self.eq((b'2', b''), next(it))
+                self.eq((b'1', b'3'), next(it))
+                self.eq((b'1', b'2'), next(it))
+                slab.forcecommit()
+                slab.delete(b'1', val=b'2', db=dupndb)
+                self.eq((b'1', b'1'), next(it))
+                self.eq((b'0', b''), next(it))
+                self.raises(StopIteration, next, it)
+
+                slab.put(b'1', b'2', db=dupydb)
+                slab.put(b'1', b'3', db=dupydb)
+
+                # single key, forwards, bump after 2nd entry
+                it = slab.scanByDups(db=dupydb, lkey=b'1')
+                self.eq((b'1', b'1'), next(it))
+                self.eq((b'1', b'2'), next(it))
+                slab.forcecommit()
+                self.eq((b'1', b'3'), next(it))
+                self.raises(StopIteration, next, it)
+
+                # single key, forwards, bump/delete after 2nd entry
+                it = slab.scanByDups(db=dupydb, lkey=b'1')
+                self.eq((b'1', b'1'), next(it))
+                slab.forcecommit()
+                slab.delete(b'1', val=b'2', db=dupydb)
+                self.eq((b'1', b'3'), next(it))
+                self.raises(StopIteration, next, it)
+
+                it = slab.scanByDups(db=dupydb, lkey=b'1')
+                self.eq((b'1', b'1'), next(it))
+                slab.forcecommit()
+                slab.delete(b'1', val=b'3', db=dupydb)
+                self.raises(StopIteration, next, it)
+
+                slab.put(b'1', b'2', db=dupydb)
+                slab.put(b'1', b'3', db=dupydb)
+
+                # dupsort=yes, backwards, same keys, bump after 2nd entry
+                it = slab.scanByDupsBack(db=dupydb, lkey=b'1')
+                self.eq((b'1', b'3'), next(it))
+                self.eq((b'1', b'2'), next(it))
+                slab.forcecommit()
+                self.eq((b'1', b'1'), next(it))
+                self.raises(StopIteration, next, it)
+
+                # dupsort=yes, backwards, same keys, bump/delete after 2nd entry
+                it = slab.scanByDupsBack(db=dupydb, lkey=b'1')
+                self.eq((b'1', b'3'), next(it))
+                self.eq((b'1', b'2'), next(it))
+                slab.forcecommit()
+                slab.delete(b'1', val=b'2', db=dupndb)
+                self.eq((b'1', b'1'), next(it))
+                self.raises(StopIteration, next, it)
 
     async def test_lmdbslab_grow(self):
 

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -99,6 +99,7 @@ class LmdbSlabTest(s_t_utils.SynTest):
 
             items = list(slab.scanByDupsBack(b'\x00\x02', db=bar))
             self.eq(items, ((b'\x00\x02', b'zomg'), (b'\x00\x02', b'visi'), (b'\x00\x02', b'haha')))
+
             items = list(slab.scanByDupsBack(b'\x00\x04', db=bar))
             self.eq(items, ())
 


### PR DESCRIPTION
Add a more comprehensive bump test.

Distinguish between dupsort and iterating through a single key.

Handle failure of set_range_dup correctly (the documentation was incorrect)