### PR TITLE
Have layer reported size be actual disk usage

### DIFF
--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1492,7 +1492,7 @@ class Layer(s_nexus.Pusher):
                 except OSError:  # pragma: no cover
                     pass
                 else:
-                    totalsize += stat.st_size
+                    totalsize += stat.st_blocks * 512
         return totalsize
 
     @s_nexus.Pusher.onPushAuto('layer:set')

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -1912,7 +1912,11 @@ class StormTypesTest(s_test.SynTest):
             self.stormIsInPrint(mainlayr, mesgs)
 
             info = await core.callStorm('return ($lib.layer.get().pack())')
-            self.gt(info.get('totalsize'), 1)
+            size = info.get('totalsize')
+
+            self.gt(size, 1)
+            # Verify we're showing actual disk usage and not just apparent
+            self.lt(size, 1000000000)
 
             # Try to create an invalid layer
             mesgs = await core.stormlist('$lib.layer.add(ldef=$lib.dict(lockmemory=(42)))')


### PR DESCRIPTION
Before, it was calculating the equivalent of `ls -l`.  Now it is calculating the equivalent of `du`.