### PR TITLE
Update logging configuration to universally accept ints / strs (SYN-2232) (SYN-2049)

### DIFF
--- a/docs/synapse/devguides/devops_cortex.rst
+++ b/docs/synapse/devguides/devops_cortex.rst
@@ -38,6 +38,41 @@ You can now connect to the Cortex using the ``cmdr`` tool::
     python -m synapse.tools.cmdr tcp://root:secret@localhost:27492
 
 
+Storm Query Logging
+-------------------
+
+The Cortex can be configured to log Storm queries executed by users. This is done by setting the ``storm:log`` and
+``storm:log:level`` configuration options ( :ref:`autodoc-cortex-conf` ). The ``storm:log:level`` option may be one of
+``DEBUG``, ``INFO`` , ``WARNING``, ``ERROR``, ``CRITICAL``; or as a corresponding `Python logging`_ log level as an
+integer value. This allows an organization to set what log level their Storm queries are logged at.
+
+When enabled, the log message contains the query text and username::
+
+    2021-06-28 16:17:55,775 [INFO] Executing storm query {inet:ipv4=1.2.3.4} as [root] [cortex.py:_logStormQuery:MainThread:MainProcess]
+
+When structured logging is also enabled for a Cortex, the query text, username, and user iden are included as individual
+fields in the logged message as well::
+
+    {
+      "message": "Executing storm query {inet:ipv4=1.2.3.4} as [root]",
+      "logger": {
+        "name": "synapse.storm",
+        "process": "MainProcess",
+        "filename": "cortex.py",
+        "func": "_logStormQuery"
+      },
+      "level": "INFO",
+      "time": "2021-06-28 16:18:47,232",
+      "text": "inet:ipv4=1.2.3.4",
+      "username": "root",
+      "user": "3189065f95d3ab0a6904e604260c0be2"
+    }
+
+This logging does interplay with the underlying Cell log configuration ( :ref:`devops-cell-logging` ). The
+``storm:log:level`` value must be greater than or equal to the base log level of the Cell, otherwise the Storm log will
+not be emitted.
+
+
 Configuring A Mirror
 --------------------
 
@@ -94,3 +129,5 @@ the Axon.
 
 For information about migrating older Cortexes to v2.8.0, please refer to the ``v2.8.0`` documentation
 `here <https://synapse.docs.vertex.link/en/v2.8.0/synapse/devguides/devops_cortex.html#x-to-2-x-x-migration>`_.
+
+.. _Python logging: https://docs.python.org/3.8/library/logging.html#logging-levels

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -636,6 +636,34 @@ def _getLogConfFromEnv(defval=None, structlog=None):
     ret = {'defval': defval, 'structlog': structlog}
     return ret
 
+def normLogLevel(valu):
+    '''
+    Norm a log level value to a integer.
+
+    Args:
+        valu: The value to norm ( a string or integer ).
+
+    Returns:
+        int: A valid Logging log level.
+    '''
+    if isinstance(valu, int):
+        if valu not in s_const.LOG_LEVEL_INVERSE_CHOICES:
+            raise s_exc.BadArg(mesg=f'Invalid log level provided: {valu}', valu=valu)
+        return valu
+    if isinstance(valu, str):
+        valu = valu.strip()
+        try:
+            valu = int(valu)
+        except ValueError:
+            valu = valu.upper()
+            ret = s_const.LOG_LEVEL_CHOICES.get(valu)
+            if ret is None:
+                raise s_exc.BadArg(mesg=f'Invalid log level provided: {valu}', valu=valu) from None
+            return ret
+        else:
+            return normLogLevel(valu)
+    raise s_exc.BadArg(mesg=f'Unknown log level type: {type(valu)} {valu}', valu=valu)
+
 def setlogging(mlogger, defval=None, structlog=None):
     '''
     Configure synapse logging.
@@ -656,10 +684,8 @@ def setlogging(mlogger, defval=None, structlog=None):
     log_struct = ret.get('structlog')
 
     if log_level:  # pragma: no cover
-        if isinstance(log_level, str):
-            log_level = log_level.upper()
-            if log_level not in s_const.LOG_LEVEL_CHOICES:
-                raise ValueError('Invalid log level provided: {}'.format(log_level))
+
+        log_level = normLogLevel(log_level)
 
         if log_struct:
             handler = logging.StreamHandler()
@@ -668,7 +694,7 @@ def setlogging(mlogger, defval=None, structlog=None):
             logging.basicConfig(level=log_level, handlers=(handler,))
         else:
             logging.basicConfig(level=log_level, format=s_const.LOG_FORMAT)
-        mlogger.info('log level set to %s', log_level)
+        mlogger.info('log level set to %s', s_const.LOG_LEVEL_INVERSE_CHOICES.get(log_level))
 
     return ret
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -966,7 +966,7 @@ class Cortex(s_cell.Cell):  # type: ignore
             'type': 'boolean'
         },
         'storm:log:level': {
-            'default': 30,
+            'default': 'INFO',
             'description': 'Logging log level to emit storm logs at.',
             'type': [
                 'integer',

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -999,9 +999,6 @@ class Cortex(s_cell.Cell):  # type: ignore
         s_version.reqVersion(corevers, reqver, exc=s_exc.BadStorageVersion,
                              mesg='cortex version in storage is incompatible with running software')
 
-        # Reset the storm:log:level from the config value to an int for internal use.
-        self.conf['storm:log:level'] = s_common.normLogLevel(self.conf.get('storm:log:level'))
-
         self.views = {}
         self.layers = {}
         self.modules = {}
@@ -1047,6 +1044,11 @@ class Cortex(s_cell.Cell):  # type: ignore
 
         self.provstor = await s_provenance.ProvStor.anit(self.dirn, proven=proven)
         self.onfini(self.provstor.fini)
+
+        # Reset the storm:log:level from the config value to an int for internal use.
+        self.conf['storm:log:level'] = s_common.normLogLevel(self.conf.get('storm:log:level'))
+        self.stormlog = self.conf.get('storm:log')
+        self.stormloglvl = self.conf.get('storm:log:level')
 
         # generic fini handler for the Cortex
         self.onfini(self._onCoreFini)
@@ -4253,9 +4255,8 @@ class Cortex(s_cell.Cell):  # type: ignore
         '''
         Log a storm query.
         '''
-        if self.conf.get('storm:log'):
-            lvl = self.conf.get('storm:log:level')
-            stormlogger.log(lvl, 'Executing storm query {%s} as [%s]', text, user.name,
+        if self.stormlog:
+            stormlogger.log(self.stormloglvl, 'Executing storm query {%s} as [%s]', text, user.name,
                             extra={'synapse': {'text': text, 'username': user.name, 'user': user.iden}})
 
     async def getNodeByNdef(self, ndef, view=None):

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -25,7 +25,6 @@ import synapse.lib.cache as s_cache
 import synapse.lib.layer as s_layer
 import synapse.lib.nexus as s_nexus
 import synapse.lib.queue as s_queue
-import synapse.lib.scope as s_scope
 import synapse.lib.storm as s_storm
 import synapse.lib.agenda as s_agenda
 import synapse.lib.config as s_config
@@ -969,8 +968,12 @@ class Cortex(s_cell.Cell):  # type: ignore
         'storm:log:level': {
             'default': 30,
             'description': 'Logging log level to emit storm logs at.',
-            'type': 'integer'
-        },
+            'type': [
+                'integer',
+                'string',
+            ],
+            'enum': ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL',],
+           },
         'http:proxy': {
             'description': 'An aiohttp-socks compatible proxy URL to use storm HTTP API.',
             'type': 'string',

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -972,8 +972,7 @@ class Cortex(s_cell.Cell):  # type: ignore
                 'integer',
                 'string',
             ],
-            'enum': ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL',],
-           },
+        },
         'http:proxy': {
             'description': 'An aiohttp-socks compatible proxy URL to use storm HTTP API.',
             'type': 'string',
@@ -999,6 +998,9 @@ class Cortex(s_cell.Cell):  # type: ignore
         corevers = self.cellinfo.get('cortex:version')
         s_version.reqVersion(corevers, reqver, exc=s_exc.BadStorageVersion,
                              mesg='cortex version in storage is incompatible with running software')
+
+        # Reset the storm:log:level from the config value to an int for internal use.
+        self.conf['storm:log:level'] = s_common.normLogLevel(self.conf.get('storm:log:level'))
 
         self.views = {}
         self.layers = {}

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1918,7 +1918,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         pars = argparse.ArgumentParser(prog=name)
         pars.add_argument('dirn', help=f'The storage directory for the {name} service.')
 
-        pars.add_argument('--log-level', default='INFO', choices=s_const.LOG_LEVEL_CHOICES,
+        pars.add_argument('--log-level', default='INFO', choices=list(s_const.LOG_LEVEL_CHOICES.keys()),
                           help='Specify the Python logging log level.', type=str.upper)
         pars.add_argument('--structured-logging', default=False, action='store_true',
                           help='Use structured logging.')

--- a/synapse/lib/const.py
+++ b/synapse/lib/const.py
@@ -1,7 +1,16 @@
 # Logging related constants
+import logging
+
 LOG_FORMAT = '%(asctime)s [%(levelname)s] %(message)s ' \
              '[%(filename)s:%(funcName)s:%(threadName)s:%(processName)s]'
-LOG_LEVEL_CHOICES = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+LOG_LEVEL_CHOICES = {
+    'DEBUG': logging.DEBUG,
+    'INFO': logging.INFO,
+    'WARNING': logging.WARNING,
+    'ERROR': logging.ERROR,
+    'CRITICAL': logging.CRITICAL,
+}
+LOG_LEVEL_INVERSE_CHOICES = {v: k for k, v in LOG_LEVEL_CHOICES.items()}
 
 # Math related constants
 kilobyte = 1000

--- a/synapse/tests/test_common.py
+++ b/synapse/tests/test_common.py
@@ -271,6 +271,19 @@ class CommonTest(s_t_utils.SynTest):
             self.false(s_common.envbool('SYN_FOO'))
             self.false(s_common.envbool('SYN_BAR'))
 
+    def test_normlog(self):
+        self.eq(10, s_common.normLogLevel(' 10 '))
+        self.eq(10, s_common.normLogLevel(10))
+        self.eq(20, s_common.normLogLevel(' inFo\n'))
+        with self.raises(s_exc.BadArg):
+            s_common.normLogLevel(100)
+        with self.raises(s_exc.BadArg):
+            s_common.normLogLevel('BEEP')
+        with self.raises(s_exc.BadArg):
+            s_common.normLogLevel('12')
+        with self.raises(s_exc.BadArg):
+            s_common.normLogLevel({'key': 'newp'})
+
     async def test_merggenr(self):
         async def asyncl(data):
             for item in data:

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1079,10 +1079,9 @@ class SynTest(unittest.TestCase):
         Returns:
             (s_cortex.Cortex, s_cortex.CoreApi): The Cortex and a Proxy representing a CoreApi object.
         '''
-        if conf is None:
-            conf = {}
-        conf['storm:log'] = True
         async with self.getTestCore(conf=conf, dirn=dirn) as core:
+            core.conf['storm:log'] = True
+            core.stormlog = True
             async with core.getLocalProxy() as prox:
                 yield core, prox
 

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1079,8 +1079,10 @@ class SynTest(unittest.TestCase):
         Returns:
             (s_cortex.Cortex, s_cortex.CoreApi): The Cortex and a Proxy representing a CoreApi object.
         '''
+        if conf is None:
+            conf = {}
+        conf['storm:log'] = True
         async with self.getTestCore(conf=conf, dirn=dirn) as core:
-            core.conf['storm:log'] = True
             async with core.getLocalProxy() as prox:
                 yield core, prox
 


### PR DESCRIPTION
- Synapse logging now accepts integer values as log levels
- Storm log level now defaults to info level
- storm log level now takes string inputs in addition to integers
- Removed ``--storm-log-level`` cortex command line argument
- Added documentation for storm query logging and cell logging