### PR TITLE
Allow benchmark script to run on remote cortices

### DIFF
--- a/scripts/benchmark_cortex.py
+++ b/scripts/benchmark_cortex.py
@@ -9,10 +9,11 @@ import pathlib
 import tempfile
 import argparse
 import datetime
+import itertools
 import contextlib
 import statistics
 import collections
-from typing import List, Dict, AsyncIterator, Tuple, Any, Callable
+from typing import List, Dict, AsyncIterator, Tuple, Any, Callable, Sequence
 
 try:
     import tqdm
@@ -34,8 +35,6 @@ import synapse.telepath as s_telepath
 import synapse.lib.base as s_base
 import synapse.lib.time as s_time
 import synapse.lib.lmdbslab as s_lmdbslab
-
-import synapse.tools.backup as s_tools_backup
 
 import synapse.tests.utils as s_t_utils
 
@@ -83,7 +82,7 @@ class TestData(s_base.Base):
     '''
     Pregenerates a bunch of data for future test runs
     '''
-    async def __anit__(self, num_records, dirn):
+    async def __anit__(self, num_records, dirn, remote=None):
         '''
         # inet:ipv4 -> inet:dns:a -> inet:fqdn
         # For each even ipv4 record, make an inet:dns:a record that points to <ipaddress>.website, if it is
@@ -97,6 +96,7 @@ class TestData(s_base.Base):
         dnsas = [(f'{ip}.website', ip) for ip in ips if ip % 2 == 0]
         dnsas += [('blackhole.website', ip) for ip in ips if ip % 10 == 0]
         random.shuffle(dnsas)
+        self.remote = remote
 
         def oe(num):
             return 'odd' if num % 2 else 'even'
@@ -119,15 +119,47 @@ class TestData(s_base.Base):
         self.urls = [(('inet:url', f'http://{hex(n)}.ninja'), {}) for n in range(num_records)]
         random.shuffle(self.urls)
 
-        tstdirctx = syntest.getTestDir(startdir=dirn)
-        self.dirn = await self.enter_context(tstdirctx)
+        if remote:
+            self.dirn = None
+            core = None
+            prox = await s_telepath.openurl(self.remote)
+            self.prox = prox
+        else:
+            tstdirctx = syntest.getTestDir(startdir=dirn)
+            self.dirn = await self.enter_context(tstdirctx)
+            core = await s_cortex.Cortex.anit(self.dirn, conf=DefaultConf)
+            prox = await self.enter_context(core.getLocalProxy())
 
-        async with await s_cortex.Cortex.anit(self.dirn, conf=DefaultConf) as core:
-            await s_common.aspin(core.addNodes(self.ips))
-            await s_common.aspin(core.addNodes(self.dnsas))
-            await s_common.aspin(core.addNodes(self.urls))
-            await s_common.aspin(core.addNodes(self.asns))
-            await s_common.aspin(core.addNodes([(('ou:org', fredguid), {})]))
+        name = 'benchmark base'
+        retn = await prox.callStorm('''
+            $layr = $lib.layer.add($lib.dict(name=$name))
+
+            $view = $lib.view.add(($layr.iden,))
+            $view.set(name, $name)
+
+            return($lib.dict(view=$view,  layr=$layr))
+            ''', opts={'vars': {'name': name}})
+
+        self.viewiden, self.layriden = retn['view']['iden'], retn['layr']['iden']
+
+        orgs = [(('ou:org', fredguid), {})]
+        gen = itertools.chain(self.ips, self.dnsas, self.urls, self.asns, orgs)
+        await prox.addFeedData('syn.nodes', list(gen), viewiden=self.viewiden)
+
+        if core:
+            await core.fini()
+
+        async def fini():
+            opts = {'vars': {'view': self.viewiden, 'layer': self.layriden}}
+            await prox.callStorm('''
+                $lib.view.del($view)
+                $lib.layer.del($layer)
+            ''', opts=opts)
+            await self.prox.fini()
+
+        if remote:
+            self.onfini(fini)
+
 
 def benchmark(tags=None):
 
@@ -148,13 +180,15 @@ def benchmark(tags=None):
 class Benchmarker:
 
     def __init__(self, config: Dict[Any, Any], testdata: TestData, workfactor: int, num_iters=4, tmpdir=None,
-                 bench=None, tag=None):
+                 bench=None, tags=None):
         '''
         Args:
             config: the cortex config
             testdata: pre-generated data
             workfactor:  a positive integer indicating roughly the amount of work each benchmark should do
             num_iters:  the number of times each test is run
+            tags:  filters which individual measurements should be run (all tags must be present)
+            remote: the remote telepath URL of a remote cortex
 
         All the benchmark methods are independent and should not have an effect (other than btree caching and size)
         on the other tests.  The only precondition is that the testdata has been loaded.
@@ -166,7 +200,7 @@ class Benchmarker:
         self.testdata = testdata
         self.tmpdir = tmpdir
         self.bench = bench
-        self.tag = tag
+        self.tags = tags
 
     def printreport(self, configname: str):
         print(f'Config {configname}: {self.coreconfig}, Num Iters: {self.num_iters} Debug: {__debug__}')
@@ -201,113 +235,131 @@ class Benchmarker:
                                 'count': count}))
         return retn
 
+    async def _waitUntilLocked(self, prox: s_telepath.Proxy, layeriden: str):
+        while True:
+            stat = await prox.dyncall(layeriden, s_common.todo('stat'))
+            if stat['lock_goal'] == stat['lock_progress']:
+                return
+            await asyncio.sleep(0.1)
+
     @contextlib.asynccontextmanager
     async def getCortexAndProxy(self) -> AsyncIterator[Tuple[Any, Any]]:
-        with syntest.getTestDir(startdir=self.tmpdir) as dirn:
+        '''
+        Prepares a cortex/proxy for a benchmark run
+        '''
+        ldef = {
+            'lockmemory': self.coreconfig.get('layers:lockmemory', False),
+            'logedits': self.coreconfig.get('layers:logedits', True),
+            'name': 'tmp for benchmark',
+        }
+        core = None
 
-            s_tools_backup.backup(self.testdata.dirn, dirn, compact=False)
-
-            async with await s_cortex.Cortex.anit(dirn, conf=self.coreconfig) as core:
+        async with contextlib.AsyncExitStack() as stack:
+            if not self.testdata.remote:
+                ctx = await s_cortex.Cortex.anit(self.testdata.dirn, conf=self.coreconfig)
+                core = await stack.enter_async_context(ctx)
+                prox = await stack.enter_async_context(core.getLocalProxy())
                 assert not core.inaugural
+            else:
+                ctx = await s_telepath.openurl(self.testdata.remote)
+                prox = await stack.enter_async_context(ctx)
 
-                lockmemory = self.coreconfig.get('layers:lockmemory', False)
-                logedits = self.coreconfig.get('layers:logedits', True)
+            layer = await prox.cloneLayer(self.testdata.layriden, ldef)
+            layeriden = layer['iden']
+            view = await prox.callStorm('return($lib.view.add(($layer, ), name="tmp for benchmark"))',
+                                        opts={'vars': {'layer': layeriden}})
+            self.viewiden = view['iden']
+            self.opts = {'view': self.viewiden}
 
-                await core.view.layers[0].layrinfo.set('lockmemory', lockmemory)
-                await core.view.layers[0].layrinfo.set('logedits', logedits)
+            if ldef['lockmemory']:
+                await self._waitUntilLocked(prox, layeriden)
 
-            async with await s_cortex.Cortex.anit(dirn, conf=self.coreconfig) as core:
-                async with core.getLocalProxy() as prox:
-                    if lockmemory:
-                        await core.view.layers[0].layrslab.lockdoneevent.wait()
+            try:
+                yield core, prox
 
-                    await s_lmdbslab.Slab.syncLoopOnce()
+            finally:
+                await prox.callStorm('''
+                    $lib.view.del($view)
+                    $lib.layer.del($layer)
+                ''', opts={'vars': {'view': self.viewiden, 'layer': layeriden}})
 
-                    yield core, prox
-
-    @benchmark()
+    @benchmark({'remote'})
     async def do00EmptyQuery(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         for _ in range(self.workfactor // 10):
-            count = await acount(prox.eval(''))
+            count = await acount(prox.eval('', opts=self.opts))
 
         assert count == 0
         return self.workfactor // 10
 
-    @benchmark()
+    @benchmark({'remote'})
     async def do00NewQuery(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         for i in range(self.workfactor):
-            count = await acount(prox.eval(f'$x={i}'))
+            count = await acount(prox.eval(f'$x={i}', opts=self.opts))
 
         assert count == 0
         return self.workfactor
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do01SimpleCount(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:ipv4 | count | spin'))
+        count = await acount(prox.eval('inet:ipv4 | count | spin', opts=self.opts))
         assert count == 0
         return self.workfactor
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do02LiftSimple(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:ipv4'))
+        count = await acount(prox.eval('inet:ipv4', opts=self.opts))
         assert count == self.workfactor
         return count
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do02LiftFilterAbsent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:ipv4 | +#newp'))
+        count = await acount(prox.eval('inet:ipv4 | +#newp', opts=self.opts))
         assert count == 0
         return 1
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do02LiftFilterPresent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:ipv4 | +#all'))
+        count = await acount(prox.eval('inet:ipv4 | +#all', opts=self.opts))
         assert count == self.workfactor
         return count
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do03LiftBySecondaryAbsent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:dns:a:fqdn=newp'))
+        count = await acount(prox.eval('inet:dns:a:fqdn=newp', opts=self.opts))
         assert count == 0
         return 1
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do03LiftBySecondaryPresent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:dns:a:fqdn=blackhole.website'))
+        count = await acount(prox.eval('inet:dns:a:fqdn=blackhole.website', opts=self.opts))
         assert count == self.workfactor // 10
         return count
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do04LiftByTagAbsent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:ipv4#newp'))
+        count = await acount(prox.eval('inet:ipv4#newp', opts=self.opts))
         assert count == 0
         return 1
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do04LiftByTagPresent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:ipv4#even'))
+        count = await acount(prox.eval('inet:ipv4#even', opts=self.opts))
         assert count == self.workfactor // 2
         return count
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do05PivotAbsent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:ipv4#odd -> inet:dns:a'))
+        count = await acount(prox.eval('inet:ipv4#odd -> inet:dns:a', opts=self.opts))
         assert count == 0
         return self.workfactor // 2
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do06PivotPresent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:ipv4#even -> inet:dns:a'))
+        count = await acount(prox.eval('inet:ipv4#even -> inet:dns:a', opts=self.opts))
         assert count == self.workfactor // 2 + self.workfactor // 10
         return count
 
-    @benchmark({'official', 'addnodes'})
-    async def do07AAddNodes(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.addNodes(self.testdata.asns2))
-        assert count == self.workfactor
-        return count
-
-    @benchmark({'addnodes', })
+    @benchmark({'addnodes', 'remote'})
     async def do07AAddNodesCallStorm(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         tags_to_add = '+#test'
         count = 0
@@ -316,100 +368,99 @@ class Benchmarker:
             props_to_add = f":name = {node[1]['props']['name']}"
             form, valu = node[0]
 
-            opts = {'vars': {'valu': valu}}
+            opts = {'vars': {'valu': valu}, 'view': self.viewiden}
             await prox.callStorm(f'[ {form}=$valu {props_to_add} {tags_to_add}] return($node.pack(dorepr=1))',
                                  opts=opts)
             count += 1
         assert count == self.workfactor
         return count
 
-    @benchmark({'addnodes', })
+    @benchmark({'addnodes', 'remote'})
     async def do07AAddNodesStorm(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         tags_to_add = '+#test'
-        count = 0
+        msgs = []
 
         for node in self.testdata.asns2prop:
             props_to_add = f":name = {node[1]['props']['name']}"
             form, valu = node[0]
 
-            opts = {'vars': {'valu': valu}}
-            count += await acount(prox.storm(f'[ {form}=$valu {props_to_add} {tags_to_add}]', opts=opts))
-        assert count == self.workfactor
-        return count
+            opts = {'vars': {'valu': valu}, 'view': self.viewiden}
+            msgs.extend([x async for x in prox.storm(f'[ {form}=$valu {props_to_add} {tags_to_add}]', opts=opts)])
+            newnodes = [m for m in msgs if m[0] == 'node:edits' and m[1]['edits'][0][2][0][0] == 2]
+        assert len(newnodes) == self.workfactor
+        return len(newnodes)
 
-    @benchmark({'addnodes'})
-    async def do07AAddNodesSync(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.addNodes(self.testdata.asns2))
-        core.view.layers[0].layrslab.lenv.sync()
-        assert count == self.workfactor
-        return count
-
-    @benchmark({'official', 'addnodes'})
+    @benchmark({'official', 'addnodes', 'remote', 'this'})
     async def do07BAddNodesSimpleProp(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         '''
         Add simple node with a single non-form secondary prop
         '''
-        count = await acount(prox.addNodes(self.testdata.asns2prop))
-        assert count == self.workfactor
-        return count
+        await prox.addFeedData('syn.nodes', self.testdata.asns2prop, viewiden=self.viewiden)
 
-    @benchmark({'official', 'addnodes'})
+        assert self.workfactor == await prox.count('inet:asn:name=x', opts=self.opts)
+
+        return self.workfactor
+
+    @benchmark({'official', 'addnodes', 'remote'})
     async def do07CAddNodesFormProp(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         '''
         Add simple node with a single form secondary prop and that secondary prop form doesn't exist
         '''
-        count = await acount(prox.addNodes(self.testdata.asns2formnoexist))
-        assert count == self.workfactor
-        return count
+        await prox.addFeedData('syn.nodes', self.testdata.asns2formnoexist, viewiden=self.viewiden)
 
-    @benchmark({'official', 'addnodes'})
+        if __debug__:
+            assert self.workfactor + 1 == await prox.count('ou:org', opts=self.opts)
+        return self.workfactor
+
+    @benchmark({'official', 'addnodes', 'remote'})
     async def do07DAddNodesFormPropExists(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         '''
         Add simple node with a single form secondary prop and that secondary prop form already exists
         '''
-        count = await acount(prox.addNodes(self.testdata.asns2formexist))
-        assert count == self.workfactor
-        return count
+        await prox.addFeedData('syn.nodes', self.testdata.asns2formexist, viewiden=self.viewiden)
 
-    @benchmark({'official', 'addnodes'})
+        assert self.workfactor == await prox.count('inet:asn', opts=self.opts)
+        return self.workfactor
+
+    @benchmark({'official', 'addnodes', 'remote'})
     async def do07EAddNodesPresent(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.addNodes(self.testdata.asns))
-        assert count == self.workfactor
-        return count
+        await prox.addFeedData('syn.nodes', self.testdata.asns, viewiden=self.viewiden)
+        assert len(self.testdata.asns) == await prox.count('inet:asn', opts=self.opts)
+        return len(self.testdata.asns)
 
     @benchmark({'official', 'addnodes'})
     async def do08LocalAddNodes(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(core.addNodes(self.testdata.asns2))
+        count = await acount(core.addNodes(self.testdata.asns2, view=core.getView(self.viewiden)))
         assert count == self.workfactor
         return count
 
-    @benchmark({'official'})
+    @benchmark({'official', 'remote'})
     async def do09DelNodes(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
-        count = await acount(prox.eval('inet:url | delnode'))
+        count = await acount(prox.eval('inet:url | delnode', opts=self.opts))
         assert count == 0
         return self.workfactor
 
-    @benchmark()
+    @benchmark({'remote'})
     async def do10AutoAdds(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         q = "inet:ipv4 $val=$lib.str.format('{num}.rev', num=$(1000000-$node.value())) [:dns:rev=$val]"
-        count = await acount(prox.eval(q))
+        count = await acount(prox.eval(q, opts=self.opts))
         assert count == self.workfactor
         return self.workfactor
 
-    @benchmark()
+    @benchmark({'remote'})
     async def do10SlashAdds(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         q = '[ inet:ipv4=1.2.0.0/16 ] | spin'
-        count = await acount(prox.eval(q))
+        count = await acount(prox.eval(q, opts=self.opts))
         assert count == 0
         return 2 ** 16
 
-    @benchmark()
+    @benchmark({'remote'})
     async def do10Formatting(self, core: s_cortex.Cortex, prox: s_telepath.Proxy) -> int:
         '''
         The same as do10AutoAdds without the adds (to isolate the autoadd part)
         '''
         q = "inet:ipv4 $val=$lib.str.format('{num}.rev', num=$(1000000-$node.value()))"
-        count = await acount(prox.eval(q))
+        count = await acount(prox.eval(q, opts=self.opts))
         assert count == self.workfactor
         return self.workfactor
 
@@ -435,6 +486,7 @@ class Benchmarker:
     def _getTrialFuncs(self):
         funcs: List[Tuple[str, Callable]] = []
         funcnames = sorted(f for f in dir(self))
+        tags = set(self.tags) if self.tags is not None else set()
         for funcname in funcnames:
             func = getattr(self, funcname)
             if not hasattr(func, '_benchmark'):
@@ -442,9 +494,8 @@ class Benchmarker:
             if self.bench is not None:
                 if not any(funcname.startswith(b) for b in self.bench):
                     continue
-            if self.tag is not None:
-                if self.tag not in func._tags:
-                    continue
+            if not tags.issubset(func._tags):
+                continue
             funcs.append((funcname, func))
         return funcs
 
@@ -487,7 +538,8 @@ async def benchmarkAll(confignames: List = None,
                        niters: int = 4,
                        bench=None,
                        do_profiling=False,
-                       tag=None,
+                       tags: Sequence = None,
+                       remote: str = None,
                        ) -> None:
 
     if jsondir:
@@ -498,8 +550,8 @@ async def benchmarkAll(confignames: List = None,
 
     with syntest.getTestDir(startdir=tmpdir) as dirn:
 
-        async with await TestData.anit(workfactor, dirn) as testdata:
-            print('Initial cortex created')
+        async with await TestData.anit(workfactor, dirn, remote=remote) as testdata:
+
             if not confignames:
                 confignames = ['simple']
 
@@ -507,7 +559,7 @@ async def benchmarkAll(confignames: List = None,
                 tick = s_common.now()
                 config = Configs[configname]
                 bencher = Benchmarker(config, testdata, workfactor, num_iters=niters, tmpdir=tmpdir, bench=bench,
-                                      tag=tag)
+                                      tags=tags)
                 print(f'{num_procs}-process benchmarking: {configname}')
                 initProgress(niters * len(bencher._getTrialFuncs()))
                 try:
@@ -544,7 +596,7 @@ async def benchmarkAll(confignames: List = None,
 def getParser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', nargs='*', default=['default'])
-    # parser.add_argument('--num-clients', type=int, default=1)
+    parser.add_argument('--remote', type=str, help='Telepath URL of remote cortex (benchmark is nondestructive)')
     parser.add_argument('--workfactor', type=int, default=1000)
     parser.add_argument('--niters', type=int, default=4, help='Number of times to run each benchmark')
     parser.add_argument('--tmpdir', type=str),
@@ -554,8 +606,8 @@ def getParser():
                         help='Prefix to append to the autogenerated filename for json output.')
     parser.add_argument('--bench', '-b', nargs='*', default=None,
                         help='Prefixes of which benchmarks to run (defaults to run all)')
-    parser.add_argument('--tag', '-t', default=None,
-                        help='Tag of which suite to run (defaults to "official" if bench not set)')
+    parser.add_argument('--tags', '-t', nargs='*',
+                        help='Tag(s) of which suite to run (defaults to "official" if bench not set)')
     parser.add_argument('--do-profiling', action='store_true')
     return parser
 
@@ -568,9 +620,16 @@ if __name__ == '__main__':
         print('Error: module "yappi" must be installed to use --do-profiling')
         sys.exit(1)
 
-    if opts.bench is None and opts.tag is None:
-        opts.tag = 'official'
+    if opts.bench is None and opts.tags is None:
+        opts.tags = ['official', ]
+
+    if opts.tags is None:
+        opts.tags = []
+
+    if opts.remote:
+        opts.tags.append('remote')
 
     asyncio.run(benchmarkAll(opts.config, 1, opts.workfactor, opts.tmpdir,
                              jsondir=opts.jsondir, jsonprefix=opts.jsonprefix,
-                             niters=opts.niters, bench=opts.bench, do_profiling=opts.do_profiling, tag=opts.tag))
+                             niters=opts.niters, bench=opts.bench, do_profiling=opts.do_profiling, tags=opts.tags,
+                             remote=opts.remote))

--- a/scripts/benchmark_cortex.py
+++ b/scripts/benchmark_cortex.py
@@ -235,13 +235,6 @@ class Benchmarker:
                                 'count': count}))
         return retn
 
-    async def _waitUntilLocked(self, prox: s_telepath.Proxy, layeriden: str):
-        while True:
-            stat = await prox.dyncall(layeriden, s_common.todo('stat'))
-            if stat['lock_goal'] == stat['lock_progress']:
-                return
-            await asyncio.sleep(0.1)
-
     @contextlib.asynccontextmanager
     async def getCortexAndProxy(self) -> AsyncIterator[Tuple[Any, Any]]:
         '''
@@ -271,8 +264,7 @@ class Benchmarker:
             self.viewiden = view['iden']
             self.opts = {'view': self.viewiden}
 
-            if ldef['lockmemory']:
-                await self._waitUntilLocked(prox, layeriden)
+            await prox.dyncall(layeriden, s_common.todo('waitForHot'))
 
             try:
                 yield core, prox

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -34,8 +34,6 @@ import synapse.lib.version as s_version
 import synapse.lib.modelrev as s_modelrev
 import synapse.lib.stormsvc as s_stormsvc
 import synapse.lib.lmdbslab as s_lmdbslab
-import synapse.lib.stormhttp as s_stormhttp
-import synapse.lib.stormwhois as s_stormwhois
 import synapse.lib.provenance as s_provenance
 import synapse.lib.stormtypes as s_stormtypes
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -34,6 +34,8 @@ import synapse.lib.version as s_version
 import synapse.lib.modelrev as s_modelrev
 import synapse.lib.stormsvc as s_stormsvc
 import synapse.lib.lmdbslab as s_lmdbslab
+import synapse.lib.stormhttp as s_stormhttp
+import synapse.lib.stormwhois as s_stormwhois
 import synapse.lib.provenance as s_provenance
 import synapse.lib.stormtypes as s_stormtypes
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1086,6 +1086,38 @@ class Layer(s_nexus.Pusher):
 
         await self._initLayerStorage()
 
+    async def clone(self, newdirn):
+
+        for root, dnames, fnames in os.walk(self.dirn, topdown=True):
+
+            relpath = os.path.relpath(root, start=self.dirn)
+
+            for name in list(dnames):
+
+                relname = os.path.join(relpath, name)
+
+                srcpath = s_common.genpath(root, name)
+                dstpath = s_common.genpath(newdirn, relname)
+
+                if srcpath in s_lmdbslab._AllSlabs:
+                    slab = s_lmdbslab._AllSlabs.get(srcpath)
+                    await slab.copyslab(dstpath)
+
+                    dnames.remove(name)
+                    continue
+
+                s_common.gendir(dstpath)
+
+            for name in fnames:
+
+                srcpath = s_common.genpath(root, name)
+                # skip unix sockets etc...
+                if not os.path.isfile(srcpath):
+                    continue
+
+                dstpath = s_common.genpath(newdirn, relpath, name)
+                shutil.copy(srcpath, dstpath)
+
     async def _initLayerStorage(self):
 
         slabopts = {

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1077,7 +1077,9 @@ class Layer(s_nexus.Pusher):
 
     @s_nexus.Pusher.onPushAuto('layer:truncate')
     async def truncate(self):
-
+        '''
+        Nuke all the contents in the layer, leaving an empty layer
+        '''
         self.buidcache.clear()
 
         await self.layrslab.trash()
@@ -1087,7 +1089,9 @@ class Layer(s_nexus.Pusher):
         await self._initLayerStorage()
 
     async def clone(self, newdirn):
-
+        '''
+        Copy the contents of this layer to a new layer
+        '''
         for root, dnames, fnames in os.walk(self.dirn, topdown=True):
 
             relpath = os.path.relpath(root, start=self.dirn)
@@ -1117,6 +1121,12 @@ class Layer(s_nexus.Pusher):
 
                 dstpath = s_common.genpath(newdirn, relpath, name)
                 shutil.copy(srcpath, dstpath)
+
+    async def waitForHot(self):
+        '''
+        Wait for the layer's slab to be prefaulted and locked into memory if lockmemory is true, otherwise return.
+        '''
+        await self.layrslab.lockdoneevent.wait()
 
     async def _initLayerStorage(self):
 

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -690,7 +690,6 @@ class LayerTest(s_t_utils.SynTest):
 
             nodelist0 = [node.pack() for node in nodelist0]
 
-            count = 0
             editlist = []
 
             layr = core0.getLayer()
@@ -836,6 +835,18 @@ class LayerTest(s_t_utils.SynTest):
             self.false(await layr.hasTagProp('score'))
             nodes = await core.nodes('[test:str=bar +#test:score=100]')
 
+    async def test_layer_waitForHot(self):
+
+        async with self.getTestCore() as core:
+            layr = core.getLayer()
+
+            await asyncio.wait_for(layr.waitForHot(), timeout=1.0)
+
+        conf = {'layers:lockmemory': True}
+        async with self.getTestCore(conf=conf) as core:
+            layr = core.getLayer()
+            await asyncio.wait_for(layr.waitForHot(), timeout=1.0)
+
     async def test_layer_no_extra_logging(self):
 
         async with self.getTestCore() as core:
@@ -884,7 +895,7 @@ class LayerTest(s_t_utils.SynTest):
             self.eq('foo', await layr.getNodeValu(buid))
             self.eq((1420070400000, 1451606400000), await layr.getNodeValu(buid, '.seen'))
 
-            adir = s_common.gendir(layr.dirn, 'adir')
+            s_common.gendir(layr.dirn, 'adir')
 
             copylayrinfo = await core.cloneLayer(layr.iden)
             self.len(2, core.layers)

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -51,7 +51,7 @@ class LmdbSlabTest(s_t_utils.SynTest):
                 slab.put(b'hoho', b'haha', db=testdb)
 
                 testgenr = slab.scanKeys(db=testdb)
-                dupsgenr = slab.scanKeys(db=testdb)
+                dupsgenr = slab.scanKeys(db=dupsdb)
 
                 testlist = [next(testgenr)]
                 dupslist = [next(dupsgenr)]
@@ -65,7 +65,7 @@ class LmdbSlabTest(s_t_utils.SynTest):
                 dupslist.extend(dupsgenr)
 
                 self.eq(testlist, (b'hehe', b'hoho'))
-                self.eq(dupslist, (b'hehe', b'hoho'))
+                self.eq(dupslist, (b'hehe', b'hehe', b'hoho'))
 
                 # now lets delete the key we're on
                 testgenr = slab.scanKeys(db=testdb)
@@ -558,7 +558,7 @@ class LmdbSlabTest(s_t_utils.SynTest):
         with self.getTestDir() as dirn:
             path = os.path.join(dirn, 'test.lmdb')
             async with await s_lmdbslab.Slab.anit(path, map_size=100000, growsize=10000) as slab:
-                await slab.countByPref(b'asdf')
+                self.eq(0, await slab.countByPref(b'asdf'))
 
     async def test_lmdbslab_grow(self):
 

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -1185,6 +1185,27 @@ class LmdbSlabTest(s_t_utils.SynTest):
                 # Can't re-open while already open
                 await self.asyncraises(s_exc.SlabAlreadyOpen, s_lmdbslab.Slab.anit(path))
 
+    async def test_lmdbslab_copyslab(self):
+
+        with self.getTestDir() as dirn:
+
+            path = os.path.join(dirn, 'test.lmdb')
+            copypath = os.path.join(dirn, 'copy.lmdb')
+
+            async with await s_lmdbslab.Slab.anit(path) as slab:
+                foo = slab.initdb('foo')
+                slab.put(b'\x00\x01', b'hehe', db=foo)
+
+                await slab.copyslab(copypath)
+
+                self.true(pathlib.Path(copypath).with_suffix('.opts.yaml').exists())
+
+                async with await s_lmdbslab.Slab.anit(copypath) as slabcopy:
+                    foo = slabcopy.initdb('foo')
+                    self.eq(b'hehe', slabcopy.get(b'\x00\x01', db=foo))
+
+                await self.asyncraises(s_exc.DataAlreadyExists, slab.copyslab(copypath))
+
 class LmdbSlabMemLockTest(s_t_utils.SynTest):
 
     async def test_lmdbslabmemlock(self):

--- a/synapse/tests/test_lib_spawn.py
+++ b/synapse/tests/test_lib_spawn.py
@@ -296,7 +296,7 @@ class CoreSpawnTest(s_test.SynTest):
                 n = 4
                 tasks = [taskfunc(i) for i in range(n)]
                 try:
-                    await asyncio.wait_for(asyncio.gather(*tasks), timeout=40)
+                    await asyncio.wait_for(asyncio.gather(*tasks), timeout=80)
                 except asyncio.TimeoutError:
                     self.fail('Timeout awaiting for spawn tasks to finish.')
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -3122,7 +3122,7 @@ class StormTypesTest(s_test.SynTest):
 
             await core.nodes('[inet:ipv4=1.2.3.4]')
 
-            #TODO: should we asciify the buid here so it is json compatible?
+            # TODO: should we asciify the buid here so it is json compatible?
             q = '''$list = $lib.list()
             for ($offs, $edit) in $lib.layer.get().edits(wait=$lib.false) {
                 $list.append($edit)


### PR DESCRIPTION
Add --remote parameter to benchmark_cortex script. It causes temporary layers and views to be created for benchmarking.

Also fix a getTagCount/bump heisenbug I stumbled upon.