### PR TITLE
Reduce unit test memory usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,7 +511,7 @@ jobs:
       - test_steps_osx
 
   python37:
-    parallelism: 16
+    parallelism: 8
     docker:
       - image: circleci/python:3.7.9
         environment:
@@ -527,7 +527,7 @@ jobs:
       - test_steps_python
 
   python38:
-    parallelism: 16
+    parallelism: 8
     docker:
       - image: circleci/python:3.8
         environment:

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -4163,7 +4163,7 @@ class Cortex(s_cell.Cell):  # type: ignore
     async def stormlist(self, text, opts=None):
         return [m async for m in self.storm(text, opts=opts)]
 
-    @s_cache.memoize(size=10000)
+    @s_cache.memoizemethod(size=10000)
     def getStormQuery(self, text, mode='storm'):
         '''
         Parse storm query text and return a Query object.

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -91,7 +91,6 @@ class AstNode:
                 yield item
 
     def init(self, core):
-        self.core = core
         [k.init(core) for k in self.kids]
         self.prepare()
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1490,14 +1490,14 @@ class Layer(s_nexus.Pusher):
     async def getFormCounts(self):
         return self.formcounts.pack()
 
-    @s_cache.memoize()
+    @s_cache.memoizemethod()
     def getPropAbrv(self, form, prop):
         return self.propabrv.bytsToAbrv(s_msgpack.en((form, prop)))
 
     def setPropAbrv(self, form, prop):
         return self.propabrv.setBytsToAbrv(s_msgpack.en((form, prop)))
 
-    @s_cache.memoize()
+    @s_cache.memoizemethod()
     def getTagPropAbrv(self, *args):
         return self.tagpropabrv.bytsToAbrv(s_msgpack.en(args))
 

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -165,7 +165,7 @@ class SlabAbrv:
         if item is not None:
             self.offs = s_common.int64un(item[0]) + 1
 
-    @s_cache.memoize()
+    @s_cache.memoizemethod()
     def abrvToByts(self, abrv):
         byts = self.slab.get(abrv, db=self.abrv2name)
         if byts is None:
@@ -173,7 +173,7 @@ class SlabAbrv:
 
         return byts
 
-    @s_cache.memoize()
+    @s_cache.memoizemethod()
     def bytsToAbrv(self, byts):
         abrv = self.slab.get(byts, db=self.name2abrv)
         if abrv is None:

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -44,7 +44,7 @@ class Scrubber:
 
         return pode
 
-    @s_cache.memoize()
+    @s_cache.memoizemethod()
     def _isTagInc(self, tag):
         if tag in self.inctags:
             return True

--- a/synapse/lib/stormlib/model.py
+++ b/synapse/lib/stormlib/model.py
@@ -325,19 +325,19 @@ class LibModel(s_stormtypes.Lib):
             'tagprop': self._methTagProp,
         }
 
-    @s_cache.memoize(size=100)
+    @s_cache.memoizemethod(size=100)
     async def _methType(self, name):
         type_ = self.model.type(name)
         if type_ is not None:
             return ModelType(type_)
 
-    @s_cache.memoize(size=100)
+    @s_cache.memoizemethod(size=100)
     async def _methProp(self, name):
         prop = self.model.prop(name)
         if prop is not None:
             return ModelProp(prop)
 
-    @s_cache.memoize(size=100)
+    @s_cache.memoizemethod(size=100)
     async def _methForm(self, name):
         form = self.model.form(name)
         if form is not None:

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -1212,7 +1212,7 @@ class Loc(Type):
         norm = '.'.join(norms)
         return norm, {}
 
-    @s_cache.memoize()
+    @s_cache.memoizemethod()
     def stems(self, valu):
         norm, info = self.norm(valu)
         parts = norm.split('.')


### PR DESCRIPTION
Add a decorator "memoizemethod" that doesn't cause circular references with self.

Also removed an unused back-ref to the cortex from an ast node.