### PR TITLE
Bug movetags tagprops

### DIFF
--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -785,7 +785,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 logger.warning('NO CERTIFICATE FOUND! generating self-signed certificate.')
                 with s_common.getTempDir() as dirn:
                     cdir = s_certdir.CertDir(dirn)
-                    pkey, cert = cdir.genHostCert('cortex')
+                    pkey, cert = cdir.genHostCert(self.getCellType())
                     cdir.savePkeyPem(pkey, pkeypath)
                     cdir.saveCertPem(cert, certpath)
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -992,6 +992,7 @@ class Layer(s_nexus.Pusher):
         self.nodedata = self.dataslab.initdb('nodedata')
         self.dataname = self.dataslab.initdb('dataname', dupsort=True)
 
+        self.nodeeditlog = None
         if self.logedits:
             self.nodeeditlog = s_slabseqn.SlabSeqn(self.nodeeditslab, 'nodeedits')
 
@@ -1014,8 +1015,9 @@ class Layer(s_nexus.Pusher):
         return valu
 
     async def stat(self):
-        ret = {**self.layrslab.statinfo()}
-        if hasattr(self, 'nodeeditlog'):
+        ret = {**self.layrslab.statinfo(),
+               }
+        if self.logedits:
             ret['nodeeditlog_indx'] = (self.nodeeditlog.index(), 0, 0)
         return ret
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1014,10 +1014,10 @@ class Layer(s_nexus.Pusher):
         return valu
 
     async def stat(self):
-        return {
-            'nodeeditlog_indx': (self.nodeeditlog.index(), 0, 0),
-            **self.layrslab.statinfo()
-        }
+        ret = {**self.layrslab.statinfo()}
+        if hasattr(self, 'nodeeditlog'):
+            ret['nodeeditlog_indx'] = (self.nodeeditlog.index(), 0, 0)
+        return ret
 
     async def _onLayrFini(self):
         [(await wind.fini()) for wind in self.windows]

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2014,8 +2014,16 @@ class MoveTagCmd(Cmd):
                 if newt is None:
                     continue
 
+                # Capture tagprop information before moving tags
+                tgfo = {tagp: node.getTagProp(name, tagp) for tagp in node.getTagProps(name)}
+
+                # Move the tags
                 await node.delTag(name)
                 await node.addTag(newt, valu=valu)
+
+                # re-apply any captured tagprop data
+                for tagp, tagp_valu in tgfo.items():
+                    await node.setTagProp(newt, tagp, tagp_valu)
 
         await snap.printf(f'moved tags on {count} nodes.')
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2841,13 +2841,15 @@ class CortexBasicTest(s_t_utils.SynTest):
         async with self.getTestCore(conf=conf) as core:
             async with await core.snap() as snap:
                 await self.agenlen(2, snap.eval('[test:str=foo test:str=bar]'))
-            await self.agenlen(2, core.eval('test:str'))
+            self.len(2, await core.nodes('test:str'))
 
             layr = core.getLayer()
             await self.agenlen(0, layr.splices())
             await self.agenlen(0, layr.splicesBack())
             await self.agenlen(0, layr.syncNodeEdits(0))
             self.eq(0, layr.getNodeEditOffset())
+
+            self.nn(await core.stat())
 
     async def test_feed_syn_nodes(self):
         async with self.getTestCore() as core0:

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -118,6 +118,19 @@ class StormTest(s_t_utils.SynTest):
             self.len(1, await core.nodes('syn:tag=aaa.barbarella.ccc'))
             self.len(1, await core.nodes('syn:tag=aaa.barbarella.ddd'))
 
+        # Move a tag with tagprops
+        async with self.getTestCore() as core:
+            await core.addTagProp('test', ('int', {}), {})
+            nodes = await core.nodes('[test:int=1 +#hehe.haha +#hehe.beep:test=10]')
+            self.eq(nodes[0].tagprops.get('hehe.beep'), {'test': 10})
+
+            await core.nodes('movetag hehe woah')
+
+            self.len(0, await core.nodes('#hehe'))
+            nodes = await core.nodes('#woah')
+            self.len(1, nodes)
+            self.eq(nodes[0].tagprops.get('woah.beep'), {'test': 10})
+
         # Sad path
         async with self.getTestCore() as core:
             # Test moving a tag to itself

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -155,9 +155,11 @@ class StormTest(s_t_utils.SynTest):
         # Sad path
         async with self.getTestCore() as core:
             # Test moving a tag to itself
-            await self.agenraises(s_exc.BadOperArg, core.eval('movetag foo.bar foo.bar'))
+            with self.raises(s_exc.BadOperArg):
+                await core.nodes('movetag foo.bar foo.bar')
             # Test moving a tag which does not exist
-            await self.agenraises(s_exc.BadOperArg, core.eval('movetag foo.bar duck.knight'))
+            with self.raises(s_exc.BadOperArg):
+                await core.nodes('movetag foo.bar duck.knight')
 
     async def test_storm_spin(self):
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -31,13 +31,13 @@ class StormTest(s_t_utils.SynTest):
                 await tagnode.set('doc', 'haha doc')
                 await tagnode.set('title', 'haha title')
 
-            await s_common.aspin(core.eval('movetag hehe woot'))
+            await core.nodes('movetag hehe woot')
 
-            await self.agenlen(0, core.eval('#hehe'))
-            await self.agenlen(0, core.eval('#hehe.haha'))
+            self.len(0, await core.nodes('#hehe'))
+            self.len(0, await core.nodes('#hehe.haha'))
 
-            await self.agenlen(1, core.eval('#woot'))
-            await self.agenlen(1, core.eval('#woot.haha'))
+            self.len(1, await core.nodes('#woot'))
+            self.len(1, await core.nodes('#woot.haha'))
 
             async with await core.snap() as snap:
 
@@ -79,10 +79,10 @@ class StormTest(s_t_utils.SynTest):
 
                 await tagnode.set('doc', 'haha doc')
 
-            await s_common.aspin(core.eval('movetag hehe woot'))
+            await core.nodes('movetag hehe woot')
 
-            await self.agenlen(0, core.eval('#hehe'))
-            await self.agenlen(1, core.eval('#woot'))
+            self.len(0, await core.nodes('#hehe'))
+            self.len(1, await core.nodes('#woot'))
 
             async with await core.snap() as snap:
                 newt = await core.getNodeByNdef(('syn:tag', 'woot'))
@@ -97,18 +97,10 @@ class StormTest(s_t_utils.SynTest):
                 tnode = await snap.getNodeByNdef(('syn:tag', 'a.b'))
                 await tnode.addTag('foo', (None, None))
 
-            await alist(core.eval('movetag a.b a.m'))
-            await self.agenlen(2, core.eval('#foo'))
-            await self.agenlen(1, core.eval('syn:tag=a.b +#foo'))
-            await self.agenlen(1, core.eval('syn:tag=a.m +#foo'))
-
-        # Test moving a tag to itself
-        async with self.getTestCore() as core:
-            await self.agenraises(s_exc.BadOperArg, core.eval('movetag foo.bar foo.bar'))
-
-        # Test moving a tag which does not exist
-        async with self.getTestCore() as core:
-            await self.agenraises(s_exc.BadOperArg, core.eval('movetag foo.bar duck.knight'))
+            await core.nodes('movetag a.b a.m')
+            self.len(2, await core.nodes('#foo'))
+            self.len(1, await core.nodes('syn:tag=a.b +#foo'))
+            self.len(1, await core.nodes('syn:tag=a.m +#foo'))
 
         # Test moving a tag to another tag which is a string prefix of the source
         async with self.getTestCore() as core:
@@ -120,11 +112,18 @@ class StormTest(s_t_utils.SynTest):
                 node = await snap.addNode('test:str', 'Q')
                 await node.addTag('aaa.barbarella.ccc', (None, None))
 
-            await alist(core.eval('movetag aaa.b aaa.barbarella'))
+            await core.nodes('movetag aaa.b aaa.barbarella')
 
-            await self.agenlen(7, core.eval('syn:tag'))
-            await self.agenlen(1, core.eval('syn:tag=aaa.barbarella.ccc'))
-            await self.agenlen(1, core.eval('syn:tag=aaa.barbarella.ddd'))
+            self.len(7, await core.nodes('syn:tag'))
+            self.len(1, await core.nodes('syn:tag=aaa.barbarella.ccc'))
+            self.len(1, await core.nodes('syn:tag=aaa.barbarella.ddd'))
+
+        # Sad path
+        async with self.getTestCore() as core:
+            # Test moving a tag to itself
+            await self.agenraises(s_exc.BadOperArg, core.eval('movetag foo.bar foo.bar'))
+            # Test moving a tag which does not exist
+            await self.agenraises(s_exc.BadOperArg, core.eval('movetag foo.bar duck.knight'))
 
     async def test_storm_spin(self):
 


### PR DESCRIPTION
- Replace eval() with nodes() in movetags test
- Update movetags move tagprops
- Fix Core.stat() when logedits is disabled
- Fix cert name for self-signed certs to be the celltype as opposed to hardcoding cortex.