### PR TITLE
Backup quality of life

### DIFF
--- a/synapse/lib/boss.py
+++ b/synapse/lib/boss.py
@@ -27,6 +27,14 @@ class Boss(s_base.Base):
     async def promote(self, name, user, info=None):
         '''
         Promote the currently running task.
+
+        Args:
+            name (str): The name of the task.
+            user: The User who owns the task.
+            info: An optional information dictionary containing information about the task.
+
+        Returns:
+            s_task.Task: The Synapse Task object.
         '''
         task = asyncio.current_task()
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1354,6 +1354,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             raise
 
         finally:
+            logger.debug(f'iterBackupArchive completed for {name}')
             raise s_exc.DmonSpawn(mesg=mesg)
 
     async def iterNewBackupArchive(self, user, name=None, remove=False):

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -99,8 +99,10 @@ async def _doIterBackup(path, chunksize=1024):
     while True:
         byts = await link0.recv(chunksize)
         if not byts:
-            return
+            break
         yield byts
+
+    await coro
 
 async def _iterBackupWork(path, linkinfo, done):
     '''

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1254,6 +1254,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         '''
         (In a separate process) Actually do the backup
         '''
+        # This logging call is okay to run since we're executing in
+        # our own process space and no logging has been configured.
         s_common.setlogging(logger, loglevel)
         pipe.send('ready')
         data = pipe.recv()
@@ -1371,7 +1373,6 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             link = s_scope.get('link')
             linkinfo = await link.getSpawnInfo()
             linkinfo['loglevel'] = logger.getEffectiveLevel()
-            logger.info(linkinfo)
 
             await self.boss.promote('backup:stream', user=user)
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -103,6 +103,7 @@ async def _doIterBackup(path, chunksize=1024):
         yield byts
 
     await coro
+    await link0.fini()
 
 async def _iterBackupWork(path, linkinfo, done):
     '''
@@ -1311,7 +1312,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         cellguid = os.path.join(path, 'cell.guid')
         if not os.path.isfile(cellguid):
             mesg = 'Specified backup path has no cell.guid file.'
-            raise s_exc.BadArg(mesg=mesg)
+            raise s_exc.BadArg(mesg=mesg, arg='path', valu=path)
 
         link = s_scope.get('link')
         linkinfo = await link.getSpawnInfo()
@@ -1407,7 +1408,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         finally:
             if remove:
+                logger.debug(f'Removing {path}')
                 await s_coro.executor(shutil.rmtree, path, ignore_errors=True)
+                logger.debug(f'Removed {path}')
+            logger.debug(f'iterNewBackupArchive completed for {name}')
             raise s_exc.DmonSpawn(mesg=mesg)
 
     async def isUserAllowed(self, iden, perm, gateiden=None):

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -126,6 +126,10 @@ def _iterBackupProc(path, linkinfo, done):
     '''
     Multiprocessing target for streaming a backup.
     '''
+    # This logging call is okay to run since we're executing in
+    # our own process space and no logging has been configured.
+    s_common.setlogging(logger, linkinfo.get('loglevel'))
+
     asyncio.run(_iterBackupWork(path, linkinfo, done))
 
 class CellApi(s_base.Base):
@@ -1228,7 +1232,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             retn = await s_coro.executor(waitforproc)
 
         except (asyncio.CancelledError, Exception):
-            logger.exception('Error performing backup to [{dirn}]')
+            logger.exception(f'Error performing backup to [{dirn}]')
             proc.terminate()
             raise
 
@@ -1299,6 +1303,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         link = s_scope.get('link')
         linkinfo = await link.getSpawnInfo()
+        linkinfo['loglevel'] = logger.getEffectiveLevel()
 
         await self.boss.promote('backup:stream', user=user)
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1171,7 +1171,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             task.add_done_callback(functools.partial(done, self))
 
             if wait:
-                logger.info(f'Waiting for backup to complete [{name}]')
+                logger.info(f'Waiting for backup task to complete [{name}]')
                 await task
 
             return name
@@ -1317,7 +1317,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         linkinfo = await link.getSpawnInfo()
         linkinfo['loglevel'] = logger.getEffectiveLevel()
 
-        await self.boss.promote('backup:stream', user=user)
+        await self.boss.promote('backup:stream', user=user, info={'name': name})
 
         ctx = multiprocessing.get_context('spawn')
         done = ctx.Queue()
@@ -1374,7 +1374,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             linkinfo = await link.getSpawnInfo()
             linkinfo['loglevel'] = logger.getEffectiveLevel()
 
-            await self.boss.promote('backup:stream', user=user)
+            await self.boss.promote('backup:stream', user=user, info={'name': name})
 
             ctx = multiprocessing.get_context('spawn')
             done = ctx.Queue()

--- a/synapse/lib/stormsvc.py
+++ b/synapse/lib/stormsvc.py
@@ -200,9 +200,9 @@ class StormSvcClient(s_base.Base, s_stormtypes.Proxy):
             await self.proxy.waitready()
             return await s_stormtypes.Proxy.deref(self, name)
         except asyncio.TimeoutError:
-            mesg = 'Timeout waiting for storm service'
-            raise s_exc.StormRuntimeError(mesg=mesg, name=name) from None
+            mesg = f'Timeout waiting for storm service {self.name}.{name}'
+            raise s_exc.StormRuntimeError(mesg=mesg, name=name, service=self.name) from None
         except AttributeError as e:  # pragma: no cover
             # possible client race condition seen in the real world
-            mesg = f'Error dereferencing storm service - {str(e)}'
-            raise s_exc.StormRuntimeError(mesg=mesg, name=name) from None
+            mesg = f'Error dereferencing storm service - {self.name}.{name} - {str(e)}'
+            raise s_exc.StormRuntimeError(mesg=mesg, name=name, service=self.name) from None

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -18,14 +18,14 @@ import synapse.lib.link as s_link
 import synapse.tests.utils as s_t_utils
 
 # Defective versions of spawned backup processes
-def _sleeperProc(pipe, srcdir, dstdir, lmdbpaths):
+def _sleeperProc(pipe, srcdir, dstdir, lmdbpaths, loglevel):
     time.sleep(3.0)
 
-def _sleeper2Proc(pipe, srcdir, dstdir, lmdbpaths):
+def _sleeper2Proc(pipe, srcdir, dstdir, lmdbpaths, loglevel):
     pipe.send('ready')
     time.sleep(2.0)
 
-def _exiterProc(pipe, srcdir, dstdir, lmdbpaths):
+def _exiterProc(pipe, srcdir, dstdir, lmdbpaths, loglevel):
     pipe.send('ready')
     pipe.send('captured')
     sys.exit(1)

--- a/synapse/tools/backup.py
+++ b/synapse/tools/backup.py
@@ -57,7 +57,7 @@ def capturelmdbs(srcdir, skipdirs=None, onlydirs=None):
 
     with contextlib.ExitStack() as stack:
         for path in lmdbpaths:
-            logger.info(f'Capturing txn for {path}')
+            logger.debug(f'Capturing txn for {path}')
             datafile = os.path.join(path, 'data.mdb')
             stat = os.stat(datafile)
             map_size = stat.st_size

--- a/synapse/tools/backup.py
+++ b/synapse/tools/backup.py
@@ -45,9 +45,11 @@ def capturelmdbs(srcdir, skipdirs=None, onlydirs=None):
         if skipdirs is None:
             skipdirs = []
 
-        skipdirs.append('**/tmp')
+        srcdir = glob.escape(os.path.abspath(srcdir))
+        skipdirs.append(os.path.join(srcdir, 'tmp/*.lmdb'))
+        skipdirs.append(os.path.join(srcdir, '*/tmp/*.lmdb'))
 
-        srcdirglob = s_common.genpath(glob.escape(os.path.abspath(srcdir)), '**/*.lmdb')
+        srcdirglob = s_common.genpath(srcdir, '**/*.lmdb')
         fniter = glob.iglob(srcdirglob, recursive=True)
         lmdbpaths = [fn for fn in fniter if not any([fnmatch.fnmatch(fn, pattern) for pattern in skipdirs])]
 

--- a/synapse/tools/backup.py
+++ b/synapse/tools/backup.py
@@ -55,6 +55,7 @@ def capturelmdbs(srcdir, skipdirs=None, onlydirs=None):
 
     with contextlib.ExitStack() as stack:
         for path in lmdbpaths:
+            logger.info(f'Capturing txn for {path}')
             datafile = os.path.join(path, 'data.mdb')
             stat = os.stat(datafile)
             map_size = stat.st_size


### PR DESCRIPTION
- don't capture txns for lmdb slabs in tmp directories under the srcdir
- await the tarball coroutine and ensure the link is fini'd
- add logging statements through backup related routines
- push the main processes log level into multiprocessing processes