### PR TITLE
LibLift/Snap caching issue fix (SYN-2565)

### DIFF
--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -792,6 +792,16 @@ class Snap(s_base.Base):
                     node.bylayer['tags'].pop((tag, prop), None)
                     continue
 
+                if etyp == s_layer.EDIT_NODEDATA_SET:
+                    name, data, oldv = parms
+                    node.nodedata[name] = data
+                    continue
+
+                if etyp == s_layer.EDIT_NODEDATA_DEL:
+                    name, oldv = parms
+                    node.nodedata.pop(name, None)
+                    continue
+
         [await func(*args, **kwargs) for (func, args, kwargs) in callbacks]
 
         if actualedits:


### PR DESCRIPTION
Fixes issue where the livenodes cache in a snap would cache a node's nodedata while under lib.lift.byNodeData. This produced some odd edge cases where you could set the node data, fetch the value immediately after, but get back the original cached value.