### PR TITLE
Update FixedCache.put() to avoid cache miss on next get

### DIFF
--- a/synapse/lib/cache.py
+++ b/synapse/lib/cache.py
@@ -35,13 +35,12 @@ class FixedCache:
         return val
 
     def put(self, key, val):
+        while len(self.fifo) > self.size - 1:
+            delkey = self.fifo.popleft()
+            self.cache.pop(delkey, None)
 
         self.cache[key] = val
         self.fifo.append(key)
-
-        while len(self.fifo) > self.size:
-            key = self.fifo.popleft()
-            self.cache.pop(key, None)
 
     def get(self, key):
         if self.iscorocall:
@@ -55,13 +54,7 @@ class FixedCache:
         if valu is s_common.novalu:
             return valu
 
-        self.cache[key] = valu
-        self.fifo.append(key)
-
-        while len(self.fifo) > self.size:
-            key = self.fifo.popleft()
-            self.cache.pop(key, None)
-
+        self.put(key, valu)
         return valu
 
     async def aget(self, key):
@@ -76,13 +69,7 @@ class FixedCache:
         if valu is s_common.novalu:
             return valu
 
-        self.cache[key] = valu
-        self.fifo.append(key)
-
-        while len(self.fifo) > self.size:
-            key = self.fifo.popleft()
-            self.cache.pop(key, None)
-
+        self.put(key, valu)
         return valu
 
     def clear(self):
@@ -192,7 +179,7 @@ class TagGlobs:
             def fini():
                 try:
                     self.globs.remove(glob)
-                except ValueError:
+                except ValueError:  # pragma: no cover
                     pass
                 self.cache.clear()
             base.onfini(fini)

--- a/synapse/tests/test_lib_cache.py
+++ b/synapse/tests/test_lib_cache.py
@@ -64,11 +64,23 @@ class CacheTest(s_t_utils.SynTest):
         cache.put('BAR', 'BAR')
         cache.put('BAZ', 'BAZ')
 
-        self.eq(2, len(cache))
+        self.len(2, cache)
 
         self.eq('BAR', cache.get('BAR'))
         self.eq('BAZ', cache.get('BAZ'))
         self.eq('foo', cache.get('FOO'))
+
+        cache.clear()
+
+        self.eq('bar', cache.get('BAR'))
+        self.eq('baz', cache.get('BAZ'))
+
+        self.len(2, cache)
+
+        cache.put('BAR', 'BAZ')
+        self.eq('BAZ', cache.get('BAR'))
+
+        self.len(2, cache)
 
         def callback(name):
             return s_common.novalu


### PR DESCRIPTION
There was a possible use case where calling FixedCache.put() would cause
a cache miss on the next .get() of the same key. This behavior was very
situational and would only happen if .put() was called with the same key
that was at the end of the fifo.