### PR TITLE
Fix lookup mode with valid substrings

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -207,19 +207,20 @@ class Lookup(Query):
 
             for kid in self.kids[0]:
                 tokn = await kid.compute(runt, None)
-                for form, _, _ in s_scrape.scrape_types:
-                    regx = s_scrape.regexes.get(form)
-                    if regx.match(tokn):
+                for form, valu in s_scrape.scrape(tokn):
+                    # restrict to only full matches
+                    if valu != tokn:
+                        continue
 
-                        if self.autoadd:
-                            node = await runt.snap.addNode(form, tokn)
+                    if self.autoadd:
+                        node = await runt.snap.addNode(form, tokn)
+                        yield node, runt.initPath(node)
+
+                    else:
+                        norm, info = runt.model.form(form).type.norm(tokn)
+                        node = await runt.snap.getNodeByNdef((form, norm))
+                        if node is not None:
                             yield node, runt.initPath(node)
-
-                        else:
-                            norm, info = runt.model.form(form).type.norm(tokn)
-                            node = await runt.snap.getNodeByNdef((form, norm))
-                            if node is not None:
-                                yield node, runt.initPath(node)
 
         realgenr = lookgenr()
         if len(self.kids) > 1:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -5029,3 +5029,12 @@ class CortexBasicTest(s_t_utils.SynTest):
             layr = core.getView().layers[0].iden
             visi = await core.auth.addUser('visi')
             visi.confirm(('layer', 'read'), gateiden=layr)
+
+    async def test_cortex_lookup_mode(self):
+        async with self.getTestCoreAndProxy() as (_core, proxy):
+            retn = await proxy.count('[inet:email=foo.com@vertex.link]')
+            self.eq(1, retn)
+
+            opts = {'mode': 'lookup'}
+            retn = await proxy.count('foo.com@vertex.link', opts=opts)
+            self.eq(1, retn)


### PR DESCRIPTION
In lookup (or autoadd) mode, when the string contains a substring that can be scraped the full string is used with the matching substring form, which then causes a norming error.  This change restricts lookup parsing to only include full matches.