### PR TITLE
Resolve issue where a spawn process' slab fails

### DIFF
--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -815,6 +815,7 @@ class Slab(s_base.Base):
                 continue
             break
 
+        self.dirty = False
         self.lenv.close()
         self.allslabs.pop(self.path, None)
         del self.lenv

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -998,6 +998,10 @@ class Slab(s_base.Base):
                 return name
             except lmdb.MapFullError:
                 self._handle_mapfull()
+            except lmdb.MapResizedError:
+                # This can only happen if readonly and another process added data (e.g. cortex spawn)
+                # _initCoXact knows the magic to resolve this
+                self._initCoXact()
 
     def dropdb(self, name):
         '''

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -921,7 +921,7 @@ class LmdbSlabTest(s_t_utils.SynTest):
 
                 proc = mpctx.Process(target=self.make_slab, args=(path,))
                 proc.start()
-                proc.join(3)
+                proc.join(10)
                 self.nn(proc.exitcode)
                 slab.initdb('foo')
                 self.true(True)

--- a/synapse/tests/test_lib_spawn.py
+++ b/synapse/tests/test_lib_spawn.py
@@ -31,7 +31,7 @@ def make_core(dirn, conf, queries, queue, event):
             for q in queries:
                 await core.nodes(q)
 
-            await  core.view.layers[0].layrslab.sync()
+            await core.view.layers[0].layrslab.sync()
 
             spawninfo = await core.getSpawnInfo()
             queue.put(spawninfo)

--- a/synapse/tests/test_lib_spawn.py
+++ b/synapse/tests/test_lib_spawn.py
@@ -541,7 +541,7 @@ class CoreSpawnTest(s_test.SynTest):
 
                     # Ensure the spawncore loaded the service
                     coro = prox.storm('$lib.service.wait(real)', opts).list()
-                    msgs = await asyncio.wait_for(coro, 12)
+                    msgs = await asyncio.wait_for(coro, 30)
 
                     msgs = await prox.storm('help', opts=opts).list()
                     self.stormIsInPrint('foobar', msgs)


### PR DESCRIPTION
Previously, if a main process' slab mapsize increases, any existing spawn processes (which have the same slabs open readonly) would get a lmdb.MapResizedError when calling slab.initdb.

Now, initdb correctly handles that case.