### PR TITLE
Update tests for increased code coverage

### DIFF
--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -27,9 +27,12 @@ class FixedCache:
         return len(self.cache)
 
     def pop(self, key):
-        if key in self.fifo:
-            self.fifo.remove(key)
-        return self.cache.pop(key, None)
+        val = self.cache.pop(key, s_common.novalu)
+        if val is s_common.novalu:
+            return None
+
+        self.fifo.remove(key)
+        return val
 
     def put(self, key, val):
 

--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -27,6 +27,8 @@ class FixedCache:
         return len(self.cache)
 
     def pop(self, key):
+        if key in self.fifo:
+            self.fifo.remove(key)
         return self.cache.pop(key, None)
 
     def put(self, key, val):

--- a/synapse/lib/reflect.py
+++ b/synapse/lib/reflect.py
@@ -49,7 +49,7 @@ def getItemLocals(item):
         try:
             valu = getattr(item, name, None)
             yield name, valu
-        except Exception:
+        except Exception:  # pragma: no cover
             pass # various legit reasons...
 
 def getShareInfo(item):

--- a/synapse/tests/test_lib_cache.py
+++ b/synapse/tests/test_lib_cache.py
@@ -31,6 +31,18 @@ class CacheTest(s_t_utils.SynTest):
         self.nn(cache.cache.get('BAR'))
         self.nn(cache.cache.get('BAZ'))
 
+        self.eq('bar', cache.pop('BAR'))
+        self.eq('baz', cache.pop('BAZ'))
+
+        self.len(0, cache.fifo)
+        self.len(0, cache.cache)
+
+        self.eq('foo', cache.get('FOO'))
+        self.eq('bar', cache.get('BAR'))
+
+        self.len(2, cache.fifo)
+        self.len(2, cache.cache)
+
         cache.clear()
 
         self.len(0, cache.fifo)

--- a/synapse/tests/test_lib_cache.py
+++ b/synapse/tests/test_lib_cache.py
@@ -1,5 +1,7 @@
 import regex
 
+import synapse.exc as s_exc
+import synapse.common as s_common
 import synapse.tests.utils as s_t_utils
 
 import synapse.lib.base as s_base
@@ -8,6 +10,13 @@ import synapse.lib.cache as s_cache
 class CacheTest(s_t_utils.SynTest):
 
     def test_lib_cache_fixed(self):
+
+        async def acallback(name):
+            return name.lower()
+
+        cache = s_cache.FixedCache(acallback, size=2)
+        with self.raises(s_exc.BadArg):
+            cache.get('FOO')
 
         def callback(name):
             return name.lower()
@@ -37,6 +46,9 @@ class CacheTest(s_t_utils.SynTest):
         self.len(0, cache.fifo)
         self.len(0, cache.cache)
 
+        self.none(cache.pop('FOO'))
+        self.none(cache.pop('FAZ'))
+
         self.eq('foo', cache.get('FOO'))
         self.eq('bar', cache.get('BAR'))
 
@@ -44,6 +56,61 @@ class CacheTest(s_t_utils.SynTest):
         self.len(2, cache.cache)
 
         cache.clear()
+
+        self.len(0, cache.fifo)
+        self.len(0, cache.cache)
+
+        cache.put('FOO', 'FOO')
+        cache.put('BAR', 'BAR')
+        cache.put('BAZ', 'BAZ')
+
+        self.eq(2, len(cache))
+
+        self.eq('BAR', cache.get('BAR'))
+        self.eq('BAZ', cache.get('BAZ'))
+        self.eq('foo', cache.get('FOO'))
+
+        def callback(name):
+            return s_common.novalu
+
+        cache = s_cache.FixedCache(callback, size=2)
+        self.eq(s_common.novalu, cache.get('FOO'))
+        self.eq(s_common.novalu, cache.get('BAR'))
+
+        self.len(0, cache.fifo)
+        self.len(0, cache.cache)
+
+    async def test_lib_cache_fixed_async(self):
+        def callback(name):
+            return name.lower()
+
+        cache = s_cache.FixedCache(callback, size=2)
+
+        await self.asyncraises(s_exc.BadOperArg, cache.aget('FOO'))
+
+        async def acallback(name):
+            return name.lower()
+
+        cache = s_cache.FixedCache(acallback, size=2)
+
+        self.eq('foo', await cache.aget('FOO'))
+        self.eq('bar', await cache.aget('BAR'))
+
+        self.len(2, cache.fifo)
+        self.len(2, cache.cache)
+
+        self.nn(cache.cache.get('FOO'))
+        self.nn(cache.cache.get('BAR'))
+
+        self.eq('foo', await cache.aget('FOO'))
+        self.eq('faz', await cache.aget('FAZ'))
+
+        async def acallback(name):
+            return s_common.novalu
+
+        cache = s_cache.FixedCache(acallback, size=2)
+        self.eq(s_common.novalu, await cache.aget('FOO'))
+        self.eq(s_common.novalu, await cache.aget('BAR'))
 
         self.len(0, cache.fifo)
         self.len(0, cache.cache)

--- a/synapse/tests/test_lib_reflect.py
+++ b/synapse/tests/test_lib_reflect.py
@@ -5,15 +5,13 @@ import synapse.lib.version as s_version
 
 import synapse.tests.utils as s_t_utils
 
-class Lol: pass
-class Foo(Lol): pass
+class Lol:
+    def lol(self):
+        return 'lol'
 
-class Bar:
-    def __init__(self):
-        self.foo = Foo()
-
-    def _syn_reflect(self):
-        return s_reflect.getItemInfo(self.foo)
+class Foo(Lol):
+    def foo(self):
+        return 'foo'
 
 class Echo(s_base.Base):
     def echo(self, args):
@@ -41,6 +39,17 @@ class ReflectTest(s_t_utils.SynTest):
         names = s_reflect.getClsNames(foo)
         self.isin('synapse.tests.test_lib_reflect.Lol', names)
         self.isin('synapse.tests.test_lib_reflect.Foo', names)
+
+    def test_reflect_getMethName(self):
+        foo = Foo()
+        name = s_reflect.getMethName(foo.foo)
+        self.eq('synapse.tests.test_lib_reflect.Foo.foo', name)
+
+    def test_reflect_getItemLocals(self):
+        foo = Foo()
+        locls = s_reflect.getItemLocals(foo)
+        self.isin(('foo', foo.foo), locls)
+        self.isin(('lol', foo.lol), locls)
 
     async def test_telemeth(self):
         self.none(getattr(Echo, '_syn_sharinfo_synapse.tests.test_lib_reflect_Echo', None))

--- a/synapse/tests/test_tools_cryo_list.py
+++ b/synapse/tests/test_tools_cryo_list.py
@@ -1,0 +1,24 @@
+import synapse.tests.utils as s_t_utils
+import synapse.tools.cryo.list as s_cryolist
+
+class CryoListTest(s_t_utils.SynTest):
+
+    async def test_cryolist(self):
+
+        async with self.getTestCryo() as cryo:
+
+            items = [(None, {'key': i}) for i in range(20)]
+
+            tank = await cryo.init('hehe')
+            await tank.puts(items)
+
+            cryourl = cryo.getLocalUrl()
+
+            argv = [cryourl]
+            retn, outp = await self.execToolMain(s_cryolist.main, argv)
+
+            self.eq(0, retn)
+            outp.expect(cryourl)
+            outp.expect('hehe: ')
+            outp.expect("'indx': 20,")
+            outp.expect("'entries': 20}")

--- a/synapse/tools/cryo/list.py
+++ b/synapse/tools/cryo/list.py
@@ -25,6 +25,8 @@ def main(argv, outp=s_output.stdout):
 
                 outp.printf(f'    {name}: {info}')
 
+    return 0
+
 if __name__ == '__main__':  # pragma: no cover
     logging.basicConfig()
     sys.exit(main(sys.argv[1:]))

--- a/synapse/tools/hive/load.py
+++ b/synapse/tools/hive/load.py
@@ -54,5 +54,7 @@ async def main(argv, outp=s_output.stdout):
                 f'Please use a version of Synapse which supports {valu}; current version is {s_version.verstring}.')
             return 1
 
+    return 0
+
 if __name__ == '__main__':  # pragma: no cover
     sys.exit(asyncio.run(main(sys.argv[1:])))


### PR DESCRIPTION
- Updated `synapse.lib.cache.FixedCache.pop()` to remove the key from the fifo and the cache
- Updated `synapse.tests.test_lib_cache.py::CacheTest` to cover missing edge case in `synapse.lib.cache`
- Added test for `synapse.lib.reflect.getItemLocals()`
- Added test for `synapse.lib.reflect.getMethName()`
- Updated test for `synapse.tools.cryo.cat`:
  - Covered edge case for `--verbose`
  - Covered edge case for output when specifying `--msgpack`
- Created new test for `synapse.tools.cryo.list`
- Added check for synapse version check in:
  - `csvtool`
  - `hive.load`
  - `hive.save`
- Added `return 0` in `main()` of `cryo.list` and `hive.load` for consistent return values from tools
