### PR TITLE
Rstorm and genpkg tweaks SYN-2165

### DIFF
--- a/synapse/lib/rstorm.py
+++ b/synapse/lib/rstorm.py
@@ -2,6 +2,7 @@ import os
 import copy
 import json
 import pprint
+import logging
 import contextlib
 
 import regex
@@ -20,6 +21,8 @@ import synapse.cmds.cortex as s_cmds_cortex
 import synapse.tools.genpkg as s_genpkg
 
 re_directive = regex.compile(r'^\.\.\s(storm.*|[^:])::(?:\s(.*)$|$)')
+
+logger = logging.getLogger(__name__)
 
 class StormOutput(s_cmds_cortex.StormCmd):
     '''
@@ -300,6 +303,7 @@ class StormRst(s_base.Base):
             text = text.strip()
 
             handler = self._getHandler(directive)
+            logger.debug(f'Executing {directive} -> {text}')
             await handler(text)
 
             return

--- a/synapse/tests/test_tools_genpkg.py
+++ b/synapse/tests/test_tools_genpkg.py
@@ -69,6 +69,18 @@ class GenPkgTest(s_test.SynTest):
             self.eq(pdef['logo']['mime'], 'image/svg')
             self.eq(pdef['logo']['file'], 'c3R1ZmYK')
 
+            # nodocs
+            savepath = s_common.genpath(core.dirn, 'testpkg_nodocs.json')
+            argv = ('--no-docs', '--save', savepath, ymlpath)
+
+            await s_genpkg.main(argv)
+
+            pdef = s_common.yamlload(savepath)
+
+            self.eq(pdef['name'], 'testpkg')
+            self.eq(pdef['docs'][0]['title'], 'Foo Bar')
+            self.eq(pdef['docs'][0]['content'], '')
+
     def test_files(self):
         assets = s_files.getAssets()
         self.isin('test.dat', assets)

--- a/synapse/tools/genpkg.py
+++ b/synapse/tools/genpkg.py
@@ -45,7 +45,7 @@ def loadOpticFiles(pkgdef, path):
                     'file': base64.b64encode(fd.read()).decode(),
                 }
 
-def loadPkgProto(path, opticdir=None):
+def loadPkgProto(path, opticdir=None, no_docs=False):
 
     full = s_common.genpath(path)
     pkgdef = s_common.yamlload(full)
@@ -78,6 +78,10 @@ def loadPkgProto(path, opticdir=None):
         if docdef.get('title') is None:
             mesg = 'Each entry in docs must have a title.'
             raise s_exc.BadPkgDef(mesg=mesg)
+
+        if no_docs:
+            docdef['content'] = ''
+            continue
 
         path = docdef.pop('path', None)
         if path is not None:
@@ -135,11 +139,13 @@ async def main(argv, outp=s_output.stdout):
     pars.add_argument('--push', metavar='<url>', help='A telepath URL of a Cortex or PkgRepo.')
     pars.add_argument('--save', metavar='<path>', help='Save the completed package JSON to a file.')
     pars.add_argument('--optic', metavar='<path>', help='Load Optic module files from a directory.')
+    pars.add_argument('--no-docs', default=False, action='store_true',
+                      help='Do not require docs to be present and replace any doc content with empty strings.')
     pars.add_argument('pkgfile', metavar='<pkgfile>', help='Path to a storm package prototype yml file.')
 
     opts = pars.parse_args(argv)
 
-    pkgdef = loadPkgProto(opts.pkgfile, opticdir=opts.optic)
+    pkgdef = loadPkgProto(opts.pkgfile, opticdir=opts.optic, no_docs=opts.no_docs)
 
     if opts.save:
         s_common.jssave(pkgdef, opts.save)


### PR DESCRIPTION
- Allow genpkg to build without requiring docs on disk.
- log rstorm directives being executed.