### PR TITLE
Allow pushing a single-file premade package: SYN-2072

### DIFF
--- a/synapse/tests/test_tools_genpkg.py
+++ b/synapse/tests/test_tools_genpkg.py
@@ -81,6 +81,21 @@ class GenPkgTest(s_test.SynTest):
             self.eq(pdef['docs'][0]['title'], 'Foo Bar')
             self.eq(pdef['docs'][0]['content'], '')
 
+            # No push, no save:  nothing to do
+            argv = (ymlpath,)
+            retn = await s_genpkg.main(argv)
+            self.ne(0, retn)
+
+            # Invalid:  save with pre-made file
+            argv = ('--save', savepath, savepath)
+            retn = await s_genpkg.main(argv)
+            self.ne(0, retn)
+
+            # Push a premade json
+            argv = ('--push', url, savepath)
+            retn = await s_genpkg.main(argv)
+            self.eq(0, retn)
+
     def test_files(self):
         assets = s_files.getAssets()
         self.isin('test.dat', assets)


### PR DESCRIPTION
One can now specify the output of --save as the package, and use --push to send it to a cortex or repo.