### PR TITLE
Resolve some grammar ambiguities

### DIFF
--- a/synapse/lib/parser.py
+++ b/synapse/lib/parser.py
@@ -361,7 +361,8 @@ class AstConverter(lark.Transformer):
 with s_datfile.openDatFile('synapse.lib/storm.lark') as larkf:
     _grammar = larkf.read().decode()
 
-LarkParser = lark.Lark(_grammar, regex=True, start=['query', 'lookup', 'cmdrargs'], propagate_positions=True)
+LarkParser = lark.Lark(_grammar, regex=True, start=['query', 'lookup', 'cmdrargs'],
+                       propagate_positions=True)
 
 class Parser:
     '''
@@ -479,6 +480,7 @@ ruleClassMap = {
     'andexpr': s_ast.AndCond,
     'condsubq': s_ast.SubqCond,
     'dollarexpr': s_ast.DollarExpr,
+    'dollarexpr2': s_ast.DollarExpr,
     'edgeaddn1': s_ast.EditEdgeAdd,
     'edgedeln1': s_ast.EditEdgeDel,
     'edgeaddn2': lambda kids: s_ast.EditEdgeAdd(kids, n2=True),
@@ -587,6 +589,8 @@ JUSTCHARS: /[^()=\[\]{}'"\s]*[^,()=\[\]{}'"\s]/
 
 CmdStringParser = lark.Lark(CmdStringGrammar,
                             start='cmdstring',
+                            parser='lalr',
+                            debug=True,
                             regex=True,
                             propagate_positions=True)
 

--- a/synapse/lib/parser.py
+++ b/synapse/lib/parser.py
@@ -609,7 +609,6 @@ JUSTCHARS: /[^()=\[\]{}'"\s]*[^,()=\[\]{}'"\s]/
 
 CmdStringParser = lark.Lark(CmdStringGrammar,
                             start='cmdstring',
-                            debug=True,
                             regex=True,
                             propagate_positions=True)
 

--- a/synapse/lib/parser.py
+++ b/synapse/lib/parser.py
@@ -480,7 +480,6 @@ ruleClassMap = {
     'andexpr': s_ast.AndCond,
     'condsubq': s_ast.SubqCond,
     'dollarexpr': s_ast.DollarExpr,
-    'dollarexpr2': s_ast.DollarExpr,
     'edgeaddn1': s_ast.EditEdgeAdd,
     'edgedeln1': s_ast.EditEdgeDel,
     'edgeaddn2': lambda kids: s_ast.EditEdgeAdd(kids, n2=True),
@@ -589,7 +588,6 @@ JUSTCHARS: /[^()=\[\]{}'"\s]*[^,()=\[\]{}'"\s]/
 
 CmdStringParser = lark.Lark(CmdStringGrammar,
                             start='cmdstring',
-                            parser='lalr',
                             debug=True,
                             regex=True,
                             propagate_positions=True)

--- a/synapse/lib/storm.lark
+++ b/synapse/lib/storm.lark
@@ -202,9 +202,8 @@ CMPR: /(?!<-)[@?!<>^~=][@!<>^~=]*/
 
 _safe_cmpr: BYNAME | CMPR
 
-_rootvalunodollarexpr: _varvalu | relpropvalu | univpropvalu | tagvalu | tagpropvalu | DOUBLEQUOTEDSTRING
-    | SINGLEQUOTEDSTRING
-_rootvalu: _rootvalunodollarexpr | dollarexpr
+_rootvalu: _varvalu | relpropvalu | univpropvalu | tagvalu | tagpropvalu | DOUBLEQUOTEDSTRING
+    | SINGLEQUOTEDSTRING | dollarexpr
 
 // Common subset + stuff allowable in command arguments
 _argvalu: _rootvalu | valulist | embedquery
@@ -215,7 +214,7 @@ _basevalu: _argvalu | baresubquery
 _valu: _basevalu | NONQUOTEWORD
 
 // Just like _valu, but doesn't allow valu lists or unquoted strings or queries
-_exprvalu: NUMBER | HEXNUMBER | BOOL | _rootvalunodollarexpr
+_exprvalu: NUMBER | HEXNUMBER | BOOL | _rootvalu
 
 // command arguments
 _toknvalu: _argvalu | WORDTOKN
@@ -276,7 +275,7 @@ _cond: notcond | "(" _WS? _condexpr _WS? ")"
     | tagpropcond | hastagpropcond
     | tagcond | tagvalucond
     | condsubq | arraycond
-    | _varvalu | dollarexpr2
+    | _varvalu | dollarexpr
 
 notcond: "not" _WS _cond
 
@@ -301,6 +300,7 @@ _ARRAYCONDSTART: "*["
 _condexpr: _cond | orexpr | andexpr
 orexpr: _condexpr _WS "or" _WS _cond
 andexpr: _condexpr _WS "and" _WS _cond
+
 
 DOUBLEQUOTEDSTRING: ESCAPED_STRING
 SINGLEQUOTEDSTRING: /'[^']*'/
@@ -341,9 +341,7 @@ BASEPROP: /[a-z_][a-z0-9]*(?:(\:\:|\:|\.)[a-z_][a-z0-9]*)*/
 CMDNAME: /\b(?!(init|fini|function|return|yield|break|continue|for|while|switch|else|elif|if|not|or|and)\b)[a-z][a-z0-9.]+\b/
 
 // The entry point for a $(...) expression.  The initial dollar sign is now optional
-dollarexpr: "$"? _dollarexprroot
-dollarexpr2: "$" _dollarexprroot
-_dollarexprroot: "(" _WSCOMM? expror _WSCOMM? ")"
+dollarexpr: "$"? "(" _WSCOMM? expror _WSCOMM? ")"
 EXPRCMPR: /<=|>=|<|>|=|!=|~=|\^=/
 EXPRPLUS: "+"
 EXPRMINUS: "-"
@@ -363,4 +361,4 @@ AND: "and"
 ?exprcmp: exprsum | exprcmp _WSCOMM? EXPRCMPR _WSCOMM? exprsum
 ?exprsum: exprproduct | exprsum _WSCOMM? (EXPRPLUS | EXPRMINUS) _WSCOMM? exprproduct
 ?exprproduct: _expratom | exprproduct _WSCOMM? (EXPRTIMES | EXPRDIVIDE) _WSCOMM? _expratom
-_expratom: _exprvalu | "(" _WSCOMM? expror _WSCOMM? ")"
+_expratom: _exprvalu

--- a/synapse/lib/storm.lark
+++ b/synapse/lib/storm.lark
@@ -16,7 +16,7 @@
 
 // Entry point for an unadorned storm query
 query: [_WSCOMM? "|"] _WSCOMM? (_querystartnon | _querystartedit | _querystartcommand)? _WSCOMM?
-lookup: looklist _WS? [ "|" query ]
+lookup: _WS? looklist _WS? [ "|" query ]
 
 // A query that starts with a command
 _querystartcommand: stormcmd [ _WSCOMM? "|" _WSCOMM? (_querystartcommand |  _querystartnon | _querystartedit) ]
@@ -302,7 +302,6 @@ _ARRAYCONDSTART: "*["
 _condexpr: _cond | orexpr | andexpr
 orexpr: _condexpr _WS "or" _WS _cond
 andexpr: _condexpr _WS "and" _WS _cond
-
 
 DOUBLEQUOTEDSTRING: ESCAPED_STRING
 SINGLEQUOTEDSTRING: /'[^']*'/

--- a/synapse/lib/storm.lark
+++ b/synapse/lib/storm.lark
@@ -16,7 +16,7 @@
 
 // Entry point for an unadorned storm query
 query: [_WSCOMM? "|"] _WSCOMM? (_querystartnon | _querystartedit | _querystartcommand)? _WSCOMM?
-lookup: _WS? looklist _WS? [ "|" query ]
+lookup: looklist _WS? [ "|" query ]
 
 // A query that starts with a command
 _querystartcommand: stormcmd [ _WSCOMM? "|" _WSCOMM? (_querystartcommand |  _querystartnon | _querystartedit) ]
@@ -32,13 +32,13 @@ _morenons: ( _WSCOMM? "|" _WSCOMM? | _WSCOMM) (_querystartcommand | _querystartn
 _editblock: "[" _WS? _editopers _WS? "]"
 _editopers: _editoper (_WS _editoper)*
 
-///A single edit operation
+// A single edit operation
 _editoper: editnodeadd
             | editpropset | editunivset | edittagpropset | edittagadd
             | editpropdel | editunivdel | edittagpropdel | edittagdel
             | editparens | edgeaddn1 | edgedeln1 | edgeaddn2 | edgedeln2
 
-///Parenthesis in an edit block don't have incoming nodes
+// Parenthesis in an edit block don't have incoming nodes
 editparens: "(" _WS? editnodeadd [ _WS _editopers ] _WS? ")"
 edittagadd: "+" [SETTAGOPER] tagname [_WS? "=" _WS? _valu]
 editunivdel: "-" univprop
@@ -82,7 +82,7 @@ switchcase: "switch" _WS _varvalu _WS? "{" (_WSCOMM? (DEFAULTCASE | DOUBLEQUOTED
 DEFAULTCASE: "*"
 CASEBARE: /(?!\*)([^:\s"']+)/
 
-yieldvalu: YIELD _WS _valu
+yieldvalu: YIELD _WS _argvalu
 
 initblock: "init" _WSCOMM? "{" query "}"
 finiblock: "fini" _WSCOMM? "{" query "}"
@@ -202,9 +202,9 @@ CMPR: /(?!<-)[@?!<>^~=][@!<>^~=]*/
 
 _safe_cmpr: BYNAME | CMPR
 
-// Common subset of values allowed
-_rootvalu: _varvalu | relpropvalu | univpropvalu | tagvalu | tagpropvalu | DOUBLEQUOTEDSTRING
-    | SINGLEQUOTEDSTRING | dollarexpr
+_rootvalunodollarexpr: _varvalu | relpropvalu | univpropvalu | tagvalu | tagpropvalu | DOUBLEQUOTEDSTRING
+    | SINGLEQUOTEDSTRING
+_rootvalu: _rootvalunodollarexpr | dollarexpr
 
 // Common subset + stuff allowable in command arguments
 _argvalu: _rootvalu | valulist | embedquery
@@ -215,7 +215,7 @@ _basevalu: _argvalu | baresubquery
 _valu: _basevalu | NONQUOTEWORD
 
 // Just like _valu, but doesn't allow valu lists or unquoted strings or queries
-_exprvalu: NUMBER | HEXNUMBER | BOOL | _rootvalu
+_exprvalu: NUMBER | HEXNUMBER | BOOL | _rootvalunodollarexpr
 
 // command arguments
 _toknvalu: _argvalu | WORDTOKN
@@ -238,6 +238,7 @@ _EMBEDQUERYSTART: "${"
 NONQUOTEWORD: /(?!\/\/)[\w\-\+\?\*\/\\][^\s\),=\]}\|]*/
 
 // An unquoted string within a storm command argument list
+// TODO: revisit this doesn't make sense
 WORDTOKN: /(?!\/[\/\*])[\w\+\-\?\*\/\\][^\s\=\|\}\)]*/
 
 // An unquoted string within a list syntax
@@ -268,13 +269,14 @@ filtoper: FILTPREFIX _cond
 FILTPREFIX: "+" | "-"
 
 // Condition used for filters
+// TODO:  unify cond and dollarexpr
 _cond: notcond | "(" _WS? _condexpr _WS? ")"
     | hasrelpropcond | relpropcond
     | abspropcond | hasabspropcond
     | tagpropcond | hastagpropcond
     | tagcond | tagvalucond
     | condsubq | arraycond
-    | _varvalu | dollarexpr
+    | _varvalu | dollarexpr2
 
 notcond: "not" _WS _cond
 
@@ -339,7 +341,9 @@ BASEPROP: /[a-z_][a-z0-9]*(?:(\:\:|\:|\.)[a-z_][a-z0-9]*)*/
 CMDNAME: /\b(?!(init|fini|function|return|yield|break|continue|for|while|switch|else|elif|if|not|or|and)\b)[a-z][a-z0-9.]+\b/
 
 // The entry point for a $(...) expression.  The initial dollar sign is now optional
-dollarexpr: "$"? "(" _WSCOMM? expror _WSCOMM? ")"
+dollarexpr: "$"? _dollarexprroot
+dollarexpr2: "$" _dollarexprroot
+_dollarexprroot: "(" _WSCOMM? expror _WSCOMM? ")"
 EXPRCMPR: /<=|>=|<|>|=|!=|~=|\^=/
 EXPRPLUS: "+"
 EXPRMINUS: "-"

--- a/synapse/tests/test_lib_grammar.py
+++ b/synapse/tests/test_lib_grammar.py
@@ -14,6 +14,7 @@ import synapse.tests.utils as s_t_utils
 # flake8: noqa: E501
 
 _Queries = [
+    'test:array*[=1.2.3.4]',
     'macro.set hehe ${ inet:ipv4 }',
     '$q=${#foo.bar}',
     'metrics.edits.byprop inet:fqdn:domain --newv $lib.null',
@@ -581,10 +582,16 @@ _Queries = [
     'inet:ipv4=1.2.3.4 -+> #*',
     'inet:ipv4=1.2.3.4 -+> #biz.*',
     'inet:ipv4=1.2.3.4 -+> #bar.baz',
+    'function middlechild(arg2) { yield $rockbottom($arg2) }',
+    '[test:comp=(10,bar)] yield { -> test:int}',
+    'test:arrayprop +:ints*[ range=(50,100) ]',
+    'inet:ipv4 +(($foo and $bar))',
+    'inet:ipv4 +($(0 and 1))',
 ]
 
 # Generated with print_parse_list below
 _ParseResults = [
+    'Query: [LiftByArray: [Const: test:array, Const: =, Const: 1.2.3.4]]',
     'Query: [CmdOper: [Const: macro.set, List: [Const: hehe, EmbedQuery:  inet:ipv4 ]]]',
     'Query: [SetVarOper: [Const: q, EmbedQuery: #foo.bar]]',
     'Query: [CmdOper: [Const: metrics.edits.byprop, List: [Const: inet:fqdn:domain, Const: --newv, VarDeref: [VarValue: [Const: lib], Const: null]]]]',
@@ -1069,7 +1076,11 @@ _ParseResults = [
     'Query: [LiftPropBy: [Const: inet:ipv4, Const: =, Const: 1.2.3.4], PivotToTags: [TagMatch: [Const: *]], isjoin=True]',
     'Query: [LiftPropBy: [Const: inet:ipv4, Const: =, Const: 1.2.3.4], PivotToTags: [TagMatch: [Const: biz.*]], isjoin=True]',
     'Query: [LiftPropBy: [Const: inet:ipv4, Const: =, Const: 1.2.3.4], PivotToTags: [TagMatch: [Const: bar.baz]], isjoin=True]',
-
+    'Query: [Function: [Const: middlechild, FuncArgs: [Const: arg2], Query: [YieldValu: [FuncCall: [VarValue: [Const: rockbottom], CallArgs: [VarValue: [Const: arg2]], CallKwargs: []]]]]]',
+    'Query: [EditNodeAdd: [FormName: [Const: test:comp], Const: =, List: [Const: 10, Const: bar]], SubQuery: [Query: [FormPivot: [AbsProp: test:int], isjoin=False]]]',
+    'Query: [LiftProp: [Const: test:arrayprop], FiltOper: [Const: +, ArrayCond: [RelProp: [Const: ints], Const: range=, List: [Const: 50, Const: 100]]]]',
+    'Query: [LiftProp: [Const: inet:ipv4], FiltOper: [Const: +, AndCond: [VarValue: [Const: foo], VarValue: [Const: bar]]]]',
+    'Query: [LiftProp: [Const: inet:ipv4], FiltOper: [Const: +, DollarExpr: [ExprAndNode: [Const: 0, Const: and, Const: 1]]]]',
 ]
 
 class GrammarTest(s_t_utils.SynTest):

--- a/synapse/tests/test_lib_storm_format.py
+++ b/synapse/tests/test_lib_storm_format.py
@@ -1,9 +1,9 @@
 import synapse.lib.storm_format as s_storm_format
 import synapse.lib.parser as s_parser
 
-from synapse.tests.test_lib_grammar import _Queries
+from synapse.tests.test_lib_grammar import Queries
 
 def test_highlight_storm():
 
-    for _, query in enumerate(_Queries):
+    for _, query in enumerate(Queries):
         s_storm_format.highlight_storm(s_parser.LarkParser, query)


### PR DESCRIPTION
Resolve two Storm grammar ambiguities:

* The yield keyword in front of a subquery vs. yielding from a function
* Parenthesis inside a dollar expression being another dollar expression vs. just a nodeexpr.

Also identify but didn't resolve an ambiguity between filter conditions and dollar expressions.