### PR TITLE
Toggle migrationMode via storm in sync service

### DIFF
--- a/synapse/tests/test_tools_sync020.py
+++ b/synapse/tests/test_tools_sync020.py
@@ -431,6 +431,11 @@ class SyncTest(s_t_utils.SynTest):
                 self.false(sync.push_tasks[wlyr.iden].done())
                 self.false(sync._queues[wlyr.iden].isfini)
 
+                # trigger migrmode reset on connection drop
+                sync.migrmode_evnt.clear()
+                task = sync.schedCoro(sync._destPushLyrNodeedits(wlyr.iden))
+                self.true(await s_coro.event_wait(sync.migrmode_evnt, timeout=5))
+
     async def test_sync_assvr(self):
         with self.getTestDir() as dirn, self.withSetLoggingMock():
             argv = [

--- a/synapse/tests/test_tools_sync020.py
+++ b/synapse/tests/test_tools_sync020.py
@@ -251,6 +251,20 @@ class SyncTest(s_t_utils.SynTest):
             mesgs = await core.stormlist(f'migrsync.status')
             self.eq(4, ''.join([x[1].get('mesg') for x in mesgs if x[0] == 'print']).count('active'))
 
+            # enable/disable migrationMode
+            self.false(core.agenda.enabled)
+            self.false(core.trigson)
+
+            mesgs = await core.stormlist(f'migrsync.migrationmode.disable')
+            self.stormIsInPrint('migrationMode successfully disabled', mesgs)
+            self.true(core.agenda.enabled)
+            self.true(core.trigson)
+
+            mesgs = await core.stormlist(f'migrsync.migrationmode.enable')
+            self.stormIsInPrint('migrationMode successfully enabled', mesgs)
+            self.false(core.agenda.enabled)
+            self.false(core.trigson)
+
     async def test_startSyncFromFile(self):
         conf_sync = {
             'poll_s': 1,
@@ -338,6 +352,12 @@ class SyncTest(s_t_utils.SynTest):
                 sync.dest = 'foobar'
                 stopres = await syncprx.stopSync()
                 self.len(2, stopres)  # returns the two layers stopped
+
+                retn = await syncprx.enableMigrationMode()
+                self.isin('encountered an error', retn)
+
+                retn = await syncprx.disableMigrationMode()
+                self.isin('encountered an error', retn)
 
     async def test_startSyncFromLast(self):
         conf_sync = {

--- a/synapse/tests/test_tools_sync020.py
+++ b/synapse/tests/test_tools_sync020.py
@@ -4,6 +4,7 @@ import asyncio
 import itertools
 import contextlib
 
+import synapse.exc as s_exc
 import synapse.cortex as s_cortex
 import synapse.telepath as s_telepath
 
@@ -454,6 +455,15 @@ class SyncTest(s_t_utils.SynTest):
                 lyriden = '75adb79a576b31a65f0a1afad5d90665'
                 self.raises(s_sync.SyncInvalidTelepath, sync._getLayerUrl, 'baz://0.0.0.0:123', lyriden)
                 self.eq(f'{tbase}/cortex/layer/{lyriden}', sync._getLayerUrl(tbase, lyriden))
+
+                self.none(sync.migrmode.valu)
+                await self.asyncraises(s_exc.BadTypeValu, sync.setMigrationModeOverride('foobar'))
+                await sync.setMigrationModeOverride(True)
+                self.true(sync.migrmode.valu)
+
+            # check that migrmode override persists
+            async with await s_sync.SyncMigrator.initFromArgv(argv) as sync:
+                self.true(sync.migrmode.valu)
 
     async def test_sync_srcIterLyrSplices(self):
         async with self._getSyncSvc() as (core, turl, fkcore, fkurl, sync):

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -106,6 +106,9 @@ class MigrSplices(s_sync.SyncMigrator):
     async def disableMigrationMode(self):  # pragma: no cover
         pass
 
+    async def enableMigrationMode(self):  # pragma: no cover
+        pass
+
     async def _initCellDmon(self):
         pass
 

--- a/synapse/tools/migrate_020.py
+++ b/synapse/tools/migrate_020.py
@@ -103,7 +103,7 @@ class MigrSplices(s_sync.SyncMigrator):
         '''
         pass
 
-    async def _disableMigrationMode(self):  # pragma: no cover
+    async def disableMigrationMode(self):  # pragma: no cover
         pass
 
     async def _initCellDmon(self):


### PR DESCRIPTION
- migrationMode is still auto-enabled on startSync commands and auto-disabled on stopSync