### PR TITLE
Add module conf data to storm service definitions

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1352,6 +1352,8 @@ class Cortex(s_cell.Cell):  # type: ignore
         for mdef in mods:
             modtext = mdef.get('storm')
             self.getStormQuery(modtext)
+            mdef.setdefault('modconf', {})
+            mdef['modconf']['svciden'] = svciden
 
         for cdef in cmds:
             cdef['pkgname'] = pkgname

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1357,7 +1357,8 @@ class Cortex(s_cell.Cell):  # type: ignore
             modtext = mdef.get('storm')
             self.getStormQuery(modtext)
             mdef.setdefault('modconf', {})
-            mdef['modconf']['svciden'] = svciden
+            if svciden:
+                mdef['modconf']['svciden'] = svciden
 
         for cdef in cmds:
             cdef['pkgname'] = pkgname

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -174,7 +174,8 @@ reqValidPkgdef = s_config.getJsValidator({
             'type': 'object',
             'properties': {
                 'name': {'type': 'string'},
-                'storm': {'type': 'string'}
+                'storm': {'type': 'string'},
+                'modconf': {'type': 'object'},
             },
             'additionalProperties': True,
             'required': ['name', 'storm']

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -526,9 +526,10 @@ class LibBase(Lib):
             raise s_exc.NoSuchName(mesg=mesg, name=name)
 
         text = mdef.get('storm')
+        modconf = mdef.get('modconf')
 
         query = await self.runt.getStormQuery(text)
-        runt = await self.runt.getScopeRuntime(query, impd=True)
+        runt = await self.runt.getScopeRuntime(query, opts={'vars': modconf}, impd=True)
 
         # execute the query in a module scope
         async for item in query.run(runt, s_common.agen()):

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -529,7 +529,7 @@ class LibBase(Lib):
         modconf = mdef.get('modconf')
 
         query = await self.runt.getStormQuery(text)
-        runt = await self.runt.getScopeRuntime(query, opts={'vars': modconf}, impd=True)
+        runt = await self.runt.getScopeRuntime(query, opts={'vars': {'modconf': modconf}}, impd=True)
 
         # execute the query in a module scope
         async for item in query.run(runt, s_common.agen()):

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -117,7 +117,13 @@ class RealService(s_stormsvc.StormSvc):
             'name': 'foo',
             'version': (0, 0, 1),
             'modules': (
-                {'name': 'foo.bar', 'storm': 'function asdf(x, y) { return ($($x + $y)) }'},
+                {'name': 'foo.bar',
+                 'storm': '''
+                 function asdf(x, y) { return ($($x + $y)) }
+                 function printmodconf() { $lib.print("yes") $lib.print($modconf.svciden) $lib.print($modconf.key) return ($lib.true) }
+                 ''',
+                 'modconf': {'key': 'valu'},
+                 },
             ),
             'commands': (
                 {
@@ -524,6 +530,11 @@ class StormSvcTest(s_test.SynTest):
                     # even though it has invalid add/del, it should still work
                     nodes = await core.nodes('lifter')
                     self.len(1, nodes)
+
+                    # modconf data is available to commands
+                    msgs = await core.stormlist('$real_lib = $lib.import("foo.bar") $ret=$real_lib.printmodconf()')
+                    for m in msgs:
+                        print(m)
 
                 async with await s_cortex.Cortex.anit(dirn) as core:
 

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -120,7 +120,10 @@ class RealService(s_stormsvc.StormSvc):
                 {'name': 'foo.bar',
                  'storm': '''
                  function asdf(x, y) { return ($($x + $y)) }
-                 function printmodconf() { $lib.print("yes") $lib.print($modconf.svciden) $lib.print($modconf.key) return ($lib.true) }
+                 function printmodconf() {
+                     for ($k, $v) in $modconf { $lib.print('{k}={v}', k=$k, v=$v) }
+                     return ( $lib.true )
+                 }
                  ''',
                  'modconf': {'key': 'valu'},
                  },
@@ -532,9 +535,9 @@ class StormSvcTest(s_test.SynTest):
                     self.len(1, nodes)
 
                     # modconf data is available to commands
-                    msgs = await core.stormlist('$real_lib = $lib.import("foo.bar") $ret=$real_lib.printmodconf()')
-                    for m in msgs:
-                        print(m)
+                    msgs = await core.stormlist('$real_lib = $lib.import("foo.bar") $real_lib.printmodconf()')
+                    self.stormIsInPrint(f'svciden={iden}', msgs)
+                    self.stormIsInPrint('key=valu', msgs)
 
                 async with await s_cortex.Cortex.anit(dirn) as core:
 


### PR DESCRIPTION
- Allow module authors to plumb metadata into modconf field
- Push the svciden into the modconf data