### PR TITLE
Runt pivotout support and docstrings

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -1283,6 +1283,11 @@ class PivotOut(PivotOper):
             if form is None:
                 continue
 
+            if prop.isrunt:
+                async for pivo in runt.snap.nodesByPropValu(form.name, '=', valu):
+                    yield pivo, path.fork(pivo)
+                continue
+
             pivo = await runt.snap.getNodeByNdef((form.name, valu))
             if pivo is None:  # pragma: no cover
                 continue

--- a/synapse/lib/hiveauth.py
+++ b/synapse/lib/hiveauth.py
@@ -333,6 +333,17 @@ class Auth(s_nexus.Pusher):
         return gate
 
     async def addUser(self, name, passwd=None, email=None):
+        '''
+        Add a User to the Hive.
+
+        Args:
+            name (str): The name of the User.
+            passwd (str): A optional password for the user.
+            email (str): A optional emall for the user.
+
+        Returns:
+            HiveUser: A Hive User.
+        '''
 
         if self.usersbyname.get(name) is not None:
             raise s_exc.DupUserName(name=name)

--- a/synapse/lib/stormlib/backup.py
+++ b/synapse/lib/stormlib/backup.py
@@ -3,7 +3,9 @@ import synapse.lib.stormtypes as s_stormtypes
 
 @s_stormtypes.registry.registerLib
 class BackupLib(s_stormtypes.Lib):
-
+    '''
+    A Storm Library for interacting with the backup APIs in the Cortex.
+    '''
     _storm_lib_path = ('backup',)
 
     def getObjLocals(self):
@@ -19,6 +21,7 @@ class BackupLib(s_stormtypes.Lib):
 
         Args:
             name (str): The name of the backup to generate.
+
             wait (bool): If true, wait for the backup to complete before returning.
 
         Returns:

--- a/synapse/tests/test_model_syn.py
+++ b/synapse/tests/test_model_syn.py
@@ -251,6 +251,13 @@ class SynModelTest(s_t_utils.SynTest):
             nodes = await core.nodes(q)
             self.ge(len(nodes), 7)
 
+            # Wildcard pivot out from a prop and ensure we got the form
+            q = 'syn:prop=test:comp -> * '
+            nodes = await core.nodes(q)
+            self.len(2, nodes)
+            self.eq({('syn:form', 'test:comp'), ('syn:type', 'test:comp')},
+                    {n.ndef for n in nodes})
+
             # Some forms inherit from a single type
             nodes = await core.nodes('syn:type="inet:addr" -> syn:type:subof')
             self.ge(len(nodes), 2)


### PR DESCRIPTION
- Allow pivotout ( ``-> *``) to work with runt nodes
- Add a few missing docstrings