### PR TITLE
Devops guide documentation updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,5 @@ COPY synapse/docker/start-cron.sh /start-cron.sh
 
 COPY docker/bootstrap.sh /build/synapse/bootstrap.sh
 RUN /build/synapse/bootstrap.sh
+
+VOLUME /vertex/storage

--- a/docs/synapse/devguides/devops_axon.rst
+++ b/docs/synapse/devguides/devops_axon.rst
@@ -2,3 +2,8 @@ Axon Operations
 ===============
 
 TBD
+
+Configuration Options
+---------------------
+
+For a list of boot time configuration options for the Axon, see the listing at :ref:`autodoc-axon-conf`.

--- a/docs/synapse/devguides/devops_axon.rst
+++ b/docs/synapse/devguides/devops_axon.rst
@@ -1,7 +1,8 @@
 Axon Operations
 ===============
 
-TBD
+The Axon is an interface for providing binary / blob storage inside of the Synapse ecosystem. This indexes binaries
+based on SHA-256 hash so we do not duplicate the storage of the same set of bytes twice.
 
 Configuration Options
 ---------------------

--- a/docs/synapse/devguides/devops_cell.rst
+++ b/docs/synapse/devguides/devops_cell.rst
@@ -27,6 +27,18 @@ Cell implementations can extend the configuration variables available by specify
 
 Depending on deployment requirements, a combination of methods can be used for loading the configurations into the Cell.
 
+.. note::
+    The service directory (refered to as ``dirn``) should be considered a persistent directory for a given Synaspe
+    service. Inside of this directory there are several files stored which are neccesary in order for a given instance
+    of a service deployment to work properly.
+
+    Docker images made by Vertex to support Synapse services will have default volumes for ``/vertex/storage``.
+    We use this as the default service directory for default entry points in documentation. This location can either
+    have a persistent docker volume present for it created, or a external location on disk can be mapped into this
+    location. Any orchestration tooling should consider the requirements for service directory data to be persistent,
+    unless stated otherwise.
+
+
 Config File
 ***********
 

--- a/docs/synapse/devguides/devops_cell.rst
+++ b/docs/synapse/devguides/devops_cell.rst
@@ -3,19 +3,19 @@ Cell Operations
 
 As detailed in :ref:`dev_architecture`, the ``Cell`` implements a number of core management functionalities,
 and is therefore used as the base class for Synapse applications.  It is also recommended to implement ``Cell`` for
-custom services.
+custom Storm Services and other Synapse related components.
 
 .. _devops-cell-config:
 
-Configuring a Cell Service
---------------------------
+Configuring a Cell
+------------------
 
 A Cell has a set of base configuration data that will also be inherited by any implementations:
 
-- ``dirn``: The storage directory for the Cell which is a required argument for service startup.
+- ``dirn``: The storage directory for the Cell which is a required argument for Cell startup.
 - ``telepath``: Optional override for the Telepath URL to listen on.
 - ``https``: Optional override for the port to bind for the HTTPS/REST API.
-- ``name``: Optional additional name to share the service as.
+- ``name``: Optional additional name to share the cell as.
 
 The Cell class also specifies configuration variables in ``confdefs``:
 
@@ -28,14 +28,14 @@ Cell implementations can extend the configuration variables available by specify
 Depending on deployment requirements, a combination of methods can be used for loading the configurations into the Cell.
 
 .. note::
-    The service directory (refered to as ``dirn``) should be considered a persistent directory for a given Synapse
-    service. Inside of this directory there are several files stored which are neccesary in order for a given instance
-    of a service deployment to work properly.
+    The Cell directory (refered to as ``dirn``) should be considered a persistent directory for a given Synapse
+    cell. Inside of this directory there are several files stored which are necessary in order for a given instance
+    of a cell deployment to work properly.
 
-    Docker images made by Vertex to support Synapse services will have default volumes for ``/vertex/storage``.
-    We use this as the default service directory for default entry points in documentation. This location can either
+    Docker images made by Vertex to support Synapse cells will have default volumes for ``/vertex/storage``.
+    We use this as the default cell directory for default entry points in documentation. This location can either
     have a persistent docker volume present for it created, or a external location on disk can be mapped into this
-    location. Any orchestration tooling should consider the requirements for service directory data to be persistent,
+    location. Any orchestration tooling should consider the requirements for cell directory data to be persistent,
     unless stated otherwise.
 
 
@@ -53,8 +53,8 @@ The format of this file is YAML, and variable names are specified without altera
 Environment Variables
 *********************
 
-Environment variable names are automatically generated for a Cell service using the following naming convention:
-``SYN_<cell_subclass_name>_<variable_name>``.  Variable names with colons are replaced with underscores,
+Environment variable names are automatically generated for a Cell configuration options using the following naming
+convention: ``SYN_<cell_subclass_name>_<variable_name>``.  Variable names with colons are replaced with underscores,
 and the raw environment variable value is deserialized as yaml, prior to performing type validation.
 
 Command Line
@@ -72,11 +72,11 @@ Variable names with colons are replaced with a single dash.
     #. cell.yaml values
 
     These may all be mixed and matched for a given deployment.
-    If a backup of a service is made and the deployment uses configuration data from command line arguments and
+    If a backup of a Cell is made and the deployment uses configuration data from command line arguments and
     environment variables, those will need to be considered when moving/restoring the backup.
 
-Starting a Cell Service
------------------------
+Starting a Cell
+---------------
 
 The examples provided below are intended for Cell implementations outside of the Synapse level components,
 which have their own servers in the ``synapse.servers`` module.
@@ -84,19 +84,19 @@ which have their own servers in the ``synapse.servers`` module.
 As Main Module
 **************
 
-Cell implementations may define the following as the main application entrypoint (where MySvc is the Cell subclass)::
+Cell implementations may define the following as the main application entrypoint (where MyCell is the Cell subclass)::
 
     if __name__ == '__main__':
-        asyncio.run(MySvc.execmain(sys.argv[1:]))
+        asyncio.run(MyCell.execmain(sys.argv[1:]))
 
-The service can then be started with::
+The cell can then be started with::
 
     python -m path.to.main /path/to/dirn
 
 As Cell Server
 **************
 
-The generic Cell server can also be used for starting the service by specifying the constructor as an argument::
+The generic Cell server can also be used for starting the Cell by specifying the constructor as an argument::
 
-    python -m synapse.servers.cell path.to.MySvc /path/to/dirn
+    python -m synapse.servers.cell path.to.MyCell /path/to/dirn
 

--- a/docs/synapse/devguides/devops_cell.rst
+++ b/docs/synapse/devguides/devops_cell.rst
@@ -28,7 +28,7 @@ Cell implementations can extend the configuration variables available by specify
 Depending on deployment requirements, a combination of methods can be used for loading the configurations into the Cell.
 
 .. note::
-    The service directory (refered to as ``dirn``) should be considered a persistent directory for a given Synaspe
+    The service directory (refered to as ``dirn``) should be considered a persistent directory for a given Synapse
     service. Inside of this directory there are several files stored which are neccesary in order for a given instance
     of a service deployment to work properly.
 

--- a/docs/synapse/devguides/devops_cortex.rst
+++ b/docs/synapse/devguides/devops_cortex.rst
@@ -90,3 +90,8 @@ Cleanup
 *******
 
 After migration is fully complete, delete the now-unused directory "migration" inside the cortex directory.
+
+Configuration Options
+---------------------
+
+For a list of boot time configuration options for the Cortex, see the listing at :ref:`autodoc-cortex-conf`.

--- a/docs/synapse/devguides/devops_cryotank.rst
+++ b/docs/synapse/devguides/devops_cryotank.rst
@@ -1,4 +1,7 @@
 Cryotank Operations
 ===================
 
-TDB
+Configuration Options
+---------------------
+
+For a list of boot time configuration options for the Cryotank, see the listing at :ref:`autodoc-cryocell-conf`.

--- a/docs/synapse/devguides/index_autoconf.rst
+++ b/docs/synapse/devguides/index_autoconf.rst
@@ -1,0 +1,13 @@
+Cell Configuration Options
+##########################
+
+The following section contains configuration options for Synapse Cell implementations which are baked into the core
+Synapse package. These boot-time options may be set using information found at :ref:`devops-cell-config`.
+
+.. toctree::
+    :titlesonly:
+
+    ../autodocs/conf_axon
+    ../autodocs/conf_cortex
+    ../autodocs/conf_cryocell
+    ../autodocs/conf_syncmigrator

--- a/docs/synapse/devguides/index_cells.rst
+++ b/docs/synapse/devguides/index_cells.rst
@@ -1,0 +1,15 @@
+
+Synapse Devops
+##############
+
+The DevOps guide contains information useful for running **Synapse** ecosystem components. This will continue to be
+updated and expanded over time.
+
+.. toctree::
+    :titlesonly:
+
+    devops_general
+    devops_cell
+    devops_cortex
+    devops_axon
+    devops_cryotank

--- a/docs/synapse/devops.rst
+++ b/docs/synapse/devops.rst
@@ -12,15 +12,7 @@ updated and expanded over time.
 .. toctree::
     :titlesonly:
 
-    devguides/devops_general
-    devguides/devops_cell
-    devguides/devops_cortex
-    devguides/devops_axon
-    devguides/devops_cryotank
-
-    autodocs/conf_axon
-    autodocs/conf_cortex
-    autodocs/conf_cryocell
-    autodocs/conf_syncmigrator
+    devguides/index_cells
+    devguides/index_autoconf
 
 .. _index:              ../index.html

--- a/synapse/tests/test_tools_autodoc.py
+++ b/synapse/tests/test_tools_autodoc.py
@@ -49,6 +49,7 @@ class TestAutoDoc(s_t_utils.SynTest):
                 buf = fd.read()
             s = buf.decode()
 
+            self.isin('autodoc-stormvarservicecell-conf', s)
             self.isin('StormvarServiceCell Configuration Options', s)
             self.isin('See :ref:`devops-cell-config` for', s)
             self.isin('auth\:passwd', s)

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -361,9 +361,10 @@ async def docConfdefs(ctor, reflink=':ref:`devops-cell-config`'):
     rst = RstHelp()
 
     clsname = cls.__name__
+
     conf = cls.initCellConf()  # type: s_config.Config
 
-    rst.addHead(f'{clsname} Configuration Options', lvl=0)
+    rst.addHead(f'{clsname} Configuration Options', lvl=0, link=f'.. _autodoc-{clsname.lower()}-conf:')
     rst.addLines(f'The following are boot-time configuration options for the cell.')
 
     rst.addLines(f'See {reflink} for details on how to set these options.')

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -361,7 +361,6 @@ async def docConfdefs(ctor, reflink=':ref:`devops-cell-config`'):
     rst = RstHelp()
 
     clsname = cls.__name__
-
     conf = cls.initCellConf()  # type: s_config.Config
 
     rst.addHead(f'{clsname} Configuration Options', lvl=0, link=f'.. _autodoc-{clsname.lower()}-conf:')


### PR DESCRIPTION
- Add layers to the devopsguide so its doesnt become a flat documentation list.
- Update autodoc to include refs for autoconf data, Add links to refs in the various cell files.
- add `/vertex/storage` volume to base dockerfile.
- Add note about service directory persistence.