### PR TITLE
Revise activeCoro API, et al

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -3156,7 +3156,7 @@ class Cortex(s_cell.Cell):  # type: ignore
                 async with await s_telepath.openurl(url) as proxy:
                     await self._pushBulkEdits(layr, proxy, pdef)
 
-        await self.addActiveCoro(push, iden=iden)
+        self.addActiveCoro(push, iden=iden)
 
     async def runLayrPull(self, layr, pdef):
         url = pdef.get('url')
@@ -3168,7 +3168,7 @@ class Cortex(s_cell.Cell):  # type: ignore
                 async with await s_telepath.openurl(url) as proxy:
                     await self._pushBulkEdits(proxy, layr, pdef)
 
-        await self.addActiveCoro(pull, iden=iden)
+        self.addActiveCoro(pull, iden=iden)
 
     async def _pushBulkEdits(self, layr0, layr1, pdef):
 
@@ -3216,7 +3216,7 @@ class Cortex(s_cell.Cell):  # type: ignore
                     await self.setStormVar(gvar, offs)
 
     async def _checkNexsIndx(self):
-        layroffs = [await layr.getNodeEditOffset() for layr in self.layers.values()]
+        layroffs = [await layr.getEditIndx() for layr in self.layers.values()]
         if layroffs:
             maxindx = max(layroffs)
             if maxindx > await self.getNexsIndx():

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -911,7 +911,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         Args:
             func (coroutine function): The function run as a coroutine.
             iden (str): The iden to use for the coroutine.
-            base (Optional[Base]):  if present, this active coro will be fini'd whe
+            base (Optional[Base]):  if present, this active coro will be fini'd
                                     when the base is fini'd
 
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -904,13 +904,16 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         except Exception as e: # pragma: no cover
             logger.warning(f'_setAhaActive failed: {e}')
 
-    async def addActiveCoro(self, func, iden=None):
+    def addActiveCoro(self, func, iden=None, base=None):
         '''
         Add a function callback to be run as a coroutine when the Cell is active.
 
         Args:
             func (coroutine function): The function run as a coroutine.
             iden (str): The iden to use for the coroutine.
+            base (Optional[Base]):  if present, this active coro will be fini'd whe
+                                    when the base is fini'd
+
 
         Returns:
             str: A GUID string that identifies the coroutine for delActiveCoro()
@@ -918,75 +921,78 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         NOTE:
             This will re-fire the coroutine if it exits and the Cell is still active.
         '''
+        if base and base.isfini:
+            raise s_exc.IsFini()
 
         if iden is None:
             iden = s_common.guid()
 
-        cdef = {'func': func}
+        cdef = {'func': func, 'base': base}
         self.activecoros[iden] = cdef
 
+        if base:
+            async def fini():
+                await self.delActiveCoro(iden)
+            base.onfini(fini)
+
         if self.isactive:
-            await self._fireActiveCoro(iden, cdef)
+            self._fireActiveCoro(iden, cdef)
 
         return iden
 
     async def delActiveCoro(self, iden):
         '''
-        Remove a callback previously added with addActiveCoro().
+        Remove an Active coroutine previously added with addActiveCoro().
 
         Args:
-            iden (str): The GUID returned by addActiveCoro()
+            iden (str): The iden returned by addActiveCoro()
         '''
-
-        cent = self.activecoros.pop(iden, None)
-        if cent is None:
+        cdef = self.activecoros.pop(iden, None)
+        if cdef is None:
             return
 
-        task = cent.get('task')
-        if task is not None:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            except Exception as e:
-                logger.warning(f'delActiveCoro Task: {e}')
+        await self._killActiveCoro(cdef)
 
-    async def _fireActiveCoros(self):
+    def _fireActiveCoros(self):
         for iden, cdef in self.activecoros.items():
-            await self._fireActiveCoro(iden, cdef)
+            self._fireActiveCoro(iden, cdef)
 
-    async def _fireActiveCoro(self, iden, cdef):
+    def _fireActiveCoro(self, iden, cdef):
         func = cdef.get('func')
+
         async def wrap():
             while not self.isfini:
                 try:
                     await func()
                 except asyncio.CancelledError:
                     raise
-                except Exception as e:
-                    logger.warning(f'activeCoro Error: {func} {e}')
+                except Exception:  # pragma no cover
+                    logger.exception(f'activeCoro Error: {func}')
                     await asyncio.sleep(1)
 
         cdef['task'] = self.schedCoro(wrap())
 
     async def _killActiveCoros(self):
         for cdef in self.activecoros.values():
-            task = cdef.pop('task', None)
-            if task is not None:
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
-                except Exception as e: # pragma: no cover
-                    logger.warning(f'killActiveCoros Task: {e}')
+            await self._killActiveCoro(cdef)
+
+    async def _killActiveCoro(self, cdef):
+        task = cdef.pop('task', None)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+                task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception: # pragma: no cover
+                logger.exception('activeCoro in _killActiveCoros')
 
     async def setCellActive(self, active):
         self.isactive = active
 
         if self.isactive:
-            await self._fireActiveCoros()
+            self._fireActiveCoros()
             await self._execCellUpdates()
             await self.initServiceActive()
         else:

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -983,7 +983,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             try:
                 await task
                 task.result()
-            except asyncio.CancelledError:
+            except asyncio.CancelledError:  # pragma:  no cover
                 pass
             except Exception: # pragma: no cover
                 logger.exception('activeCoro in _killActiveCoros')

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -169,11 +169,6 @@ class LayerApi(s_cell.CellApi):
         await self._reqUserAllowed(self.liftperm)
         return await self.layr.getEditIndx()
 
-    async def getNodeEditOffset(self):
-        s_common.deprecated('getNodeEditOffset')  # changed method name
-        await self._reqUserAllowed(self.liftperm)
-        return await self.layr.getEditIndx()
-
     async def getIden(self):
         await self._reqUserAllowed(self.liftperm)
         return self.layr.iden

--- a/synapse/lib/task.py
+++ b/synapse/lib/task.py
@@ -61,8 +61,10 @@ class Task(s_base.Base):
 
         try:
             await self.task
-        except (asyncio.CancelledError, Exception):
+        except asyncio.CancelledError:
             pass
+        except Exception:  # pragma:  no cover
+            logger.exception('Task completed with exception')
 
         if self.root is not None:
             self.root.kids.pop(self.iden)

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -3,6 +3,7 @@ An RMI framework for synapse.
 '''
 
 import os
+import time
 import asyncio
 import logging
 import collections
@@ -834,6 +835,7 @@ class Client(s_base.Base):
         self.schedCoro(self._teleLinkLoop())
 
     async def _teleLinkLoop(self):
+        lastlog = 0.0
 
         while not self.isfini:
 
@@ -852,7 +854,10 @@ class Client(s_base.Base):
                 raise
 
             except Exception as e:
-                logger.warning(f'telepath client ({s_urlhelp.sanitizeUrl(url)}): {e}')
+                now = time.monotonic()
+                if now > lastlog + 60.0:  # don't logspam the disconnect message more than 1/min
+                    logger.info(f'telepath client ({s_urlhelp.sanitizeUrl(url)}): {e}')
+                    lastlog = now
                 await self.waitfini(timeout=self._t_conf.get('retrysleep', 0.2))
 
     async def proxy(self, timeout=10):

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -3011,7 +3011,7 @@ class CortexBasicTest(s_t_utils.SynTest):
             await self.agenlen(0, layr.splices())
             await self.agenlen(0, layr.splicesBack())
             await self.agenlen(0, layr.syncNodeEdits(0))
-            self.eq(0, await layr.getNodeEditOffset())
+            self.eq(0, await layr.getEditIndx())
 
             self.nn(await core.stat())
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -760,7 +760,7 @@ class CellTest(s_t_utils.SynTest):
             async with await s_cell.Cell.anit(dirn) as cell:
 
                 # Note: cell starts active, so coro should immediate run
-                iden = cell.addActiveCoro(coro)
+                cell.addActiveCoro(coro)
 
                 async def step():
                     await asyncio.wait_for(evt0.wait(), timeout=2)
@@ -785,6 +785,8 @@ class CellTest(s_t_utils.SynTest):
                     self.len(2, cell.activecoros)
 
                 self.len(1, cell.activecoros)
+
+                self.raises(s_exc.IsFini, cell.addActiveCoro, coro, base=base)
 
                 # now deactivate and it gets cancelled
                 await cell.setCellActive(False)

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -82,7 +82,7 @@ class LayerTest(s_t_utils.SynTest):
                     await core01.view.addLayer(layr.iden)
 
                     # test initial sync
-                    offs = await core00.getView().layers[0].getNodeEditOffset()
+                    offs = await core00.getView().layers[0].getEditIndx()
                     evnt = await layr.waitUpstreamOffs(layriden, offs)
                     await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -102,14 +102,14 @@ class LayerTest(s_t_utils.SynTest):
                     # make sure updates show up
                     await core00.nodes('[ inet:fqdn=vertex.link ]')
 
-                    offs = await core00.getView().layers[0].getNodeEditOffset()
+                    offs = await core00.getView().layers[0].getEditIndx()
                     evnt = await layr.waitUpstreamOffs(layriden, offs)
                     await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
                     self.len(1, await core01.nodes('inet:fqdn=vertex.link'))
 
                 await core00.nodes('[ inet:ipv4=5.5.5.5 ]')
-                offs = await core00.getView().layers[0].getNodeEditOffset()
+                offs = await core00.getView().layers[0].getEditIndx()
 
                 # test what happens when we go down and come up again...
                 async with self.getTestCore(dirn=path01) as core01:
@@ -123,7 +123,7 @@ class LayerTest(s_t_utils.SynTest):
 
                     await core00.nodes('[ inet:ipv4=5.6.7.8 ]')
 
-                    offs = await core00.getView().layers[0].getNodeEditOffset()
+                    offs = await core00.getView().layers[0].getEditIndx()
                     evnt = await layr.waitUpstreamOffs(layriden, offs)
                     await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -169,7 +169,7 @@ class LayerTest(s_t_utils.SynTest):
                     layr = core01.getLayer(ldef.get('iden'))
 
                     # Sync core01 with core00
-                    offs = await core00.getView().layers[0].getNodeEditOffset()
+                    offs = await core00.getView().layers[0].getEditIndx()
                     evnt = await layr.waitUpstreamOffs(layriden, offs)
                     await asyncio.wait_for(evnt.wait(), timeout=8.0)
 
@@ -222,7 +222,7 @@ class LayerTest(s_t_utils.SynTest):
                         await core02.view.addLayer(layr.iden)
 
                         # core00 is synced
-                        offs = await core00.getView().layers[0].getNodeEditOffset()
+                        offs = await core00.getView().layers[0].getEditIndx()
                         evnt = await layr.waitUpstreamOffs(iden00, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -232,7 +232,7 @@ class LayerTest(s_t_utils.SynTest):
                         self.nn(nodes[0].tags.get('hehe.haha'))
 
                         # core01 is synced
-                        offs = await core01.getView().layers[0].getNodeEditOffset()
+                        offs = await core01.getView().layers[0].getEditIndx()
                         evnt = await layr.waitUpstreamOffs(iden01, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -244,7 +244,7 @@ class LayerTest(s_t_utils.SynTest):
                         # updates from core00 show up
                         await core00.nodes('[ inet:fqdn=vertex.link ]')
 
-                        offs = await core00.getView().layers[0].getNodeEditOffset()
+                        offs = await core00.getView().layers[0].getEditIndx()
                         evnt = await layr.waitUpstreamOffs(iden00, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -253,7 +253,7 @@ class LayerTest(s_t_utils.SynTest):
                         # updates from core01 show up
                         await core01.nodes('[ inet:fqdn=google.com ]')
 
-                        offs = await core01.getView().layers[0].getNodeEditOffset()
+                        offs = await core01.getView().layers[0].getEditIndx()
                         evnt = await layr.waitUpstreamOffs(iden01, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -268,14 +268,14 @@ class LayerTest(s_t_utils.SynTest):
                         layr = core02.getView().layers[-1]
 
                         # test we catch up to core00
-                        offs = await core00.getView().layers[0].getNodeEditOffset()
+                        offs = await core00.getView().layers[0].getEditIndx()
                         evnt = await layr.waitUpstreamOffs(iden00, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
                         self.len(1, await core02.nodes('inet:ipv4=5.5.5.5'))
 
                         # test we catch up to core01
-                        offs = await core01.getView().layers[0].getNodeEditOffset()
+                        offs = await core01.getView().layers[0].getEditIndx()
                         evnt = await layr.waitUpstreamOffs(iden01, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -284,7 +284,7 @@ class LayerTest(s_t_utils.SynTest):
                         # test we get updates from core00
                         await core00.nodes('[ inet:ipv4=5.6.7.8 ]')
 
-                        offs = await core00.getView().layers[0].getNodeEditOffset()
+                        offs = await core00.getView().layers[0].getEditIndx()
                         evnt = await layr.waitUpstreamOffs(iden00, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 
@@ -293,7 +293,7 @@ class LayerTest(s_t_utils.SynTest):
                         # test we get updates from core01
                         await core01.nodes('[ inet:ipv4=8.7.6.5 ]')
 
-                        offs = await core01.getView().layers[0].getNodeEditOffset()
+                        offs = await core01.getView().layers[0].getEditIndx()
                         evnt = await layr.waitUpstreamOffs(iden01, offs)
                         await asyncio.wait_for(evnt.wait(), timeout=2.0)
 

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -1240,6 +1240,18 @@ class LayerTest(s_t_utils.SynTest):
             layr = await s_layer.Layer.anit(layrinfo, dirn)
             self.true(layr.logedits)
 
+    async def test_layer_no_logedits(self):
+
+        with self.getTestDir() as dirn:
+
+            layrinfo = {
+                'logedits': False
+            }
+            layr = await s_layer.Layer.anit(layrinfo, dirn)
+            self.false(layr.logedits)
+
+            self.eq(-1, await layr.getEditOffs())
+
     async def test_layer_iter_props(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_nexus.py
+++ b/synapse/tests/test_lib_nexus.py
@@ -145,7 +145,7 @@ class NexusTest(s_t_utils.SynTest):
         async with self.getRegrCore('migrated-nexuslog') as core00:
 
             nexsindx = await core00.getNexsIndx()
-            layrindx = max([await layr.getNodeEditOffset() for layr in core00.layers.values()])
+            layrindx = max([await layr.getEditIndx() for layr in core00.layers.values()])
             self.eq(nexsindx, layrindx)
 
             # Make sure a mirror gets updated to the correct index
@@ -156,7 +156,7 @@ class NexusTest(s_t_utils.SynTest):
 
                 await core01.sync()
 
-                layrindx = max([await layr.getNodeEditOffset() for layr in core01.layers.values()])
+                layrindx = max([await layr.getEditIndx() for layr in core01.layers.values()])
                 self.eq(nexsindx, layrindx)
 
             # Can only move index forward
@@ -167,5 +167,5 @@ class NexusTest(s_t_utils.SynTest):
         async with self.getRegrCore('migrated-nexuslog', conf=nologconf) as core:
 
             nexsindx = await core.getNexsIndx()
-            layrindx = max([await layr.getNodeEditOffset() for layr in core.layers.values()])
+            layrindx = max([await layr.getEditIndx() for layr in core.layers.values()])
             self.eq(nexsindx, layrindx)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1536,7 +1536,7 @@ class StormTest(s_t_utils.SynTest):
                         await asvisi.callStorm(f'$lib.layer.get($layr2).delPull(hehe)', opts=opts)
 
                 actv = len(core.activecoros)
-                #view0 -push-> view1 <-pull- view2
+                # view0 -push-> view1 <-pull- view2
                 await core.callStorm(f'$lib.layer.get($layr0).addPush("tcp://root:secret@127.0.0.1:{port}/*/layer/{layr1}")', opts=opts)
                 await core.callStorm(f'$lib.layer.get($layr2).addPull("tcp://root:secret@127.0.0.1:{port}/*/layer/{layr1}")', opts=opts)
 
@@ -1550,7 +1550,7 @@ class StormTest(s_t_utils.SynTest):
                 self.len(1, [t for t in tasks if t.get('name').startswith('layer pull:')])
                 self.len(1, [t for t in tasks if t.get('name').startswith('layer push:')])
 
-                offs = await core.layers.get(layr2).getEditOffs(defv=-1)
+                offs = await core.layers.get(layr2).getEditOffs()
                 await core.nodes('[ ps:contact=* ]', opts={'view': view0})
                 await core.layers.get(layr2).waitEditOffs(offs + 1, timeout=3)
                 self.len(1, await core.nodes('ps:contact', opts={'view': view2}))
@@ -1564,7 +1564,7 @@ class StormTest(s_t_utils.SynTest):
 
                 await asyncio.sleep(0)
 
-                offs = await core.layers.get(layr2).getEditOffs(defv=-1)
+                offs = await core.layers.get(layr2).getEditOffs()
                 await core.nodes('[ ps:contact=* ]', opts={'view': view0})
                 await core.layers.get(layr2).waitEditOffs(offs + 1, timeout=3)
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -1898,7 +1898,7 @@ class StormTypesTest(s_test.SynTest):
                 url = core2.getLocalUrl('*/layer')
 
                 layriden = core2.view.layers[0].iden
-                offs = await core2.view.layers[0].getNodeEditOffset()
+                offs = await core2.view.layers[0].getEditIndx()
 
                 layers = set(core.layers.keys())
                 q = f'layer.add --upstream {url}'


### PR DESCRIPTION
De-async unnecessary async activeCoro methods on cell.  Refactor killing an activeCoro a tad.

Rename layer.getNodeEditOffset to getEditIndx to conform to new convention.

Add a base parameter to addActiveCoro to facilitate auto-delete.

Remove now-implicit defv argument to layer.getEditOffs.

Reduce telepath.Client logspam.