### PR TITLE
Greedy ioloop working

### DIFF
--- a/synapse/glob.py
+++ b/synapse/glob.py
@@ -65,7 +65,7 @@ def initloop():
 
 def setGreedCoro(loop: asyncio.AbstractEventLoop):
     greedy_threshold = os.environ.get('SYN_GREEDY_CORO')
-    if greedy_threshold is not None:
+    if greedy_threshold is not None:  # pragma: no cover
         logger.info(f'Setting ioloop.slow_callback_duration to {greedy_threshold}')
         loop.set_debug(True)
         loop.slow_callback_duration = float(greedy_threshold)

--- a/synapse/glob.py
+++ b/synapse/glob.py
@@ -47,20 +47,25 @@ def initloop():
             _glob_loop = asyncio.get_running_loop()
             # if we get here, it's us!
             _glob_thrd = threading.currentThread()
+            # Enable debug and greedy coro collection
+            setGreedCoro(_glob_loop)
 
         except RuntimeError:
-
-            # otherwise, lets fire one...
             _glob_loop = asyncio.new_event_loop()
-            greedy_threshold = os.environ.get('SYN_GREEDY_CORO')
-            if greedy_threshold is not None:
-                _glob_loop.slow_callback_duration = float(greedy_threshold)
+            setGreedCoro(_glob_loop)
 
             _glob_thrd = threading.Thread(target=_glob_loop.run_forever, name='SynLoop')
             _glob_thrd.setDaemon(True)
             _glob_thrd.start()
 
     return _glob_loop
+
+def setGreedCoro(loop: asyncio.AbstractEventLoop):
+    greedy_threshold = os.environ.get('SYN_GREEDY_CORO')
+    if greedy_threshold is not None:
+        print(f'setting ioloop.slow_callback_duration to {greedy_threshold}')
+        loop.set_debug(True)
+        loop.slow_callback_duration = float(greedy_threshold)
 
 def iAmLoop():
     initloop()

--- a/synapse/glob.py
+++ b/synapse/glob.py
@@ -1,8 +1,11 @@
 import os
 import signal
 import asyncio
+import logging
 import threading
 import faulthandler
+
+logger = logging.getLogger(__name__)
 
 _glob_loop = None
 _glob_thrd = None
@@ -63,7 +66,7 @@ def initloop():
 def setGreedCoro(loop: asyncio.AbstractEventLoop):
     greedy_threshold = os.environ.get('SYN_GREEDY_CORO')
     if greedy_threshold is not None:
-        print(f'setting ioloop.slow_callback_duration to {greedy_threshold}')
+        logger.info(f'Setting ioloop.slow_callback_duration to {greedy_threshold}')
         loop.set_debug(True)
         loop.slow_callback_duration = float(greedy_threshold)
 


### PR DESCRIPTION
 - Re-enable the ``SYN_GREEDY_CORO`` flag
- Set the ioloop into debug mode when this is enabled

This should be considered for use in development/debugging, not for general production use.