### PR TITLE
Scrape URLs capturing prefix characters (SYN-2606)

### DIFF
--- a/synapse/lib/scrape.py
+++ b/synapse/lib/scrape.py
@@ -30,14 +30,14 @@ re_fang = regex.compile("|".join(map(regex.escape, FANGS.keys())), regex.IGNOREC
 
 # these must be ordered from most specific to least specific to allow first=True to work
 scrape_types = [  # type: ignore
-    ('inet:url', r'[a-zA-Z][a-zA-Z0-9]*://(?(?=[,.]+[ \'\"\t\n\r\f\v])|[^ \'\"\t\n\r\f\v])+', {}),
-    ('inet:email', r'(?=(?:[^a-z0-9_.+-]|^)([a-z0-9_\.\-+]{1,256}@(?:[a-z0-9_-]{1,63}\.){1,10}(?:%s))(?:[^a-z0-9_.-]|[.\s]|$))' % tldcat, {}),
-    ('inet:server', r'((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?):[0-9]{1,5})', {}),
-    ('inet:ipv4', r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)', {}),
-    ('inet:fqdn', r'(?=(?:[^a-z0-9_.-]|^)((?:[a-z0-9_-]{1,63}\.){1,10}(?:%s))(?:[^a-z0-9_.-]|[.\s]|$))' % tldcat, {}),
-    ('hash:md5', r'(?=(?:[^A-Za-z0-9]|^)([A-Fa-f0-9]{32})(?:[^A-Za-z0-9]|$))', {}),
-    ('hash:sha1', r'(?=(?:[^A-Za-z0-9]|^)([A-Fa-f0-9]{40})(?:[^A-Za-z0-9]|$))', {}),
-    ('hash:sha256', r'(?=(?:[^A-Za-z0-9]|^)([A-Fa-f0-9]{64})(?:[^A-Za-z0-9]|$))', {}),
+    ('inet:url', r'(?P<valu>[a-zA-Z][a-zA-Z0-9]*://(?(?=[,.]+[ \'\"\t\n\r\f\v])|[^ \'\"\t\n\r\f\v])+)', {}),
+    ('inet:email', r'(?=(?:[^a-z0-9_.+-]|^)(?P<valu>[a-z0-9_\.\-+]{1,256}@(?:[a-z0-9_-]{1,63}\.){1,10}(?:%s))(?:[^a-z0-9_.-]|[.\s]|$))' % tldcat, {}),
+    ('inet:server', r'(?P<valu>(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?):[0-9]{1,5})', {}),
+    ('inet:ipv4', r'(?P<valu>(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))', {}),
+    ('inet:fqdn', r'(?=(?:[^a-z0-9_.-]|^)(?P<valu>(?:[a-z0-9_-]{1,63}\.){1,10}(?:%s))(?:[^a-z0-9_.-]|[.\s]|$))' % tldcat, {}),
+    ('hash:md5', r'(?=(?:[^A-Za-z0-9]|^)(?P<valu>[A-Fa-f0-9]{32})(?:[^A-Za-z0-9]|$))', {}),
+    ('hash:sha1', r'(?=(?:[^A-Za-z0-9]|^)(?P<valu>[A-Fa-f0-9]{40})(?:[^A-Za-z0-9]|$))', {}),
+    ('hash:sha256', r'(?=(?:[^A-Za-z0-9]|^)(?P<valu>[A-Fa-f0-9]{64})(?:[^A-Za-z0-9]|$))', {}),
 ]
 
 regexes = {name: regex.compile(rule, regex.IGNORECASE) for (name, rule, opts) in scrape_types}
@@ -69,14 +69,19 @@ def scrape(text, ptype=None, refang=True, first=False):
     '''
 
     if refang:
+        print(f'otext {text=}')
         text = refang_text(text)
+        print(f'ntext {text=}')
 
     for ruletype, _, _ in scrape_types:
         if ptype and ptype != ruletype:
             continue
 
         regx = regexes.get(ruletype)
-        for valu in regx.findall(text):
+        for valu in regx.finditer(text):  # type: regex.Match
+            print(ruletype, valu)
+            mnfo = valu.groupdict()
+            valu = mnfo.get('valu')
             yield (ruletype, valu)
             if first:
                 return

--- a/synapse/tests/test_lib_scrape.py
+++ b/synapse/tests/test_lib_scrape.py
@@ -28,6 +28,21 @@ data1 = '''
     tcp://foo.bar.org:4665/,,..a
 '''
 
+data2 = '''
+A bunch of prefixed urls
+
+<https://www.foobar.com/things.html>
+
+(https://blog.newp.com/scrape/all/the/urls)
+
+[https://www.thingspace.com/blog/giggles.html]
+
+{https://testme.org/test.php}
+
+https://c2server.com/evil/malware/doesnot[care+]aboutstandards{at-all}
+
+'''
+
 class ScrapeTest(s_t_utils.SynTest):
 
     def test_scrape(self):
@@ -63,6 +78,13 @@ class ScrapeTest(s_t_utils.SynTest):
         nodes.remove(('inet:url', 'tcp://foo.bar.org:4665/'))
         nodes.remove(('inet:url', 'tcp://foo.bar.org:4665/'))
         nodes.remove(('inet:url', 'tcp://foo.bar.org:4665/,,..a'))
+
+        nodes = list(s_scrape.scrape(data2))
+        nodes.remove(('inet:url', 'https://www.foobar.com/things.html'))
+        nodes.remove(('inet:url', 'https://blog.newp.com/scrape/all/the/urls'))
+        nodes.remove(('inet:url', 'https://www.thingspace.com/blog/giggles.html'))
+        nodes.remove(('inet:url', 'https://testme.org/test.php'))
+        nodes.remove(('inet:url', 'https://c2server.com/evil/malware/doesnot[care+]aboutstandards{at-all}'))
 
     def test_scrape_sequential(self):
         md5 = ('a' * 32, 'b' * 32, )


### PR DESCRIPTION
- Cut over scrape from using findall to finditer and adding named capture groups
- Add some common text prefixes for URLs and strip associated trailing values if encountered