### PR TITLE
Add some missing mesg arguments to exceptions (SYN-2671)

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -2618,7 +2618,7 @@ class VarValue(Value):
 
     def validate(self, runt):
         if runt.runtvars.get(self.name) is None:
-            raise s_exc.NoSuchVar(name=self.name)
+            raise s_exc.NoSuchVar(mesg=f'Missing variable: {self.name}', name=self.name)
 
     def prepare(self):
         assert isinstance(self.kids[0], Const)
@@ -2638,7 +2638,7 @@ class VarValue(Value):
         if valu is not s_common.novalu:
             return valu
 
-        raise s_exc.NoSuchVar(name=self.name)
+        raise s_exc.NoSuchVar(mesg=f'Missing variable: {self.name}', name=self.name)
 
 class VarDeref(Value):
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -703,11 +703,11 @@ class HugeNum(Type):
         huge = s_common.hugenum(valu)
         if huge > hugemax:
             mesg = f'Value ({valu}) is too large for hugenum.'
-            raise s_exc.BadTypeValu(mesg)
+            raise s_exc.BadTypeValu(mesg=mesg)
 
         if abs(huge) > hugemax:
             mesg = f'Value ({valu}) is too small for hugenum.'
-            raise s_exc.BadTypeValu(mesg)
+            raise s_exc.BadTypeValu(mesg=mesg)
 
         if self.opts.get('norm'):
             huge.normalize(), {}

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -37,7 +37,7 @@ class DnsName(s_types.Str):
             parts = [c for c in norm[:-len(self.inarpa6)][::-1] if c != '.']
             try:
                 if len(parts) != 32:
-                    raise s_exc.BadTypeValu
+                    raise s_exc.BadTypeValu(mesg='Invalid number of ipv6 parts')
                 temp = int(''.join(parts), 16)
                 ipv6norm, info = self.modl.type('inet:ipv6').norm(temp)
             except s_exc.BadTypeValu as e:


### PR DESCRIPTION
A quick pass for a few missing `mesg` values