### PR TITLE
Bug service permission check

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1131,6 +1131,9 @@ class Runtime:
     async def warn(self, mesg, **info):
         return await self.snap.warn(mesg, **info)
 
+    async def warnonce(self, mesg, **info):
+        return await self.snap.warnonce(mesg, **info)
+
     def tick(self):
         pass
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -390,11 +390,11 @@ class LibService(Lib):
         Returns:
             dict: A Storm Service definition.
         '''
-        self.runt.user.confirm(('service', 'get', name))
         ssvc = self.runt.snap.core.getStormSvc(name)
         if ssvc is None:
             mesg = f'No service with name/iden: {name}'
             raise s_exc.NoSuchName(mesg=mesg)
+        self.runt.user.confirm(('service', 'get', ssvc.iden))
         return ssvc
 
     async def _libSvcList(self):

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -347,6 +347,21 @@ class LibService(Lib):
             'wait': self._libSvcWait,
         }
 
+    async def _checkSvcGetPerm(self, ssvc):
+        '''
+        Helper to handle service.get.* permissions
+        '''
+        try:
+            self.runt.user.confirm(('service', 'get', ssvc.iden))
+        except s_exc.AuthDeny as e:
+            try:
+                self.runt.user.confirm(('service', 'get', ssvc.name))
+            except s_exc.AuthDeny as sub_e:
+                raise e from None
+            else:
+                mesg = 'Use of service.get.<servicename> permissions are deprecated.'
+                await self.runt.warn(mesg, svcname=ssvc.name, svciden=ssvc.iden)
+
     async def _libSvcAdd(self, name, url):
         '''
         Add a Storm Service to the Cortex.
@@ -394,7 +409,7 @@ class LibService(Lib):
         if ssvc is None:
             mesg = f'No service with name/iden: {name}'
             raise s_exc.NoSuchName(mesg=mesg)
-        self.runt.user.confirm(('service', 'get', ssvc.iden))
+        await self._checkSvcGetPerm(ssvc)
         return ssvc
 
     async def _libSvcList(self):
@@ -428,12 +443,11 @@ class LibService(Lib):
         Returns:
             True: When the service is ready.
         '''
-        self.runt.user.confirm(('service', 'get'))
         ssvc = self.runt.snap.core.getStormSvc(name)
         if ssvc is None:
             mesg = f'No service with name/iden: {name}'
             raise s_exc.NoSuchName(mesg=mesg, name=name)
-
+        await self._checkSvcGetPerm(ssvc)
         await ssvc.ready.wait()
 
 @registry.registerLib

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -360,7 +360,7 @@ class LibService(Lib):
                 raise e from None
             else:
                 mesg = 'Use of service.get.<servicename> permissions are deprecated.'
-                await self.runt.warn(mesg, svcname=ssvc.name, svciden=ssvc.iden)
+                await self.runt.warnonce(mesg, svcname=ssvc.name, svciden=ssvc.iden)
 
     async def _libSvcAdd(self, name, url):
         '''

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -585,7 +585,7 @@ class StormSvcTest(s_test.SynTest):
                     self.len(0, core.getStormSvcs())
                     # make sure all the dels ran, except for the BoomService (which should fail)
                     nodes = await core.nodes('inet:ipv4')
-                    ans = set(['1.2.3.4', '5.5.5.5', '6.6.6.6', '8.8.8.8', '123.123.123.123'])
+                    ans = {'1.2.3.4', '5.5.5.5', '6.6.6.6', '8.8.8.8', '123.123.123.123'}
                     reprs = set(map(lambda k: k.repr(), nodes))
                     self.eq(ans, reprs)
 

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -486,7 +486,7 @@ class StormSvcTest(s_test.SynTest):
                     with self.raises(s_exc.NoSuchStormSvc):
                         await core._runStormSvcAdd(s_common.guid())
 
-                    # # force a wait for command loads
+                    # force a wait for command loads
                     await core.nodes('$lib.service.wait(fake)')
                     await core.nodes('$lib.service.wait(prim)')
                     await core.nodes('$lib.service.wait(boom)')

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -463,7 +463,7 @@ class StormSvcTest(s_test.SynTest):
                 curl = f'tcp://127.0.0.1:{port}/lift'
                 durl = f'tcp://127.0.0.1:{port}/dead'
 
-                async with await s_cortex.Cortex.anit(dirn) as core:
+                async with self.getTestCore(dirn=dirn) as core:
 
                     await core.nodes(f'service.add fake {lurl}')
                     iden = core.getStormSvcs()[0].iden
@@ -542,7 +542,7 @@ class StormSvcTest(s_test.SynTest):
                     self.stormIsInPrint(f'svciden={iden}', msgs)
                     self.stormIsInPrint('key=valu', msgs)
 
-                async with await s_cortex.Cortex.anit(dirn) as core:
+                async with self.getTestCore(dirn=dirn) as core:
 
                     nodes = await core.nodes('$lib.service.wait(fake)')
                     nodes = await core.nodes('[ inet:ipv4=6.6.6.6 ] | ohhai')


### PR DESCRIPTION
- Fix how service permissions are handled in ``$lib.service.get()`` to validate against the service iden and not the name given to the function. The existing behavior is of checking against `service.get.<name>` is also preserved but now issues a warning instead.
- ``$lib.service.wait()`` now checks the full permission instead of just ``service.get``. This made it is so that a user that only has permissions for a single service can now wait on that service.
 - Misc test code tidiness.