### PR TITLE
Docs updated quickstart

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@ Improved Documentation
   (`#1763 <https://github.com/vertexproject/synapse/pull/1763>`_)
 - Add Vertex branding to the Synapse documentation.
   (`#1767 <https://github.com/vertexproject/synapse/pull/1767>`_)
+- Update Backups documentation in the Devops guide.
+  (`#1764 <https://github.com/vertexproject/synapse/pull/1764>`_)
+
 
 v2.0.0 - 2020-06-08
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Improved Documentation
   (`#1767 <https://github.com/vertexproject/synapse/pull/1767>`_)
 - Update Backups documentation in the Devops guide.
   (`#1764 <https://github.com/vertexproject/synapse/pull/1764>`_)
+- Update Cortex quickstart references.
+  (`#1770 <https://github.com/vertexproject/synapse/pull/1770>`_)
 
 
 v2.0.0 - 2020-06-08

--- a/docs/synapse/quickstart.rst
+++ b/docs/synapse/quickstart.rst
@@ -61,12 +61,12 @@ on solid-state/flash drives.
 Using the Command Line
 ----------------------
 
-A Synapse Cortex server may be started from the command line using the synapse.servers.cortex python module.  The only
-required argument is a directory which is used for storage.::
+A Synapse Cortex server may be started from the command line using the ``synapse.servers.cortex`` python module. The
+only required argument is a directory which is used for storage.::
 
     python -m synapse.servers.cortex /path/to/cortex
 
-This will start a Cortex server which uses ``/path/to/cortex`` for storage.  The Cortex may be reached via
+This will start a Cortex server which uses ``/path/to/cortex`` for storage. The Cortex may be reached via
 **telepath** (for future commands) via the url ``cell:///path/to/cortex``.
 
 Relative paths may also be used by removing a forward-slash from the URL.  For example, if executing from the
@@ -84,10 +84,14 @@ The following docker-compose.yml file can be used to deploy a Cortex server usin
 
         core00:
 
-            image: vertexproject/synapse-cortex:v0.2.x
+            image: vertexproject/synapse-cortex:v2.x.x
 
             volumes:
                 - /path/to/storage:/vertex/storage
+
+            environment:
+                # Set a default password for the root user
+                - SYN_CORTEX_AUTH_PASSWD=secretsauce
 
             ports:
                 - "4443:4443"
@@ -169,28 +173,5 @@ Once an alias is created, the name may be specified in place of the telepath con
 From here, the remote user is free to use the "storm" command to execute queries from the CLI.
 See :ref:`storm-ref-intro` for details. Additionally, the HTTPS API is now available on the default port 4443.
 See :ref:`http-api` for details.
-
-Cortex Backups
-==============
-
-It is strongly recommended that you regularly backup production Cortex instances. The Synapse backup tool
-(synapse.tools.backup) may be used to create a snapshot of a running Cortex without the need to bring the service down
-or interrupt availability. It is important to avoid standard file copy operations on running LMDB files due to
-potentially causing sparse file expansion or producing a corrupt copy. LMDB makes use of sparse files which allocate
-file block storage only when the blocks are written to. This means a file copy tool which is not sparse-file aware can
-inadvertently cause massive file expansion during copy. Once a backup is created ( and has not been loaded by a Cortex )
-it is safe to zip/copy the backup files normally.::
-
-    python -m synapse.tools.backup /path/to/cortex /path/to/backup
-
-The newly created directory ``/path/to/backup`` is a full backup of the **Cortex** in ``/path/to/cortex``. To restore
-from backup, replace the ``/path/to/cortex`` folder with the ``/path/to/backup`` folder and start the server as
-normal.::
-
-    mv /path/to/cortex /path/to/cortex_old
-    mv /path/to/backup /path/to/cortex
-    python -m synapse.servers.cortex /path/to/cortex
-
-See :ref:`quick_start_cortex` for details on running a **Cortex** server.
 
 .. _Index:              ../index.html

--- a/docs/synapse/quickstart.rst
+++ b/docs/synapse/quickstart.rst
@@ -87,6 +87,7 @@ The following docker-compose.yml file can be used to deploy a Cortex server usin
             image: vertexproject/synapse-cortex:v2.x.x
 
             volumes:
+                # Map in a persistent storage directory
                 - /path/to/storage:/vertex/storage
 
             environment:
@@ -94,7 +95,9 @@ The following docker-compose.yml file can be used to deploy a Cortex server usin
                 - SYN_CORTEX_AUTH_PASSWD=secretsauce
 
             ports:
+                # Default https port
                 - "4443:4443"
+                # Default telepath port
                 - "27492:27492"
 
 The server may then be started using typical docker-compose commands or more advanced orchestration.

--- a/docs/synapse/quickstart.rst
+++ b/docs/synapse/quickstart.rst
@@ -6,12 +6,16 @@
 Getting Started
 ###############
 
-This quick start will help you get a **Cortex** up and running, introduce a few devops basics, and get you access to the **Storm** hypergraph query engine.
+This quick start will help you get a **Cortex** up and running, introduce a few devops basics, and get you access to
+the **Storm** hypergraph query engine.
 
 Installing Synapse
 ==================
 
-**Synapse** is a python 3.7 package with several dependencies such as msgpack and lmdb which are compiled python modules.  Synapse makes extensive use of the newest asynchronous design patterns in python and is not compatible with python versions prior to 3.7.  To use Synapse in a production deployment or a multi-version python environment it may easiest to deploy the pre-built docker containers.
+**Synapse** is a python 3.7 package with several dependencies such as msgpack and lmdb which are compiled python
+modules.  Synapse makes extensive use of the newest asynchronous design patterns in python and is not compatible with
+python versions prior to 3.7.  To use Synapse in a production deployment or a multi-version python environment it may
+easiest to deploy the pre-built docker containers.
 
 Docker Containers
 -----------------
@@ -22,41 +26,52 @@ The Synapse release process creates several docker containers for use in product
     A Synapse Cortex server image which uses the volume /vertex/storage for storage.
 
 *vertexproject/synapse*
-    The Synapse base image with installed dependencies.  This image is mostly useful as a base image for custom entry points.
+    The Synapse base image with installed dependencies.  This image is mostly useful as a base image for custom entry
+    points.
 
-Each Synapse release will build and upload tagged images to Docker Hub.  It is strongly recommended that docker based deployments specify specific version tags.
+Each Synapse release will build and upload tagged images to Docker Hub.  It is strongly recommended that docker based
+deployments specify specific version tags.
 
 From Python Package
 -------------------
 
-Python packages are built for Synapse releases and uploaded to the Python Package Index (pypi) at https://pypi.org/project/synapse/.  The "pip" command may be used to install directly from pypi::
+Python packages are built for Synapse releases and uploaded to the Python Package Index (pypi) at
+https://pypi.org/project/synapse/.  The "pip" command may be used to install directly from pypi::
 
     pip install synapse
 
-It is recommended that build scripts and automated installations specify an exact version or version range to prevent unintended updates.
+It is recommended that build scripts and automated installations specify an exact version or version range to prevent
+unintended updates.
 
 From Github
 -----------
 
-For development and tracking pre-release Synapse versions, use the Github repo (https://github.com/vertexproject/synapse) to checkout the Synapse source code.  Using a git checkout of the master branch in production deployments is strongly discouraged.
+For development and tracking pre-release Synapse versions, use the Github repo
+(https://github.com/vertexproject/synapse) to checkout the Synapse source code.  Using a git checkout of the master
+branch in production deployments is strongly discouraged.
 
 .. _quick_start_cortex:
 
 Starting a Cortex
 =================
 
-Each deployed Cortex requires a storage directory.  For performance, it is recommended that the filesystem is running on solid-state/flash drives.
+Each deployed Cortex requires a storage directory.  For performance, it is recommended that the filesystem is running
+on solid-state/flash drives.
 
 Using the Command Line
 ----------------------
 
-A Synapse Cortex server may be started from the command line using the synapse.servers.cortex python module.  The only required argument is a directory which is used for storage.::
+A Synapse Cortex server may be started from the command line using the synapse.servers.cortex python module.  The only
+required argument is a directory which is used for storage.::
 
     python -m synapse.servers.cortex /path/to/cortex
 
-This will start a Cortex server which uses ``/path/to/cortex`` for storage.  The Cortex may be reached via **telepath** (for future commands) via the url ``cell:///path/to/cortex``.
+This will start a Cortex server which uses ``/path/to/cortex`` for storage.  The Cortex may be reached via
+**telepath** (for future commands) via the url ``cell:///path/to/cortex``.
 
-Relative paths may also be used by removing a forward-slash from the URL.  For example, if executing from the ``/path/to/`` directory, the URL ``cell://cortex`` could be used.  For the remaining examples in this document, the cell://cortex URL will be used.
+Relative paths may also be used by removing a forward-slash from the URL.  For example, if executing from the
+``/path/to/`` directory, the URL ``cell://cortex`` could be used.  For the remaining examples in this document, the
+cell://cortex URL will be used.
 
 Using Docker
 ------------
@@ -85,7 +100,9 @@ The server may then be started using typical docker-compose commands or more adv
 Adding Initial Users/Roles/Rules
 ================================
 
-To prepare for sharing a Cortex via telepath or HTTP, roles and users should be created with permissions to allow no more access than necessary.  The following commands create the user "visi" who can add nodes, set properties, and add tags::
+To prepare for sharing a Cortex via telepath or HTTP, roles and users should be created with permissions to allow no
+more access than necessary.  The following commands create the user "visi" who can add nodes, set properties, and add
+tags::
 
     python -m synapse.tools.cellauth cell://cortex modify visi --adduser
     python -m synapse.tools.cellauth cell://cortex modify visi --passwd secretsauce
@@ -97,7 +114,8 @@ To allow remote access for the default root user account, a password can be set 
 
     python -m synapse.tools.cellauth cell://cortex modify root --passwd secretsauce
 
-Granular permissions based on types of nodes and tags may be used to create roles based on domain-specific workflows.  The following permissions exist for controlling access to nodes and tags.
+Granular permissions based on types of nodes and tags may be used to create roles based on domain-specific workflows.
+The following permissions exist for controlling access to nodes and tags.
 
 *node:add*
      Add any form of node.
@@ -132,11 +150,15 @@ Granular permissions based on types of nodes and tags may be used to create role
 Remote Access
 =============
 
-Once the user accounts have been created, the Cortex will allow connections from remote systems and users using either the Synapse RPC protocol named telepath or the HTTPS API.  Assuming our server is named "cortex.vertex.link", the user "visi" configured earlier would be able to access the Cortex remotely using the Synapse Commander (see :ref:`syn-tools-cmdr`) via the following command::
+Once the user accounts have been created, the Cortex will allow connections from remote systems and users using either
+the Synapse RPC protocol named telepath or the HTTPS API.  Assuming our server is named "cortex.vertex.link", the user
+"visi" configured earlier would be able to access the Cortex remotely using the Synapse Commander
+(see :ref:`syn-tools-cmdr`) via the following command::
 
     python -m synapse.tools.cmdr tcp://visi:secretsauce@cortex.vertex.link:27492/
 
-To manage multiple services and protect sensitive information in the telepath URL, you may create an entry in your telepath "aliases" file located at ``~/.syn/aliases.yaml``::
+To manage multiple services and protect sensitive information in the telepath URL, you may create an entry in your
+telepath "aliases" file located at ``~/.syn/aliases.yaml``::
 
     core00: tcp://visi:secretsauce@cortex.vertex.link:27492/
 
@@ -144,17 +166,26 @@ Once an alias is created, the name may be specified in place of the telepath con
 
     python -m synapse.tools.cmdr core00
 
-From here, the remote user is free to use the "storm" command to execute queries from the CLI.  See :ref:`storm-ref-intro` for details.  Additionally, the HTTPS API is now available on the default port 4443.  See :ref:`http-api` for details.
+From here, the remote user is free to use the "storm" command to execute queries from the CLI.
+See :ref:`storm-ref-intro` for details. Additionally, the HTTPS API is now available on the default port 4443.
+See :ref:`http-api` for details.
 
 Cortex Backups
 ==============
 
-It is strongly recommended that you regularly backup production Cortex instances.  The Synapse backup tool (synapse.tools.backup) may be used to create a snapshot of a running Cortex without the need to bring the service down or interrupt availability.  It is important to avoid standard file copy operations on running LMDB files due to potentially causing sparse file expansion or producing a corrupt copy.  LMDB makes use of sparse files which allocate file block storage only when the blocks are written to.  This means a file copy tool which is not sparse-file aware can inadvertently cause massive file expansion during copy.  Once a backup is created ( and has not been loaded by a Cortex ) it is safe to zip/copy the backup files normally.::
+It is strongly recommended that you regularly backup production Cortex instances. The Synapse backup tool
+(synapse.tools.backup) may be used to create a snapshot of a running Cortex without the need to bring the service down
+or interrupt availability. It is important to avoid standard file copy operations on running LMDB files due to
+potentially causing sparse file expansion or producing a corrupt copy. LMDB makes use of sparse files which allocate
+file block storage only when the blocks are written to. This means a file copy tool which is not sparse-file aware can
+inadvertently cause massive file expansion during copy. Once a backup is created ( and has not been loaded by a Cortex )
+it is safe to zip/copy the backup files normally.::
 
     python -m synapse.tools.backup /path/to/cortex /path/to/backup
 
-The newly created directory ``/path/to/backup`` is a full backup of the **Cortex** in ``/path/to/cortex``.  To restore from backup, replace the ``/path/to/cortex`` folder with the
-``/path/to/backup`` folder and start the server as normal.::
+The newly created directory ``/path/to/backup`` is a full backup of the **Cortex** in ``/path/to/cortex``. To restore
+from backup, replace the ``/path/to/cortex`` folder with the ``/path/to/backup`` folder and start the server as
+normal.::
 
     mv /path/to/cortex /path/to/cortex_old
     mv /path/to/backup /path/to/cortex


### PR DESCRIPTION
- Change long paragraphs to multilines
- Update docker-compose quickstart example
- Remove quickstart backup langauge, move relevant bits to the devops docs.