### PR TITLE
Tighten lark-parser version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ PyYAML>=5.4,<6.0
 aiohttp>=3.6.3,<4.0
 aiohttp-socks>=0.5.5,<0.6.0
 prompt-toolkit>=3.0.4,<3.1.0
-lark-parser>=0.11.0,<0.12.0
+lark-parser==0.11.2
 Pygments>=2.7.4,<2.8.0
 fastjsonschema>=2.14.3,<2.15
 packaging>=20.0,<21.0

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         'aiohttp>=3.6.3,<4.0',
         'aiohttp-socks>=0.5.5,<0.6.0',
         'prompt-toolkit>=3.0.4,<3.1.0',
-        'lark-parser>=0.11.0,<0.12.0',
+        'lark-parser==0.11.2',
         'Pygments>=2.7.4,<2.8.0',
         'packaging>=20.0,<21.0',
         'fastjsonschema>=2.14.3,<2.15',


### PR DESCRIPTION
It changed an error message our tests depend on.