### PR TITLE
lib.inet.http updates SYN-2035 SYN-2065

### DIFF
--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -130,13 +130,13 @@ class LibHttp(s_stormtypes.Lib):
                 raise
             except Exception as e:
                 logger.exception(f'Error during http {meth} @ {url}')
-                errname, erfo = s_common.err(e)
+                errname, errinfo = s_common.err(e)
                 info = {
                     'code': -1,
                     'headers': dict(),
                     'url': url,
                     'body': b'',
-                    'erfo': erfo,
+                    'errinfo': errinfo,
                     'errname': errname,
                 }
                 return HttpResp(info)
@@ -152,7 +152,7 @@ class HttpResp(s_stormtypes.Prim):
         {'name': 'body', 'desc': 'The raw HTTP response body as bytes.', 'type': 'bytes', },
         {'name': 'headers', 'type': 'dict', 'desc': 'The HTTP Response headers.'},
         {'name': 'errname', 'type': 'str', 'desc': 'The name of the exception if an exception occurred.'},
-        {'name': 'erfo', 'type': 'dict', 'desc': 'Exception information if an exception occurred.'},
+        {'name': 'errinfo', 'type': 'dict', 'desc': 'Exception information if an exception occurred.'},
         {'name': 'json', 'desc': 'Get the JSON deserialized response.',
             'type': {'type': 'function', '_funcname': '_httpRespJson',
                      'returns': {'type': 'prim'}
@@ -172,7 +172,7 @@ class HttpResp(s_stormtypes.Prim):
         self.locls['body'] = self.valu.get('body')
         self.locls['headers'] = self.valu.get('headers')
         self.locls['errname'] = self.valu.get('errname', '')
-        self.locls['erfo'] = self.valu.get('erfo', {})
+        self.locls['errinfo'] = self.valu.get('errinfo', {})
 
     def getObjLocals(self):
         return {

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -1,5 +1,8 @@
 import json
 import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
 
 import aiohttp
 import aiohttp_socks
@@ -26,6 +29,8 @@ class LibHttp(s_stormtypes.Lib):
                        'default': True, },
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
+                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
+                       'default': None, }
                   ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }}},
         {'name': 'post', 'desc': 'Post data to a given URL.',
@@ -42,6 +47,8 @@ class LibHttp(s_stormtypes.Lib):
                        'default': True, },
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
+                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
+                       'default': None, }
                   ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }}},
         {'name': 'request', 'desc': 'Make an HTTP request using the given HTTP method to the url.',
@@ -59,6 +66,8 @@ class LibHttp(s_stormtypes.Lib):
                        'default': True, },
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
+                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
+                       'default': None, }
                    ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }
                   }
@@ -73,21 +82,23 @@ class LibHttp(s_stormtypes.Lib):
             'request': self._httpRequest,
         }
 
-    async def _httpEasyGet(self, url, headers=None, ssl_verify=True, params=None):
-        return await self._httpRequest('get', url, headers=headers, ssl_verify=ssl_verify, params=params)
+    async def _httpEasyGet(self, url, headers=None, ssl_verify=True, params=None, timeout=None):
+        return await self._httpRequest('GET', url, headers=headers, ssl_verify=ssl_verify, params=params,
+                                       timeout=timeout)
 
-    async def _httpPost(self, url, headers=None, json=None, body=None, ssl_verify=True, params=None):
-        return await self._httpRequest('POST', url, headers=headers, json=json,
-                                       body=body, ssl_verify=ssl_verify, params=params)
+    async def _httpPost(self, url, headers=None, json=None, body=None, ssl_verify=True, params=None, timeout=None):
+        return await self._httpRequest('POST', url, headers=headers, json=json, body=body,
+                                       ssl_verify=ssl_verify, params=params, timeout=timeout)
 
     async def _httpRequest(self, meth, url, headers=None, json=None, body=None, ssl_verify=True,
-                           params=None):
+                           params=None, timeout=None):
         meth = await s_stormtypes.tostr(meth)
         url = await s_stormtypes.tostr(url)
         json = await s_stormtypes.toprim(json)
         body = await s_stormtypes.toprim(body)
         headers = await s_stormtypes.toprim(headers)
         params = await s_stormtypes.toprim(params)
+        timeout = await s_stormtypes.toint(timeout, noneok=True)
 
         kwargs = {}
         if not ssl_verify:
@@ -102,7 +113,12 @@ class LibHttp(s_stormtypes.Lib):
         if proxyurl is not None:
             connector = aiohttp_socks.ProxyConnector.from_url(proxyurl)
 
-        async with aiohttp.ClientSession(connector=connector) as sess:
+        if timeout:
+            timeout = aiohttp.ClientTimeout(total=timeout)
+        else:
+            timeout = aiohttp.client.DEFAULT_TIMEOUT
+
+        async with aiohttp.ClientSession(connector=connector, timeout=timeout) as sess:
             try:
                 async with sess.request(meth, url, headers=headers, json=json, data=body, **kwargs) as resp:
                     info = {
@@ -116,8 +132,17 @@ class LibHttp(s_stormtypes.Lib):
             except asyncio.CancelledError:  # pragma: no cover
                 raise
             except Exception as e:
-                mesg = f'Error during http {meth} - {str(e)}'
-                raise s_exc.StormRuntimeError(mesg=mesg, headers=headers, json=json, body=body, params=params) from None
+                logger.error(f'Error during http {meth} @ {url}- {str(e)}')
+                errname, erfo = s_common.err(e)
+                erfo['errname'] = errname
+                info = {
+                    'code': -1,
+                    'headers': dict(),
+                    'url': url,
+                    'body': b'',
+                    'erfo': erfo,
+                }
+                return HttpResp(info)
 
 @s_stormtypes.registry.registerType
 class HttpResp(s_stormtypes.Prim):
@@ -125,9 +150,11 @@ class HttpResp(s_stormtypes.Prim):
     Implements the Storm API for a HTTP response.
     '''
     _storm_locals = (
-        {'name': 'code', 'desc': 'The HTTP status code.', 'type': 'int', },
+        {'name': 'code', 'desc': 'The HTTP status code. It is -1 if a exception occured.',
+            'type': 'int', },
         {'name': 'body', 'desc': 'The raw HTTP response body as bytes.', 'type': 'bytes', },
         {'name': 'headers', 'type': 'dict', 'desc': 'The HTTP Response headers.'},
+        {'name': 'erfo', 'type': 'dict', 'desc': 'Exception information if a error occured.'},
         {'name': 'json', 'desc': 'Get the JSON deserialized response.',
             'type': {'type': 'function', '_funcname': '_httpRespJson',
                      'returns': {'type': 'prim'}
@@ -146,6 +173,7 @@ class HttpResp(s_stormtypes.Prim):
         self.locls['code'] = self.valu.get('code')
         self.locls['body'] = self.valu.get('body')
         self.locls['headers'] = self.valu.get('headers')
+        self.locls['erfo'] = self.valu.get('erfo', {})
 
     def getObjLocals(self):
         return {

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -152,7 +152,7 @@ class HttpResp(s_stormtypes.Prim):
         {'name': 'body', 'desc': 'The raw HTTP response body as bytes.', 'type': 'bytes', },
         {'name': 'headers', 'type': 'dict', 'desc': 'The HTTP Response headers.'},
         {'name': 'errname', 'type': 'str', 'desc': 'The name of the exception if an exception occurred.'},
-        {'name': 'erfo', 'type': 'dict', 'desc': 'Exception information if a error occurred.'},
+        {'name': 'erfo', 'type': 'dict', 'desc': 'Exception information if an exception occurred.'},
         {'name': 'json', 'desc': 'Get the JSON deserialized response.',
             'type': {'type': 'function', '_funcname': '_httpRespJson',
                      'returns': {'type': 'prim'}

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -130,14 +130,13 @@ class LibHttp(s_stormtypes.Lib):
                 raise
             except Exception as e:
                 logger.exception(f'Error during http {meth} @ {url}')
-                errname, errinfo = s_common.err(e)
+                err = s_common.err(e)
                 info = {
                     'code': -1,
                     'headers': dict(),
                     'url': url,
                     'body': b'',
-                    'errinfo': errinfo,
-                    'errname': errname,
+                    'err': err,
                 }
                 return HttpResp(info)
 
@@ -151,8 +150,7 @@ class HttpResp(s_stormtypes.Prim):
             'type': 'int', },
         {'name': 'body', 'desc': 'The raw HTTP response body as bytes.', 'type': 'bytes', },
         {'name': 'headers', 'type': 'dict', 'desc': 'The HTTP Response headers.'},
-        {'name': 'errname', 'type': 'str', 'desc': 'The name of the exception if an exception occurred.'},
-        {'name': 'errinfo', 'type': 'dict', 'desc': 'Exception information if an exception occurred.'},
+        {'name': 'err', 'type': 'list', 'desc': 'Tufo of the error type and information if an exception occurred.'},
         {'name': 'json', 'desc': 'Get the JSON deserialized response.',
             'type': {'type': 'function', '_funcname': '_httpRespJson',
                      'returns': {'type': 'prim'}
@@ -171,8 +169,7 @@ class HttpResp(s_stormtypes.Prim):
         self.locls['code'] = self.valu.get('code')
         self.locls['body'] = self.valu.get('body')
         self.locls['headers'] = self.valu.get('headers')
-        self.locls['errname'] = self.valu.get('errname', '')
-        self.locls['errinfo'] = self.valu.get('errinfo', {})
+        self.locls['err'] = self.valu.get('err', ())
 
     def getObjLocals(self):
         return {

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -30,7 +30,7 @@ class LibHttp(s_stormtypes.Lib):
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
                       {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
-                       'default': None, }
+                       'default': 300, }
                   ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }}},
         {'name': 'post', 'desc': 'Post data to a given URL.',
@@ -48,7 +48,7 @@ class LibHttp(s_stormtypes.Lib):
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
                       {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
-                       'default': None, }
+                       'default': 300, }
                   ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }}},
         {'name': 'request', 'desc': 'Make an HTTP request using the given HTTP method to the url.',
@@ -67,7 +67,7 @@ class LibHttp(s_stormtypes.Lib):
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
                       {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
-                       'default': None, }
+                       'default': 300, }
                    ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }
                   }
@@ -82,16 +82,16 @@ class LibHttp(s_stormtypes.Lib):
             'request': self._httpRequest,
         }
 
-    async def _httpEasyGet(self, url, headers=None, ssl_verify=True, params=None, timeout=None):
+    async def _httpEasyGet(self, url, headers=None, ssl_verify=True, params=None, timeout=300):
         return await self._httpRequest('GET', url, headers=headers, ssl_verify=ssl_verify, params=params,
                                        timeout=timeout)
 
-    async def _httpPost(self, url, headers=None, json=None, body=None, ssl_verify=True, params=None, timeout=None):
+    async def _httpPost(self, url, headers=None, json=None, body=None, ssl_verify=True, params=None, timeout=300):
         return await self._httpRequest('POST', url, headers=headers, json=json, body=body,
                                        ssl_verify=ssl_verify, params=params, timeout=timeout)
 
     async def _httpRequest(self, meth, url, headers=None, json=None, body=None, ssl_verify=True,
-                           params=None, timeout=None):
+                           params=None, timeout=300):
         meth = await s_stormtypes.tostr(meth)
         url = await s_stormtypes.tostr(url)
         json = await s_stormtypes.toprim(json)
@@ -113,10 +113,7 @@ class LibHttp(s_stormtypes.Lib):
         if proxyurl is not None:
             connector = aiohttp_socks.ProxyConnector.from_url(proxyurl)
 
-        if timeout:
-            timeout = aiohttp.ClientTimeout(total=timeout)
-        else:
-            timeout = aiohttp.client.DEFAULT_TIMEOUT
+        timeout = aiohttp.ClientTimeout(total=timeout)
 
         async with aiohttp.ClientSession(connector=connector, timeout=timeout) as sess:
             try:

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -29,7 +29,7 @@ class LibHttp(s_stormtypes.Lib):
                        'default': True, },
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
-                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
+                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request in seconds.',
                        'default': 300, }
                   ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }}},
@@ -47,7 +47,7 @@ class LibHttp(s_stormtypes.Lib):
                        'default': True, },
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
-                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
+                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request in seconds.',
                        'default': 300, }
                   ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }}},
@@ -66,7 +66,7 @@ class LibHttp(s_stormtypes.Lib):
                        'default': True, },
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None, },
-                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request.',
+                      {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request in seconds.',
                        'default': 300, }
                    ),
                   'returns': {'type': 'storm:http:resp', 'desc': 'The response object.', }

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -131,13 +131,13 @@ class LibHttp(s_stormtypes.Lib):
             except Exception as e:
                 logger.exception(f'Error during http {meth} @ {url}')
                 errname, erfo = s_common.err(e)
-                erfo['errname'] = errname
                 info = {
                     'code': -1,
                     'headers': dict(),
                     'url': url,
                     'body': b'',
                     'erfo': erfo,
+                    'errname': errname,
                 }
                 return HttpResp(info)
 
@@ -147,11 +147,12 @@ class HttpResp(s_stormtypes.Prim):
     Implements the Storm API for a HTTP response.
     '''
     _storm_locals = (
-        {'name': 'code', 'desc': 'The HTTP status code. It is -1 if a exception occured.',
+        {'name': 'code', 'desc': 'The HTTP status code. It is -1 if a exception occurred.',
             'type': 'int', },
         {'name': 'body', 'desc': 'The raw HTTP response body as bytes.', 'type': 'bytes', },
         {'name': 'headers', 'type': 'dict', 'desc': 'The HTTP Response headers.'},
-        {'name': 'erfo', 'type': 'dict', 'desc': 'Exception information if a error occured.'},
+        {'name': 'errname', 'type': 'str', 'desc': 'The name of the exception if an exception occurred.'},
+        {'name': 'erfo', 'type': 'dict', 'desc': 'Exception information if a error occurred.'},
         {'name': 'json', 'desc': 'Get the JSON deserialized response.',
             'type': {'type': 'function', '_funcname': '_httpRespJson',
                      'returns': {'type': 'prim'}
@@ -170,6 +171,7 @@ class HttpResp(s_stormtypes.Prim):
         self.locls['code'] = self.valu.get('code')
         self.locls['body'] = self.valu.get('body')
         self.locls['headers'] = self.valu.get('headers')
+        self.locls['errname'] = self.valu.get('errname', '')
         self.locls['erfo'] = self.valu.get('erfo', {})
 
     def getObjLocals(self):

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -132,7 +132,7 @@ class LibHttp(s_stormtypes.Lib):
             except asyncio.CancelledError:  # pragma: no cover
                 raise
             except Exception as e:
-                logger.error(f'Error during http {meth} @ {url}- {str(e)}')
+                logger.exception(f'Error during http {meth} @ {url}')
                 errname, erfo = s_common.err(e)
                 erfo['errname'] = errname
                 info = {

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -147,7 +147,7 @@ class HttpResp(s_stormtypes.Prim):
     Implements the Storm API for a HTTP response.
     '''
     _storm_locals = (
-        {'name': 'code', 'desc': 'The HTTP status code. It is -1 if a exception occurred.',
+        {'name': 'code', 'desc': 'The HTTP status code. It is -1 if an exception occurred.',
             'type': 'int', },
         {'name': 'body', 'desc': 'The raw HTTP response body as bytes.', 'type': 'bytes', },
         {'name': 'headers', 'type': 'dict', 'desc': 'The HTTP Response headers.'},

--- a/synapse/tests/test_lib_stormhttp.py
+++ b/synapse/tests/test_lib_stormhttp.py
@@ -60,9 +60,9 @@ class StormHttpTest(s_test.SynTest):
             q = '''
             $params=(1138)
             $resp = $lib.inet.http.get($url, params=$params, ssl_verify=$lib.false)
-            return ( ($resp.code, $resp.errname) )
+            return ( ($resp.code, $resp.err) )
             '''
-            code, errname = await core.callStorm(q, opts=opts)
+            code, (errname, _) = await core.callStorm(q, opts=opts)
             self.eq(code, -1)
             self.eq('TypeError', errname)
 
@@ -112,9 +112,9 @@ class StormHttpTest(s_test.SynTest):
             )
             $resp = $lib.inet.http.request(GET, $url, headers=$hdr, params=$params, ssl_verify=$lib.false, timeout=$timeout)
             $code = $resp.code
-            return (($code, $resp.errname, $resp.errinfo))
+            return (($code, $resp.err))
             '''
-            code, errname, errinfo = await core.callStorm(q, opts=opts)
+            code, (errname, errinfo) = await core.callStorm(q, opts=opts)
             self.eq(code, -1)
             self.eq('TimeoutError', errname)
             self.isin('mesg', errinfo)
@@ -192,9 +192,9 @@ class StormHttpTest(s_test.SynTest):
             $json = $lib.dict(query="test:str")
             $body = $json
             $resp=$lib.inet.http.post($url, json=$json, body=$body, ssl_verify=$(0))
-            return ( ($resp.code, $resp.errname) )
+            return ( ($resp.code, $resp.err) )
             '''
-            code, errname = await core.callStorm(text, opts=opts)
+            code, (errname, _) = await core.callStorm(text, opts=opts)
             self.eq(code, -1)
             self.eq('ValueError', errname)
 
@@ -204,7 +204,7 @@ class StormHttpTest(s_test.SynTest):
             resp = await core.callStorm('return($lib.axon.wget("http://vertex.link"))')
             self.ne(-1, resp['mesg'].find('Can not connect to proxy 127.0.0.1:1'))
 
-            q = '$resp=$lib.inet.http.get("http://vertex.link") return(($resp.code, $resp.errname))'
-            code, errname = await core.callStorm(q)
+            q = '$resp=$lib.inet.http.get("http://vertex.link") return(($resp.code, $resp.err))'
+            code, (errname, _) = await core.callStorm(q)
             self.eq(code, -1)
             self.eq('ProxyConnectionError', errname)

--- a/synapse/tests/test_lib_stormhttp.py
+++ b/synapse/tests/test_lib_stormhttp.py
@@ -60,11 +60,11 @@ class StormHttpTest(s_test.SynTest):
             q = '''
             $params=(1138)
             $resp = $lib.inet.http.get($url, params=$params, ssl_verify=$lib.false)
-            return ( ($resp.code, $resp.erfo) )
+            return ( ($resp.code, $resp.errname) )
             '''
-            code, erfo = await core.callStorm(q, opts=opts)
+            code, errname = await core.callStorm(q, opts=opts)
             self.eq(code, -1)
-            self.eq('TypeError', erfo.get('errname'))
+            self.eq('TypeError', errname)
 
     async def test_storm_http_request(self):
 
@@ -112,11 +112,11 @@ class StormHttpTest(s_test.SynTest):
             )
             $resp = $lib.inet.http.request(GET, $url, headers=$hdr, params=$params, ssl_verify=$lib.false, timeout=$timeout)
             $code = $resp.code
-            return (($code, $resp.erfo))
+            return (($code, $resp.errname))
             '''
-            code, erfo = await core.callStorm(q, opts=opts)
+            code, errname = await core.callStorm(q, opts=opts)
             self.eq(code, -1)
-            self.eq('TimeoutError', erfo.get('errname'))
+            self.eq('TimeoutError', errname)
 
     async def test_storm_http_post(self):
 
@@ -190,11 +190,11 @@ class StormHttpTest(s_test.SynTest):
             $json = $lib.dict(query="test:str")
             $body = $json
             $resp=$lib.inet.http.post($url, json=$json, body=$body, ssl_verify=$(0))
-            return ( ($resp.code, $resp.erfo) )
+            return ( ($resp.code, $resp.errname) )
             '''
-            code, erfo = await core.callStorm(text, opts=opts)
+            code, errname = await core.callStorm(text, opts=opts)
             self.eq(code, -1)
-            self.eq('ValueError', erfo.get('errname'))
+            self.eq('ValueError', errname)
 
     async def test_storm_http_proxy(self):
         conf = {'http:proxy': 'socks5://user:pass@127.0.0.1:1'}
@@ -202,7 +202,7 @@ class StormHttpTest(s_test.SynTest):
             resp = await core.callStorm('return($lib.axon.wget("http://vertex.link"))')
             self.ne(-1, resp['mesg'].find('Can not connect to proxy 127.0.0.1:1'))
 
-            q = '$resp=$lib.inet.http.get("http://vertex.link") return(($resp.code, $resp.erfo))'
-            code, erfo = await core.callStorm(q)
+            q = '$resp=$lib.inet.http.get("http://vertex.link") return(($resp.code, $resp.errname))'
+            code, errname = await core.callStorm(q)
             self.eq(code, -1)
-            self.eq('ProxyConnectionError', erfo.get('errname'))
+            self.eq('ProxyConnectionError', errname)

--- a/synapse/tests/test_lib_stormhttp.py
+++ b/synapse/tests/test_lib_stormhttp.py
@@ -112,11 +112,13 @@ class StormHttpTest(s_test.SynTest):
             )
             $resp = $lib.inet.http.request(GET, $url, headers=$hdr, params=$params, ssl_verify=$lib.false, timeout=$timeout)
             $code = $resp.code
-            return (($code, $resp.errname))
+            return (($code, $resp.errname, $resp.errinfo))
             '''
-            code, errname = await core.callStorm(q, opts=opts)
+            code, errname, errinfo = await core.callStorm(q, opts=opts)
             self.eq(code, -1)
             self.eq('TimeoutError', errname)
+            self.isin('mesg', errinfo)
+            self.eq('', errinfo.get('mesg'))  # timeouterror has no mesg
 
     async def test_storm_http_post(self):
 

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -677,6 +677,12 @@ class HttpReflector(s_httpapi.Handler):
                     d[k].append(v.decode())
         resp['headers'] = dict(self.request.headers)
         resp['path'] = self.request.path
+
+        sleep = resp.get('params', {}).get('sleep')
+        if sleep:
+            sleep = int(sleep[0])
+            await asyncio.sleep(sleep)
+
         self.sendRestRetn(resp)
 
     async def post(self):


### PR DESCRIPTION
* Add timeout arguments to $lib.inet.http calls. 
* Make the underlying implementation capture exceptions and return a -1 status code instead of raising.