### PR TITLE
Fix a nested nexus action in stormservice deletion

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,4 +1,5 @@
 -r requirements_dev.txt
+nbconvert==5.6.1
 sphinx>=1.8.2,<2.0.0
 jupyter>=1.0.0,<2.0.0
 hide-code>=0.5.2,<0.5.3

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1581,7 +1581,7 @@ class Cortex(s_cell.Cell):  # type: ignore
 
         opts = {'vars': {'cmdconf': {'svciden': iden}}}
         coro = s_common.aspin(self.storm(evnt, opts=opts))
-        if name is 'add':
+        if name == 'add':
             await coro
         else:
             self.schedCoro(coro)

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1568,6 +1568,8 @@ class Cortex(s_cell.Cell):  # type: ignore
         await self.svchive.set(iden, sdef)
 
     async def runStormSvcEvent(self, iden, name):
+        assert name in ('add', 'del')
+
         sdef = self.svchive.get(iden)
         if sdef is None:
             mesg = f'No storm service with iden: {iden}'
@@ -1576,7 +1578,13 @@ class Cortex(s_cell.Cell):  # type: ignore
         evnt = sdef.get('evts', {}).get(name, {}).get('storm')
         if evnt is None:
             return
-        await s_common.aspin(self.storm(evnt, opts={'vars': {'cmdconf': {'svciden': iden}}}))
+
+        opts = {'vars': {'cmdconf': {'svciden': iden}}}
+        coro = s_common.aspin(self.storm(evnt, opts=opts))
+        if name is 'add':
+            await coro
+        else:
+            self.schedCoro(coro)
 
     async def _setStormSvc(self, sdef):
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -1444,13 +1444,13 @@ class Queue(StormType):
         if size is not None:
             size = await toint(size)
 
-        todo = s_common.todo('coreQueueGets', self.name, offs, wait=wait, size=size)
+        todo = s_common.todo('coreQueueGets', self.name, offs, cull=cull, wait=wait, size=size)
         gatekeys = self._getGateKeys('get')
 
         async for item in self.runt.dyniter('cortex', todo, gatekeys=gatekeys):
             yield item
 
-    async def _methQueuePuts(self, items, wait=False):
+    async def _methQueuePuts(self, items):
         todo = s_common.todo('coreQueuePuts', self.name, items)
         gatekeys = self._getGateKeys('put')
         return await self.runt.dyncall('cortex', todo, gatekeys=gatekeys)

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -612,7 +612,7 @@ class StormSvcTest(s_test.SynTest):
                     self.none(core.getStormCmd('ohhai'))
 
                     # ensure del event ran
-                    q = 'for ($offs, $mesg) in $lib.queue.get(vertex).gets(wait=10) {return (($offs, $mesg))}'
+                    q = 'for ($o, $m) in $lib.queue.get(vertex).gets(wait=10) {return (($o, $m))}'
                     retn = await core.callStorm(q)
                     self.eq(retn, (0, 'done'))
 
@@ -834,11 +834,11 @@ class StormSvcTest(s_test.SynTest):
 
                         # Make sure it got removed from both
                         self.none(core00.getStormCmd('ohhai'))
-                        queue = core00.multiqueue.list()
-                        self.len(0, queue)
-                        self.notin('foo.bar', core00.stormmods)
+                        q = 'for ($o, $m) in $lib.queue.get(vertex).gets(wait=10) {return (($o, $m))}'
+                        retn = await core00.callStorm(q)
+                        self.eq(retn, (0, 'done'))
 
                         self.none(core01.getStormCmd('ohhai'))
-                        queue = core01.multiqueue.list()
-                        self.len(0, queue)
-                        self.notin('foo.bar', core01.stormmods)
+                        q = 'for ($o, $m) in $lib.queue.get(vertex).gets(wait=10) {return (($o, $m))}'
+                        retn = await core01.callStorm(q)
+                        self.eq(retn, (0, 'done'))

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -159,7 +159,7 @@ class RealService(s_stormsvc.StormSvc):
             'storm': '$lib.queue.add(vertex)',
         },
         'del': {
-            'storm': '$lib.queue.del(vertex)',
+            'storm': '$que=$lib.queue.get(vertex) $que.put(done)',
         },
     }
 
@@ -611,9 +611,10 @@ class StormSvcTest(s_test.SynTest):
                     # make sure stormcmd got deleted
                     self.none(core.getStormCmd('ohhai'))
 
-                    # ensure fini ran
-                    queue = core.multiqueue.list()
-                    self.len(0, queue)
+                    # ensure del event ran
+                    q = 'for ($offs, $mesg) in $lib.queue.get(vertex).gets(wait=10) {return (($offs, $mesg))}'
+                    retn = await core.callStorm(q)
+                    self.eq(retn, (0, 'done'))
 
                     # specifically call teardown
                     for svc in core.getStormSvcs():


### PR DESCRIPTION
For service deletion, spin the del event storm commmand off in a schedcoro so it is out of line with the bottom half of the nexus function. This changes the del event semantics by executing a del handler without the presence of the supporting package, but breaks a nested nexus loop action.