### PR TITLE
Feat axon structlog

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -13,7 +13,6 @@ import synapse.common as s_common
 import synapse.lib.cell as s_cell
 import synapse.lib.base as s_base
 import synapse.lib.const as s_const
-import synapse.lib.scope as s_scope
 import synapse.lib.share as s_share
 import synapse.lib.config as s_config
 import synapse.lib.hashset as s_hashset
@@ -659,12 +658,7 @@ class Axon(s_cell.Cell):
             raise s_exc.NoSuchFile(mesg='Axon does not contain the requested file.', sha256=s_common.ehex(sha256))
 
         fhash = s_common.ehex(sha256)
-        extra = {'sha256': fhash}
-        sess = s_scope.get('sess')
-        if sess:
-            extra['user'] = sess.user.iden
-            extra['username'] = sess.user.name
-        logger.debug(f'Getting blob [{fhash}].', extra={'synapse': extra})
+        logger.debug(f'Getting blob [{fhash}].', extra=await self.getLogExtra(sha256=fhash))
 
         async for byts in self._get(sha256):
             yield byts
@@ -794,12 +788,7 @@ class Axon(s_cell.Cell):
                 return int.from_bytes(byts, 'big')
 
             fhash = s_common.ehex(sha256)
-            extra = {'sha256': fhash}
-            sess = s_scope.get('sess')
-            if sess:
-                extra['user'] = sess.user.iden
-                extra['username'] = sess.user.name
-            logger.debug(f'Saving blob to Axon [{fhash}].', extra={'synapse': extra})
+            logger.debug(f'Saving blob [{fhash}].', extra=await self.getLogExtra(sha256=fhash))
 
             size = await self._saveFileGenr(sha256, genr)
 
@@ -850,12 +839,7 @@ class Axon(s_cell.Cell):
                 return False
 
             fhash = s_common.ehex(sha256)
-            extra = {'sha256': fhash}
-            sess = s_scope.get('sess')
-            if sess:
-                extra['user'] = sess.user.iden
-                extra['username'] = sess.user.name
-            logger.debug(f'Deleting blob [{fhash}].', extra={'synapse': extra})
+            logger.debug(f'Deleting blob [{fhash}].', extra=await self.getLogExtra(sha256=fhash))
 
             size = int.from_bytes(byts, 'big')
             await self.axonmetrics.set('file:count', self.axonmetrics.get('file:count') - 1)
@@ -935,12 +919,7 @@ class Axon(s_cell.Cell):
         Returns:
             dict: A information dictionary containing the results of the request.
         '''
-        extra = {'url': url}
-        sess = s_scope.get('sess')
-        if sess:
-            extra['user'] = sess.user.iden
-            extra['username'] = sess.user.name
-        logger.debug(f'Wget called for [{url}].', extra={'synapse': extra})
+        logger.debug(f'Wget called for [{url}].', extra=await self.getLogExtra(url=url))
 
         connector = None
         proxyurl = self.conf.get('http:proxy')

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -891,12 +891,6 @@ class Axon(s_cell.Cell):
         Yields:
             Unpacked items from the bytes.
         '''
-        extra = {'sha256': sha256}
-        sess = s_scope.get('sess')
-        if sess:
-            extra['user'] = sess.user.iden
-            extra['username'] = sess.user.name
-        logger.debug(f'Iterating MPK file [{sha256}].', extra={'synapse': extra})
         unpk = s_msgpack.Unpk()
         async for byts in self.get(s_common.uhex(sha256)):
             for _, item in unpk.feed(byts):

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -793,7 +793,7 @@ class Axon(s_cell.Cell):
                 return int.from_bytes(byts, 'big')
 
             fhash = s_common.ehex(sha256)
-            extra = {'url': fhash}
+            extra = {'sha256': fhash}
             sess = s_scope.get('sess')
             if sess:
                 extra['user'] = sess.user.iden

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -516,6 +516,7 @@ class Axon(s_cell.Cell):
             'type': 'string',
         },
     }
+
     async def __anit__(self, dirn, conf=None):  # type: ignore
 
         await s_cell.Cell.__anit__(self, dirn, conf=conf)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1843,6 +1843,23 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
     async def getCellApi(self, link, user, path):
         return await self.cellapi.anit(self, link, user)
 
+    async def getLogExtra(self, **kwargs):
+        '''
+        Get an extra dictionary for structured logging which can be used as a extra argument for loggers.
+
+        Args:
+            **kwargs: Additional key/value items to add to the log.
+
+        Returns:
+            Dict: A dictionary
+        '''
+        extra = {**kwargs}
+        sess = s_scope.get('sess')
+        if sess:
+            extra['user'] = sess.user.iden
+            extra['username'] = sess.user.name
+        return {'synapse': extra}
+
     async def _getSpawnLogConf(self):
         conf = self.conf.get('_log_conf')
         if conf:


### PR DESCRIPTION
Add structlog for axon read/write/delete of blobs. Logs the following apis to debug log

- get()
- save() (used by put, puts, upload context manager and its save method)
- del_()
- wget()
