### PR TITLE
Sanitize logged telepath URLs

### DIFF
--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -78,6 +78,7 @@ import synapse.lib.cell as s_cell
 import synapse.lib.cache as s_cache
 import synapse.lib.nexus as s_nexus
 import synapse.lib.queue as s_queue
+import synapse.lib.urlhelp as s_urlhelp
 
 import synapse.lib.config as s_config
 import synapse.lib.lmdbslab as s_lmdbslab
@@ -2221,7 +2222,7 @@ class Layer(s_nexus.Pusher):
 
                     iden = await proxy.getIden()
                     offs = self.offsets.get(iden)
-                    logger.warning(f'upstream sync connected ({url} offset={offs})')
+                    logger.warning(f'upstream sync connected ({s_urlhelp.sanitizeUrl(url)} offset={offs})')
 
                     if offs == 0:
                         offs = await proxy.getNodeEditOffset()

--- a/synapse/lib/urlhelp.py
+++ b/synapse/lib/urlhelp.py
@@ -1,3 +1,4 @@
+import regex
 import synapse.exc as s_exc
 
 def chopurl(url):
@@ -67,3 +68,20 @@ def chopurl(url):
 
     ret['path'] = pathrem
     return ret
+
+_url_re = regex.compile(r"^(?P<front>.+?://.+?:).+?(?=@)")
+
+def sanitizeUrl(url):
+    '''
+    Returns a URL with the password (if present) replaced with ****
+
+    RFC 3986 3.2.1 'Applications should not render as clear text any data after the first colon (":") character found
+    within a userinfo subcomponent unless the data after the colon is the empty string (indicating no password)'
+
+    Essentially, replace everything between the 2nd colon (if it exists) and the first succeeding at sign.  Return the
+    original string otherwise.
+
+    Note: this depends on this being a reasonably-well formatted URI that starts with a scheme (e.g. http) and '//:'
+    Failure of this condition yields the original string.
+    '''
+    return _url_re.sub(r'\g<front>****', url)

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -676,7 +676,7 @@ class Client(s_base.Base):
                 raise
 
             except Exception as e:
-                logger.warning(f'telepath client ({url}): {e}')
+                logger.warning(f'telepath client ({s_urlhelp.sanitizeUrl(url)}): {e}')
                 await self.waitfini(timeout=self._t_conf.get('retrysleep', 0.2))
 
     async def proxy(self, timeout=10):
@@ -717,7 +717,7 @@ class Client(s_base.Base):
             except s_exc.TeleRedir as e:
                 url = e.errinfo.get('url')
                 self._setNextUrl(url)
-                logger.warning(f'telepath task redirected: ({url})')
+                logger.warning(f'telepath task redirected: ({s_urlhelp.sanitizeUrl(url)})')
                 await self._t_proxy.fini()
 
     async def waitready(self, timeout=10):

--- a/synapse/tests/test_lib_urlhelp.py
+++ b/synapse/tests/test_lib_urlhelp.py
@@ -71,3 +71,17 @@ class UrlTest(s_t_utils.SynTest):
 
         self.raises(s_exc.BadUrl, s_urlhelp.chopurl,
                     'www.vertex.link')
+
+    def test_sanitizeUrl(self):
+        data = [
+            ('http://foo.com/path#fragment', None),
+            ('http://foo.com:1234?query=bar', None),
+            ('rando:this:is:valid:URI', None),
+            ('rando:this:is@valid:URI', None),
+            ('foo://user:password@host.com', 'foo://user:****@host.com'),
+            ('foo://user:password@host.com:999', 'foo://user:****@host.com:999'),
+            ('foo://user:@host.com', None),
+        ]
+
+        for in_, out in data:
+            self.eq(s_urlhelp.sanitizeUrl(in_), in_ if out is None else out)

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -526,7 +526,7 @@ class TeleTest(s_t_utils.SynTest):
                 # make another customshare reference which will be
                 # tracked by the Sess object
                 evt = asyncio.Event()
-                async with await proxy.customshare() as _share:
+                async with await proxy.customshare():
                     self.len(3, sess.items)
                     _key = [k for k in sess.items.keys() if k and k != key][0]
                     _cshare = sess.getSessItem(_key)
@@ -685,8 +685,8 @@ class TeleTest(s_t_utils.SynTest):
                 snfo = await dmon.getSessInfo()
                 conninfo = snfo[0].get('conninfo')
                 self.eq(conninfo, {'family': 'tcp',
-                               'ipver': 'ipv6',
-                               'addr': prox.link.sock.getsockname()})
+                                   'ipver': 'ipv6',
+                                   'addr': prox.link.sock.getsockname()})
 
                 # check a standard return value
                 self.eq(30, await prox.bar(10, 20))
@@ -771,7 +771,7 @@ class TeleTest(s_t_utils.SynTest):
         addr0 = await dmon0.listen('tcp://127.0.0.1:0/')
         addr1 = await dmon1.listen('tcp://127.0.0.1:0/')
 
-        url0 = f'tcp://127.0.0.1:{addr0[1]}/foo'
+        url0 = f'tcp://user:password@127.0.0.1:{addr0[1]}/foo'
         url1 = f'tcp://127.0.0.1:{addr1[1]}/foo'
 
         fail0 = TestFail()
@@ -798,7 +798,15 @@ class TeleTest(s_t_utils.SynTest):
 
         async with await s_telepath.Client.anit(urls) as targ:
 
-            await targ.waitready()
+            with self.getAsyncLoggerStream('synapse.telepath', 'Connect call failed') as stream:
+
+                await targ.waitready()
+
+                # Verify the password doesn't leak into the log
+                self.true(await stream.wait(2))
+                stream.seek(0)
+                mesgs = stream.read()
+                self.notin('password', mesgs)
 
             self.eq(110, await targ.dostuff(100))
 


### PR DESCRIPTION
Replace the passwords in any logged telepath URLs with ****