### PR TITLE
Cell leadership awareness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
           command: |
             . venv/bin/activate
             mkdir test-reports
-            circleci tests glob synapse/tests/test_cortex.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
+            circleci tests glob synapse/tests/test_cortex.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py synapse/tests/test_lib_spawn.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
 
   test_steps_doc:
     description: "Documentation test steps"
@@ -361,7 +361,7 @@ jobs:
       - test_steps_python
 
   python37_replay:
-    parallelism: 2
+    parallelism: 4
     docker:
       - image: circleci/python:3.7
         environment:

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -899,7 +899,7 @@ class Cortex(s_cell.Cell):  # type: ignore
         self.leaderchangeaware = True
         await self.onLeaderChange(self.nexsroot.amLeader())
 
-    async def onLeaderChange(self, leader: bool):
+    async def onLeaderChange(self, leader):
         if not self.leaderchangeaware:
             return
         if leader:

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -765,6 +765,7 @@ class Cortex(s_cell.Cell):  # type: ignore
 
     viewctor = s_view.View.anit
     layrctor = s_layer.Layer.anit
+    leaderchangeaware = False
     spawncorector = 'synapse.lib.spawn.SpawnCore'
 
     async def __anit__(self, dirn, conf=None):
@@ -790,7 +791,6 @@ class Cortex(s_cell.Cell):  # type: ignore
         self.stormcmds = {}
 
         self.spawnpool = None
-        self.leaderchangeaware = True
         self.mirror = self.conf.get('mirror')
 
         self.storm_cmd_ctors = {}
@@ -900,6 +900,8 @@ class Cortex(s_cell.Cell):  # type: ignore
         await self.onLeaderChange()
 
     async def onLeaderChange(self):
+        if not self.leaderchangeaware:
+            return
         if self.nexsroot.amLeader():
             return await self.startCortexLeader()
         return await self.stopCortexLeader()

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -790,6 +790,7 @@ class Cortex(s_cell.Cell):  # type: ignore
         self.feedfuncs = {}
         self.stormcmds = {}
 
+        self.isleader = None
         self.spawnpool = None
         self.mirror = self.conf.get('mirror')
 
@@ -872,7 +873,6 @@ class Cortex(s_cell.Cell):  # type: ignore
 
         # Finalize coremodule loading & give stormservices a shot to load
         await self._initCoreMods()
-        await self._initStormSvcs()
         await self._initPureStormCmds()
 
         import synapse.lib.spawn as s_spawn  # get around circular dependency
@@ -896,12 +896,15 @@ class Cortex(s_cell.Cell):  # type: ignore
 
         # Enable leadership change awareness and fire
         # the leadership hook once at boot
+        self.isleader = self.nexsroot.amLeader()
+        await self._initStormSvcs()
         self.leaderchangeaware = True
-        await self.onLeaderChange(self.nexsroot.amLeader())
+        await self.onLeaderChange(self.isleader)
 
     async def onLeaderChange(self, leader):
         if not self.leaderchangeaware:
             return
+        self.isleader = leader
         if leader:
             return await self.startCortexLeader()
         return await self.stopCortexLeader()
@@ -1429,7 +1432,8 @@ class Cortex(s_cell.Cell):  # type: ignore
             return
 
         try:
-            await self.runStormSvcEvent(iden, 'del')
+            if self.isleader:
+                await self.runStormSvcEvent(iden, 'del')
         except asyncio.CancelledError:  # pragma: no cover
             raise
         except Exception as e:

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -789,8 +789,9 @@ class Cortex(s_cell.Cell):  # type: ignore
         self.feedfuncs = {}
         self.stormcmds = {}
 
-        self.mirror = False
         self.spawnpool = None
+        self.leaderchangeaware = True
+        self.mirror = self.conf.get('mirror')
 
         self.storm_cmd_ctors = {}
         self.storm_cmd_cdefs = {}
@@ -798,8 +799,6 @@ class Cortex(s_cell.Cell):  # type: ignore
         self.stormmods = {}     # name: mdef
         self.stormpkgs = {}     # name: pkgdef
         self.stormvars = None   # type: s_hive.HiveDict
-
-        self.stormdmons = {}
 
         self.svcsbyiden = {}
         self.svcsbyname = {}
@@ -848,10 +847,6 @@ class Cortex(s_cell.Cell):  # type: ignore
         # Initialize our storage and views
         await self._initCoreAxon()
 
-        mirror = self.conf.get('mirror')
-        if mirror is not None:
-            self.mirror = True
-
         await self._initCoreLayers()
         await self._initCoreViews()
         self.onfini(self._finiStor)
@@ -860,13 +855,11 @@ class Cortex(s_cell.Cell):  # type: ignore
 
         self.addHealthFunc(self._cortexHealth)
 
-        async def finidmon():
-            await asyncio.gather(*[dmon.fini() for dmon in self.stormdmons.values()])
-
-        self.onfini(finidmon)
-
+        self.stormdmons = await s_storm.DmonManager.anit(self)
+        self.onfini(self.stormdmons)
         self.agenda = await s_agenda.Agenda.anit(self)
         self.onfini(self.agenda)
+        await self._initStormDmons()
 
         self.trigson = self.conf.get('trigger:enable')
 
@@ -881,12 +874,6 @@ class Cortex(s_cell.Cell):  # type: ignore
         await self._initCoreMods()
         await self._initStormSvcs()
         await self._initPureStormCmds()
-
-        # Now start agenda and dmons after all coremodules have finished
-        # loading and services have gotten a shot to be registerd.
-        if self.conf.get('cron:enable'):
-            await self.agenda.start()
-        await self._initStormDmons()
 
         import synapse.lib.spawn as s_spawn  # get around circular dependency
         self.spawnpool = await s_spawn.SpawnPool.anit(self)
@@ -904,8 +891,33 @@ class Cortex(s_cell.Cell):  # type: ignore
 
         await self.postNexsAnit()
 
-        if mirror is not None:
-            await self.initCoreMirror(mirror)
+        if self.mirror is not None:
+            await self._initCoreMirror(self.mirror)
+
+        # Enable leadership change awareness and fire
+        # the leadership hook once at boot
+        self.leaderchangeaware = True
+        await self.onLeaderChange()
+
+    async def onLeaderChange(self):
+        if self.nexsroot.amLeader():
+            return await self.startCortexLeader()
+        return await self.stopCortexLeader()
+
+    async def startCortexLeader(self):
+        '''
+        Indempotent actions that are done when a Cortex is a leader.
+        '''
+        if self.conf.get('cron:enable'):
+            await self.agenda.start()
+        await self.stormdmons.start()
+
+    async def stopCortexLeader(self):
+        '''
+        Indempotent actions that are done when a Cortex is not a leader.
+        '''
+        await self.agenda.stop()
+        await self.stormdmons.stop()
 
     async def _onEvtBumpSpawnPool(self, evnt):
         await self.bumpSpawnPool()
@@ -1819,7 +1831,7 @@ class Cortex(s_cell.Cell):  # type: ignore
             if user.iden == mesg[1]['user'] or user.isAdmin():
                 yield mesg
 
-    async def initCoreMirror(self, url):
+    async def _initCoreMirror(self, url):
         '''
         Initialize this cortex as a down-stream/follower mirror from a telepath url.
 
@@ -2494,7 +2506,7 @@ class Cortex(s_cell.Cell):  # type: ignore
     async def _onAddStormDmon(self, ddef):
         iden = ddef['iden']
 
-        dmon = self.stormdmons.get(iden)
+        dmon = self.stormdmons.getDmon(iden)
         if dmon is not None:
             return dmon.pack()
 
@@ -2503,6 +2515,7 @@ class Cortex(s_cell.Cell):  # type: ignore
             ddef['user'] = user.iden
 
         dmon = await self.runStormDmon(iden, ddef)
+
         await self.stormdmonhive.set(iden, ddef)
         return dmon.pack()
 
@@ -2519,9 +2532,7 @@ class Cortex(s_cell.Cell):  # type: ignore
 
     @s_nexus.Pusher.onPush('storm:dmon:del')
     async def _delStormDmon(self, iden):
-        dmon = self.stormdmons.pop(iden, None)
-        if dmon is not None:
-            await dmon.fini()
+        await self.stormdmons.popDmon(iden)
 
     def getStormCmd(self, name):
         return self.stormcmds.get(name)
@@ -2531,7 +2542,7 @@ class Cortex(s_cell.Cell):  # type: ignore
         # validate ddef before firing task
         s_storm.reqValidDdef(ddef)
 
-        dmon = self.stormdmons.get(iden)
+        dmon = self.stormdmons.getDmon(iden)
         if dmon is not None:
             return dmon
 
@@ -2540,31 +2551,18 @@ class Cortex(s_cell.Cell):  # type: ignore
         # raises if parser failure
         self.getStormQuery(ddef.get('storm'))
 
-        dmon = await s_storm.StormDmon.anit(self, iden, ddef)
-
-        self.stormdmons[iden] = dmon
-
-        def fini():
-            self.stormdmons.pop(iden, None)
-
-        dmon.onfini(fini)
-        await dmon.run()
+        dmon = await self.stormdmons.addDmon(iden, ddef)
 
         return dmon
 
     async def getStormDmon(self, iden):
-        dmon = self.stormdmons.get(iden)
-        if dmon is not None:
-            return dmon.pack()
+        return self.stormdmons.getDmonPacked(iden)
 
     async def getStormDmons(self):
-        return list(d.pack() for d in self.stormdmons.values())
+        return self.stormdmons.getDmonsPacked()
 
     async def getStormDmonLog(self, iden):
-        dmon = self.stormdmons.get(iden)
-        if dmon is not None:
-            return dmon._getRunLog()
-        return ()
+        return self.stormdmons.getDmonRunlog(iden)
 
     def addStormLib(self, path, ctor):
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -897,12 +897,12 @@ class Cortex(s_cell.Cell):  # type: ignore
         # Enable leadership change awareness and fire
         # the leadership hook once at boot
         self.leaderchangeaware = True
-        await self.onLeaderChange()
+        await self.onLeaderChange(self.nexsroot.amLeader())
 
-    async def onLeaderChange(self):
+    async def onLeaderChange(self, leader: bool):
         if not self.leaderchangeaware:
             return
-        if self.nexsroot.amLeader():
+        if leader:
             return await self.startCortexLeader()
         return await self.stopCortexLeader()
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2556,10 +2556,10 @@ class Cortex(s_cell.Cell):  # type: ignore
         return dmon
 
     async def getStormDmon(self, iden):
-        return self.stormdmons.getDmonPacked(iden)
+        return self.stormdmons.getDmonDef(iden)
 
     async def getStormDmons(self):
-        return self.stormdmons.getDmonsPacked()
+        return self.stormdmons.getDmonDefs()
 
     async def getStormDmonLog(self, iden):
         return self.stormdmons.getDmonRunlog(iden)

--- a/synapse/lib/agenda.py
+++ b/synapse/lib/agenda.py
@@ -499,7 +499,6 @@ class Agenda(s_base.Base):
         if not self.enabled:
             return
         self._schedtask.cancel()
-        await asyncio.sleep(0)
         for task in self._running_tasks:
             task.cancel()
 

--- a/synapse/lib/agenda.py
+++ b/synapse/lib/agenda.py
@@ -490,6 +490,14 @@ class Agenda(s_base.Base):
         self._schedtask = self.schedCoro(self._scheduleLoop())
         self.enabled = True
 
+    # async def stop(self):
+    #     "Cancel the scheduler loop, and set self.enabled to False."
+    #     self._schedtask.cancel()
+    #     await asyncio.sleep(0)
+    #     # FIXME this leaks running tasks :(
+    #
+    #     self.enabled = False
+
     async def _load_all(self):
         '''
         Load all the appointments from persistent storage

--- a/synapse/lib/agenda.py
+++ b/synapse/lib/agenda.py
@@ -714,6 +714,9 @@ class Agenda(s_base.Base):
                 if not appt.enabled or not self.enabled:
                     continue
 
+                # TODO - This should be removed because the Agenda
+                # object should never even be started on a non-master
+                # Cortex object.
                 if self.core.mirror:
                     continue
 
@@ -761,8 +764,11 @@ class Agenda(s_base.Base):
             starttime = time.time()
             try:
                 opts = {'user': user.iden}
-                async for _ in self.core.eval(appt.query, opts=opts):
-                    count += 1
+                # TODO - Find a better pattern which doesn't require us to
+                # do message formulation?
+                async for mesg in self.core.storm(appt.query, opts=opts):
+                    if mesg[0] == 'node':
+                        count += 1
             except asyncio.CancelledError:
                 result = 'cancelled'
                 raise

--- a/synapse/lib/agenda.py
+++ b/synapse/lib/agenda.py
@@ -774,11 +774,8 @@ class Agenda(s_base.Base):
             starttime = time.time()
             try:
                 opts = {'user': user.iden}
-                # TODO - Find a better pattern which doesn't require us to
-                # do message formulation?
-                async for mesg in self.core.storm(appt.query, opts=opts):
-                    if mesg[0] == 'node':
-                        count += 1
+                async for node in self.core.eval(appt.query, opts=opts):
+                    count += 1
             except asyncio.CancelledError:
                 result = 'cancelled'
                 raise

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -509,7 +509,7 @@ class Base:
             **kwargs:
 
         Notes:
-            This method may called from outside of the event loop on a different thread.
+            This method may be called from outside of the event loop on a different thread.
 
         Returns:
             concurrent.futures.Future: A Future representing the eventual function execution.

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -576,10 +576,11 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         nexsroot.onfini(self)
         return nexsroot
 
-    async def onLeaderChange(self):
+    async def onLeaderChange(self, leader):
         '''
         Cell implementers may override this method to be notified when
-        nexusroot leadership changes.
+        nexusroot leadership changes. The leader arg will be a bool provided
+        if the Cell is a leader or not.
         '''
         pass
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -26,7 +26,6 @@ import synapse.lib.health as s_health
 import synapse.lib.output as s_output
 import synapse.lib.certdir as s_certdir
 import synapse.lib.httpapi as s_httpapi
-import synapse.lib.msgpack as s_msgpack
 import synapse.lib.version as s_version
 import synapse.lib.hiveauth as s_hiveauth
 
@@ -520,6 +519,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         await self._initCellSlab(readonly=readonly)
 
         self.setNexsRoot(await self._initNexsRoot())
+        self.nexsroot.onStateChange(self.onLeaderChange)
 
         self.hive = await self._initCellHive()
 
@@ -575,6 +575,13 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         self.onfini(nexsroot.fini)
         nexsroot.onfini(self)
         return nexsroot
+
+    async def onLeaderChange(self):
+        '''
+        Cell implementers may override this method to be notified when
+        nexusroot leadership changes.
+        '''
+        pass
 
     async def getNexusChanges(self, offs):
         async for item in self.nexsroot.iter(offs):

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -159,7 +159,7 @@ class LayerApi(s_cell.CellApi):
 
     async def getNodeEditOffset(self):
         await self._reqUserAllowed(self.liftperm)
-        return self.layr.getNodeEditOffset()
+        return await self.layr.getNodeEditOffset()
 
     async def getIden(self):
         await self._reqUserAllowed(self.liftperm)
@@ -913,6 +913,8 @@ class Layer(s_nexus.Pusher):
     '''
     The base class for a cortex layer.
     '''
+    nodeeditctor = s_slabseqn.SlabSeqn
+
     def __repr__(self):
         return f'Layer ({self.__class__.__name__}): {self.iden}'
 
@@ -1068,7 +1070,7 @@ class Layer(s_nexus.Pusher):
 
         self.nodeeditlog = None
         if self.logedits:
-            self.nodeeditlog = s_slabseqn.SlabSeqn(self.nodeeditslab, 'nodeedits')
+            self.nodeeditlog = self.nodeeditctor(self.nodeeditslab, 'nodeedits')
 
     def getSpawnInfo(self):
         info = self.pack()
@@ -2311,7 +2313,7 @@ class Layer(s_nexus.Pusher):
 
             yield wind
 
-    def getNodeEditOffset(self):
+    async def getNodeEditOffset(self):
         if not self.logedits:
             return 0
 

--- a/synapse/lib/nexus.py
+++ b/synapse/lib/nexus.py
@@ -325,7 +325,7 @@ class NexsRoot(s_base.Base):
                     await self.fini()
                     return
 
-                logger.warning(f'mirror loop ready ({self._ldrurl}')
+                logger.info(f'mirror loop ready ({self._ldrurl})')
 
                 while not proxy.isfini:
 

--- a/synapse/lib/spawn.py
+++ b/synapse/lib/spawn.py
@@ -318,6 +318,7 @@ class SpawnCore(s_base.Base):
         self.views = {}
         self.layers = {}
         self.nexsroot = None
+        self.isleader = False
         self.spawninfo = spawninfo
 
         self.conf = spawninfo.get('conf')
@@ -473,12 +474,14 @@ class SpawnCore(s_base.Base):
         '''
         pass
 
-    async def _runStormSvcAdd(self, iden):
+    async def _hndladdStormPkg(self, pdef):
         '''
-        For now don't actually run this in the spawn case. This only needs to be
-        done in the master Cortex, not in spawns. Loading a service here should not
-        be making persistent changes.
+        For now don't acrtually run this in the spawn case. This only needs to be
+        done in the master Cortex, not in spawns. Adding a storm service package
+        from a spawn should not be making persistent changes.
         '''
+        # Note - this represents the bottom half of addStormPkg which is made
+        # via the @s_nexus.Pusher.onPushAuto('pkg:add') decorator.
         pass
 
     async def setStormSvcEvents(self, iden, edef):

--- a/synapse/lib/spawn.py
+++ b/synapse/lib/spawn.py
@@ -476,7 +476,7 @@ class SpawnCore(s_base.Base):
 
     async def _hndladdStormPkg(self, pdef):
         '''
-        For now don't acrtually run this in the spawn case. This only needs to be
+        For now don't actually run this in the spawn case. This only needs to be
         done in the master Cortex, not in spawns. Adding a storm service package
         from a spawn should not be making persistent changes.
         '''

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -202,6 +202,7 @@ reqValidDdef = s_config.getJsValidator({
         'view': {'type': 'string', 'pattern': s_config.re_iden},
         'user': {'type': 'string', 'pattern': s_config.re_iden},
         'iden': {'type': 'string', 'pattern': s_config.re_iden},
+        'enabled': {'type': 'boolean', 'default': True},
         'stormopts': {
             'oneOf': [
                 {'type': 'null'},
@@ -783,6 +784,83 @@ stormcmds = (
     },
 )
 
+class DmonManager(s_base.Base):
+    '''
+    Manager for StormDmon objects.
+    '''
+    async def __anit__(self, core):
+        await s_base.Base.__anit__(self)
+        self.core = core
+        self.dmons = {}
+        self.enabled = False
+
+        self.onfini(self._finiAllDmons)
+
+    async def _finiAllDmons(self):
+        await asyncio.gather(*[dmon.fini() for dmon in self.dmons.values()])
+
+    async def _stopAllDmons(self):
+        await asyncio.gather(*[dmon.stop() for dmon in self.dmons.values()])
+
+    async def addDmon(self, iden, ddef):
+        dmon = await StormDmon.anit(self.core, iden, ddef)
+        self.dmons[iden] = dmon
+        # TODO Remove default=True when dmon enabled CRUD is implemented
+        if self.enabled and ddef.get('enabled', True):
+            await dmon.run()
+        return dmon
+
+    def getDmonRunlog(self, iden):
+        dmon = self.dmons.get(iden)
+        if dmon is not None:
+            return dmon._getRunLog()
+        return ()
+
+    def getDmon(self, iden):
+        return self.dmons.get(iden)
+
+    def getDmonPacked(self, iden):
+        dmon = self.dmons.get(iden)
+        if dmon:
+            return dmon.pack()
+
+    def getDmonsPacked(self):
+        return list(d.pack() for d in self.dmons.values())
+
+    async def popDmon(self, iden):
+        '''Remove the dmon and fini it if its exists.'''
+        logger.debug(f'Poping dmon {iden}')
+        dmon = self.dmons.pop(iden, None)
+        if dmon:
+            await dmon.fini()
+
+    async def start(self):
+        '''
+        Start all the dmons.
+        '''
+        if self.enabled:
+            return
+        for dmon in list(self.dmons.values()):
+            await dmon.run()
+        self.enabled = True
+
+    async def stop(self):
+        '''
+        Stop all the dmons.
+        '''
+        if not self.enabled:
+            return
+        await self._stopAllDmons()
+        await asyncio.sleep(0)
+
+    # TODO write enable/disable APIS.
+    # 1. Set dmon.status to 'disabled'
+    # 2. Be aware of ddef enabled flag to set status to 'disabled'.
+    # async def enableDmon(self, iden):
+    #     pass
+    # async def disableDmon(self, iden):
+    #     pass
+
 class StormDmon(s_base.Base):
     '''
     A background storm runtime which is restarted by the cortex.
@@ -797,20 +875,22 @@ class StormDmon(s_base.Base):
 
         self.task = None
         self.loop_task = None
+        self.enabled = ddef.get('enabled')
         self.user = core.auth.user(ddef.get('user'))
 
         self.count = 0
-        self.status = 'initializing'
+        self.status = 'initialized'
         self.err_evnt = asyncio.Event()
         self.runlog = collections.deque((), 2000)
 
-        async def fini():
-            if self.task is not None:
-                self.task.cancel()
-            if self.loop_task is not None:
-                self.loop_task.cancel()
+        self.onfini(self.stop)
 
-        self.onfini(fini)
+    async def stop(self):
+        if self.task is not None:
+            self.task.cancel()
+        if self.loop_task is not None:
+            self.loop_task.cancel()
+        self.status = 'stopped'
 
     async def run(self):
         self.task = self.schedCoro(self._run())

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -819,12 +819,12 @@ class DmonManager(s_base.Base):
     def getDmon(self, iden):
         return self.dmons.get(iden)
 
-    def getDmonPacked(self, iden):
+    def getDmonDef(self, iden):
         dmon = self.dmons.get(iden)
         if dmon:
             return dmon.pack()
 
-    def getDmonsPacked(self):
+    def getDmonDefs(self):
         return list(d.pack() for d in self.dmons.values())
 
     async def popDmon(self, iden):

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -201,6 +201,7 @@ class LibDmon(Lib):
             'name': name,
             'user': self.runt.user.iden,
             'storm': str(quer),
+            'enabled': True,
             'stormopts': opts,
         }
 

--- a/synapse/tests/test_cmds_cortex.py
+++ b/synapse/tests/test_cmds_cortex.py
@@ -367,7 +367,8 @@ class CmdCoreTest(s_t_utils.SynTest):
 
             jsdata = [item for item in s_common.jslines(path)]
             self.len(2, jsdata)
-            self.eq(jsdata[0][0], ('test:int', 20))
+            self.eq({tuple(n[0]) for n in jsdata},
+                    {('test:int', 20), ('test:int', 30)})
 
     async def test_storm_file_optfile(self):
 

--- a/synapse/tests/test_cmds_cron.py
+++ b/synapse/tests/test_cmds_cron.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import datetime
 from datetime import timezone as tz
 from unittest import mock
@@ -11,6 +12,8 @@ import synapse.tests.utils as s_t_utils
 MINSECS = 60
 HOURSECS = 60 * MINSECS
 DAYSECS = 24 * HOURSECS
+
+logger = logging.getLogger(__name__)
 
 class CmdCronTest(s_t_utils.SynTest):
 

--- a/synapse/tests/test_cmds_cron.py
+++ b/synapse/tests/test_cmds_cron.py
@@ -17,8 +17,6 @@ class CmdCronTest(s_t_utils.SynTest):
     async def test_cron(self):
         MONO_DELT = 1543827303.0
         unixtime = datetime.datetime(year=2018, month=12, day=5, hour=7, minute=0, tzinfo=tz.utc).timestamp()
-        sync = asyncio.Event()
-        lastquery = None
         s_provenance.reset()
 
         def timetime():
@@ -26,13 +24,6 @@ class CmdCronTest(s_t_utils.SynTest):
 
         def looptime():
             return unixtime - MONO_DELT
-
-        async def myeval(query, user=None):
-            nonlocal lastquery
-            lastquery = query
-            sync.set()
-            return
-            yield None
 
         loop = asyncio.get_running_loop()
 

--- a/synapse/tests/test_lib_agenda.py
+++ b/synapse/tests/test_lib_agenda.py
@@ -166,7 +166,7 @@ class AgendaTest(s_t_utils.SynTest):
         def looptime():
             return unixtime - MONO_DELT
 
-        async def myeval(query, opts=None):
+        async def mystorm(query, opts=None):
             nonlocal lastquery
             lastquery = query
             sync.set()
@@ -181,8 +181,7 @@ class AgendaTest(s_t_utils.SynTest):
         loop = asyncio.get_running_loop()
         with mock.patch.object(loop, 'time', looptime), mock.patch('time.time', timetime), self.getTestDir() as dirn:
             core = mock.Mock()
-            core.mirror = False
-            core.eval = myeval
+            core.storm = mystorm
             core.slab = await s_lmdbslab.Slab.anit(dirn, map_size=s_t_utils.TEST_MAP_SIZE, readonly=False)
             db = core.slab.initdb('hive')
             core.hive = await s_hive.SlabHive.anit(core.slab, db=db)

--- a/synapse/tests/test_lib_agenda.py
+++ b/synapse/tests/test_lib_agenda.py
@@ -166,7 +166,7 @@ class AgendaTest(s_t_utils.SynTest):
         def looptime():
             return unixtime - MONO_DELT
 
-        async def mystorm(query, opts=None):
+        async def myeval(query, opts=None):
             nonlocal lastquery
             lastquery = query
             sync.set()
@@ -181,7 +181,7 @@ class AgendaTest(s_t_utils.SynTest):
         loop = asyncio.get_running_loop()
         with mock.patch.object(loop, 'time', looptime), mock.patch('time.time', timetime), self.getTestDir() as dirn:
             core = mock.Mock()
-            core.storm = mystorm
+            core.eval = myeval
             core.slab = await s_lmdbslab.Slab.anit(dirn, map_size=s_t_utils.TEST_MAP_SIZE, readonly=False)
             db = core.slab.initdb('hive')
             core.hive = await s_hive.SlabHive.anit(core.slab, db=db)

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -91,7 +91,7 @@ class LayerTest(s_t_utils.SynTest):
                     await core01.view.addLayer(layr.iden)
 
                     # test initial sync
-                    offs = core00.getView().layers[0].getNodeEditOffset()
+                    offs = await core00.getView().layers[0].getNodeEditOffset()
                     evnt = await layr.waitUpstreamOffs(layriden, offs)
                     await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -110,14 +110,14 @@ class LayerTest(s_t_utils.SynTest):
                     # make sure updates show up
                     await core00.nodes('[ inet:fqdn=vertex.link ]')
 
-                    offs = core00.getView().layers[0].getNodeEditOffset()
+                    offs = await core00.getView().layers[0].getNodeEditOffset()
                     evnt = await layr.waitUpstreamOffs(layriden, offs)
                     await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
                     self.len(1, await core01.nodes('inet:fqdn=vertex.link'))
 
                 await core00.nodes('[ inet:ipv4=5.5.5.5 ]')
-                offs = core00.getView().layers[0].getNodeEditOffset()
+                offs = await core00.getView().layers[0].getNodeEditOffset()
 
                 # test what happens when we go down and come up again...
                 async with self.getTestCore(dirn=path01) as core01:
@@ -131,7 +131,7 @@ class LayerTest(s_t_utils.SynTest):
 
                     await core00.nodes('[ inet:ipv4=5.6.7.8 ]')
 
-                    offs = core00.getView().layers[0].getNodeEditOffset()
+                    offs = await core00.getView().layers[0].getNodeEditOffset()
                     evnt = await layr.waitUpstreamOffs(layriden, offs)
                     await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -177,7 +177,7 @@ class LayerTest(s_t_utils.SynTest):
                     layr = core01.getLayer(ldef.get('iden'))
 
                     # Sync core01 with core00
-                    offs = core00.getView().layers[0].getNodeEditOffset()
+                    offs = await core00.getView().layers[0].getNodeEditOffset()
                     evnt = await layr.waitUpstreamOffs(layriden, offs)
                     await asyncio.wait_for(evnt.wait(), timeout=8.0)
 
@@ -230,7 +230,7 @@ class LayerTest(s_t_utils.SynTest):
                         await core02.view.addLayer(layr.iden)
 
                         # core00 is synced
-                        offs = core00.getView().layers[0].getNodeEditOffset()
+                        offs = await core00.getView().layers[0].getNodeEditOffset()
                         evnt = await layr.waitUpstreamOffs(iden00, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -240,7 +240,7 @@ class LayerTest(s_t_utils.SynTest):
                         self.nn(nodes[0].tags.get('hehe.haha'))
 
                         # core01 is synced
-                        offs = core01.getView().layers[0].getNodeEditOffset()
+                        offs = await core01.getView().layers[0].getNodeEditOffset()
                         evnt = await layr.waitUpstreamOffs(iden01, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -252,7 +252,7 @@ class LayerTest(s_t_utils.SynTest):
                         # updates from core00 show up
                         await core00.nodes('[ inet:fqdn=vertex.link ]')
 
-                        offs = core00.getView().layers[0].getNodeEditOffset()
+                        offs = await core00.getView().layers[0].getNodeEditOffset()
                         evnt = await layr.waitUpstreamOffs(iden00, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -261,7 +261,7 @@ class LayerTest(s_t_utils.SynTest):
                         # updates from core01 show up
                         await core01.nodes('[ inet:fqdn=google.com ]')
 
-                        offs = core01.getView().layers[0].getNodeEditOffset()
+                        offs = await core01.getView().layers[0].getNodeEditOffset()
                         evnt = await layr.waitUpstreamOffs(iden01, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -276,14 +276,14 @@ class LayerTest(s_t_utils.SynTest):
                         layr = core02.getView().layers[-1]
 
                         # test we catch up to core00
-                        offs = core00.getView().layers[0].getNodeEditOffset()
+                        offs = await core00.getView().layers[0].getNodeEditOffset()
                         evnt = await layr.waitUpstreamOffs(iden00, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
                         self.len(1, await core02.nodes('inet:ipv4=5.5.5.5'))
 
                         # test we catch up to core01
-                        offs = core01.getView().layers[0].getNodeEditOffset()
+                        offs = await core01.getView().layers[0].getNodeEditOffset()
                         evnt = await layr.waitUpstreamOffs(iden01, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -292,7 +292,7 @@ class LayerTest(s_t_utils.SynTest):
                         # test we get updates from core00
                         await core00.nodes('[ inet:ipv4=5.6.7.8 ]')
 
-                        offs = core00.getView().layers[0].getNodeEditOffset()
+                        offs = await core00.getView().layers[0].getNodeEditOffset()
                         evnt = await layr.waitUpstreamOffs(iden00, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -301,7 +301,7 @@ class LayerTest(s_t_utils.SynTest):
                         # test we get updates from core01
                         await core01.nodes('[ inet:ipv4=8.7.6.5 ]')
 
-                        offs = core01.getView().layers[0].getNodeEditOffset()
+                        offs = await core01.getView().layers[0].getNodeEditOffset()
                         evnt = await layr.waitUpstreamOffs(iden01, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 

--- a/synapse/tests/test_lib_msgpack.py
+++ b/synapse/tests/test_lib_msgpack.py
@@ -137,6 +137,15 @@ class MsgPackTest(s_t_utils.SynTest):
         self.false(s_msgpack.isok({1, 2}))  # set
         self.false(s_msgpack.isok(print))  # function
 
+        buf2 = b'\x81\xc0\xcd\x04\xd2'
+        struct2 = {
+            None: 1234
+        }
+        ustruct2 = s_msgpack.un(buf2)
+        self.eq(ustruct2, struct2)
+        pbuf2 = s_msgpack.en(ustruct2)
+        self.eq(buf2, pbuf2)
+
     def test_msgpack_large_data(self):
 
         big_string = s_const.mebibyte * 129 * 'V'

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -1679,7 +1679,7 @@ class StormTypesTest(s_test.SynTest):
                 url = core2.getLocalUrl('*/layer')
 
                 layriden = core2.view.layers[0].iden
-                offs = core2.view.layers[0].getNodeEditOffset()
+                offs = await core2.view.layers[0].getNodeEditOffset()
 
                 layers = set(core.layers.keys())
                 q = f'layer.add --upstream {url}'
@@ -2324,6 +2324,7 @@ class StormTypesTest(s_test.SynTest):
                 self.stormIsInPrint(':type=m1', mesgs)
 
                 # Make sure it ran
+                await asyncio.sleep(0)
                 await asyncio.sleep(0)
                 await self.agenlen(1, prox.eval('graph:node:type=m1'))
 

--- a/synapse/tests/test_tools_migrate020.py
+++ b/synapse/tests/test_tools_migrate020.py
@@ -1100,7 +1100,7 @@ class MigrationTest(s_t_utils.SynTest):
 
                 # the only nodeedits should be for file:byte node adds
                 exp = len([x for x in tdata['podes'] if x[0][0] == 'inet:fqdn'])
-                offs = lyr0.getNodeEditOffset()
+                offs = await lyr0.getNodeEditOffset()
                 self.eq(exp, offs)
                 nes = [nodeedits for offs, nodeedits in lyr0.nodeeditlog.iter(0)]
                 self.len(exp, nes)

--- a/synapse/tests/test_tools_pullfile.py
+++ b/synapse/tests/test_tools_pullfile.py
@@ -45,7 +45,7 @@ class TestPullFile(s_t_utils.SynTest):
                     with open(pathlib.Path(wdir, visihash), 'rb') as fd:
                         self.eq(b'visi', fd.read())
 
-                    self.true(outp.expect(f'b\'{nonehash}\' not in axon store'))
+                    self.true(outp.expect(f'{nonehash} not in axon store'))
                     self.true(outp.expect(f'Fetching {testhash} to file'))
                     self.true(outp.expect(f'Fetching {visihash} to file'))
 

--- a/synapse/tools/pullfile.py
+++ b/synapse/tools/pullfile.py
@@ -1,7 +1,6 @@
 import sys
 import pathlib
 import argparse
-import binascii
 
 import synapse.common as s_common
 import synapse.telepath as s_telepath
@@ -27,11 +26,12 @@ def main(argv, outp=None):
     with s_telepath.openurl(opts.axon) as axon:
 
         # reminder: these are the hashes *not* available
-        awants = axon.wants([binascii.unhexlify(h) for h in opts.hashes])
-        for a in awants:
-            outp.printf(f'{binascii.hexlify(a)} not in axon store')
 
-        exists = [h for h in opts.hashes if binascii.unhexlify(h) not in awants]
+        awants = axon.wants([s_common.uhex(h) for h in opts.hashes])
+        for a in awants:
+            outp.printf(f'{s_common.ehex(a)} not in axon store')
+
+        exists = [h for h in opts.hashes if s_common.uhex(h) not in awants]
 
         for h in exists:
 
@@ -39,7 +39,7 @@ def main(argv, outp=None):
                 outp.printf(f'Fetching {h} to file')
 
                 with open(outdir.joinpath(h), 'wb') as fd:
-                    for b in axon.get(binascii.unhexlify(h)):
+                    for b in axon.get(s_common.uhex(h)):
                         fd.write(b)
 
                 outp.printf(f'Fetched {h} to file')


### PR DESCRIPTION
* Add a leadership change callback that individual cells can implement if they need to be leader aware.
* Implement cortex leadership change awareness. Now StormDmons and Agenda jobs only run on the leaders.
* Change agenda jobs from using deprecated eval api in favor of storm.
* Encapsulate StormDmons into a single object that allows dmons to be started and stopped dynamically.  Added some plumbing for an enabled flag, did not implement an individual enable/disable crud.
* Make Layer.getNodeEditOffset an async api
* Cull some dead code from test_cmds_cron

* Fix stormsvcclient and cortex to only run svcevents on leaders. change stormsvc initialization to one once during leadership change at the end of boot.

* Use synapse.common funcs in pullfile, avoid a binary prefix leakage

* Sneak in an additional msgpack test

* Fix a log message for mirror loop.

* Add spawn to replay tests, Increase replay parallelism