### PR TITLE
Bug aha possible attributeerror (SYN-2337)

### DIFF
--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -747,7 +747,7 @@ class Proxy(s_base.Base):
     async def task(self, todo, name=None):
 
         if self.isfini:
-            raise s_exc.IsFini()
+            raise s_exc.IsFini(mesg='Telepath Proxy isfini')
 
         if self.sess is not None:
             return await self.taskv2(todo, name=name)
@@ -973,7 +973,7 @@ class Client(s_base.Base):
         await self.waitready(timeout=timeout)
         ret = self._t_proxy
         if ret is None or ret.isfini is True:
-            raise s_exc.NoSuchObj(mesg='Telepath Client Proxy is not available.')
+            raise s_exc.IsFini(mesg='Telepath Client Proxy is not available.')
         return ret
 
     async def _initTeleLink(self, url):
@@ -1026,6 +1026,8 @@ class Client(s_base.Base):
                 self._setNextUrl(url)
                 logger.warning(f'telepath task redirected: ({s_urlhelp.sanitizeUrl(url)})')
                 await self._t_proxy.fini()
+
+        raise s_exc.IsFini(mesg='Telepath Client isfini')
 
     async def waitready(self, timeout=10):
         await asyncio.wait_for(self._t_ready.wait(), self._t_conf.get('timeout', timeout))

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -982,16 +982,12 @@ class Client(s_base.Base):
         self._t_proxy._link_poolsize = self._t_conf.get('link_poolsize', 4)
 
         async def fini():
-            if self.isfini:
-                # Since we teardown the proxy on client teardown, we don't want
-                # to be modifying the client during fini by adding a new active task
-                # after we've killed the existing active tasks
-                return
             if self._t_named_meths:
                 for name in self._t_named_meths:
                     delattr(self, name)
                 self._t_named_meths.clear()
-            await self._fireLinkLoop()
+            if not self.isfini:
+                await self._fireLinkLoop()
 
         self._t_proxy.onfini(fini)
 

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -153,7 +153,7 @@ async def getAhaProxy(urlinfo):
             raise
 
         except Exception as e:
-            logger.exception(f'aha resolver ({s_urlhelp.sanitizeUrl(ahaurl)})')
+            logger.exception(f'aha resolver ({ahaurl})')
             laste = e
 
     if laste is not None:

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -331,7 +331,7 @@ class AhaTest(s_test.SynTest):
 
                     await aha.fini()
 
-                    with self.raises(s_exc.NoSuchObj):
+                    with self.raises(s_exc.IsFini):
 
                         async with await s_telepath.openurl('aha://root:secret@0.cryo.mynet') as proxy:
                             self.fail('Should never reach a connection.')

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -333,5 +333,5 @@ class AhaTest(s_test.SynTest):
 
                     with self.raises(s_exc.NoSuchObj):
 
-                        async with await s_telepath.openurl('aha://root:secret@0.ryo.mynet') as proxy:
+                        async with await s_telepath.openurl('aha://root:secret@0.cryo.mynet') as proxy:
                             self.fail('Should never reach a connection.')

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -2,12 +2,15 @@ import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.telepath as s_telepath
 
+import synapse.lib.aha as s_aha
+
 import synapse.tools.backup as s_tools_backup
 
 import synapse.tests.utils as s_test
 
 
 class AhaTest(s_test.SynTest):
+    aha_ctor = s_aha.AhaCell.anit
 
     async def test_lib_aha_mirrors(self):
 
@@ -294,3 +297,41 @@ class AhaTest(s_test.SynTest):
                 self.len(1, s_telepath.aha_clients)
                 self.nn(info.get('client'))
                 await fini()
+
+    async def test_lib_aha_finid_cell(self):
+
+        with self.getTestDir() as dirn:
+            async with await self.aha_ctor(dirn) as aha:
+
+                cryo0_dirn = s_common.gendir(aha.dirn, 'cryo0')
+
+                host, port = await aha.dmon.listen('tcp://127.0.0.1:0')
+                await aha.auth.rootuser.setPasswd('hehehaha')
+
+                wait00 = aha.waiter(1, 'aha:svcadd')
+                conf = {
+                    'aha:name': '0.cryo.mynet',
+                    'aha:admin': 'root@cryo.mynet',
+                    'aha:registry': [f'tcp://root:hehehaha@127.0.0.1:{port}',
+                                     f'tcp://root:hehehaha@127.0.0.1:{port}'],
+                    'dmon:listen': 'tcp://0.0.0.0:0/',
+                }
+                async with self.getTestCryo(dirn=cryo0_dirn, conf=conf) as cryo:
+
+                    await cryo.auth.rootuser.setPasswd('secret')
+
+                    ahaadmin = await cryo.auth.getUserByName('root@cryo.mynet')
+                    self.nn(ahaadmin)
+                    self.true(ahaadmin.isAdmin())
+
+                    await wait00.wait(timeout=2)
+
+                    async with await s_telepath.openurl('aha://root:secret@0.cryo.mynet') as proxy:
+                        self.nn(await proxy.getCellIden())
+
+                    await aha.fini()
+
+                    with self.raises(s_exc.NoSuchObj):
+
+                        async with await s_telepath.openurl('aha://root:secret@0.ryo.mynet') as proxy:
+                            self.fail('Should never reach a connection.')

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -813,6 +813,10 @@ class TeleTest(s_t_utils.SynTest):
             rdir1.redir = url0
             self.eq(110, await targ.dostuff(100))
 
+        # client is now fini and methods on longer work
+        with self.raises(s_exc.IsFini):
+            await targ.dostuff(100)
+
         await dmon0.fini()
         await dmon1.fini()
 


### PR DESCRIPTION
- Remove a possible attributeerror and replace it with an explicit synerr.isfini
- Prevent reuse of a Telepath client object for remote calls if it has been finid by now raising 
- Remove a invalid precondition check in telepath.client._initTeleLink
- Prevent the fini handler from _initTeleLink from re-firing when the client has been fini'd