### PR TITLE
Make the cmdr warn handler print out additional args.

### DIFF
--- a/synapse/cmds/cortex.py
+++ b/synapse/cmds/cortex.py
@@ -356,7 +356,11 @@ class StormCmd(s_cli.Cmd):
         self.printf(mesg[1].get('mesg'))
 
     def _onWarn(self, mesg, opts):
-        warn = mesg[1].get('mesg')
+        info = mesg[1]
+        warn = info.pop('mesg', '')
+        xtra = ', '.join([f'{k}={v}' for k, v in info.items()])
+        if xtra:
+            warn = ' '.join([warn, xtra])
         self.printf(f'WARNING: {warn}', color=WARNING_COLOR)
 
     def _onErr(self, mesg, opts):

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -285,7 +285,7 @@ class Type:
         '''
         func = self._type_norms.get(type(valu))
         if func is None:
-            raise s_exc.BadTypeValu(name=self.name, mesg='no norm for type: %r' % (type(valu),))
+            raise s_exc.BadTypeValu(name=self.name, mesg='no norm for type: %r.' % (type(valu),))
 
         return func(valu)
 


### PR DESCRIPTION
Prior example
```
WARNING: BadTypeValu [16909060] during pivot: no norm for type: <class 'int'>
```

New example
```
WARNING: BadTypeValu [16909060] during pivot: no norm for type: <class 'int'>. name=inet:fqdn
```
