### PR TITLE
Accept microseconds for datetime parsing

### DIFF
--- a/synapse/lib/time.py
+++ b/synapse/lib/time.py
@@ -40,7 +40,7 @@ def parse(text, base=None, chop=False):
     elif tlen == 14:
         dt = datetime.datetime.strptime(text, '%Y%m%d%H%M%S')
 
-    elif tlen in (15, 16, 17):
+    elif 15 <= tlen <= 20:
         dt = datetime.datetime.strptime(text, '%Y%m%d%H%M%S%f')
 
     else:

--- a/synapse/tests/test_lib_time.py
+++ b/synapse/tests/test_lib_time.py
@@ -1,3 +1,4 @@
+import synapse.exc as s_exc
 
 import synapse.lib.time as s_time
 
@@ -30,3 +31,6 @@ class TimeTest(s_t_utils.SynTest):
         self.eq(s_time.parse('205012170304'), 2554859040000)
         self.eq(s_time.parse('20501217030432'), 2554859072000)
         self.eq(s_time.parse('20501217030432101'), 2554859072101)
+        self.eq(s_time.parse('205012170304321015'), 2554859072101)
+        self.eq(s_time.parse('20501217030432101567'), 2554859072101)
+        self.raises(s_exc.BadTypeValu, s_time.parse, '2050121703043210156789')


### PR DESCRIPTION
datetime microseconds (%f) is valid in range(1000000)