### PR TITLE
Bug - optional arg deref

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1607,7 +1607,7 @@ class PureCmd(Cmd):
 
                     # In the event of a non-runtsafe command invocation our
                     # setArgv() method will be called with an argv computed
-                    # for each node, so we need to remap cmdopts into our path
+                    # for each node, so we need to remap cmdopts into our path & subr
                     path.initframe(initvars={'cmdopts': vars(self.opts)}, initrunt=subr)
                     subr.setVar('cmdopts', vars(self.opts))
                     yield node, path

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1609,6 +1609,7 @@ class PureCmd(Cmd):
                     # setArgv() method will be called with an argv computed
                     # for each node, so we need to remap cmdopts into our path
                     path.initframe(initvars={'cmdopts': vars(self.opts)}, initrunt=subr)
+                    subr.setVar('cmdopts', vars(self.opts))
                     yield node, path
 
             subr.loadRuntVars(query)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1608,8 +1608,9 @@ class PureCmd(Cmd):
                     # In the event of a non-runtsafe command invocation our
                     # setArgv() method will be called with an argv computed
                     # for each node, so we need to remap cmdopts into our path & subr
-                    path.initframe(initvars={'cmdopts': vars(self.opts)}, initrunt=subr)
-                    subr.setVar('cmdopts', vars(self.opts))
+                    cmdopts = vars(self.opts)
+                    path.initframe(initvars={'cmdopts': cmdopts}, initrunt=subr)
+                    subr.setVar('cmdopts', cmdopts)
                     yield node, path
 
             subr.loadRuntVars(query)

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -248,7 +248,7 @@ class StormvarService(s_cell.CellApi, s_stormsvc.StormSvc):
                     'name': 'magic',
                     'cmdargs': (
                         ('name', {}),
-                        ('--debug', {'default': 'false', 'action': 'store_true'})
+                        ('--debug', {'default': False, 'action': 'store_true'})
                     ),
                     'storm': '''
                     $fooz = $cmdopts.name

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -635,5 +635,5 @@ class StormSvcTest(s_test.SynTest):
 
             scmd = f'$foo=8.8.8.8 | magic $foo --debug'
             msgs = await core.stormlist(scmd)
-            self.stormIsInPrint('DEBUG: fooz=8.8.8.8')
+            self.stormIsInPrint('DEBUG: fooz=8.8.8.8', msgs)
             self.stormIsInPrint('my foo var is 8.8.8.8', msgs)

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -248,10 +248,13 @@ class StormvarService(s_cell.CellApi, s_stormsvc.StormSvc):
                     'name': 'magic',
                     'cmdargs': (
                         ('name', {}),
+                        ('--debug', {'default': 'false', 'action': 'store_true'})
                     ),
                     'storm': '''
                     $fooz = $cmdopts.name
-                    $fooz = $path.vars.cmdopts.name
+                    if $cmdopts.debug {
+                        $lib.print('DEBUG: fooz={fooz}', fooz=$fooz)
+                    }
                     $lib.print('my foo var is {f}', f=$fooz)
                     ''',
                 },
@@ -628,4 +631,9 @@ class StormSvcTest(s_test.SynTest):
 
             scmd = f'$foo=8.8.8.8 | magic $foo'
             msgs = await core.stormlist(scmd)
+            self.stormIsInPrint('my foo var is 8.8.8.8', msgs)
+
+            scmd = f'$foo=8.8.8.8 | magic $foo --debug'
+            msgs = await core.stormlist(scmd)
+            self.stormIsInPrint('DEBUG: fooz=8.8.8.8')
             self.stormIsInPrint('my foo var is 8.8.8.8', msgs)

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -637,3 +637,15 @@ class StormSvcTest(s_test.SynTest):
             msgs = await core.stormlist(scmd)
             self.stormIsInPrint('DEBUG: fooz=8.8.8.8', msgs)
             self.stormIsInPrint('my foo var is 8.8.8.8', msgs)
+
+            scmd = f'$foo=8.8.8.8 | magic --debug $foo'
+            msgs = await core.stormlist(scmd)
+            self.stormIsInPrint('DEBUG: fooz=8.8.8.8', msgs)
+            self.stormIsInPrint('my foo var is 8.8.8.8', msgs)
+
+            scmd = 'inet:ipv4=1.2.3.4 inet:ipv4=5.6.7.8 $foo=$node.repr() | magic $foo --debug'
+            msgs = await core.stormlist(scmd)
+            self.stormIsInPrint('my foo var is 1.2.3.4', msgs)
+            self.stormIsInPrint('DEBUG: fooz=1.2.3.4', msgs)
+            self.stormIsInPrint('my foo var is 5.6.7.8', msgs)
+            self.stormIsInPrint('DEBUG: fooz=5.6.7.8', msgs)


### PR DESCRIPTION
fix an issue where cmdopts were not being properly set onto the subruntime of a purecmd when nodes were flowing through it.