### PR TITLE
Add missing toprim/tostr calls for whois guid generation.

### DIFF
--- a/synapse/lib/stormwhois.py
+++ b/synapse/lib/stormwhois.py
@@ -31,7 +31,8 @@ class LibWhois(s_stormtypes.Lib):
         Raises:
             StormRuntimeError: If form is not supported in this method
         '''
-
+        form = await s_stormtypes.tostr(form)
+        props = await s_stormtypes.toprim(props)
         if form == 'iprec':
             guid_props = ('net4', 'net6', 'asof', 'id')
         elif form == 'ipcontact':

--- a/synapse/tests/test_lib_stormwhois.py
+++ b/synapse/tests/test_lib_stormwhois.py
@@ -26,6 +26,12 @@ class StormWhoisTest(s_test.SynTest):
             guid_exp = s_common.guid(sorted((props['net4'], str(props['asof']), props['id'])))
             self.len(1, await core.nodes(f'inet:whois:iprec={guid_exp}'))
 
+            stormcmd = '''$props=$lib.dict(net4="10.0.0.0/28", asof=(2554869000000), id='NET-10-0-0-0-1', status=validated)
+            return ($lib.inet.whois.guid($props, 'iprec'))
+            '''
+            guid = await core.callStorm(stormcmd)
+            self.eq(guid_exp, guid)
+
             # contact
             pscontact = s_common.guid()
             props = {


### PR DESCRIPTION
Add toprim/tostr calls to _whoisGuid() to allow heavy Dict objects to be hashed.