### PR TITLE
Fix autodoc form examples

### DIFF
--- a/synapse/models/crypto.py
+++ b/synapse/models/crypto.py
@@ -40,31 +40,31 @@ class CryptoModule(s_module.CoreModule):
                 }),
 
                 ('hash:md5', ('hex', {'size': 32}), {
-                    'doc': 'A hex encodeded MD5 hash',
+                    'doc': 'A hex encodeded MD5 hash.',
                     'ex': ex_md5
                 }),
                 ('hash:sha1', ('hex', {'size': 40}), {
-                    'doc': 'A hex encoded SHA1 hash',
+                    'doc': 'A hex encoded SHA1 hash.',
                     'ex': ex_sha1
                 }),
                 ('hash:sha256', ('hex', {'size': 64}), {
-                    'doc': 'A hex encoded SHA256 hash',
+                    'doc': 'A hex encoded SHA256 hash.',
                     'ex': ex_sha256
                 }),
                 ('hash:sha384', ('hex', {'size': 96}), {
-                    'doc': 'A hex encoded SHA384 hash',
+                    'doc': 'A hex encoded SHA384 hash.',
                     'ex': ex_sha384
                 }),
                 ('hash:sha512', ('hex', {'size': 128}), {
-                    'doc': 'A hex encoded SHA512 hash',
+                    'doc': 'A hex encoded SHA512 hash.',
                     'ex': ex_sha512
                 }),
                 ('hash:lm', ('hex', {'size': 32}), {
-                    'doc': 'A hex encoded Microsoft Windows LM password hash',
+                    'doc': 'A hex encoded Microsoft Windows LM password hash.',
                     'ex': ex_md5
                 }),
                 ('hash:ntlm', ('hex', {'size': 32}), {
-                    'doc': 'A hex encoded Microsoft Windows NTLM password hash',
+                    'doc': 'A hex encoded Microsoft Windows NTLM password hash.',
                     'ex': ex_md5
                 }),
 
@@ -127,11 +127,11 @@ class CryptoModule(s_module.CoreModule):
                     ('mod', ('hex', {}), {'ro': 1,
                        'doc': 'The RSA key modulus.'}),
                     ('pub:exp', ('int', {}), {'ro': 1,
-                       'doc': 'The public exponent'}),
+                       'doc': 'The public exponent.'}),
                     ('bits', ('int', {}),
-                     {'doc': 'The length of the modulus in bits'}),
+                     {'doc': 'The length of the modulus in bits.'}),
                     ('priv:exp', ('hex', {}),
-                     {'doc': 'The private exponent'}),
+                     {'doc': 'The private exponent.'}),
                     ('priv:p', ('hex', {}),
                      {'doc': 'One of the two private primes.'}),
                     ('priv:q', ('hex', {}),
@@ -174,7 +174,7 @@ class CryptoModule(s_module.CoreModule):
                     }),
 
                     ('version', ('int', {'enums': x509vers}), {
-                        'doc': 'The version integer in the certificate. (ex. 2 == v3 )',
+                        'doc': 'The version integer in the certificate. (ex. 2 == v3 ).',
                     }),
 
                     ('validity:notbefore', ('time', {}), {

--- a/synapse/models/crypto.py
+++ b/synapse/models/crypto.py
@@ -40,7 +40,7 @@ class CryptoModule(s_module.CoreModule):
                 }),
 
                 ('hash:md5', ('hex', {'size': 32}), {
-                    'doc': 'A hex encodeded MD5 hash.',
+                    'doc': 'A hex encoded MD5 hash.',
                     'ex': ex_md5
                 }),
                 ('hash:sha1', ('hex', {'size': 40}), {
@@ -127,11 +127,11 @@ class CryptoModule(s_module.CoreModule):
                     ('mod', ('hex', {}), {'ro': 1,
                        'doc': 'The RSA key modulus.'}),
                     ('pub:exp', ('int', {}), {'ro': 1,
-                       'doc': 'The public exponent.'}),
+                       'doc': 'The public exponent of the key.'}),
                     ('bits', ('int', {}),
                      {'doc': 'The length of the modulus in bits.'}),
                     ('priv:exp', ('hex', {}),
-                     {'doc': 'The private exponent.'}),
+                     {'doc': 'The private exponent of the key.'}),
                     ('priv:p', ('hex', {}),
                      {'doc': 'One of the two private primes.'}),
                     ('priv:q', ('hex', {}),

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -264,7 +264,7 @@ class DnsModule(s_module.CoreModule):
                         'doc': 'The DNS PTR record returned by the lookup of a IPv6 address.',
                     }),
                     ('cname', ('inet:dns:cname', {}), {'ro': True,
-                        'doc': 'The DNS CNAME record returned by the lookup',
+                        'doc': 'The DNS CNAME record returned by the lookup.',
                     }),
                     ('mx', ('inet:dns:mx', {}), {'ro': True,
                         'doc': 'The DNS MX record returned by the lookup.',

--- a/synapse/models/economic.py
+++ b/synapse/models/economic.py
@@ -99,7 +99,7 @@ class EconModule(s_module.CoreModule):
                         'doc': 'The point in time where the purchase was paid in full.'}),
 
                     ('campaign', ('ou:campaign', {}), {
-                        'doc': 'The campaign that the purchase was in support of'}),
+                        'doc': 'The campaign that the purchase was in support of.'}),
                     # TODO price
                 )),
 

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -194,7 +194,7 @@ class FileModule(s_module.CoreModule):
                 }),
 
                 ('file:mime', ('str', {'lower': 1}), {
-                    'doc': 'A file mime name string',
+                    'doc': 'A file mime name string.',
                     'ex': 'text/plain',
                 }),
 
@@ -238,11 +238,11 @@ class FileModule(s_module.CoreModule):
                 }),
 
                 ('pe:resource:type', ('int', {'enums': s_l_pe.getRsrcTypes()}), {
-                    'doc': 'The typecode for the resource',
+                    'doc': 'The typecode for the resource.',
                 }),
 
                 ('pe:langid', ('int', {'enums': s_l_pe.getLangCodes()}), {
-                    'doc': 'The PE language id',
+                    'doc': 'The PE language id.',
                 }),
 
             ),
@@ -280,19 +280,19 @@ class FileModule(s_module.CoreModule):
 
                     ('mime:pe:imphash', ('guid', {}), {
                         'doc': 'The PE import hash of the file as calculated by pefile; '
-                               'https://github.com/erocarrera/pefile'}),
+                               'https://github.com/erocarrera/pefile .'}),
 
                     ('mime:pe:compiled', ('time', {}), {
                         'doc': 'The compile time of the file according to the PE header.'}),
 
                     ('mime:pe:pdbpath', ('file:path', {}), {
-                        'doc': 'The PDB string according to the PE'}),
+                        'doc': 'The PDB string according to the PE.'}),
 
                     ('mime:pe:exports:time', ('time', {}), {
-                        'doc': 'The export time of the file according to the PE'}),
+                        'doc': 'The export time of the file according to the PE.'}),
 
                     ('mime:pe:exports:libname', ('str', {}), {
-                        'doc': 'The export library name according to the PE'}),
+                        'doc': 'The export library name according to the PE.'}),
 
                     ('mime:pe:richhdr', ('hash:sha256', {}), {
                         'doc': 'The sha256 hash of the rich header bytes.'}),
@@ -330,48 +330,48 @@ class FileModule(s_module.CoreModule):
                 ('file:mime:pe:resource', {}, (
                     ('file', ('file:bytes', {}), {
                         'ro': True,
-                        'doc': 'The file containing the resource',
+                        'doc': 'The file containing the resource.',
                     }),
                     ('type', ('pe:resource:type', {}), {
                         'ro': True,
-                        'doc': 'The typecode for the resource',
+                        'doc': 'The typecode for the resource.',
                     }),
                     ('langid', ('pe:langid', {}), {
                         'ro': True,
-                        'doc': 'The language code for the resource',
+                        'doc': 'The language code for the resource.',
                     }),
                     ('resource', ('file:bytes', {}), {
                         'ro': True,
-                        'doc': 'The sha256 hash of the resource bytes',
+                        'doc': 'The sha256 hash of the resource bytes.',
                     }),
                 )),
 
                 ('file:mime:pe:export', {}, (
                     ('file', ('file:bytes', {}), {
                         'ro': True,
-                        'doc': 'The file containing the export',
+                        'doc': 'The file containing the export.',
                     }),
                     ('name', ('str', {}), {
                         'ro': True,
-                        'doc': 'The name of the export in the file',
+                        'doc': 'The name of the export in the file.',
                     }),
                 )),
 
                 ('file:mime:pe:vsvers:keyval', {}, (
                     ('name', ('str', {}), {
                         'ro': True,
-                        'doc': 'The key for the vsversion keyval pair',
+                        'doc': 'The key for the vsversion keyval pair.',
                     }),
                     ('value', ('str', {}), {
                         'ro': True,
-                        'doc': 'The value for the vsversion keyval pair',
+                        'doc': 'The value for the vsversion keyval pair.',
                     }),
                 )),
 
                 ('file:mime:pe:vsvers:info', {}, (
                     ('file', ('file:bytes', {}), {
                         'ro': True,
-                        'doc': 'The file containing the vsversion keyval pair',
+                        'doc': 'The file containing the vsversion keyval pair.',
                     }),
                     ('keyval', ('file:mime:pe:vsvers:keyval', {}), {
                         'ro': True,
@@ -382,7 +382,7 @@ class FileModule(s_module.CoreModule):
                 ('file:string', {}, (
                     ('file', ('file:bytes', {}), {
                         'ro': True,
-                        'doc': 'The file containing the string',
+                        'doc': 'The file containing the string.',
                     }),
                     ('string', ('str', {}), {
                         'ro': True,

--- a/synapse/models/geopol.py
+++ b/synapse/models/geopol.py
@@ -10,22 +10,22 @@ class PolModule(s_module.CoreModule):
 
                     ('pol:country',
                         ('guid', {}),
-                        {'doc': 'A GUID for a country'}
+                        {'doc': 'A GUID for a country.'}
                     ),
 
                     ('pol:iso2',
                         ('str', {'lower': True, 'regex': '^[a-z0-9]{2}$', 'nullval': '??'}),
-                        {'doc': 'The 2 digit ISO country code', 'ex': 'us'}
+                        {'doc': 'The 2 digit ISO country code.', 'ex': 'us'}
                     ),
 
                     ('pol:iso3',
                         ('str', {'lower': True, 'regex': '^[a-z0-9]{3}$', 'nullval': '??'}),
-                        {'doc': 'The 3 digit ISO country code', 'ex': 'usa'}
+                        {'doc': 'The 3 digit ISO country code.', 'ex': 'usa'}
                     ),
 
                     ('pol:isonum',
                         ('int', {}),
-                        {'doc': 'The ISO integer country code', 'ex': '840'}
+                        {'doc': 'The ISO integer country code.', 'ex': '840'}
                     ),
 
                 ),

--- a/synapse/models/geospace.py
+++ b/synapse/models/geospace.py
@@ -261,10 +261,10 @@ class GeoModule(s_module.CoreModule):
 
                 'ctors': (
                     ('geo:dist', 'synapse.models.geospace.Dist', {}, {
-                        'doc': 'A geographic distance (base unit is mm)', 'ex': '10 km'
+                        'doc': 'A geographic distance (base unit is mm).', 'ex': '10 km'
                     }),
                     ('geo:latlong', 'synapse.models.geospace.LatLong', {}, {
-                        'doc': 'A Lat/Long string specifying a point on Earth',
+                        'doc': 'A Lat/Long string specifying a point on Earth.',
                         'ex': '-12.45,56.78'
                     }),
                 ),
@@ -304,7 +304,7 @@ class GeoModule(s_module.CoreModule):
                     ('geo:nloc', {}, (
 
                         ('ndef', ('ndef', {}), {'ro': True,
-                            'doc': 'The node with location in geo/time'}),
+                            'doc': 'The node with location in geospace and time.'}),
 
                         ('ndef:form', ('str', {}), {'ro': True,
                             'doc': 'The form of node referenced by the ndef.'}),
@@ -313,7 +313,7 @@ class GeoModule(s_module.CoreModule):
                             'doc': 'The latitude/longitude the node was observed.'}),
 
                         ('time', ('time', {}), {'ro': True,
-                            'doc': 'The time the node was observed at location'}),
+                            'doc': 'The time the node was observed at location.'}),
 
                         ('place', ('geo:place', {}), {
                             'doc': 'The place corresponding to the latlong property.'}),

--- a/synapse/models/gov/cn.py
+++ b/synapse/models/gov/cn.py
@@ -7,11 +7,11 @@ class GovCnModule(s_module.CoreModule):
             'types': (
                 ('gov:cn:icp',
                     ('int', {}),
-                    {'doc': 'A Chinese Internet Content Provider ID'},
+                    {'doc': 'A Chinese Internet Content Provider ID.'},
                  ),
                 ('gov:cn:mucd',
                     ('int', {}),
-                    {'doc': 'A Chinese PLA MUCD'},
+                    {'doc': 'A Chinese PLA MUCD.'},
                  ),
             ),
             'forms': (

--- a/synapse/models/gov/intl.py
+++ b/synapse/models/gov/intl.py
@@ -9,7 +9,7 @@ class GovIntlModule(s_module.CoreModule):
                     'doc': 'An ISO Object Identifier string.'}),
 
                 ('gov:intl:un:m49', ('int', {'min': 1, 'max': 999}), {
-                    'doc': 'UN M49 Numeric Country Code'}),
+                    'doc': 'UN M49 Numeric Country Code.'}),
             ),
 
             'forms': (

--- a/synapse/models/gov/us.py
+++ b/synapse/models/gov/us.py
@@ -5,15 +5,15 @@ class GovUsModule(s_module.CoreModule):
     def getModelDefs(self):
         modl = {
             'types': (
-                ('gov:us:ssn', ('int', {}), {'doc': 'A US Social Security Number (SSN)'}),
-                ('gov:us:zip', ('int', {}), {'doc': 'A US Zip Code'}),
-                ('gov:us:cage', ('str', {'lower': True}), {'doc': 'A Commercial and Government Entity (CAGE) code'}),
+                ('gov:us:ssn', ('int', {}), {'doc': 'A US Social Security Number (SSN).'}),
+                ('gov:us:zip', ('int', {}), {'doc': 'A US Zip Code.'}),
+                ('gov:us:cage', ('str', {'lower': True}), {'doc': 'A Commercial and Government Entity (CAGE) code.'}),
             ),
 
             'forms': (
                 ('gov:us:cage', {}, (
-                    ('name0', ('ou:name', {}), {'doc': 'The name of the organization'}),
-                    ('name1', ('str', {'lower': True}), {'doc': 'Name Part 1'}),
+                    ('name0', ('ou:name', {}), {'doc': 'The name of the organization.'}),
+                    ('name1', ('str', {'lower': True}), {'doc': 'Name Part 1.'}),
                     ('street', ('str', {'lower': True}), {}),
                     ('city', ('str', {'lower': True}), {}),
                     ('state', ('str', {'lower': True}), {}),

--- a/synapse/models/gov/us.py
+++ b/synapse/models/gov/us.py
@@ -6,7 +6,7 @@ class GovUsModule(s_module.CoreModule):
         modl = {
             'types': (
                 ('gov:us:ssn', ('int', {}), {'doc': 'A US Social Security Number (SSN).'}),
-                ('gov:us:zip', ('int', {}), {'doc': 'A US Zip Code.'}),
+                ('gov:us:zip', ('int', {}), {'doc': 'A US Postal Zip Code.'}),
                 ('gov:us:cage', ('str', {'lower': True}), {'doc': 'A Commercial and Government Entity (CAGE) code.'}),
             ),
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -928,7 +928,7 @@ class InetModule(s_module.CoreModule):
 
                     ('inet:ssl:cert', ('comp', {'fields': (('server', 'inet:server'), ('file', 'file:bytes'))}), {
                         'doc': 'An SSL certificate file served by a server.',
-                        'ex': '(1.2.3.4:443, guid:ff....fff)',
+                        'ex': '(1.2.3.4:443, guid:d41d8cd98f00b204e9800998ecf8427e)',
                     }),
 
                     ('inet:port', ('int', {'min': 0, 'max': 0xffff}), {
@@ -976,7 +976,7 @@ class InetModule(s_module.CoreModule):
 
                     ('inet:web:acct', ('comp', {'fields': (('site', 'inet:fqdn'), ('user', 'inet:user'))}), {
                         'doc': 'An account with a given Internet-based site or service.',
-                        'ex': 'twitter.com/invisig0th'
+                        'ex': '(twitter.com, invisig0th)'
                     }),
 
                     ('inet:web:action', ('guid', {}), {
@@ -998,7 +998,7 @@ class InetModule(s_module.CoreModule):
 
                     ('inet:web:group', ('comp', {'fields': (('site', 'inet:fqdn'), ('id', 'inet:group'))}), {
                         'doc': 'A group hosted within or registered with a given Internet-based site or service.',
-                        'ex': 'somesite.com/mycoolgroup'
+                        'ex': '(somesite.com, mycoolgroup)'
                     }),
 
                     ('inet:web:logon', ('guid', {}), {
@@ -1011,7 +1011,7 @@ class InetModule(s_module.CoreModule):
 
                     ('inet:web:mesg', ('comp', {'fields': (('from', 'inet:web:acct'), ('to', 'inet:web:acct'), ('time', 'time'))}), {
                         'doc': 'A message sent from one web account to another web account.',
-                        'ex': 'twitter.com/invisig0th|twitter.com/gobbles|20041012130220'
+                        'ex': '((twitter.com, invisig0th), (twitter.com, gobbles), 20041012130220)'
                     }),
 
                     ('inet:web:post', ('guid', {}), {

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -830,7 +830,7 @@ class InetModule(s_module.CoreModule):
                     }),
 
                     ('inet:ipv4range', 'synapse.models.inet.IPv4Range', {}, {
-                        'doc': 'An IPv6 address range',
+                        'doc': 'An IPv6 address range.',
                         'ex': '1.2.3.4-1.2.3.8'
                     }),
 
@@ -840,7 +840,7 @@ class InetModule(s_module.CoreModule):
                     }),
 
                     ('inet:ipv6range', 'synapse.models.inet.IPv6Range', {}, {
-                        'doc': 'An IPv6 address range',
+                        'doc': 'An IPv6 address range.',
                         'ex': '(2607:f8b0:4004:809::200e, 2607:f8b0:4004:809::2011)'
                     }),
 
@@ -1028,7 +1028,7 @@ class InetModule(s_module.CoreModule):
                     }),
 
                     ('inet:whois:rec', ('comp', {'fields': (('fqdn', 'inet:fqdn'), ('asof', 'time'))}), {
-                        'doc': 'A domain whois record'
+                        'doc': 'A domain whois record.'
                     }),
 
                     ('inet:whois:recns', ('comp', {'fields': (('ns', 'inet:fqdn'), ('rec', 'inet:whois:rec'))}), {
@@ -1503,7 +1503,7 @@ class InetModule(s_module.CoreModule):
                             'doc': 'The ASN to which the IPv4 address is currently assigned.'}),
 
                         ('latlong', ('geo:latlong', {}), {
-                            'doc': 'The best known latitude/longitude for the node'}),
+                            'doc': 'The best known latitude/longitude for the node.'}),
 
                         ('loc', ('loc', {}), {
                             'doc': 'The geo-political location string for the IPv4.'}),
@@ -1527,7 +1527,7 @@ class InetModule(s_module.CoreModule):
                             'doc': 'The mapped ipv4.'}),
 
                         ('latlong', ('geo:latlong', {}), {
-                            'doc': 'The last known latitude/longitude for the node'}),
+                            'doc': 'The last known latitude/longitude for the node.'}),
 
                         ('place', ('geo:place', {}), {
                             'doc': 'The geo:place assocated with the latlong property.'}),
@@ -1687,11 +1687,11 @@ class InetModule(s_module.CoreModule):
                         }),
                         ('path', ('str', {}), {
                             'ro': True,
-                            'doc': 'The path in the URL w/o parameters'
+                            'doc': 'The path in the URL w/o parameters.'
                         }),
                         ('params', ('str', {}), {
                             'ro': True,
-                            'doc': 'The URL parameter string'
+                            'doc': 'The URL parameter string.'
                         }),
                         ('port', ('inet:port', {}), {
                             'ro': True,
@@ -1722,19 +1722,19 @@ class InetModule(s_module.CoreModule):
                     ('inet:urlredir', {}, (
                         ('src', ('inet:url', {}), {
                             'ro': True,
-                            'doc': 'The original/source URL before redirect'
+                            'doc': 'The original/source URL before redirect.'
                         }),
                         ('src:fqdn', ('inet:fqdn', {}), {
                             'ro': True,
-                            'doc': 'The FQDN within the src URL (if present)'
+                            'doc': 'The FQDN within the src URL (if present).'
                         }),
                         ('dst', ('inet:url', {}), {
                             'ro': True,
-                            'doc': 'The redirected/destination URL'
+                            'doc': 'The redirected/destination URL.'
                         }),
                         ('dst:fqdn', ('inet:fqdn', {}), {
                             'ro': True,
-                            'doc': 'The FQDN within the dst URL (if present)'
+                            'doc': 'The FQDN within the dst URL (if present).'
                         }),
                     )),
 
@@ -1794,7 +1794,7 @@ class InetModule(s_module.CoreModule):
                             'doc': 'The email address associated with the account.'
                         }),
                         ('latlong', ('geo:latlong', {}), {
-                            'doc': 'The last known latitude/longitude for the node'
+                            'doc': 'The last known latitude/longitude for the node.'
                         }),
                         ('place', ('geo:place', {}), {
                             'doc': 'The geo:place assocated with the latlong property.'
@@ -1995,7 +1995,7 @@ class InetModule(s_module.CoreModule):
                             'doc': 'A self-declared location for the group.'
                         }),
                         ('latlong', ('geo:latlong', {}), {
-                            'doc': 'The last known latitude/longitude for the node'
+                            'doc': 'The last known latitude/longitude for the node.'
                         }),
                         ('place', ('geo:place', {}), {
                             'doc': 'The geo:place assocated with the latlong property.'
@@ -2184,7 +2184,7 @@ class InetModule(s_module.CoreModule):
                             'doc': 'The content of the fax field of the contact.'
                         }),
                         ('url', ('inet:url', {}), {
-                            'doc': 'The URL specified for the contact'
+                            'doc': 'The URL specified for the contact.'
                         }),
                         ('whois:fqdn', ('inet:fqdn', {}), {
                             'doc': 'The whois server FQDN for the given contact (most likely a registrar).'

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -155,7 +155,7 @@ class ItModule(s_module.CoreModule):
             ),
             'types': (
                 ('it:hostname', ('str', {'strip': True, 'lower': True}), {
-                    'doc': 'The name of a host or sytsem',
+                    'doc': 'The name of a host or system',
                 }),
                 ('it:host', ('guid', {}), {
                     'doc': 'A GUID that represents a host or system.'

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -150,12 +150,12 @@ class ItModule(s_module.CoreModule):
         modl = {
             'ctors': (
                 ('it:semver', 'synapse.models.infotech.SemVer', {}, {
-                    'doc': 'Semantic Version type',
+                    'doc': 'Semantic Version type.',
                 }),
             ),
             'types': (
                 ('it:hostname', ('str', {'strip': True, 'lower': True}), {
-                    'doc': 'The name of a host or system',
+                    'doc': 'The name of a host or system.',
                 }),
                 ('it:host', ('guid', {}), {
                     'doc': 'A GUID that represents a host or system.'
@@ -247,7 +247,7 @@ class ItModule(s_module.CoreModule):
                     'doc': 'A file that triggered an alert on a specific antivirus signature.',
                 }),
                 ('it:auth:passwdhash', ('guid', {}), {
-                    'doc': 'An instance of a password hash',
+                    'doc': 'An instance of a password hash.',
                 }),
                 ('it:exec:proc', ('guid', {}), {
                     'doc': 'A process executing on a host. May be an actual (e.g., endpoint) or virtual (e.g., malware sandbox) host.',
@@ -283,7 +283,7 @@ class ItModule(s_module.CoreModule):
                     'doc': 'An instance of a host getting a registry key.',
                 }),
                 ('it:exec:reg:set', ('guid', {}), {
-                    'doc': 'An instance of a host creating or setting a registry key',
+                    'doc': 'An instance of a host creating or setting a registry key.',
                 }),
                 ('it:exec:reg:del', ('guid', {}), {
                     'doc': 'An instance of a host deleting a registry key.',
@@ -398,7 +398,7 @@ class ItModule(s_module.CoreModule):
                         'doc': 'A short description of the software.',
                     }),
                     ('author:org', ('ou:org', {}), {
-                        'doc': 'Organization which authored the software',
+                        'doc': 'Organization which authored the software.',
                     }),
                     ('author:acct', ('inet:web:acct', {}), {
                         'doc': 'Web account of the software author.',
@@ -466,7 +466,7 @@ class ItModule(s_module.CoreModule):
                 ('it:prod:softver', {}, (
 
                     ('software', ('it:prod:soft', {}), {
-                        'doc': 'Software associated with this version instance',
+                        'doc': 'Software associated with this version instance.',
                     }),
                     ('software:name', ('str', {'lower': True, 'strip': True}), {
                         'doc': 'The name of the software at a particular version.',
@@ -478,7 +478,7 @@ class ItModule(s_module.CoreModule):
                         'doc': 'Normalized version of the version string.',
                     }),
                     ('arch', ('it:dev:str', {}), {
-                        'doc': 'Software architecture',
+                        'doc': 'Software architecture.',
                     }),
                     ('semver', ('it:semver', {}), {
                         'doc': 'System normalized semantic version number.',
@@ -540,7 +540,7 @@ class ItModule(s_module.CoreModule):
                         'doc': 'The signature name.'
                     }),
                     ('desc', ('str', {}), {
-                        'doc': 'A free-form description of the signature',
+                        'doc': 'A free-form description of the signature.',
                     }),
                     ('url', ('inet:url', {}), {
                         'doc': 'A reference URL for information about the signature.',
@@ -602,7 +602,7 @@ class ItModule(s_module.CoreModule):
                         'doc': 'The command string used to launch the process, including any command line parameters.',
                     }),
                     ('pid', ('int', {}), {
-                        'doc': 'The process ID',
+                        'doc': 'The process ID.',
                     }),
                     ('time', ('time', {}), {
                         'doc': 'The start time for the process.',
@@ -614,7 +614,7 @@ class ItModule(s_module.CoreModule):
                         'doc': 'The path to the executable of the process.',
                     }),
                     ('src:exe', ('file:path', {}), {
-                        'doc': 'The path to the executable which started the process',
+                        'doc': 'The path to the executable which started the process.',
                     }),
                     ('src:proc', ('it:exec:proc', {}), {
                         'doc': 'The process which created the process.'
@@ -983,9 +983,9 @@ class ItModule(s_module.CoreModule):
 
                 ('it:reveng:function', {}, (
                     ('name', ('str', {}), {
-                        'doc': 'The name of the function'}),
+                        'doc': 'The name of the function.'}),
                     ('description', ('str', {}), {
-                        'doc': 'Notes concerning the function'}),
+                        'doc': 'Notes concerning the function.'}),
                     ('impcalls', ('array', {'type': 'it:reveng:impfunc'}), {
                         'doc': 'Calls to imported library functions within the scope of the function.',
                     }),
@@ -994,12 +994,12 @@ class ItModule(s_module.CoreModule):
                 ('it:reveng:filefunc', {}, (
                     ('function', ('it:reveng:function', {}), {
                         'ro': True,
-                        'doc': 'The guid matching the function'}),
+                        'doc': 'The guid matching the function.'}),
                     ('file', ('file:bytes', {}), {
                         'ro': True,
                         'doc': 'The file that contains the function.'}),
                     ('va', ('int', {}), {
-                        'doc': 'The virtual address of the first codeblock of the function'}),
+                        'doc': 'The virtual address of the first codeblock of the function.'}),
                     ('rank', ('int', {}), {
                         'doc': 'The function rank score used to evaluate if it exhibits interesting behavior.'}),
                     ('complexity', ('int', {}), {
@@ -1012,7 +1012,7 @@ class ItModule(s_module.CoreModule):
                 ('it:reveng:funcstr', {}, (
                     ('function', ('it:reveng:function', {}), {
                         'ro': True,
-                        'doc': 'The guid matching the function'}),
+                        'doc': 'The guid matching the function.'}),
                     ('string', ('str', {}), {
                         'ro': True,
                         'doc': 'The string that the function references.'}),

--- a/synapse/models/material.py
+++ b/synapse/models/material.py
@@ -8,8 +8,8 @@ class MatModule(s_module.CoreModule):
     def getModelDefs(self):
         modl = {
             'types': (
-                ('mat:item', ('guid', {}), {'doc': 'A GUID assigned to a material object'}),
-                ('mat:spec', ('guid', {}), {'doc': 'A GUID assigned to a material specification'}),
+                ('mat:item', ('guid', {}), {'doc': 'A GUID assigned to a material object.'}),
+                ('mat:spec', ('guid', {}), {'doc': 'A GUID assigned to a material specification.'}),
                 ('mat:specimage', ('comp', {'fields': (('spec', 'mat:spec'), ('file', 'file:bytes'))}), {}),
                 ('mat:itemimage', ('comp', {'fields': (('item', 'mat:item'), ('file', 'file:bytes'))}), {}),
                 # TODO add base types for mass / volume
@@ -19,14 +19,14 @@ class MatModule(s_module.CoreModule):
 
                 ('mat:item', {}, (
 
-                    ('name', ('str', {'lower': True}), {'doc': 'The human readable name of the material item'}),
+                    ('name', ('str', {'lower': True}), {'doc': 'The human readable name of the material item.'}),
 
                     ('spec', ('mat:spec', {}), {
                         'doc': 'The mat:spec of which this item is an instance.',
                     }),
 
                     ('place', ('geo:place', {}), {'doc': 'The most recent place the item is known to reside.'}),
-                    ('latlong', ('geo:latlong', {}), {'doc': 'The last known lat/long location of the node'}),
+                    ('latlong', ('geo:latlong', {}), {'doc': 'The last known lat/long location of the node.'}),
 
                     ('loc', ('loc', {}), {
                         'doc': 'The geo-political location string for the node.',
@@ -36,17 +36,17 @@ class MatModule(s_module.CoreModule):
                 )),
 
                 ('mat:spec', {}, (
-                    ('name', ('str', {'lower': True}), {'doc': 'The human readable name of the material spec'}),
+                    ('name', ('str', {'lower': True}), {'doc': 'The human readable name of the material spec.'}),
                 )),
 
                 ('mat:itemimage', {}, (
-                    ('item', ('mat:item', {}), {'doc': 'The item contained within the image file'}),
-                    ('file', ('file:bytes', {}), {'doc': 'The file containing an image of the item'}),
+                    ('item', ('mat:item', {}), {'doc': 'The item contained within the image file.'}),
+                    ('file', ('file:bytes', {}), {'doc': 'The file containing an image of the item.'}),
                 )),
 
                 ('mat:specimage', {}, (
-                    ('spec', ('mat:spec', {}), {'doc': 'The spec contained within the image file'}),
-                    ('file', ('file:bytes', {}), {'doc': 'The file containing an image of the spec'}),
+                    ('spec', ('mat:spec', {}), {'doc': 'The spec contained within the image file.'}),
+                    ('file', ('file:bytes', {}), {'doc': 'The file containing an image of the spec.'}),
                 )),
             ),
         }

--- a/synapse/models/media.py
+++ b/synapse/models/media.py
@@ -11,47 +11,45 @@ class MediaModule(s_module.CoreModule):
         forms = (
             ('media:news', {}, (
                 ('url', ('inet:url', {}), {
-                    'doc': 'The (optional) URL where the news was published',
+                    'doc': 'The (optional) URL where the news was published.',
                     'ex': 'http://cnn.com/news/mars-lander.html',
                 }),
                 ('url:fqdn', ('inet:fqdn', {}), {
-                    'doc': 'The FQDN within the news URL',
+                    'doc': 'The FQDN within the news URL.',
                     'ex': 'cnn.com',
                 }),
                 ('file', ('file:bytes', {}), {
-                    'doc': 'The (optional) file blob containing or published as the news',
+                    'doc': 'The (optional) file blob containing or published as the news.',
                 }),
                 ('title', ('str', {'lower': True}), {
-                    'doc': 'Title/Headline for the news',
+                    'doc': 'Title/Headline for the news.',
                     'ex': 'mars lander reaches mars',
                 }),
                 ('summary', ('str', {}), {
-                    'doc': 'A brief summary of the news item',
+                    'doc': 'A brief summary of the news item.',
                     'ex': 'lorum ipsum',
                 }),
                 ('published', ('time', {}), {
-                    'doc': 'The date the news item was published',
+                    'doc': 'The date the news item was published.',
                     'ex': '20161201180433',
                 }),
                 ('org', ('ou:alias', {}), {
-                    'doc': 'The org alias which published the news',
+                    'doc': 'The org alias which published the news.',
                     'ex': 'microsoft',
                 }),
                 ('author', ('ps:name', {}), {
-                    'doc': 'The free-form author of the news',
+                    'doc': 'The free-form author of the news.',
                     'ex': 'stark,anthony'
                 }),
                 ('rss:feed', ('inet:url', {}), {
-                    'doc': 'The RSS feed that published the news',
+                    'doc': 'The RSS feed that published the news.',
                 }),
-                # ('doi',{'ptype':'media:issn','doc':'The (optional) ISSN number for the news publication'})
-                # ('issn',{'ptype':'media:issn','doc':'The (optional) ISSN number for the news publication'})
             )),
         )
 
         types = (
             ('media:news', ('guid', {}), {
-                'doc': 'A GUID for a news article or report'
+                'doc': 'A GUID for a news article or report.'
             }),
         )
 

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -13,20 +13,20 @@ class OuModule(s_module.CoreModule):
                     'ex': '541715',
                 }),
                 ('ou:org', ('guid', {}), {
-                    'doc': 'A GUID for a human organization such as a company or military unit',
+                    'doc': 'A GUID for a human organization such as a company or military unit.',
                 }),
                 ('ou:alias', ('str', {'lower': True, 'regex': r'^[0-9a-z_]+$'}), {
-                    'doc': 'An alias for the org GUID',
+                    'doc': 'An alias for the org GUID.',
                     'ex': 'vertexproject',
                 }),
                 ('ou:hasalias', ('comp', {'fields': (('org', 'ou:org'), ('alias', 'ou:alias'))}), {
                     'doc': 'The knowledge that an organization has an alias.',
                 }),
                 ('ou:orgnet4', ('comp', {'fields': (('org', 'ou:org'), ('net', 'inet:net4'))}), {
-                    'doc': "An organization's IPv4 netblock",
+                    'doc': "An organization's IPv4 netblock.",
                 }),
                 ('ou:orgnet6', ('comp', {'fields': (('org', 'ou:org'), ('net', 'inet:net6'))}), {
-                    'doc': "An organization's IPv6 netblock",
+                    'doc': "An organization's IPv6 netblock.",
                 }),
                 ('ou:name', ('str', {'lower': True, 'strip': True}), {
                     'doc': 'The name of an organization. This may be a formal name or informal name of the '
@@ -44,7 +44,7 @@ class OuModule(s_module.CoreModule):
                            'potentially during a specific period of time.',
                 }),
                 ('ou:user', ('comp', {'fields': (('org', 'ou:org'), ('user', 'inet:user'))}), {
-                    'doc': 'A user name within an organization',
+                    'doc': 'A user name within an organization.',
                 }),
                 ('ou:meet', ('guid', {}), {
                     'doc': 'A informal meeting of people which has no title or sponsor.  See also: ou:conference.',
@@ -65,62 +65,62 @@ class OuModule(s_module.CoreModule):
                     'doc': 'Represents a person attending a conference event represented by an ou:conference:event node.',
                 }),
                 ('ou:goal', ('guid', {}), {
-                    'doc': 'An assessed or stated goal which may be abstract or org specific',
+                    'doc': 'An assessed or stated goal which may be abstract or org specific.',
                 }),
                 ('ou:hasgoal', ('comp', {'fields': (('org', 'ou:org'), ('goal', 'ou:goal'))}), {
-                    'doc': 'An org has an assessed or stated goal',
+                    'doc': 'An org has an assessed or stated goal.',
                 }),
                 ('ou:campaign', ('guid', {}), {
-                    'doc': 'Represents an orgs activity in pursuit of a goal',
+                    'doc': 'Represents an orgs activity in pursuit of a goal.',
                 }),
             ),
             'forms': (
                 ('ou:goal', {}, (
                     ('name', ('str', {}), {
-                        'doc': 'A terse name for the goal',
+                        'doc': 'A terse name for the goal.',
                     }),
                     ('type', ('str', {}), {
-                        'doc': 'A user specified goal type',
+                        'doc': 'A user specified goal type.',
                     }),
                     ('desc', ('str', {}), {
-                        'doc': 'A description of the goal',
+                        'doc': 'A description of the goal.',
                     }),
                     ('prev', ('ou:goal', {}), {
-                        'doc': 'The previous/parent goal in a list or hierarchy',
+                        'doc': 'The previous/parent goal in a list or hierarchy.',
                     }),
                 )),
                 ('ou:hasgoal', {}, (
                     ('org', ('ou:org', {}), {
-                        'doc': 'The org which has the goal',
+                        'doc': 'The org which has the goal.',
                     }),
                     ('goal', ('ou:goal', {}), {
-                        'doc': 'The goal which the org has',
+                        'doc': 'The goal which the org has.',
                     }),
                     ('stated', ('bool', {}), {
-                        'doc': 'Set to true/false if the goal is known to be self stated',
+                        'doc': 'Set to true/false if the goal is known to be self stated.',
                     }),
                     ('window', ('ival', {}), {
-                        'doc': 'Set if a goal has a limited time window',
+                        'doc': 'Set if a goal has a limited time window.',
                     }),
                 )),
                 ('ou:campaign', {}, (
                     ('org', ('ou:org', {}), {
-                        'doc': 'The org carrying out the campaign',
+                        'doc': 'The org carrying out the campaign.',
                     }),
                     ('goal', ('ou:goal', {}), {
-                        'doc': 'The assessed primary goal of the campaign',
+                        'doc': 'The assessed primary goal of the campaign.',
                     }),
                     ('goals', ('array', {'type': 'ou:goal'}), {
-                        'doc': 'Additional assessed goals of the campaign',
+                        'doc': 'Additional assessed goals of the campaign.',
                     }),
                     ('name', ('str', {}), {
-                        'doc': 'A terse name of the campaign',
+                        'doc': 'A terse name of the campaign.',
                     }),
                     ('type', ('str', {}), {
-                        'doc': 'A user specified campaign type',
+                        'doc': 'A user specified campaign type.',
                     }),
                     ('desc', ('str', {}), {
-                        'doc': 'A description of the campaign',
+                        'doc': 'A description of the campaign.',
                     }),
                 )),
                 ('ou:org', {}, (
@@ -134,7 +134,7 @@ class OuModule(s_module.CoreModule):
                        'doc': 'A list of alternate names for the organization.',
                     }),
                     ('alias', ('ou:alias', {}), {
-                        'doc': 'The default alias for an organization'
+                        'doc': 'The default alias for an organization.'
                     }),
                     ('phone', ('tel:phone', {}), {
                         'doc': 'The primary phone number for the organization.',
@@ -160,37 +160,37 @@ class OuModule(s_module.CoreModule):
                 ('ou:hasalias', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'Org guid',
+                        'doc': 'The org guid.',
                     }),
                     ('alias', ('ou:alias', {}), {
                         'ro': True,
-                        'doc': 'Alias for the organization',
+                        'doc': 'Alias for the organization.',
                     }),
                 )),
                 ('ou:orgnet4', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'Org guid',
+                        'doc': 'The org guid.',
                     }),
                     ('net', ('inet:net4', {}), {
                         'ro': True,
-                        'doc': 'Netblock owned by the organization',
+                        'doc': 'Netblock owned by the organization.',
                     }),
                     ('name', ('str', {'lower': True, 'strip': True}), {
-                        'doc': 'The name that the organization assigns to this netblock'
+                        'doc': 'The name that the organization assigns to this netblock.'
                     }),
                 )),
                 ('ou:orgnet6', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'Org guid',
+                        'doc': 'The org guid.',
                     }),
                     ('net', ('inet:net6', {}), {
                         'ro': True,
-                        'doc': 'Netblock owned by the organization',
+                        'doc': 'Netblock owned by the organization.',
                     }),
                     ('name', ('str', {'lower': True, 'strip': True}), {
-                        'doc': 'The name that the organization assigns to this netblock'
+                        'doc': 'The name that the organization assigns to this netblock.'
                     }),
                 )),
                 ('ou:member', {}, (
@@ -215,14 +215,14 @@ class OuModule(s_module.CoreModule):
                 ('ou:suborg', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'The org which owns the sub organization',
+                        'doc': 'The org which owns the sub organization.',
                     }),
                     ('sub', ('ou:org', {}), {
                         'ro': True,
                         'doc': 'The sub org which owned by the org.',
                     }),
                     ('perc', ('int', {'min': 0, 'max': 100}), {
-                        'doc': 'The optional percentage of sub which is owned by org',
+                        'doc': 'The optional percentage of sub which is owned by org.',
                     }),
                     ('current', ('bool', {}), {
                         'doc': 'Bool indicating if the suborg relationship still current.',
@@ -245,11 +245,11 @@ class OuModule(s_module.CoreModule):
                 ('ou:user', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'Org guid',
+                        'doc': 'The org guid.',
                     }),
                     ('user', ('inet:user', {}), {
                         'ro': True,
-                        'doc': 'The username associated with the organization',
+                        'doc': 'The username associated with the organization.',
                     }),
                 )),
                 ('ou:meet', {}, (
@@ -356,7 +356,7 @@ class OuModule(s_module.CoreModule):
                         'doc': 'The inet:url node for the conference event website.',
                     }),
                     ('contact', ('ps:contact', ()), {
-                        'doc': 'Contact info for the event',
+                        'doc': 'Contact info for the event.',
                     }),
                     ('start', ('time', {}), {
                         'doc': 'The event start date / time.',

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -160,7 +160,7 @@ class OuModule(s_module.CoreModule):
                 ('ou:hasalias', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'The org guid.',
+                        'doc': 'The org guid which has the alias.',
                     }),
                     ('alias', ('ou:alias', {}), {
                         'ro': True,
@@ -170,7 +170,7 @@ class OuModule(s_module.CoreModule):
                 ('ou:orgnet4', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'The org guid.',
+                        'doc': 'The org guid which owns the netblock.',
                     }),
                     ('net', ('inet:net4', {}), {
                         'ro': True,
@@ -183,7 +183,7 @@ class OuModule(s_module.CoreModule):
                 ('ou:orgnet6', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'The org guid.',
+                        'doc': 'The org guid which owns the netblock.',
                     }),
                     ('net', ('inet:net6', {}), {
                         'ro': True,
@@ -245,7 +245,7 @@ class OuModule(s_module.CoreModule):
                 ('ou:user', {}, (
                     ('org', ('ou:org', {}), {
                         'ro': True,
-                        'doc': 'The org guid.',
+                        'doc': 'The org guid which owns the netblock.',
                     }),
                     ('user', ('inet:user', {}), {
                         'ro': True,

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -27,20 +27,20 @@ class PsModule(s_module.CoreModule):
                            ' resource, potentially during a specific period of time.'
                 }),
                 ('ps:contact', ('guid', {}), {
-                    'doc': 'A GUID for a contact info record',
+                    'doc': 'A GUID for a contact info record.',
                 }),
             ),
             'forms': (
                 ('ps:tokn', {}, ()),
                 ('ps:name', {}, (
                     ('sur', ('ps:tokn', {}), {
-                        'doc': 'The surname part of the name'
+                        'doc': 'The surname part of the name.'
                     }),
                     ('middle', ('ps:tokn', {}), {
-                        'doc': 'The middle name part of the name'
+                        'doc': 'The middle name part of the name.'
                     }),
                     ('given', ('ps:tokn', {}), {
-                        'doc': 'The given name part of the name'
+                        'doc': 'The given name part of the name.'
                     }),
                 )),
                 ('ps:person', {}, (
@@ -51,19 +51,19 @@ class PsModule(s_module.CoreModule):
                         'doc': 'The primary image of a person.'
                     }),
                     ('nick', ('inet:user', {}), {
-                        'doc': 'A username commonly used by the person',
+                        'doc': 'A username commonly used by the person.',
                     }),
                     ('name', ('ps:name', {}), {
                         'doc': 'The localized name for the person.',
                     }),
                     ('name:sur', ('ps:tokn', {}), {
-                        'doc': 'The surname of the person'
+                        'doc': 'The surname of the person.'
                     }),
                     ('name:middle', ('ps:tokn', {}), {
-                        'doc': 'The middle name of the person'
+                        'doc': 'The middle name of the person.'
                     }),
                     ('name:given', ('ps:tokn', {}), {
-                        'doc': 'The given name of the person'
+                        'doc': 'The given name of the person.'
                     }),
                 )),
                 ('ps:persona', {}, (
@@ -77,7 +77,7 @@ class PsModule(s_module.CoreModule):
                         'doc': 'The primary image of a suspected person.'
                     }),
                     ('nick', ('inet:user', {}), {
-                        'doc': 'A username commonly used by the suspected person',
+                        'doc': 'A username commonly used by the suspected person.',
                     }),
                     ('name', ('ps:name', {}), {
                         'doc': 'The localized name for the suspected person.',
@@ -131,7 +131,7 @@ class PsModule(s_module.CoreModule):
                         'doc': 'The ps:person GUID which owns this contact.',
                     }),
                     ('name', ('ps:name', {}), {
-                        'doc': 'The person name listed for the contact',
+                        'doc': 'The person name listed for the contact.',
                     }),
                     ('title', ('str', {'lower': True, 'strip': True}), {
                         'doc': 'The job/org title listed for this contact.',
@@ -167,7 +167,7 @@ class PsModule(s_module.CoreModule):
                         'doc': 'The street address listed for the contact.',
                     }),
                     ('phone', ('tel:phone', {}), {
-                        'doc': 'The main phone number for this contact',
+                        'doc': 'The main phone number for this contact.',
                     }),
                     ('phone:fax', ('tel:phone', {}), {
                         'doc': 'The fax number for this contact.',

--- a/synapse/models/risk.py
+++ b/synapse/models/risk.py
@@ -7,10 +7,10 @@ class RiskModule(s_module.CoreModule):
         modl = {
             'types': (
                 ('risk:vuln', ('guid', {}), {
-                    'doc': 'A unique vulnerability',
+                    'doc': 'A unique vulnerability.',
                 }),
                 ('risk:hasvuln', ('guid', {}), {
-                    'doc': 'An instance of a vulnerability present in a target',
+                    'doc': 'An instance of a vulnerability present in a target.',
                 }),
                 ('risk:attack', ('guid', {}), {
                     'doc': 'An instance of an actor attacking a target.'
@@ -19,14 +19,14 @@ class RiskModule(s_module.CoreModule):
             'forms': (
                 ('risk:vuln', {}, (
                     ('name', ('str', {}), {
-                        'doc': 'A user specified name for the vulnerability',
+                        'doc': 'A user specified name for the vulnerability.',
                     }),
 
                     ('type', ('str', {}), {
-                        'doc': 'A user specified type for the vulnerability',
+                        'doc': 'A user specified type for the vulnerability.',
                     }),
                     ('desc', ('str', {}), {
-                        'doc': 'A description of the vulnerability',
+                        'doc': 'A description of the vulnerability.',
                     }),
                     ('cve', ('it:sec:cve', {}), {
                         'doc': 'The CVE ID of the vulnerability.',
@@ -38,88 +38,88 @@ class RiskModule(s_module.CoreModule):
                         'doc': 'The vulnerability present in the target.'
                     }),
                     ('person', ('ps:person', {}), {
-                        'doc': 'The vulnerable person',
+                        'doc': 'The vulnerable person.',
                     }),
                     ('org', ('ou:org', {}), {
-                        'doc': 'The vulnerable org',
+                        'doc': 'The vulnerable org.',
                     }),
                     ('place', ('geo:place', {}), {
-                        'doc': 'The vulnerable place',
+                        'doc': 'The vulnerable place.',
                     }),
                     ('software', ('it:prod:softver', {}), {
-                        'doc': 'The vulnerable software',
+                        'doc': 'The vulnerable software.',
                     }),
                     ('spec', ('mat:spec', {}), {
-                        'doc': 'The vulnerable material specification',
+                        'doc': 'The vulnerable material specification.',
                     }),
                     ('item', ('mat:item', {}), {
-                        'doc': 'The vulnerable material item',
+                        'doc': 'The vulnerable material item.',
                     }),
                 )),
 
                 ('risk:attack', {}, (
                     ('time', ('time', {}), {
-                        'doc': 'Set if the time of the attack is known',
+                        'doc': 'Set if the time of the attack is known.',
                     }),
                     ('success', ('bool', {}), {
-                        'doc': 'Set if the attack was known to have succeeded or not',
+                        'doc': 'Set if the attack was known to have succeeded or not.',
                     }),
                     ('targeted', ('bool', {}), {
-                        'doc': 'Set if the attack was assessed to be targeted or not',
+                        'doc': 'Set if the attack was assessed to be targeted or not.',
                     }),
                     ('campaign', ('ou:campaign', {}), {
-                        'doc': 'Set if the attack was part of a larger campaign',
+                        'doc': 'Set if the attack was part of a larger campaign.',
                     }),
                     ('prev', ('risk:attack', {}), {
-                        'doc': 'The previous/parent attack in a list or hierarchy',
+                        'doc': 'The previous/parent attack in a list or hierarchy.',
                     }),
                     ('actor:org', ('ou:org', {}), {
-                        'doc': 'The org that carried out the attack',
+                        'doc': 'The org that carried out the attack.',
                     }),
                     ('actor:person', ('ps:person', {}), {
-                        'doc': 'The person that carried out the attack',
+                        'doc': 'The person that carried out the attack.',
                     }),
                     ('target:org', ('ou:org', {}), {
-                        'doc': 'The org was the target of the attack',
+                        'doc': 'The org was the target of the attack.',
                     }),
                     ('target:host', ('it:host', {}), {
-                        'doc': 'The host was the target of the attack',
+                        'doc': 'The host was the target of the attack.',
                     }),
                     ('target:person', ('ps:person', {}), {
-                        'doc': 'The person was the target of the attack',
+                        'doc': 'The person was the target of the attack.',
                     }),
                     ('via:ipv4', ('inet:ipv4', {}), {
-                        'doc': 'The target host was contacted via the IPv4 address',
+                        'doc': 'The target host was contacted via the IPv4 address.',
                     }),
                     ('via:ipv6', ('inet:ipv6', {}), {
-                        'doc': 'The target host was contacted via the IPv6 address',
+                        'doc': 'The target host was contacted via the IPv6 address.',
                     }),
                     ('via:email', ('inet:email', {}), {
-                        'doc': 'The target person/org was contacted via the email address',
+                        'doc': 'The target person/org was contacted via the email address.',
                     }),
                     ('via:phone', ('tel:phone', {}), {
-                        'doc': 'The target person/org was contacted via the phone number',
+                        'doc': 'The target person/org was contacted via the phone number.',
                     }),
                     ('used:vuln', ('risk:vuln', {}), {
-                        'doc': 'The actor used the vuln in the attack',
+                        'doc': 'The actor used the vuln in the attack.',
                     }),
                     ('used:url', ('inet:url', {}), {
-                        'doc': 'The actor used the url in the attack',
+                        'doc': 'The actor used the url in the attack.',
                     }),
                     ('used:host', ('it:host', {}), {
-                        'doc': 'The actor used the host in the attack',
+                        'doc': 'The actor used the host in the attack.',
                     }),
                     ('used:email', ('inet:email', {}), {
-                        'doc': 'The actor used the email in the attack',
+                        'doc': 'The actor used the email in the attack.',
                     }),
                     ('used:file', ('file:bytes', {}), {
-                        'doc': 'The actor used the file in the attack',
+                        'doc': 'The actor used the file in the attack.',
                     }),
                     ('used:server', ('inet:server', {}), {
-                        'doc': 'The actor used the server in the attack',
+                        'doc': 'The actor used the server in the attack.',
                     }),
                     ('used:software', ('it:prod:softver', {}), {
-                        'doc': 'The actor used the software in the attack',
+                        'doc': 'The actor used the software in the attack.',
                     }),
                 )),
             ),

--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -152,7 +152,7 @@ class SynModule(s_module.CoreModule):
                     ('title', ('str', {}), {'doc': 'A display title for the tag.'}),
 
                     ('base', ('str', {}), {'ro': 1,
-                        'doc': 'The tag base name. Eg baz for foo.bar.baz'}),
+                        'doc': 'The tag base name. Eg baz for foo.bar.baz .'}),
                 )),
                 ('syn:type', {'runt': True}, (
                     ('doc', ('str', {'strip': True}), {
@@ -184,7 +184,7 @@ class SynModule(s_module.CoreModule):
                     ('univ', ('bool', {}), {
                         'doc': 'Specifies if a prop is universal.', 'ro': True}),
                     ('base', ('str', {'strip': True}), {
-                        'doc': 'Base name of the property', 'ro': True}),
+                        'doc': 'Base name of the property.', 'ro': True}),
                     ('ro', ('bool', {}), {
                         'doc': 'If the property is read-only after being set.', 'ro': True}),
                     ('extmodel', ('bool', {}), {
@@ -198,7 +198,7 @@ class SynModule(s_module.CoreModule):
                 )),
                 ('syn:trigger', {'runt': True}, (
                     ('vers', ('int', {}), {
-                        'doc': 'Trigger version', 'ro': True,
+                        'doc': 'Trigger version.', 'ro': True,
                     }),
                     ('doc', ('str', {}), {
                         'doc': 'A documentation string describing the trigger.',
@@ -207,16 +207,16 @@ class SynModule(s_module.CoreModule):
                         'doc': 'A user friendly name/alias for the trigger.',
                     }),
                     ('cond', ('str', {'strip': True, 'lower': True}), {
-                        'doc': 'The trigger condition', 'ro': True,
+                        'doc': 'The trigger condition.', 'ro': True,
                     }),
                     ('user', ('str', {}), {
-                        'doc': 'User who owns the trigger', 'ro': True,
+                        'doc': 'User who owns the trigger.', 'ro': True,
                     }),
                     ('storm', ('str', {}), {
                         'doc': 'The Storm query for the trigger.', 'ro': True,
                     }),
                     ('enabled', ('bool', {}), {
-                        'doc': 'Trigger enabled status', 'ro': True,
+                        'doc': 'Trigger enabled status.', 'ro': True,
                     }),
                     ('form', ('str', {'lower': True, 'strip': True}), {
                         'doc': 'Form the trigger is watching for.'

--- a/synapse/models/telco.py
+++ b/synapse/models/telco.py
@@ -136,11 +136,11 @@ class TelcoModule(s_module.CoreModule):
 
                 ('tel:mob:imei', 'synapse.models.telco.Imei', {}, {
                     'ex': '490154203237518',
-                    'doc': 'An International Mobile Equipment Id'}),
+                    'doc': 'An International Mobile Equipment Id.'}),
 
                 ('tel:mob:imsi', 'synapse.models.telco.Imsi', {}, {
                     'ex': '310150123456789',
-                    'doc': 'An International Mobile Subscriber Id'}),
+                    'doc': 'An International Mobile Subscriber Id.'}),
 
                 ('tel:phone', 'synapse.models.telco.Phone', {}, {
                     'ex': '+15558675309',
@@ -158,7 +158,7 @@ class TelcoModule(s_module.CoreModule):
 
                 ('tel:mob:tac', ('int', {}), {
                     'ex': '49015420',
-                    'doc': 'A mobile Type Allocation Code'}),
+                    'doc': 'A mobile Type Allocation Code.'}),
 
                 ('tel:mob:imid', ('comp', {'fields': (('imei', 'tel:mob:imei'), ('imsi', 'tel:mob:imsi'))}), {
                     'ex': '(490154203237518, 310150123456789)',
@@ -172,11 +172,11 @@ class TelcoModule(s_module.CoreModule):
                     'doc': 'A single mobile telemetry measurement.'}),
 
                 ('tel:mob:mcc', ('str', {'regex': '^[0-9]{3}$', 'strip': 1}), {
-                    'doc': 'ITU Mobile Country Code',
+                    'doc': 'ITU Mobile Country Code.',
                 }),
 
                 ('tel:mob:mnc', ('str', {'regex': '^[0-9]{2,3}$', 'strip': 1}), {
-                    'doc': 'ITU Mobile Network Code',
+                    'doc': 'ITU Mobile Network Code.',
                 }),
 
                 ('tel:mob:carrier', ('comp', {'fields': (('mcc', 'tel:mob:mcc'), ('mnc', 'tel:mob:mnc'))}), {
@@ -237,7 +237,7 @@ class TelcoModule(s_module.CoreModule):
                         'doc': 'The time the message was sent.'
                     }),
                     ('text', ('str', {}), {
-                        'doc': 'The text of the message',
+                        'doc': 'The text of the message.',
                     }),
                     ('file', ('file:bytes', {}), {
                         'doc': 'A file containing related media.',
@@ -245,26 +245,26 @@ class TelcoModule(s_module.CoreModule):
                 )),
                 ('tel:mob:tac', {}, (
                     ('org', ('ou:org', {}), {
-                        'doc': 'The org guid for the manufacturer',
+                        'doc': 'The org guid for the manufacturer.',
                     }),
                     ('manu', ('str', {'lower': 1}), {
-                        'doc': 'The TAC manufacturer name',
+                        'doc': 'The TAC manufacturer name.',
                     }),
                     ('model', ('str', {'lower': 1}), {
-                        'doc': 'The TAC model name',
+                        'doc': 'The TAC model name.',
                     }),
                     ('internal', ('str', {'lower': 1}), {
-                        'doc': 'The TAC internal model name',
+                        'doc': 'The TAC internal model name.',
                     }),
                 )),
                 ('tel:mob:imei', {}, (
                     ('tac', ('tel:mob:tac', {}), {
                         'ro': 1,
-                        'doc': 'The Type Allocate Code within the IMEI'
+                        'doc': 'The Type Allocate Code within the IMEI.'
                     }),
                     ('serial', ('int', {}), {
                         'ro': 1,
-                        'doc': 'The serial number within the IMEI',
+                        'doc': 'The serial number within the IMEI.',
                     })
                 )),
                 ('tel:mob:imsi', {}, (
@@ -310,11 +310,11 @@ class TelcoModule(s_module.CoreModule):
                     }),
                 )),
                 ('tel:mob:cell', {}, (
-                    ('carrier', ('tel:mob:carrier', {}), {'doc': 'Mobile carrier'}),
-                    ('carrier:mcc', ('tel:mob:mcc', {}), {'doc': 'Mobile Country Code'}),
-                    ('carrier:mnc', ('tel:mob:mnc', {}), {'doc': 'Mobile Network Code'}),
+                    ('carrier', ('tel:mob:carrier', {}), {'doc': 'Mobile carrier.'}),
+                    ('carrier:mcc', ('tel:mob:mcc', {}), {'doc': 'Mobile Country Code.'}),
+                    ('carrier:mnc', ('tel:mob:mnc', {}), {'doc': 'Mobile Network Code.'}),
                     ('lac', ('int', {}), {'doc': 'Location Area Code. LTE networks may call this a TAC.'}),
-                    ('cid', ('int', {}), {'doc': 'Cell ID'}),
+                    ('cid', ('int', {}), {'doc': 'The Cell ID.'}),
                     ('radio', ('str', {'lower': 1, 'onespace': 1}), {'doc': 'Cell radio type.'}),
                     ('latlong', ('geo:latlong', {}), {'doc': 'Last known location of the cell site.'}),
 

--- a/synapse/tests/test_tools_autodoc.py
+++ b/synapse/tests/test_tools_autodoc.py
@@ -34,6 +34,7 @@ class TestAutoDoc(s_t_utils.SynTest):
             self.isin('Universal props are system level properties which may be present on every node.', s)
             self.isin('.created', s)
             self.notin('..created\n', s)
+            self.isin('A example of ``inet:dns:a``\\:', s)
 
     async def test_tools_autodoc_confdefs(self):
 

--- a/synapse/tests/test_tools_autodoc.py
+++ b/synapse/tests/test_tools_autodoc.py
@@ -34,7 +34,7 @@ class TestAutoDoc(s_t_utils.SynTest):
             self.isin('Universal props are system level properties which may be present on every node.', s)
             self.isin('.created', s)
             self.notin('..created\n', s)
-            self.isin('A example of ``inet:dns:a``\\:', s)
+            self.isin('An example of ``inet:dns:a``\\:', s)
 
     async def test_tools_autodoc_confdefs(self):
 

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -61,14 +61,22 @@ class DocHelp:
                 doc = prop[2].get('doc', self.forms.get(tn, self.types.get(tn, self.ctors.get(tn))))
                 self.props[(form, prop[0])] = doc
         typed = {t[0]: t for t in types}
+        ctord = {c[0]: c for c in ctors}
         self.formhelp = {}  # form name -> ex string for a given type
         for form in forms:
-            print(form)
             formname = form[0]
-            print(formname)
-            tnfo = typed.get(form[0])[2]
-            print(tnfo)
-            print(tnfo.get('ex', 'No Example'))
+            tnfo = typed.get(formname)
+            ctor = ctord.get(formname)
+            if tnfo:
+                tnfo = tnfo[2]
+                example = tnfo.get('ex')
+                self.formhelp[formname] = example
+            elif ctor:
+                ctor = ctor[3]
+                example = ctor.get('ex')
+                self.formhelp[formname] = example
+            else:
+                logger.warning(f'No ctor/type available for [{formname}]')
 
 class RstHelp:
 

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -26,7 +26,7 @@ poptsToWords = {
 }
 
 info_ignores = (
-    'storetype',
+    'stortype',
 )
 
 raw_back_slash_colon = r'\:'
@@ -244,7 +244,10 @@ def processFormsProps(rst, dochelp, forms, univ_names):
         link = f'.. _dm-form-{name.replace(":", "-")}:'
         rst.addHead(hname, lvl=2, link=link)
 
+        baseline = f'The base type for the form can be found at :ref:`dm-type-{name.replace(":", "-")}`.'
         rst.addLines(doc,
+                     '',
+                     baseline,
                      '')
 
         ex = dochelp.formhelp.get(name)

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -207,7 +207,7 @@ def processTypes(rst, dochelp, types):
         ex = info.pop('ex', None)
         if ex:
             rst.addLines('',
-                         f'An example of {name}{raw_back_slash_colon}:',
+                         f'An example of ``{name}``{raw_back_slash_colon}',
                          '',
                          f' * ``{ex}``',
                          )

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -485,7 +485,7 @@ async def docStormsvc(ctor):
         if ':' in pname:
             hname = pname.replace(':', raw_back_slash_colon)
 
-        rst.addHead(f'Storm Package\: {hname}', lvl=1)
+        rst.addHead(f'Storm Package\\: {hname}', lvl=1)
 
         rst.addLines(f'This documentation for {pname} is generated for version {s_version.fmtVersion(*pver)}')
 
@@ -577,10 +577,10 @@ def getDoc(obj, errstr):
 
 def cleanArgsRst(doc):
     '''Clean up args strings to be RST friendly.'''
-    replaces = (('*args', '\*args'),
-                ('*vals', '\*vals'),
-                ('**info', '\*\*info'),
-                ('**kwargs', '\*\*kwargs'),
+    replaces = (('*args', '\\*args'),
+                ('*vals', '\\*vals'),
+                ('**info', '\\*\\*info'),
+                ('**kwargs', '\\*\\*kwargs'),
                 )
     for (new, old) in replaces:
         doc = doc.replace(new, old)

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -76,7 +76,7 @@ class DocHelp:
                 ctor = ctor[3]
                 example = ctor.get('ex')
                 self.formhelp[formname] = example
-            else:
+            else:  # pragma: no cover
                 logger.warning(f'No ctor/type available for [{formname}]')
 
 class RstHelp:

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -54,6 +54,15 @@ class DocHelp:
                 tn = prop[1][0]
                 doc = prop[2].get('doc', self.forms.get(tn, self.types.get(tn, self.ctors.get(tn))))
                 self.props[(form, prop[0])] = doc
+        typed = {t[0]: t for t in types}
+        self.formhelp = {}  # form name -> ex string for a given type
+        for form in forms:
+            print(form)
+            formname = form[0]
+            print(formname)
+            tnfo = typed.get(form[0])[2]
+            print(tnfo)
+            print(tnfo.get('ex', 'No Example'))
 
 class RstHelp:
 

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -25,6 +25,10 @@ poptsToWords = {
     'ro': 'Read Only',
 }
 
+info_ignores = (
+    'storetype',
+)
+
 raw_back_slash_colon = r'\:'
 
 # TODO Ensure this is consistent with other documentation.
@@ -148,6 +152,9 @@ def processCtors(rst, dochelp, ctors):
             for k, v in opts.items():
                 rst.addLines(f' * {k}: ``{v}``')
 
+        for key in info_ignores:
+            info.pop(key, None)
+
         if info:
             logger.warning(f'Base type {name} has unhandled info: {info}')
 
@@ -203,6 +210,9 @@ def processTypes(rst, dochelp, types):
                          )
             for k, v in sorted(topt.items(), key=lambda x: x[0]):
                 rst.addLines(f' * {k}: ``{v}``')
+
+        for key in info_ignores:
+            info.pop(key, None)
 
         if info:
             logger.warning(f'Type {name} has unhandled info: {info}')

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -247,6 +247,15 @@ def processFormsProps(rst, dochelp, forms, univ_names):
         rst.addLines(doc,
                      '')
 
+        ex = dochelp.formhelp.get(name)
+        if ex:
+            rst.addLines('',
+                         f'A example of ``{name}``{raw_back_slash_colon}',
+                         '',
+                         f' * ``{ex}``',
+                         ''
+                         )
+
         if props:
             rst.addLines('Properties:',
                          )

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -148,7 +148,7 @@ def processCtors(rst, dochelp, ctors):
         ex = info.pop('ex', None)
         if ex:
             rst.addLines('',
-                         f'A example of ``{name}``{raw_back_slash_colon}',
+                         f'An example of ``{name}``{raw_back_slash_colon}',
                          '',
                          f' * ``{ex}``',
                          )
@@ -207,7 +207,7 @@ def processTypes(rst, dochelp, types):
         ex = info.pop('ex', None)
         if ex:
             rst.addLines('',
-                         f'A example of {name}{raw_back_slash_colon}:',
+                         f'An example of {name}{raw_back_slash_colon}:',
                          '',
                          f' * ``{ex}``',
                          )
@@ -254,7 +254,7 @@ def processFormsProps(rst, dochelp, forms, univ_names):
         ex = dochelp.formhelp.get(name)
         if ex:
             rst.addLines('',
-                         f'A example of ``{name}``{raw_back_slash_colon}',
+                         f'An example of ``{name}``{raw_back_slash_colon}',
                          '',
                          f' * ``{ex}``',
                          ''


### PR DESCRIPTION
- Fix autodoc form output to include examples in the forms.
- Add missing periods to our model docs so it doens't look like sentences just stop.
- Fix a few invalid escape sequences