### PR TITLE
Make view initialization 2 phase

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2105,6 +2105,9 @@ class Cortex(s_cell.Cell):  # type: ignore
             if iden == defiden:
                 self.view = view
 
+        for view in self.views.values():
+            view.init2()
+
         # if we have no views, we are initializing.  Add a default main view and layer.
         if not self.views:
             ldef = await self.addLayer()
@@ -2155,6 +2158,7 @@ class Cortex(s_cell.Cell):  # type: ignore
             await info.set(name, valu)
 
         view = await self._loadView(node)
+        view.init2()
 
         await self.bumpSpawnPool()
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1689,7 +1689,7 @@ class Layer(s_nexus.Pusher):
 
             return
 
-        for lkey, lval in self.layrslab.scanByDups(verb.encode(), db=self.byverb):
+        for _, lval in self.layrslab.scanByDups(verb.encode(), db=self.byverb):
             yield (s_common.ehex(lval[:32]), verb, s_common.ehex(lval[32:]))
 
     def _delNodeEdges(self, buid):

--- a/synapse/lib/spawn.py
+++ b/synapse/lib/spawn.py
@@ -386,6 +386,9 @@ class SpawnCore(s_base.Base):
 
             self.views[iden] = view
 
+        for view in self.views.values():
+            view.init2()
+
         self.addStormDmon = self.prox.addStormDmon
         self.delStormDmon = self.prox.delStormDmon
         self.getStormDmon = self.prox.getStormDmon

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -72,10 +72,6 @@ class View(s_nexus.Pusher):  # type: ignore
         self.invalid = None
         self.parent = None  # The view this view was forked from
 
-        parent = self.info.get('parent')
-        if parent is not None:
-            self.parent = self.core.getView(parent)
-
         self.permCheck = {
             'node:add': self._nodeAddConfirm,
             'prop:set': self._propSetConfirm,
@@ -85,6 +81,15 @@ class View(s_nexus.Pusher):  # type: ignore
 
         # isolate some initialization to easily override for SpawnView.
         await self._initViewLayers()
+
+    def init2(self):
+        '''
+        We have a second round of initialization so the views can get a handle to their parents which might not
+        be initialized yet
+        '''
+        parent = self.info.get('parent')
+        if parent is not None:
+            self.parent = self.core.getView(parent)
 
     def isafork(self):
         return self.parent is not None

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2,7 +2,6 @@ import copy
 import time
 import shutil
 import asyncio
-import fastjsonschema
 
 from unittest.mock import patch
 
@@ -4491,3 +4490,20 @@ class CortexBasicTest(s_t_utils.SynTest):
                                            'Error loading pkg') as stream:
                 async with self.getTestCore(dirn=dirn) as core:
                     self.true(await stream.wait(6))
+
+    async def test_cortex_view_persistence(self):
+        with self.getTestDir() as dirn:
+            async with self.getTestCore(dirn=dirn) as core:
+                view = core.view
+                NKIDS = 20
+                for _ in range(NKIDS):
+                    await view.fork()
+
+                self.len(NKIDS + 1, core.layers)
+
+            async with self.getTestCore(dirn=dirn) as core:
+                self.len(NKIDS + 1, core.layers)
+                for view in core.views.values():
+                    if view == core.view:
+                        continue
+                    self.eq(core.view, view.parent)


### PR DESCRIPTION
This avoids a persistence bug that prevented view's parents from being set due to random view deserialization order.