### PR TITLE
Fix a test teardown race condition

### DIFF
--- a/synapse/lib/nexus.py
+++ b/synapse/lib/nexus.py
@@ -298,6 +298,7 @@ class NexsRoot(s_base.Base):
                 # if we really are a mirror/follower, we have the same iden.
                 if iden != await proxy.getCellIden():
                     logger.error('remote cell has different iden!  Aborting mirror sync')
+                    await proxy.fini()  # Address a test race.
                     await self.fini()
                     return
 

--- a/synapse/tests/test_servers_cortex.py
+++ b/synapse/tests/test_servers_cortex.py
@@ -103,4 +103,4 @@ class CortexServerTest(s_t_utils.SynTest):
                                                'has different iden') as stream:
                     async with await s_cortex.Cortex.initFromArgv(argv1, outp=out1) as core01:
                         await stream.wait(timeout=2)
-                        self.true(core01.isfini)
+                        self.true(await core01.waitfini(6))


### PR DESCRIPTION
Address a race condition which prevents a nexus slab from being fini'd in test_server_cortex::CortexServerTest::test_server_mirror_badiden