### PR TITLE
Feat stormtype updates

### DIFF
--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3428,9 +3428,9 @@ class List(Prim):
                       {'name': 'valu', 'type': 'any', 'desc': 'The item to append to the list.', },
                   ),
                   'returns': {'type': 'null', }}},
-        {'name': 'reverse', 'desc': 'Reverse the order of the list',
+        {'name': 'reverse', 'desc': 'Reverse the order of the list in place',
          'type': {'type': 'function', '_funcname': '_methListReverse',
-                  'returns': {'type': 'list', 'desc': 'The reversed list'}}},
+                  'returns': {'type': 'null', }}},
     )
     _storm_typename = 'list'
     _ismutable = True
@@ -3501,8 +3501,7 @@ class List(Prim):
                                           len=len(self.valu), indx=indx) from None
 
     async def _methListReverse(self):
-        valu = self.valu[::-1]
-        return List(valu, path=self.path)
+        self.valu.reverse()
 
     async def _methListLength(self):
         s_common.deprecated('StormType List.length()')

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3413,6 +3413,9 @@ class List(Prim):
                       {'name': 'valu', 'type': 'any', 'desc': 'The item to append to the list.', },
                   ),
                   'returns': {'type': 'null', }}},
+        {'name': 'reverse', 'desc': 'Reverse the order of the list',
+         'type': {'type': 'function', '_funcname': '_methListReverse',
+                  'returns': {'type': 'list', 'desc': 'The reversed list'}}},
     )
     _storm_typename = 'list'
     _ismutable = True
@@ -3429,6 +3432,7 @@ class List(Prim):
             'index': self._methListIndex,
             'length': self._methListLength,
             'append': self._methListAppend,
+            'reverse': self._methListReverse,
         }
 
     async def setitem(self, name, valu):
@@ -3479,6 +3483,10 @@ class List(Prim):
         except IndexError as e:
             raise s_exc.StormRuntimeError(mesg=str(e), valurepr=repr(self.valu),
                                           len=len(self.valu), indx=indx) from None
+
+    async def _methListReverse(self):
+        valu = self.valu[::-1]
+        return List(valu, path=self.path)
 
     async def _methListLength(self):
         s_common.deprecated('StormType List.length()')

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -5035,6 +5035,7 @@ class View(Prim):
     _storm_locals = (
         {'name': 'iden', 'desc': 'The iden of the View.', 'type': 'str', },
         {'name': 'layers', 'desc': 'The ``storm:layer`` objects associated with the ``storm:view``.', 'type': 'list', },
+        {'name': 'parent', 'desc': 'The parent View. Will be ``$lib.null`` if the view is not a fork.', 'type': 'str'},
         {'name': 'triggers', 'desc': 'The ``storm:trigger`` objects associated with the ``storm:view``.',
          'type': 'list', },
         {'name': 'set', 'desc': 'Set a arbitrary value in the View definition.',
@@ -5106,6 +5107,7 @@ class View(Prim):
         self.locls.update(self.getObjLocals())
         self.locls.update({
             'iden': self.valu.get('iden'),
+            'parent': self.valu.get('parent'),
             'triggers': [Trigger(self.runt, tdef) for tdef in self.valu.get('triggers')],
             'layers': [Layer(self.runt, ldef, path=self.path) for ldef in self.valu.get('layers')],
         })

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -897,6 +897,25 @@ class StormTypesTest(s_test.SynTest):
             ret = await core.callStorm(q)
             self.eq(ret, ('baz', 'bar', 'foo',))
 
+            # sort a list
+            q = '$v=(foo,bar,baz) $v.sort() return ($v)'
+            ret = await core.callStorm(q)
+            self.eq(ret, ('bar', 'baz', 'foo',))
+
+            # Sort a few text objects
+            q = '$foo=$lib.text(foo) $bar=$lib.text(bar) $baz=$lib.text(baz) $v=($foo, $bar, $baz) $v.sort() return ($v)'
+            ret = await core.callStorm(q)
+            self.eq(ret, ('bar', 'baz', 'foo',))
+
+            # incompatible sort types
+            with self.raises(s_exc.StormRuntimeError):
+                await core.callStorm('$v=(foo,bar,(1)) $v.sort() return ($v)')
+
+            # mix Prims and heavy objects
+            with self.raises(s_exc.StormRuntimeError):
+                q = '$foo=$lib.text(foo) $bar=$lib.text(bar) $v=($foo, aString, $bar,) $v.sort() return ($v)'
+                await core.callStorm(q)
+
             # Python Tuples can be treated like a List object for accessing via data inside of.
             q = '[ test:comp=(10,lol) ] $x=$node.ndef().index(1).index(1) [ test:str=$x ]'
             nodes = await core.nodes(q)

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -892,6 +892,11 @@ class StormTypesTest(s_test.SynTest):
             self.eq(nodes[0].ndef, ('test:str', 'bar'))
             self.eq(nodes[1].ndef, ('test:int', 3))
 
+            # Reverse a list
+            q = '$v=(foo,bar,baz) $v=$v.reverse() return ($v)'
+            ret = await core.callStorm(q)
+            self.eq(ret, ('baz', 'bar', 'foo',))
+
             # Python Tuples can be treated like a List object for accessing via data inside of.
             q = '[ test:comp=(10,lol) ] $x=$node.ndef().index(1).index(1) [ test:str=$x ]'
             nodes = await core.nodes(q)

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -893,7 +893,7 @@ class StormTypesTest(s_test.SynTest):
             self.eq(nodes[1].ndef, ('test:int', 3))
 
             # Reverse a list
-            q = '$v=(foo,bar,baz) $v=$v.reverse() return ($v)'
+            q = '$v=(foo,bar,baz) $v.reverse() return ($v)'
             ret = await core.callStorm(q)
             self.eq(ret, ('baz', 'bar', 'foo',))
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -2618,6 +2618,10 @@ class StormTypesTest(s_test.SynTest):
             '''
             forkiden, forklayr = await core.callStorm(q)
 
+            # Parent is populated on the fork and not the default view
+            q = '''$dp=$lib.view.get().parent $fp=$lib.view.get($iden).parent return (($dp, $fp))'''
+            self.eq((None, mainiden), await core.callStorm(q, opts={'vars': {'iden': forkiden}}))
+
             self.isin(forkiden, core.views)
             self.isin(forklayr, core.layers)
 


### PR DESCRIPTION
Add the following stormtypes updatse

- Implement ``__lt__`` on Prim and use functools total ordering to allow sorting Prims of the same type in a list.
- List.reverse()
- List.sort(reversed=false)
- Add View.parent property to the View object.