### PR TITLE
Explicitly close generators where the remote side closed early

### DIFF
--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -14,7 +14,6 @@ import synapse.lib.link as s_link
 import synapse.lib.scope as s_scope
 import synapse.lib.share as s_share
 import synapse.lib.certdir as s_certdir
-import synapse.lib.urlhelp as s_urlhelp
 import synapse.lib.reflect as s_reflect
 
 class Sess(s_base.Base):
@@ -180,6 +179,11 @@ async def t2call(link, meth, args, kwargs):
                 logger.info('t2call task %s cancelled', meth.__name__)
             else:
                 logger.exception('error during task %s', meth.__name__)
+
+            if isinstance(valu, types.AsyncGeneratorType):
+                await valu.aclose()
+            elif isinstance(valu, types.GeneratorType):
+                valu.close()
 
             if not link.isfini:
 
@@ -347,6 +351,7 @@ class Daemon(s_base.Base):
             return await link.fini()
 
         self.links.add(link)
+
         async def fini():
             self.links.discard(link)
 

--- a/synapse/tests/test_daemon.py
+++ b/synapse/tests/test_daemon.py
@@ -1,3 +1,9 @@
+import asyncio
+
+import synapse.lib.cell as s_cell
+import synapse.lib.coro as s_coro
+import synapse.lib.stormsvc as s_stormsvc
+
 import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.daemon as s_daemon
@@ -49,3 +55,100 @@ class DaemonTest(s_t_utils.SynTest):
             with self.raises(s_exc.LinkShutDown):
                 async with await s_telepath.openurl(f'tcp://127.0.0.1:{port}/foo') as foo:
                     pass
+
+class SvcApi(s_cell.CellApi, s_stormsvc.StormSvc):
+    _storm_svc_name = 'foo'
+    _storm_svc_pkgs = (  # type:  ignore
+        {
+            'name': 'foo',
+            'version': (0, 0, 1),
+            'modules': (
+                {
+                    'name': 'foo.mod',
+                    'storm': '''
+                        $x = (3)
+
+                        function run_all() {
+                            for $item in $lib.service.get($modconf.svciden).run() {
+                                {}
+                            }
+                            return ($lib.null)
+                        }
+
+                        function run_break() {
+                            for $i in $lib.service.get($modconf.svciden).run() {
+                                if ($i > $x) { return($lib.null) }
+                            }
+                            return($lib.null)
+                        }
+
+                        function run_err() {
+                            for $i in $lib.service.get($modconf.svciden).run() {
+                                if ($i > $x) { [inet:newp=3] }
+                            }
+                            return($lib.null)
+                        }
+                    '''
+                },
+            ),
+        },
+    )
+
+    async def run(self):
+        async for item in self.cell.run():
+            yield item
+
+
+class Svc(s_cell.Cell):
+    cellapi = SvcApi
+
+    async def initServiceStorage(self):
+        self.events = []
+
+    async def run(self):
+        event = asyncio.Event()
+        self.events.append(event)
+        try:
+            for i in range(100):
+                yield i
+                await asyncio.sleep(0)
+        finally:
+            event.set()
+
+
+class GenrCloseTest(s_t_utils.SynTest):
+
+    async def test_close(self):
+
+        async with self.getTestCoreProxSvc(Svc) as (core, core_prox, svc):
+
+            # storm exits early
+            await core.stormlist('$lib.import(foo.mod).run_break()')
+            self.true(await s_coro.event_wait(svc.events[0], timeout=1))
+
+            # storm raises part way through iterating
+            await core.stormlist('$lib.import(foo.mod).run_err()')
+            self.true(await s_coro.event_wait(svc.events[1], timeout=1))
+
+            # storm normal case
+            await core.stormlist('$lib.import(foo.mod).run_all()')
+            self.true(await s_coro.event_wait(svc.events[2], timeout=1))
+
+            async with svc.getLocalProxy() as svc_prox:
+
+                # telepath exits early
+                async for i in svc_prox.run():
+                    if i > 3:
+                        break
+                self.true(await s_coro.event_wait(svc.events[3], timeout=1))
+
+                # telepath normal case
+                async for i in svc_prox.run():
+                    pass
+                self.true(await s_coro.event_wait(svc.events[4], timeout=1))
+
+            # python
+            async for i in svc.run():
+                if i > 3:
+                    break
+            self.true(await s_coro.event_wait(svc.events[5], timeout=1))


### PR DESCRIPTION
This prevents resources from hanging around indefinitely from a prematurely closed connection.

Resolves SYN-1734.