### PR TITLE
Fix issue with dyncalls against remote axons

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -893,7 +893,6 @@ class Cortex(s_cell.Cell):  # type: ignore
             'cron': self.agenda,
             'cortex': self,
             'multiqueue': self.multiqueue,
-            'axon': self.axon
         })
 
         await self.auth.addAuthGate('cortex', 'cortex')
@@ -1867,6 +1866,7 @@ class Cortex(s_cell.Cell):  # type: ignore
             path = os.path.join(self.dirn, 'axon')
             self.axon = await s_axon.Axon.anit(path)
             self.axon.onfini(self.axready.clear)
+            self.dynitems['axon'] = self.axon
             self.axready.set()
             return
 
@@ -1876,6 +1876,7 @@ class Cortex(s_cell.Cell):  # type: ignore
                 try:
                     self.axon = await s_telepath.openurl(turl)
                     self.axon.onfini(teleloop)
+                    self.dynitems['axon'] = self.axon
                     self.axready.set()
                     return
                 except asyncio.CancelledError:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -4276,9 +4276,15 @@ class CortexBasicTest(s_t_utils.SynTest):
             async with self.getTestCore(conf=conf) as core:
                 async with self.getTestAxon(dirn=dirn) as axon:
                     self.true(await asyncio.wait_for(core.axready.wait(), 10))
-                    size, sha2 = await core.axon.put(b'asdfasdf')
+
+                    # Use dyncalls, not direct object access.
+                    asdfhash_h = '2413fb3709b05939f04cf2e92f7d0897fc2596f9ad0b8a9ea855c7bfebaae892'
+                    size, sha2 = await core.callStorm('return( $lib.bytes.put($buf) )',
+                                                      {'vars': {'buf': b'asdfasdf'}})
                     self.eq(size, 8)
-                    self.eq(s_common.ehex(sha2), '2413fb3709b05939f04cf2e92f7d0897fc2596f9ad0b8a9ea855c7bfebaae892')
+                    self.eq(sha2, asdfhash_h)
+                    self.true(await core.callStorm('return( $lib.bytes.has($hash) )',
+                                                   {'vars': {'hash': asdfhash_h}}))
 
                 unset = False
                 for _ in range(20):


### PR DESCRIPTION
Only add the axon to Cortex.dynitems once we've created a local one or connected to a remote axon.

Bug uncovered during integration testing for #1822 