### PR TITLE
Feat tee parallel

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3220,7 +3220,7 @@ class TeeCmd(Cmd):
                     print('do parallel NO INPUT')
 
                     # inq = asyncio.Queue(maxsize=8)
-                    outq = asyncio.Queue(maxsize=8)
+                    outq = asyncio.Queue(maxsize=16)
                     sempahore = asyncio.BoundedSemaphore(value=16)  # smoll
                     for subr in runts:
                         self.runt.snap.schedCoro(self.doit(sempahore, outq, subr))

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3168,10 +3168,14 @@ class TeeCmd(Cmd):
         async with contextlib.AsyncExitStack() as stack:
 
             runts = []
-            for text in self.opts.query:
-                query = await runt.getStormQuery(text)
-                subr = await stack.enter_async_context(runt.getSubRuntime(query))
-                runts.append(subr)
+            query_arguments = await s_stormtypes.toprim(self.opts.query)
+            for arg in query_arguments:
+                if isinstance(arg, str):
+                    arg = (arg, )
+                for text in arg:
+                    query = await runt.getStormQuery(text)
+                    subr = await stack.enter_async_context(runt.getSubRuntime(query))
+                    runts.append(subr)
             size = len(runts)
 
             outq_size = 32

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3199,7 +3199,6 @@ class TeeCmd(Cmd):
             item = None
             async for item in genr:
                 node, path = item
-                npath = path.fork(node)
 
                 if self.opts.parallel:
                     print('do parallel')
@@ -3210,7 +3209,7 @@ class TeeCmd(Cmd):
                 else:
 
                     for subr in runts:
-                        subg = s_common.agen((node, npath))
+                        subg = s_common.agen((node, path.fork(node)))
                         async for subitem in subr.execute(genr=subg):
                             yield subitem
 
@@ -3221,7 +3220,6 @@ class TeeCmd(Cmd):
                 if self.opts.parallel:
                     print('do parallel NO INPUT')
 
-                    # inq = asyncio.Queue(maxsize=8)
                     outq = asyncio.Queue(maxsize=32)
                     sempahore = asyncio.BoundedSemaphore(value=16)  # smoll
                     for subr in runts:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3142,7 +3142,7 @@ class TeeCmd(Cmd):
         inet:ipv4=1.2.3.4 | tee --join { -> * } { <- * }
 
         # Execute multiple enrichment queries in parallel.
-        inet:ipv4=1.2.3.4 | tee -p { enrich.foo} {enrich.bar }
+        inet:ipv4=1.2.3.4 | tee -p { enrich.foo } { enrich.bar } { enrich.baz }
 
     '''
     name = 'tee'

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3220,7 +3220,7 @@ class TeeCmd(Cmd):
                     print('do parallel NO INPUT')
 
                     # inq = asyncio.Queue(maxsize=8)
-                    outq = asyncio.Queue(maxsize=16)
+                    outq = asyncio.Queue(maxsize=32)
                     sempahore = asyncio.BoundedSemaphore(value=16)  # smoll
                     for subr in runts:
                         self.runt.snap.schedCoro(self.doit(sempahore, outq, subr))

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3182,7 +3182,7 @@ class TeeCmd(Cmd):
             size = len(runts)
 
             if self.opts.concurrency < 1:
-                raise s_exc.StormRuntimeError(mesg='Concurrency value must be greater than 0.')
+                raise s_exc.BadArg(mesg='Concurrency must be greater than 0.', concurrency=self.opts.concurrency)
             semaphore_size = self.opts.concurrency
             outq_size = semaphore_size * 2
 
@@ -3255,13 +3255,9 @@ class TeeCmd(Cmd):
 
     async def pipeline(self, semaphore, outq, runt, genr=None):
         try:
-            # print('hey yo!')
             async with semaphore:
-                # print(f'GOT  {semaphore} -  {runt.query} !!!!!!!!!!!!')
                 async for subitem in runt.execute(genr=genr):
-                    # print(f'putting: {runt.query} {subitem[0]}')
                     await outq.put(subitem)
-            # print(f'RELEASE {runt.query}')
 
             await outq.put(None)
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3252,7 +3252,7 @@ class TeeCmd(Cmd):
         try:
             print('hey yo!')
             async with semaphore:
-                print(f'GOT  {semaphore=} -  {runt.query} !!!!!!!!!!!!')
+                print(f'GOT  {semaphore} -  {runt.query} !!!!!!!!!!!!')
                 async for subitem in runt.execute(genr=genr):
                     # print(f'putting: {runt.query} {subitem[0]}')
                     await outq.put(subitem)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3252,7 +3252,7 @@ class TeeCmd(Cmd):
             async with semaphore:
                 print(f'GOT  {semaphore=} -  {runt.query} !!!!!!!!!!!!')
                 async for subitem in runt.execute():
-                    print(f'putting: {runt.query} {subitem[0]}')
+                    # print(f'putting: {runt.query} {subitem[0]}')
                     await outq.put(subitem)
             print(f'RELEASE {runt.query}')
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3131,7 +3131,7 @@ class TeeCmd(Cmd):
     '''
     Execute multiple Storm queries on each node in the input stream, joining output streams together.
 
-    Commands are executed in order they are given.
+    Commands are executed in order they are given; unless the ``--parallel`` switch is provided.
 
     Examples:
 
@@ -3140,6 +3140,9 @@ class TeeCmd(Cmd):
 
         # Also emit the inbound node
         inet:ipv4=1.2.3.4 | tee --join { -> * } { <- * }
+
+        # Execute multiple enrichment queries in parallel.
+        inet:ipv4=1.2.3.4 | tee -p { enrich.foo} {enrich.bar }
 
     '''
     name = 'tee'

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3198,6 +3198,8 @@ class TeeCmd(Cmd):
 
             item = None
             async for item in genr:
+                node, path = item
+                npath = path.fork(node)
 
                 if self.opts.parallel:
                     print('do parallel')
@@ -3208,7 +3210,7 @@ class TeeCmd(Cmd):
                 else:
 
                     for subr in runts:
-                        subg = s_common.agen(item)
+                        subg = s_common.agen((node, npath))
                         async for subitem in subr.execute(genr=subg):
                             yield subitem
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1206,7 +1206,19 @@ class StormTest(s_t_utils.SynTest):
             }
             self.eq(exp, {n.ndef for n in nodes})
 
+            # --parallel is a thing
             q = '$foo=woot.com tee --parallel { inet:ipv4=1.2.3.4 } { .created } { inet:fqdn=$foo <- * } { [inet:asn=1234] } { .created }'
+            # msgs = await core.stormlist(q)
+            #
+            # for m in msgs:
+            async for m in core.storm(q):
+                print(m)
+            print('88888888888888888888888888' * 2)
+            print('88888888888888888888888888' * 2)
+            print('88888888888888888888888888' * 2)
+            print('88888888888888888888888888' * 2)
+
+            q = '$foo=woot.com inet:fqdn=$foo inet:fqdn=com | tee --parallel { inet:ipv4=1.2.3.4 } { .created } { inet:fqdn=$foo <- * } { [inet:asn=1234] } { .created }'
             # msgs = await core.stormlist(q)
             #
             # for m in msgs:

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1170,6 +1170,25 @@ class StormTest(s_t_utils.SynTest):
             self.eq(nodes[2].ndef[0], ('media:news'))
             self.eq(nodes[3].ndef, ('inet:ipv4', 0x01020304))
 
+            # Queries can be a heavy list
+            q = '$list = $lib.list(${ -> * }, ${ <- * }, ${ -> edge:refs:n2 :n1 -> * }) inet:ipv4=1.2.3.4 | tee --join $list'
+            nodes = await core.nodes(q)
+            self.len(4, nodes)
+            self.eq(nodes[0].ndef, ('inet:asn', 0))
+            self.eq(nodes[1].ndef[0], ('inet:dns:a'))
+            self.eq(nodes[2].ndef[0], ('media:news'))
+            self.eq(nodes[3].ndef, ('inet:ipv4', 0x01020304))
+
+            # Queries can be a input list
+            q = 'inet:ipv4=1.2.3.4 | tee --join $list'
+            queries = ('-> *', '<- *', '-> edge:refs:n2 :n1 -> *')
+            nodes = await core.nodes(q, {'vars': {'list': queries}})
+            self.len(4, nodes)
+            self.eq(nodes[0].ndef, ('inet:asn', 0))
+            self.eq(nodes[1].ndef[0], ('inet:dns:a'))
+            self.eq(nodes[2].ndef[0], ('media:news'))
+            self.eq(nodes[3].ndef, ('inet:ipv4', 0x01020304))
+
             # Empty queries are okay - they will just return the input node
             q = 'inet:ipv4=1.2.3.4 | tee {}'
             nodes = await core.nodes(q)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1274,21 +1274,6 @@ class StormTest(s_t_utils.SynTest):
             ]
             self.eq(exp, [x.ndef for x in nodes])
 
-            # Adjusting concurrency alters the execution flow
-            q = '$foo=woot.com tee --parallel -c 2 { $lib.time.sleep("0.5") inet:ipv4=1.2.3.4 }  { $lib.time.sleep("0.25") inet:fqdn=$foo <- * | sleep 1} { [inet:asn=1234] }'
-            nodes = await core.nodes(q)
-            self.len(4, nodes)
-            exp = [
-                ('inet:dns:a', ('woot.com', 0x01020304)),
-                ('inet:ipv4', 0x01020304),
-                ('inet:asn', 1234),
-                ('inet:fqdn', 'woot.com'),
-            ]
-            self.eq(exp, [x.ndef for x in nodes])
-
-            with self.raises(s_exc.BadArg):
-                await core.nodes('tee --parallel -c 0 { }')
-
             # A fatal execption is fatal to the runtime
             q = '$foo=woot.com tee --parallel { $lib.time.sleep("0.5") inet:ipv4=1.2.3.4 }  { $lib.time.sleep("0.25") inet:fqdn=$foo <- * | sleep 1} { [inet:asn=newp] }'
             msgs = await core.stormlist(q)

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1179,6 +1179,27 @@ class StormTest(s_t_utils.SynTest):
             self.eq(nodes[2].ndef[0], ('media:news'))
             self.eq(nodes[3].ndef, ('inet:ipv4', 0x01020304))
 
+            # A empty list of queries still works as an nop
+            q = '$list = $lib.list() | tee $list'
+            msgs = await core.stormlist(q)
+            self.len(2, msgs)
+            self.eq(('init', 'fini'), [m[0] for m in msgs])
+
+            q = 'inet:ipv4=1.2.3.4 $list = $lib.list() | tee --join $list'
+            msgs = await core.stormlist(q)
+            self.len(3, msgs)
+            self.eq(('init', 'node', 'fini'), [m[0] for m in msgs])
+
+            q = '$list = $lib.list() | tee --parallel $list'
+            msgs = await core.stormlist(q)
+            self.len(2, msgs)
+            self.eq(('init', 'fini'), [m[0] for m in msgs])
+
+            q = 'inet:ipv4=1.2.3.4 $list = $lib.list() | tee --parallel --join $list'
+            msgs = await core.stormlist(q)
+            self.len(3, msgs)
+            self.eq(('init', 'node', 'fini'), [m[0] for m in msgs])
+
             # Queries can be a input list
             q = 'inet:ipv4=1.2.3.4 | tee --join $list'
             queries = ('-> *', '<- *', '-> edge:refs:n2 :n1 -> *')

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1213,33 +1213,31 @@ class StormTest(s_t_utils.SynTest):
             async for m in core.storm(q):
                 print(m)
 
-            return
+            # Variables are scoped down into the sub runtime
+            q = (
+                f'$foo=5 tee '
+                f'{{ [ inet:asn=3 ] }} '
+                f'{{ [ inet:asn=4 ] $lib.print("made asn node: {{node}}", node=$node) }} '
+                f'{{ [ inet:asn=$foo ] }}'
+            )
+            msgs = await core.stormlist(q)
+            self.stormIsInPrint("made asn node: Node{(('inet:asn', 4)", msgs)
+            podes = [m[1] for m in msgs if m[0] == 'node']
+            self.eq({('inet:asn', 3), ('inet:asn', 4), ('inet:asn', 5)},
+                    {p[0] for p in podes})
 
-            # # Variables are scoped down into the sub runtime
-            # q = (
-            #     f'$foo=5 tee '
-            #     f'{{ [ inet:asn=3 ] }} '
-            #     f'{{ [ inet:asn=4 ] $lib.print("made asn node: {{node}}", node=$node) }} '
-            #     f'{{ [ inet:asn=$foo ] }}'
-            # )
-            # msgs = await core.stormlist(q)
-            # self.stormIsInPrint("made asn node: Node{(('inet:asn', 4)", msgs)
-            # podes = [m[1] for m in msgs if m[0] == 'node']
-            # self.eq({('inet:asn', 3), ('inet:asn', 4), ('inet:asn', 5)},
-            #         {p[0] for p in podes})
-            #
-            # # lift a non-existent node and feed to tee.
-            # q = 'inet:fqdn=newp.com tee { inet:ipv4=1.2.3.4 } { inet:ipv4 -> * }'
-            # nodes = await core.nodes(q)
-            # self.len(2, nodes)
-            # exp = {
-            #     ('inet:asn', 0),
-            #     ('inet:ipv4', 0x01020304),
-            # }
-            # self.eq(exp, {x.ndef for x in nodes})
-            #
-            # q = 'tee'
-            # await self.asyncraises(s_exc.StormRuntimeError, core.nodes(q))
+            # lift a non-existent node and feed to tee.
+            q = 'inet:fqdn=newp.com tee { inet:ipv4=1.2.3.4 } { inet:ipv4 -> * }'
+            nodes = await core.nodes(q)
+            self.len(2, nodes)
+            exp = {
+                ('inet:asn', 0),
+                ('inet:ipv4', 0x01020304),
+            }
+            self.eq(exp, {x.ndef for x in nodes})
+
+            q = 'tee'
+            await self.asyncraises(s_exc.StormRuntimeError, core.nodes(q))
 
     async def test_storm_yieldvalu(self):
 


### PR DESCRIPTION
Add a ``--parallel`` option to the ``tee`` command to execute the queries in parallel, as opposed to serial. This will result in mixed output streams.
Add a ``--concurrency`` switch to control the number of parallel query executions allowed to occur at a given time.
