### PR TITLE
Support generating nodeedits when form is not present

### DIFF
--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1912,10 +1912,10 @@ class Layer(s_nexus.Pusher):
                 nodeedits[2].append(edit)
                 continue
 
-            if flag == 1:
-                if not nodeedits[0] == buid:
-                    continue
+            if not nodeedits[0] == buid:
+                nodeedits = (buid, None, [])
 
+            if flag == 1:
                 name = lkey[33:].decode()
                 valu, stortype = s_msgpack.un(lval)
 
@@ -1924,9 +1924,6 @@ class Layer(s_nexus.Pusher):
                 continue
 
             if flag == 2:
-                if not nodeedits[0] == buid:
-                    continue
-
                 name = lkey[33:].decode()
                 tagv = s_msgpack.un(lval)
 
@@ -1935,9 +1932,6 @@ class Layer(s_nexus.Pusher):
                 continue
 
             if flag == 3:
-                if not nodeedits[0] == buid:
-                    continue
-
                 tag, prop = lkey[33:].decode().split(':')
                 valu, stortype = s_msgpack.un(lval)
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1766,6 +1766,9 @@ class Layer(s_nexus.Pusher):
         '''
         Evaluates whether any tables hold a reference to a buid and adds/removes a buid:form entry.
         '''
+        if not edittypes:
+            return
+
         hasref = True
         deltypes = {EDIT_NODE_DEL, EDIT_PROP_DEL, EDIT_TAG_DEL, EDIT_TAGPROP_DEL, EDIT_NODEDATA_DEL, EDIT_EDGE_DEL}
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1650,12 +1650,13 @@ class Layer(s_nexus.Pusher):
 
         tenc = tag.encode()
 
-        tagabrv = self.tagabrv.bytsToAbrv(tenc)
         formabrv = self.setPropAbrv(form, None)
 
         oldb = self.layrslab.pop(buid + b'\x02' + tenc, db=self.bybuid)
         if oldb is None:
             return ()
+
+        tagabrv = self.tagabrv.bytsToAbrv(tenc)
 
         self.layrslab.delete(tagabrv + formabrv, buid, db=self.bytag)
 
@@ -2065,7 +2066,8 @@ class Layer(s_nexus.Pusher):
 
             if flag == 3:
                 if not nodeedits[0] == buid:
-                    continue
+                    form = await self._getFormByBuid(buid)
+                    nodeedits = (buid, form, [])
 
                 tag, prop = lkey[33:].decode().split(':')
                 valu, stortype = s_msgpack.un(lval)

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1085,8 +1085,6 @@ class Layer(s_nexus.Pusher):
                 form, _ = self.getAbrvProp(lkey[:8])
                 return form
 
-        return None
-
     async def getFormInByTag(self, buid):
         '''
         Retrieve form name for a buid using tag index.
@@ -1095,8 +1093,6 @@ class Layer(s_nexus.Pusher):
             if lval == buid:
                 form, _ = self.getAbrvProp(lkey[8:])
                 return form
-
-        return None
 
     async def getNodeValu(self, buid, prop=None):
         '''

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1076,7 +1076,7 @@ class Layer(s_nexus.Pusher):
 
         return s_msgpack.un(byts)
 
-    async def getFormInByProp(self, buid):
+    async def _getFormInByProp(self, buid):
         '''
         Retrieve form name for a buid using prop index.
         '''
@@ -1085,7 +1085,7 @@ class Layer(s_nexus.Pusher):
                 form, _ = self.getAbrvProp(lkey[:8])
                 return form
 
-    async def getFormInByTag(self, buid):
+    async def _getFormInByTag(self, buid):
         '''
         Retrieve form name for a buid using tag index.
         '''
@@ -1840,7 +1840,7 @@ class Layer(s_nexus.Pusher):
             verb = lkey[32:].decode()
             yield verb, s_common.ehex(n1buid)
 
-    async def iterIsoNodeEdgesN1(self):
+    async def _iterIsoNodeEdgesN1(self):
         '''
         Return a generator of edges where the associated buid is not in this layer.
         '''
@@ -1925,7 +1925,7 @@ class Layer(s_nexus.Pusher):
             prop = self.getAbrvProp(abrv)
             yield prop[0], valu
 
-    async def iterIsoNodeData(self):
+    async def _iterIsoNodeData(self):
         '''
         Return a generator of node data where the associated buid is not in this layer.
         '''
@@ -1975,7 +1975,7 @@ class Layer(s_nexus.Pusher):
 
             if flag == 1:
                 if not nodeedits[0] == buid:
-                    form = await self.getFormInByProp(buid)
+                    form = await self._getFormInByProp(buid)
                     nodeedits = (buid, form, [])
 
                 name = lkey[33:].decode()
@@ -1987,7 +1987,7 @@ class Layer(s_nexus.Pusher):
 
             if flag == 2:
                 if not nodeedits[0] == buid:
-                    form = await self.getFormInByTag(buid)
+                    form = await self._getFormInByTag(buid)
                     nodeedits = (buid, form, [])
 
                 name = lkey[33:].decode()
@@ -2023,10 +2023,10 @@ class Layer(s_nexus.Pusher):
 
             yield nodeedits
 
-        async for buid, prop, valu in self.iterIsoNodeData():
+        async for buid, prop, valu in self._iterIsoNodeData():
             yield (buid, None, [(EDIT_NODEDATA_SET, (prop, valu, None), ())])
 
-        async for n1buid, verb, n2iden in self.iterIsoNodeEdgesN1():
+        async for n1buid, verb, n2iden in self._iterIsoNodeEdgesN1():
             yield (n1buid, None, [(EDIT_EDGE_ADD, (verb, n2iden), ())])
 
     async def initUpstreamSync(self, url):

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1120,17 +1120,6 @@ class Layer(s_nexus.Pusher):
 
         return s_msgpack.un(byts)
 
-    async def _getFormByBuid(self, buid):
-        '''
-        Retrieve form name for a buid
-        '''
-        byts = self.layrslab.get(buid, db=self.formbybuid)
-
-        if byts is None:
-            return None
-
-        return byts.decode()
-
     async def getNodeValu(self, buid, prop=None):
         '''
         Retrieve either the form valu or a prop valu for the given node by buid.

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1690,6 +1690,10 @@ class Layer(s_nexus.Pusher):
 
     def _editTagPropSet(self, buid, form, edit, sode):
 
+        if form is None:
+            logger.warning(f'Invalid tagprop set edit, form is None: {edit}')
+            return ()
+
         tag, prop, valu, oldv, stortype = edit[1]
 
         tenc = tag.encode()
@@ -1761,6 +1765,10 @@ class Layer(s_nexus.Pusher):
 
     def _editNodeDataSet(self, buid, form, edit, sode):
 
+        if form is None:
+            logger.warning(f'Invalid nodedata set edit, form is None: {edit}')
+            return ()
+
         name, valu, oldv = edit[1]
         abrv = self.setPropAbrv(name, None)
 
@@ -1798,6 +1806,10 @@ class Layer(s_nexus.Pusher):
         )
 
     def _editNodeEdgeAdd(self, buid, form, edit, sode):
+
+        if form is None:
+            logger.warning(f'Invalid node edge edit, form is None: {edit}')
+            return ()
 
         verb, n2iden = edit[1]
 

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -978,7 +978,7 @@ class Slab(s_base.Base):
 
     def prefexists(self, byts, db=None):
         '''
-        Returns bool for whether a prefix exists in the db.
+        Returns True if a prefix exists in the db.
         '''
         realdb, _ = self.dbnames[db]
         with self.xact.cursor(db=realdb) as curs:
@@ -988,6 +988,22 @@ class Slab(s_base.Base):
             lkey = curs.key()
 
             if lkey[:len(byts)] == byts:
+                return True
+
+            return False
+
+    def rangeexists(self, lmin, lmax=None, db=None):
+        '''
+        Returns True if at least one key exists in the range.
+        '''
+        realdb, _ = self.dbnames[db]
+        with self.xact.cursor(db=realdb) as curs:
+            if not curs.set_range(lmin):
+                return False
+
+            lkey = curs.key()
+
+            if lkey[:len(lmin)] >= lmin and (lmax is None or lkey[:len(lmax)] <= lmax):
                 return True
 
             return False

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -976,6 +976,23 @@ class Slab(s_base.Base):
         with self.xact.cursor(db=realdb) as curs:
             return curs.set_key_dup(lkey, lval)
 
+    def prefexists(self, byts, db=None):
+        '''
+        Returns bool for whether a prefix exists in the db.
+        '''
+        with Scan(self, db) as scan:
+
+            if not scan.set_range(byts):
+                return False
+
+            size = len(byts)
+            for lkey, lval in scan.iternext():
+                if lkey[:size] == byts:
+                    return True
+                break
+
+            return False
+
     def stat(self, db=None):
         self._acqXactForReading()
         realdb, dupsort = self.dbnames[db]

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -756,27 +756,33 @@ class LayerTest(s_t_utils.SynTest):
             # add node - buid:form exists
             nodes = await core.nodes('[ inet:ipv4=1.2.3.4 :loc=us ]')
             buid0 = nodes[0].buid
-            self.eq('inet:ipv4', await layr00._getFormByBuid(buid0))
+            fenc = layr00.layrslab.get(buid0 + b'\x09', db=layr00.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             # add edge and nodedata
             nodes = await core.nodes('[ inet:ipv4=2.3.4.5 ]')
             buid1 = nodes[0].buid
-            self.eq('inet:ipv4', await layr00._getFormByBuid(buid1))
+            fenc = layr00.layrslab.get(buid1 + b'\x09', db=layr00.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             await core.nodes('inet:ipv4=1.2.3.4 [ +(refs)> {inet:ipv4=2.3.4.5} ] $node.data.set(spam, ham)')
-            self.eq('inet:ipv4', await layr00._getFormByBuid(buid0))
+            fenc = layr00.layrslab.get(buid0 + b'\x09', db=layr00.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             # remove edge, map still exists
             await core.nodes('inet:ipv4=1.2.3.4 [ -(refs)> {inet:ipv4=2.3.4.5} ]')
-            self.eq('inet:ipv4', await layr00._getFormByBuid(buid0))
+            fenc = layr00.layrslab.get(buid0 + b'\x09', db=layr00.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             # remove nodedata, map still exists
             await core.nodes('inet:ipv4=1.2.3.4 $node.data.pop(spam)')
-            self.eq('inet:ipv4', await layr00._getFormByBuid(buid0))
+            fenc = layr00.layrslab.get(buid0 + b'\x09', db=layr00.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             # delete node - buid:form removed
             await core.nodes('inet:ipv4=1.2.3.4 | delnode')
-            self.none(await layr00._getFormByBuid(buid0))
+            fenc = layr00.layrslab.get(buid0 + b'\x09', db=layr00.bybuid)
+            self.none(fenc)
 
             await core.nodes('[ inet:ipv4=5.6.7.8 ]')
 
@@ -788,34 +794,41 @@ class LayerTest(s_t_utils.SynTest):
             await alist(view01.eval('[ inet:ipv4=6.7.8.9 ]'))
 
             # buid:form for a node in child doesn't exist
-            self.none(await layr01._getFormByBuid(buid1))
+            fenc = layr01.layrslab.get(buid1 + b'\x09', db=layr01.bybuid)
+            self.none(fenc)
 
             # add prop, buid:form map exists
             nodes = await alist(view01.eval('inet:ipv4=2.3.4.5 [ :loc=ru ]'))
             self.len(1, nodes)
-            self.eq('inet:ipv4', await layr01._getFormByBuid(buid1))
+            fenc = layr01.layrslab.get(buid1 + b'\x09', db=layr01.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             # add nodedata and edge
             await alist(view01.eval('inet:ipv4=2.3.4.5 [ +(refs)> {inet:ipv4=6.7.8.9} ] $node.data.set(faz, baz)'))
 
             # remove prop, map still exists due to nodedata
             await alist(view01.eval('inet:ipv4=2.3.4.5 [ -:loc ]'))
-            self.eq('inet:ipv4', await layr01._getFormByBuid(buid1))
+            fenc = layr01.layrslab.get(buid1 + b'\x09', db=layr01.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             # remove nodedata, map still exists due to edge
             await alist(view01.eval('inet:ipv4=2.3.4.5 $node.data.pop(faz)'))
-            self.eq('inet:ipv4', await layr01._getFormByBuid(buid1))
+            fenc = layr01.layrslab.get(buid1 + b'\x09', db=layr01.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             # remove edge, map is deleted
             await alist(view01.eval('inet:ipv4=2.3.4.5 [ -(refs)> {inet:ipv4=6.7.8.9} ]'))
-            self.none(await layr01._getFormByBuid(buid1))
+            fenc = layr01.layrslab.get(buid1 + b'\x09', db=layr01.bybuid)
+            self.none(fenc)
 
             # edges between two nodes in parent
             await alist(view01.eval('inet:ipv4=2.3.4.5 [ +(refs)> {inet:ipv4=5.6.7.8} ]'))
-            self.eq('inet:ipv4', await layr01._getFormByBuid(buid1))
+            fenc = layr01.layrslab.get(buid1 + b'\x09', db=layr01.bybuid)
+            self.eq('inet:ipv4', fenc.decode())
 
             await alist(view01.eval('inet:ipv4=2.3.4.5 [ -(refs)> {inet:ipv4=5.6.7.8} ]'))
-            self.none(await layr01._getFormByBuid(buid1))
+            fenc = layr01.layrslab.get(buid1 + b'\x09', db=layr01.bybuid)
+            self.none(fenc)
 
     async def test_layer(self):
 

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -747,6 +747,76 @@ class LayerTest(s_t_utils.SynTest):
                     for nodeedit in layr.nodeeditlog.sliceBack(lastoffs, 2):
                         self.eq(meta, nodeedit[1][1])
 
+    async def test_layer_form_by_buid(self):
+
+        async with self.getTestCore() as core:
+
+            layr00 = core.view.layers[0]
+
+            # add node - buid:form exists
+            nodes = await core.nodes('[ inet:ipv4=1.2.3.4 :loc=us ]')
+            buid0 = nodes[0].buid
+            self.eq('inet:ipv4', await layr00._getFormByBuid(buid0))
+
+            # add edge and nodedata
+            nodes = await core.nodes('[ inet:ipv4=2.3.4.5 ]')
+            buid1 = nodes[0].buid
+            self.eq('inet:ipv4', await layr00._getFormByBuid(buid1))
+
+            await core.nodes('inet:ipv4=1.2.3.4 [ +(refs)> {inet:ipv4=2.3.4.5} ] $node.data.set(spam, ham)')
+            self.eq('inet:ipv4', await layr00._getFormByBuid(buid0))
+
+            # remove edge, map still exists
+            await core.nodes('inet:ipv4=1.2.3.4 [ -(refs)> {inet:ipv4=2.3.4.5} ]')
+            self.eq('inet:ipv4', await layr00._getFormByBuid(buid0))
+
+            # remove nodedata, map still exists
+            await core.nodes('inet:ipv4=1.2.3.4 $node.data.pop(spam)')
+            self.eq('inet:ipv4', await layr00._getFormByBuid(buid0))
+
+            # delete node - buid:form removed
+            await core.nodes('inet:ipv4=1.2.3.4 | delnode')
+            self.none(await layr00._getFormByBuid(buid0))
+
+            nodes = await core.nodes('[ inet:ipv4=5.6.7.8 ]')
+
+            # fork a view
+            info = await core.view.fork()
+            layr01 = core.getLayer(info['layers'][0]['iden'])
+            view01 = core.getView(info['iden'])
+
+            await alist(view01.eval('[ inet:ipv4=6.7.8.9 ]'))
+
+            # buid:form for a node in child doesn't exist
+            self.none(await layr01._getFormByBuid(buid1))
+
+            # add prop, buid:form map exists
+            nodes = await alist(view01.eval('inet:ipv4=2.3.4.5 [ :loc=ru ]'))
+            self.len(1, nodes)
+            self.eq('inet:ipv4', await layr01._getFormByBuid(buid1))
+
+            # add nodedata and edge
+            await alist(view01.eval('inet:ipv4=2.3.4.5 [ +(refs)> {inet:ipv4=6.7.8.9} ] $node.data.set(faz, baz)'))
+
+            # remove prop, map still exists due to nodedata
+            await alist(view01.eval('inet:ipv4=2.3.4.5 [ -:loc ]'))
+            self.eq('inet:ipv4', await layr01._getFormByBuid(buid1))
+
+            # remove nodedata, map still exists due to edge
+            await alist(view01.eval('inet:ipv4=2.3.4.5 $node.data.pop(faz)'))
+            self.eq('inet:ipv4', await layr01._getFormByBuid(buid1))
+
+            # remove edge, map is deleted
+            await alist(view01.eval('inet:ipv4=2.3.4.5 [ -(refs)> {inet:ipv4=6.7.8.9} ]'))
+            self.none(await layr01._getFormByBuid(buid1))
+
+            # edges between two nodes in parent
+            await alist(view01.eval('inet:ipv4=2.3.4.5 [ +(refs)> {inet:ipv4=5.6.7.8} ]'))
+            self.eq('inet:ipv4', await layr01._getFormByBuid(buid1))
+
+            await alist(view01.eval('inet:ipv4=2.3.4.5 [ -(refs)> {inet:ipv4=5.6.7.8} ]'))
+            self.none(await layr01._getFormByBuid(buid1))
+
     async def test_layer(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -71,12 +71,14 @@ class LayerTest(s_t_utils.SynTest):
                 async with await core00.snap() as snap:
 
                     props = {'tick': 12345}
-                    node = await snap.addNode('test:str', 'foo', props=props)
-                    await node.setTagProp('bar', 'score', 10)
-                    await node.setData('baz', 'nodedataiscool')
+                    node1 = await snap.addNode('test:str', 'foo', props=props)
+                    await node1.setTagProp('bar', 'score', 10)
+                    await node1.setData('baz', 'nodedataiscool')
 
-                    node = await snap.addNode('test:str', 'bar', props=props)
-                    await node.setData('baz', 'nodedataiscool')
+                    node2 = await snap.addNode('test:str', 'bar', props=props)
+                    await node2.setData('baz', 'nodedataiscool')
+
+                    await node1.addEdge('refs', node2.iden())
 
                 async with self.getTestCore(dirn=path01) as core01:
 
@@ -106,6 +108,7 @@ class LayerTest(s_t_utils.SynTest):
                         self.eq(node.props.get('tick'), 12345)
                         self.eq(node.tagprops.get(('bar', 'score')), 10)
                         self.eq(await node.getData('baz'), 'nodedataiscool')
+                        self.len(1, await alist(node.iterEdgesN1()))
 
                     # make sure updates show up
                     await core00.nodes('[ inet:fqdn=vertex.link ]')

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -778,7 +778,7 @@ class LayerTest(s_t_utils.SynTest):
             await core.nodes('inet:ipv4=1.2.3.4 | delnode')
             self.none(await layr00._getFormByBuid(buid0))
 
-            nodes = await core.nodes('[ inet:ipv4=5.6.7.8 ]')
+            await core.nodes('[ inet:ipv4=5.6.7.8 ]')
 
             # fork a view
             info = await core.view.fork()

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -656,6 +656,24 @@ class LayerTest(s_t_utils.SynTest):
             nodes = await core.nodes('inet:ipv4=1.2.3.4 [ +#foo.bar=2015 ]')
             self.eq((1325376000000, 1420070400001), nodes[0].getTag('foo.bar'))
 
+            nodeedits = [
+                (buid, None, (
+                    (s_layer.EDIT_PROP_SET, ('loc', 'us', None, s_layer.STOR_TYPE_LOC), ()),
+                )),
+            ]
+
+            nodeedits_out = await layr.storNodeEdits(nodeedits, {})
+            self.notin('loc', nodeedits_out[0][1]['props'])
+
+            nodeedits = [
+                (buid, None, (
+                    (s_layer.EDIT_TAG_SET, ('faz.baz', (None, None), (None, None)), ()),
+                )),
+            ]
+
+            nodeedits_out = await layr.storNodeEdits(nodeedits, {})
+            self.notin('faz.baz', nodeedits_out[0][1]['tags'])
+
     async def test_layer_nodeedits(self):
 
         async with self.getTestCoreAndProxy() as (core0, prox0):

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -131,6 +131,13 @@ class LmdbSlabTest(s_t_utils.SynTest):
             items = list(slab.scanByDups(b'\x00\x04', db=bar))
             self.eq(items, ())
 
+            self.true(slab.prefexists(b'\x00', db=baz))
+            self.true(slab.prefexists(b'\x00\x01', db=baz))
+            self.false(slab.prefexists(b'\x00\x03', db=baz))
+            self.false(slab.prefexists(b'\x02', db=baz))
+            self.true(slab.prefexists(b'\xff\xff', db=baz))
+            self.false(slab.prefexists(b'\xff\xff', db=foo))
+
             # backwards scan tests
 
             items = list(slab.scanByPrefBack(b'\x00', db=foo))

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -138,6 +138,14 @@ class LmdbSlabTest(s_t_utils.SynTest):
             self.true(slab.prefexists(b'\xff\xff', db=baz))
             self.false(slab.prefexists(b'\xff\xff', db=foo))
 
+            self.true(slab.rangeexists(b'\x00', b'\x01', db=baz))
+            self.true(slab.rangeexists(b'\x00\x00', b'\x00\x04', db=baz))
+            self.false(slab.rangeexists(b'\x00\x04', b'\x01', db=baz))
+            self.true(slab.rangeexists(b'\x05', None, db=baz))
+            self.false(slab.rangeexists(b'\xfa', b'\xfc', db=baz))
+            self.false(slab.rangeexists(b'\x00\x00', b'\x00\x00', db=foo))
+            self.false(slab.rangeexists(b'\x01\x04', b'\x01\x05', db=foo))
+
             # backwards scan tests
 
             items = list(slab.scanByPrefBack(b'\x00', db=foo))

--- a/synapse/tests/test_lib_view.py
+++ b/synapse/tests/test_lib_view.py
@@ -76,6 +76,12 @@ class ViewTest(s_t_utils.SynTest):
             self.len(1, await view2.callStorm('test:int=9 return($node.data.list())'))
             self.len(0, await core.callStorm('test:int=9 return($node.data.list())'))
 
+            # Add edges that will only exist in the child
+            await alist(view2.eval('test:int=9 [ +(refs)> {test:int=10} ]'))
+            await alist(view2.eval('test:int=12 [ +(refs)> {test:int=11} ]'))
+            self.len(2, await alist(view2.eval('test:int -(refs)> *')))
+            self.len(0, await core.nodes('test:int -(refs)> *'))
+
             # Forker and forkee have their layer configuration frozen
             tmplayr = await core.addLayer()
             tmpiden = tmplayr['iden']
@@ -137,6 +143,9 @@ class ViewTest(s_t_utils.SynTest):
             # Node data that was only set in child is present in parent
             self.len(1, await core.callStorm('test:int=9 return($node.data.list())'))
             self.len(1, await core.nodes('yield $lib.lift.byNodeData(spam)'))
+
+            # Edge that was only set in child present in parent
+            self.len(2, await core.nodes('test:int -(refs)> *'))
 
             # The child count includes all the nodes in the view
             self.eq(1004, (await view2.getFormCounts()).get('test:int'))

--- a/synapse/tests/test_lib_view.py
+++ b/synapse/tests/test_lib_view.py
@@ -8,12 +8,14 @@ from synapse.tests.utils import alist
 class ViewTest(s_t_utils.SynTest):
     async def test_view_fork_merge(self):
         async with self.getTestCore() as core:
+            await core.nodes('[ test:int=9 ]')
             await core.nodes('[ test:int=10 ]')
             await core.auth.addUser('visi')
+            await core.addTagProp('score', ('int', {}), {})
 
-            nodes = await alist(core.eval('test:int=10'))
-            self.len(1, nodes)
-            self.eq(1, (await core.getFormCounts()).get('test:int'))
+            self.len(1, await alist(core.eval('test:int=9')))
+            self.len(1, await alist(core.eval('test:int=10')))
+            self.eq(2, (await core.getFormCounts()).get('test:int'))
 
             # Fork the main view
             vdef2 = await core.view.fork()
@@ -29,7 +31,7 @@ class ViewTest(s_t_utils.SynTest):
             # A node added to the parent after the fork is still seen by the child
             nodes = await alist(view2.eval('test:int=11'))
             self.len(1, nodes)
-            self.eq(2, (await core.getFormCounts()).get('test:int'))
+            self.eq(3, (await core.getFormCounts()).get('test:int'))
 
             # A node added to the child is not seen by the parent
             nodes = await alist(view2.eval('[ test:int=12 ]'))
@@ -37,26 +39,16 @@ class ViewTest(s_t_utils.SynTest):
 
             nodes = await core.nodes('test:int=12')
             self.len(0, nodes)
-            self.eq(2, (await core.view.getFormCounts()).get('test:int'))
-
-            # Set a prop in the child
-            await alist(view2.eval('test:int=11 [:loc=us]'))
-            self.len(1, await alist(view2.eval('test:int=11 +:loc=us')))
-            self.len(0, await core.nodes('test:int=11 +:loc=us'))
-
-            # Check that we can get the prop-only nodeedit out
-            lyr2 = view2.layers[0]
-            edits = [e async for ne in lyr2.iterLayerNodeEdits() for e in ne[2]]
-            self.isin((2, ('loc', 'us', None, 15), ()), edits)
+            self.eq(3, (await core.view.getFormCounts()).get('test:int'))
 
             # Deleting nodes from the child view should not affect the main
             await alist(view2.eval('test:int | delnode'))
 
-            self.eq(2, (await core.view.getFormCounts()).get('test:int'))
+            self.eq(3, (await core.view.getFormCounts()).get('test:int'))
             nodes = await alist(view2.eval('test:int=10'))
             self.len(1, nodes)
 
-            self.eq(2, (await core.getFormCounts()).get('test:int'))
+            self.eq(3, (await core.getFormCounts()).get('test:int'))
             await self.agenlen(0, view2.eval('test:int=12'))
 
             # Until we get tombstoning, the child view can't delete a node in the lower layer
@@ -68,6 +60,21 @@ class ViewTest(s_t_utils.SynTest):
             # Add a bunch of nodes to require chunking of splices when merging
             for i in range(1000):
                 await self.agenlen(1, view2.eval('[test:int=$val]', opts={'vars': {'val': i + 1000}}))
+
+            # Add prop that will only exist in the child
+            await alist(view2.eval('test:int=10 [:loc=us]'))
+            self.len(1, await alist(view2.eval('test:int=10 +:loc=us')))
+            self.len(0, await core.nodes('test:int=10 +:loc=us'))
+
+            # Add tag that will only exist in child
+            await alist(view2.eval('test:int=11 [+#foo.bar:score=20]'))
+            self.len(1, await alist(view2.eval('test:int=11 +#foo.bar:score=20')))
+            self.len(0, await core.nodes('test:int=11 +:loc=us +#foo.bar:score=20'))
+
+            # Add nodedata that will only exist in child
+            await alist(view2.eval('test:int=9 $node.data.set(spam, ham)'))
+            self.len(1, await view2.callStorm('test:int=9 return($node.data.list())'))
+            self.len(0, await core.callStorm('test:int=9 return($node.data.list())'))
 
             # Forker and forkee have their layer configuration frozen
             tmplayr = await core.addLayer()
@@ -103,13 +110,13 @@ class ViewTest(s_t_utils.SynTest):
                     await prox.eval('test:int=12', opts={'view': view2.iden}).list()
 
             # The parent count is correct
-            self.eq(2, (await core.view.getFormCounts()).get('test:int'))
+            self.eq(3, (await core.view.getFormCounts()).get('test:int'))
 
             # Merge the child back into the parent
             await view2.merge()
 
             # The parent counts includes all the nodes that were merged
-            self.eq(1003, (await core.view.getFormCounts()).get('test:int'))
+            self.eq(1004, (await core.view.getFormCounts()).get('test:int'))
 
             # A node added to the child is now present in the parent
             nodes = await core.nodes('test:int=12')
@@ -119,8 +126,20 @@ class ViewTest(s_t_utils.SynTest):
             nodes = await view2.nodes('test:int=10')
             self.len(1, nodes)
 
+            # Prop that was only set in child is present in parent
+            self.len(1, await core.nodes('test:int=10 +:loc=us'))
+            self.len(1, await core.nodes('test:int:loc=us'))
+
+            # Tag that was only set in child is present in parent
+            self.len(1, await core.nodes('test:int=11 +#foo.bar:score=20'))
+            self.len(1, await core.nodes('test:int#foo.bar'))
+
+            # Node data that was only set in child is present in parent
+            self.len(1, await core.callStorm('test:int=9 return($node.data.list())'))
+            self.len(1, await core.nodes('yield $lib.lift.byNodeData(spam)'))
+
             # The child count includes all the nodes in the view
-            self.eq(1003, (await view2.getFormCounts()).get('test:int'))
+            self.eq(1004, (await view2.getFormCounts()).get('test:int'))
 
             # The child can see nodes that got merged
             nodes = await view2.nodes('test:int=12')

--- a/synapse/tests/test_lib_view.py
+++ b/synapse/tests/test_lib_view.py
@@ -39,6 +39,16 @@ class ViewTest(s_t_utils.SynTest):
             self.len(0, nodes)
             self.eq(2, (await core.view.getFormCounts()).get('test:int'))
 
+            # Set a prop in the child
+            await alist(view2.eval('test:int=11 [:loc=us]'))
+            self.len(1, await alist(view2.eval('test:int=11 +:loc=us')))
+            self.len(0, await core.nodes('test:int=11 +:loc=us'))
+
+            # Check that we can get the prop-only nodeedit out
+            lyr2 = view2.layers[0]
+            edits = [e async for ne in lyr2.iterLayerNodeEdits() for e in ne[2]]
+            self.isin((2, ('loc', 'us', None, 15), ()), edits)
+
             # Deleting nodes from the child view should not affect the main
             await alist(view2.eval('test:int | delnode'))
 

--- a/synapse/tests/test_tools_migrate020.py
+++ b/synapse/tests/test_tools_migrate020.py
@@ -1052,7 +1052,7 @@ class MigrationTest(s_t_utils.SynTest):
                 nes1 = [nodeedits for offs, nodeedits in lyr1.nodeeditlog.iter(0)]
                 sodes1 = [await lyr1.storNodeEdits(nes[0], None) for nes in nes1]
 
-                await self._checkCore(core, tdata)
+                await self._checkCore(core, tdata, nodesonly=True)
 
     async def test_migr_splice_errs(self):
         conf = {


### PR DESCRIPTION
- Adds a new buid:form row in bybuid table so that edits can be generated for props, nodedata, edges when the parent ndef does not exist in the layer
- Add form is None check into setters
- Generate nodeedits for edges (previously not implemented)
- Fixes a bug where nodes with tags in the parent only raises an error when attempting to delete in the child