### PR TITLE
Thesilence docs

### DIFF
--- a/docs/synapse/userguides/index_tools.rst
+++ b/docs/synapse/userguides/index_tools.rst
@@ -4,11 +4,12 @@
 Tools
 #####
 
-Synapse includes a number of tools. **cmdr** provides an interactive command shell to a Cortex, while other tools allow
-users to perform specific tasks. These tools are documented below.
+Synapse includes a number of tools. **storm** provides an interactive command line interface to a Synapse Cortex using the Storm query language - it is the primary means for users to interact with Synapse. **cmdr** provides an interactive command shell to a Cortex, primarily intended for developers or administrator use. Other tools focus on specific tasks. These tools are documented below.
 
 .. toctree::
     :titlesonly:
+
+    syn_tools_storm
 
     syn_tools_cmdr
     syn_ref_cmdr

--- a/docs/synapse/userguides/storm_ref_cmd.rstorm
+++ b/docs/synapse/userguides/storm_ref_cmd.rstorm
@@ -1219,8 +1219,7 @@ The ``spin`` command is used to suppress the output of a Storm query. ``Spin`` s
 
 - Count the number of email addresses without displaying the inet:email nodes:
 
-
-.. 
+ 
 .. storm-cli:: inet:email | count | spin
 
 

--- a/docs/synapse/userguides/storm_ref_intro.rst
+++ b/docs/synapse/userguides/storm_ref_intro.rst
@@ -5,23 +5,29 @@
 Storm Reference - Introduction
 ==============================
 
-**Storm** is the query language used to interact with data in a Cortex. Storm allows you to ask about, retrieve, annotate, add, modify, and delete data from a Cortex. Most Synapse users (e.g., those conducting analysis on the data) will access Storm via the Synapse  **cmdr** command-line interface (CLI) (see :ref:`syn-tools-cmdr`), using the :ref:`syn-storm` command to invoke a Storm query:
+**Storm** is the query language used to interact with data in Synapse. Storm allows you to ask about, retrieve, annotate, add, modify, and delete data from a Synapse Cortex. Most Synapse users will access Synapse via the Storm command-line interface (**Storm CLI**) (see :ref:`syn-tools-storm`):
 
-``cli> storm <query>``
+``storm> <query>``
 
-This section covers the following important high-level Storm concepts:
+.. note::
+
+  If you're just getting started with Synapse, you can use the Synapse Quickstart_ to quickly set up and connect to a local Cortex using the Storm CLI.
+
+This section covers several important high-level Storm concepts:
 
 - `Storm Background`_
 - `Basic Storm Operations`_
 
   - `Lift, Filter, and Pivot Criteria`_
-  
-- `Advanced Storm Operations`_
+
+- `Whitespace and Literals in Storm`_
 - `Storm Operating Concepts`_
 
   - `Operation Chaining`_
   - `Storm as a Pipeline`_
   - `Node Consumption`_
+  
+- `Advanced Storm Operations`_
 
 .. _storm-bkgd:
 
@@ -32,39 +38,39 @@ In designing Storm, we needed it to be flexible and powerful enough to allow int
 
 Wherever possible, we masked Storm’s underlying programmatic complexity. The intent is for Storm to act more like a "data language", allowing users to:
 
-- **Reference data and query parameters in an intuitive form.** Through features such as type safety, property normalization, and syntax and query optimization, Storm takes a "do what I mean" approach. To the extent possible, Storm removes the burden of translating or standardizing data from the user.
+- **Reference data and query operations in an intuitive form.** By using features such as property normalization, type enforcement / type awareness, and syntax and query optimization, Storm takes a "do what I mean" approach that makes it simple to use and understand. Once you get the gist of it, Storm "just works"!
 
-- **Use a simple yet powerful syntax to run Storm queries.** To avoid feeling like a programming language (or even a traditional database query language), Storm avoids the use of operator-like functions and parameters. Instead, Storm:
+- **Use a simple yet powerful syntax to run Storm queries.** To avoid feeling like a programming language (or even a traditional database query language), Storm avoids the use of operator-like functions and parameters. Instead, Storm uses:
   
-  - Leverages intuitive keyboard symbols for efficient querying.
-  - Uses a natural language-like syntax so using Storm feels more like "asking a question" than "constructing a data query".
+  - Intuitive keyboard symbols (such as an "arrow" ( ``->`` ) for pivot operations) for efficient querying.
+  - A natural language-like syntax so that using Storm feels more like "asking a question" than "constructing a data query".
 
-Analysts still need to learn the Storm "language" - forms (:ref:`data-form`) and tags (:ref:`data-tag`) are Storm's "words", and the Storm syntax allows you to construct "sentences". That said, the intent is for Storm to function more like "how do I ask this question of the data?" and not "how do I write a program to get the data I need?"
+Analysts still need to learn the Storm "language" - forms (:ref:`data-form`) and tags (:ref:`data-tag`) are Storm's "words", and Storm operators allows you to construct "sentences". That said, the intent is for Storm to function more like "how do I ask this question about the data?" and not "how do I write a program to get the data I need?"
 
-Finally – and most importantly – **giving analysts direct access to Storm to allow them to create arbitrary queries provides them with an extraordinarily powerful analytical tool.** Analysts are not constrained by working with a set of predefined queries provided to them through a GUI or an API. Instead, they can follow their analysis wherever it takes them, creating queries as needed and working with the data in whatever manner is most appropriate to their research.
+Finally – and most importantly – **giving analysts direct access to Storm allows them to create arbitrary queries and provides them with an extraordinarily powerful analytical tool.** Analysts are not constrained to a set of "canned" queries provided through a GUI or an API. Instead, they can follow their analysis wherever it takes them, creating queries as needed and working with the data in whatever manner is most appropriate to their research.
 
 .. _storm-ops-basic:
 
 Basic Storm Operations
 ----------------------
 
-Storm allows users to perform all of the common operations used to interact with the data in a Cortex:
+Storm allows users to perform all of the common operations used to interact with the data in a Synapse Cortex:
 
 - **Lift:** – retrieve data based on specified criteria. (:ref:`storm-ref-lift`)
-- **Filter:** – take a set of lifted nodes and refine your results by including or excluding a subset of nodes based on specified criteria. (:ref:`storm-ref-filter`)
-- **Pivot:** – take a set of lifted nodes and identify other nodes that share one or more properties or property values with the lifted set. (:ref:`storm-ref-pivot`)
-- **Data modification:** – add, modify, annotate, and delete nodes from a Cortex. (:ref:`storm-ref-data-mod`)
+- **Filter:** – refine your results by including or excluding a subset of nodes based on specified criteria. (:ref:`storm-ref-filter`)
+- **Pivot:** – take a set of nodes and identify other nodes that share one or more property values with the lifted set. (:ref:`storm-ref-pivot`)
+- **Data modification:** – add, modify, annotate, and delete nodes from a Synapse Cortex. (:ref:`storm-ref-data-mod`)
 
 Additional operations include:
 
-- **Traverse** light edges. (:ref:`light-edge` :ref:`walk-light-edge`)
-- **Pipe** (send) nodes to Storm commands (:ref:`storm-ref-cmd`). Storm supports an extensible set of commands such as :ref:`storm-limit`, :ref:`storm-max`, or :ref:`storm-uniq` support specific functionality to further extend the power of Storm. Available commands can be displayed with ``storm help``. Additional functionality (such as connectors to third-party data sources) can be implemented in Storm and exposed as commands.
+- **Traverse** light edges. (:ref:`light-edge`, :ref:`walk-light-edge`)
+- **Pipe** (send) nodes to Storm commands (:ref:`storm-ref-cmd`). Storm supports an extensible set of commands such as :ref:`storm-limit`, :ref:`storm-max`, or :ref:`storm-uniq`. These commands provide specific functionality to further extend the analytical power of Storm. Additional Storm commands allow management of permissions for users and roles, Synapse views and layers, and Synapse's automation features (:ref:`storm-ref-automation`). Available commands can be displayed by running ``help`` from the Storm CLI.
 
-Storm also supports powerful features such as the use of **variables** (:ref:`storm-adv-vars`) in queries, the availability of **libraries** (:ref:`stormtypes-libs-header`) to extend Storm's functionality, and the ability to issue **subqueries** (:ref:`storm-ref-subquery`) within Storm itself.
+Storm also incorporates a number of :ref:`storm-ops-adv` that provide even greater power and flexibility.
 
-.. NOTE::
+.. note::
 
-  While Storm queries can range from the very simple to the highly complex, all Storm queries are constructed from this relatively small set of "building blocks" - and unless you're working with more advanced Storm, you'll only need a handful of blocks: typically lift, filter, pivot, traverse light edges, and pipe to Storm commands.
+  While Storm queries can range from the very simple to the highly complex, all Storm queries are constructed from this relatively small set of "building blocks". Most users, especially when they first start, only need the handful of blocks listed above!
 
 
 Lift, Filter, and Pivot Criteria
@@ -80,23 +86,118 @@ The main operations carried out with Storm are lifting, filtering, and pivoting 
 
 All of the above elements – nodes, properties, values, and tags – are the fundamental building blocks of the Synapse data model (see :ref:`data-model-terms`). **As such, an understanding of the Synapse data model is essential to effective use of Storm.**
 
-.. _storm-ops-adv:
+.. _storm-whitespace-literals:
 
-Advanced Storm Operations
--------------------------
+Whitespace and Literals in Storm
+--------------------------------
 
-In our experience, the more analysts use Storm, the more they want even greater power and flexibility from the language to support their analytical workflow. To meet these demands, Storm evolved a number of advanced features, including:
+Storm allows (and in some cases requires) whitespace within Storm to delimit syntax elements such as commands and command arguments. Quotation marks are used to **preserve** whitespace characters and other special characters in literals used within Storm.
 
-- Subqueries (:ref:`storm-ref-subquery`)
-- Variables (:ref:`storm-adv-vars`)
-- Methods (:ref:`storm-adv-methods`)
-- Libraries (:ref:`storm-adv-libs`)
-- Control Flow (:ref:`storm-adv-control`)
+.. _storm-whitespace:
 
-**Analysts do not need to use or understand these more advanced concepts in order to use Storm or Synapse.** Basic Storm functions are sufficient for a wide range of analytical needs and workflows. However, these additional features are available to both “power users” and developers as needed:
+Using Whitespace Characters
++++++++++++++++++++++++++++
 
-- For analysts, once they are comfortable with Storm basics, many of them want to expand their Storm skills **specifically because it facilitates their analysis.**
-- For developers, writing extensions to Synapse in Storm has the advantage that the extension **can be deployed or updated on the fly.** Contrast this with extensions written in Python, for example, which would require restarting the system during a maintenance window in order to deploy or update the code.
+Whitespace characters (i.e., spaces) are used within the Storm CLI to delimit command line arguments. Specifically, whitespace characters are used to separate commands, command arguments, command operators, variables and literals.
+
+When entering a query/command on the Storm CLI, one or more whitespace characters are **required** between the following command line arguments:
+
+- A command (such as ``max``) and command line parameters (in this case, the property ``:asof``):
+  
+  ``storm> inet:whois:rec:fqdn=vertex.link | max :asof``
+  
+- An unquoted literal and any subsequent CLI argument or operator:
+  
+  ``storm> inet:email=support@vertex.link | count``
+  
+  ``storm> inet:email=support@vertex.link -> *``
+
+Whitespace characters can **optionally** be used when performing the following CLI operations:
+
+- Assigning values using the equals sign assignment operator:
+  
+  ``storm> [inet:ipv4=192.168.0.1]``
+  
+  ``storm> [inet:ipv4 = 192.168.0.1]``
+
+- Comparison operations:
+  
+  ``storm> file:bytes:size>65536``
+  
+  ``storm> file:bytes:size > 65536``
+
+- Pivot operations:
+  
+  ``storm> inet:ipv4->*``
+  
+  ``storm> inet:ipv4 -> *``
+  
+- Specifying the content of edit brackets or edit parentheses:
+
+  ``storm> [inet:fqdn=vertex.link]``
+  
+  ``storm> [ inet:fqdn=vertex.link ]``
+  
+  ``storm> [ inet:fqdn=vertx.link (inet:ipv4=1.2.3.4 :asn=5678) ]``
+  
+  ``storm> [ inet:fqdn=vertex.link ( inet:ipv4=1.2.3.4 :asn=5678 ) ]``
+
+Whitespace characters **cannot** be used between reserved characters when performing the following CLI operations:
+
+- Add and remove tag operations. The plus ( ``+`` ) and minus  ( ``-`` ) sign characters are used to add and remove tags to and from nodes in Synapse respectively. When performing tag operations using these characters, a whitespace character cannot be used between the actual character and the tag name (e.g., ``+#<tag>``).
+  
+  ``storm> inet:ipv4 = 192.168.0.1 [ -#oldtag +#newtag ]``
+
+.. _storm-literals:
+
+Entering Literals
++++++++++++++++++
+
+Storm uses quotation marks (single and double) to preserve whitespace and other special characters that represent literals. If values with these characters are not quoted, Synapse may misinterpret them and throw a syntax error.
+
+Single ( ``' '`` ) or double ( ``" "`` ) quotation marks can be used when entering a literal on the CLI during an assignment or comparison operation. Enclosing a literal in quotation marks is **required** when the literal:
+
+ - begins with a non-alphanumeric character,
+ - contains a space ( ``\s`` ), tab ( ``\t`` ) or newline( ``\n`` ) character, or
+ - contains a reserved Synapse character (for example, ``\ ) , = ] } |``).
+
+Enclosing a literal in **single** quotation marks will preserve the literal meaning of **each character.** That is, each character in the literal is interpreted exactly as entered.
+
+ - Note that if a literal (such as a string) **includes** a single quotation mark / tick mark, it must be enclosed in double quotes.
+ 
+  - Wrong: ``'Storm's intuitive syntax makes it easy to learn and use.'``
+  - Right: ``"Storm's intuitive syntax makes it easy to learn and use."``
+
+Enclosing a literal in **double** quotation marks will preserve the literal meaning of all characters **except for** the backslash ( ``\`` ) character, which is interpreted as an 'escape' character. The backslash can be used to include special characters such as tab (``\t``) or newline (``\n``) within a literal.
+
+ - If you need to include a literal backslash within a double-quoted literal, you must enter it as a "double backslash" (the first backslash "escapes" the following backslash character):
+ 
+   - Wrong: ``"C:\Program Files\Mozilla Firefox\firefox.exe"``
+   - Right: ``"C:\\Program Files\\Mozilla Firefox\\firefox.exe"``
+   
+ Note that because the above example does not include a single quote / tick mark as part of the literal, you can simply enclose the file path in  single quote:
+ 
+   - Also right: ``'C:\Program Files\Mozilla Firefox\firefox.exe'``
+
+The Storm queries below demonstrate assignment and comparison operations that **do not require** quotation marks:
+
+- Lifting the domain ``vtx.lk``:
+  
+  ``storm> inet:fqdn = vtx.lk``
+
+- Lifting the file name ``windowsupdate.exe``:
+  
+  ``storm> file:base = windowsupdate.exe``
+
+The commands below demonstrate assignment and comparison operations that **require** the use of quotation marks. Failing to enclose the literals below in quotation marks will result in a syntax error.
+
+- Lift the file name ``windows update.exe`` which contains a whitespace character:
+  
+  ``storm> file:base = 'windows update.exe'``
+
+- Lift the file name ``windows,update.exe`` which contains the comma special character:
+  
+  ``storm> file:base = "windows,update.exe"``
 
 .. _storm-op-concepts:
 
@@ -110,7 +211,7 @@ Storm has several notable features in the way it interacts with and operates on 
 Operation Chaining
 ++++++++++++++++++
 
-As noted above, users commonly interact with data (nodes) in a Cortex using operations such as lift, filter, and pivot. Storm allows multiple operations to be chained together to form increasingly complex queries. When Storm operations are concatenated in this manner, they are processed **in order from left to right** with each operation (lift, filter, or pivot) acting on the output of the previous operation.
+As noted above, users commonly interact with data (nodes) in Synapse using operations such as lift, filter, and pivot. Storm allows multiple operations to be chained together to form increasingly complex queries. When Storm operations are concatenated in this manner, they are processed **in order from left to right** with each operation (lift, filter, or pivot) acting on the output of the previous operation.
 
 ..  NOTE::
 
@@ -120,20 +221,20 @@ Note that most operations (other than those used solely to lift or add data) req
 
 .. NOTE::
 
-  The output of any Storm operations (other than your initial lift) is known as your **current working set**. Depending on the operation(s) performed, your current working set may not be the same as your initial working set (see :ref:`storm-node-consume` below). Your working set emerges from one Storm operation and is considered **inbound** to the next operation in the chain.
+  The output of any Storm operation (other than your initial lift) is known as your **current working set**. Depending on the operation(s) performed, your current working set may not be the same as your initial working set (see :ref:`storm-node-consume` below). Your working set emerges from one Storm operation and is considered **inbound** to the next operation in the chain.
 
-From an analysis standpoint, this means that Storm syntax can parallel an analyst’s natural thought process, as you perform one Storm operation, and then consider the "next step" you want to take in your analysis: "show me X data...that’s interesting, take a subset of X data and show me the Y data that relates to X...hm, now take the results from Y and show me any relationship to Z data..." and so on.
+From an analysis standpoint, this means that Storm syntax can parallel an analyst's natural thought process, as you perform one Storm operation and then consider the "next step" you want to take in your analysis: "show me X data...that’s interesting, take a subset of X data and show me the Y data that relates to X...hm, now take the results from Y and show me any relationship to Z data..." and so on. Each "now show me..." thought commonly corresponds to a new Storm operation that can be added to your existing Storm query to navigate through the data.
 
-From a practical standpoint, it means that **order matters** when constructing a Storm query. A lengthy Storm query is not evaluated as a whole. Instead, Synapse parses each component of the query in order, evaluating each component individually.
+From a practical standpoint, it means that **order matters** when constructing a Storm query. A lengthy Storm query is not evaluated as a whole. Instead, Synapse parses each component of the query in order, evaluating each component individually and potentially returning a new **working set** after each operation before executing the next operation.
 
-(Technically, any query you construct is first evaluated as a whole **to ensure it is a valid query** - that is, the query uses valid Storm syntax; Synapse will complain about invalid Storm. Once Synapse has checked your Storm syntax, nodes are processed by each Storm operation in order.)
+(Technically, any query you construct is first evaluated as a whole **to ensure it is a syntactically valid query** - Synapse will complain if your Storm syntax is incorrect. But once Synapse has checked your Storm syntax, nodes are processed by each Storm operation in order.)
 
 .. _storm-pipeline:
 
 Storm as a Pipeline
 +++++++++++++++++++
 
-Most objects in a Cortex are nodes (:ref:`data-node`), so most Storm operations act on nodes. Not only are chained Storm operations carried out from left to right, but **nodes pass individually through the chain.** The series of Storm operations (i.e., the overall Storm query) can be thought of as a "pipeline". Regardless of how simple or complex the Storm query is, and regardless of whether your initial working set consists of one node or 100,000 nodes, each node is "fired" through the query pipeline one at a time.
+Most objects in a Synapse Cortex are nodes (:ref:`data-node`), so most Storm operations act on nodes. Not only are chained Storm operations carried out from left to right, but **nodes pass individually through the chain.** The series of Storm operations (i.e., the overall Storm query) can be thought of as a "pipeline". Regardless of how simple or complex the Storm query is, and regardless of whether your initial working set consists of one node or 100,000 nodes, each node is "fired" through the query pipeline one at a time.
 
 A key advantage of this behavior is that it provides significant latency and memory use reduction to Storm. Because nodes are operated on one at a time, Storm can start returning results immediately even if the initial data set is quite large.
 
@@ -146,4 +247,29 @@ Node Consumption
 
 Most Storm operations **consume** nodes when the operation occurs. That is, the set of nodes (the working set) that is **inbound** to a particular Storm operation is typically transformed by that operation in some way. In fact, with few exceptions (such as the join operator (see :ref:`storm-ref-pivot`) and the Storm :ref:`storm-count` command), the nodes inbound to an operation are typically **not** retained - they are "consumed" during execution. Storm outputs only those nodes that result from carrying out the specified operation. If you lift a set of nodes and then filter the results, only those nodes captured by the filter are retained - the other nodes are consumed (discarded).
 
-In this way the operations performed in sequence may add or remove nodes from Storm’s working set, or clear the set entirely. The set is continually changing based on the last-performed operation or last-issued command. Particularly when first learning Storm, users are encouraged to break down lengthy queries into their component parts, and to validate the output (results) after the addition of each operation to the overall query.
+In this way the operations performed in sequence may add or remove nodes from Storm's **working set,** or clear the set entirely. The set is continually changing based on the last-performed operation or last-issued command. Particularly when first learning Storm, users are encouraged to break down lengthy queries into their component parts, and to validate the output (results) after the addition of each operation to the overall query.
+
+.. _storm-ops-adv:
+
+Advanced Storm Operations
+-------------------------
+
+In our experience, the more analysts use Storm, the more they want even greater power and flexibility from the language to support their analytical workflow! To meet these demands, Storm evolved a number of advanced features, including:
+
+- Subqueries (:ref:`storm-ref-subquery`)
+- Variables (:ref:`storm-adv-vars`)
+- Methods (:ref:`storm-adv-methods`)
+- Libraries (:ref:`storm-adv-libs`)
+- Control Flow (:ref:`storm-adv-control`)
+
+**Analysts do not need to use or understand these more advanced concepts in order to use Storm or Synapse.** Basic Storm functions are sufficient for a wide range of analytical needs and workflows. However, these additional features are available to both "power users" and developers as needed:
+
+- For analysts, once they are comfortable with Storm basics, many of them want to expand their Storm skills **specifically because it facilitates their analysis.**
+- For developers, writing extensions to Synapse in Storm has the advantage that the extension **can be deployed or updated on the fly.** Contrast this with extensions written in Python, for example, which would require restarting the system during a maintenance window in order to deploy or update the code.
+
+.. note::
+
+  Synapse's **Power-Ups**, which provide extended services and connections to third-party data sources, are all written in Storm and exposed to Synapse users as Storm commands!
+
+
+.. _Quickstart: https://github.com/vertexproject/synapse-quickstart

--- a/docs/synapse/userguides/storm_ref_type_specific.rstorm
+++ b/docs/synapse/userguides/storm_ref_type_specific.rstorm
@@ -51,7 +51,7 @@ Because an ``array`` is a list of typed values, ``array`` elements can be input 
 Insertion
 +++++++++
 
-As a list, an ``array`` property must be set using comma-separated values enclosed in parentheses (this is true even if the list contains only a single element; you must still use parentheses, and the single element must still be followed by a trailing comma). The list of array values will be set in the order in which they are specified. Single or double quotes are required in accordance with the standard rules for :ref:`whitespace` and :ref:`literals`.
+As a list, an ``array`` property must be set using comma-separated values enclosed in parentheses (this is true even if the list contains only a single element; you must still use parentheses, and the single element must still be followed by a trailing comma). The list of array values will be set in the order in which they are specified. Single or double quotes are required in accordance with the standard rules for using :ref:`storm-whitespace-literals`.
 
 **Example:**
 
@@ -525,7 +525,7 @@ Downselect a set of DNS A records to those with domains ending with ``.museum``:
 
 **Usage Notes**
 
-- Because the asterisk is a non-alphanumeric character, the string to be matched must be enclosed in single or double quotes (see :ref:`whitespace` and :ref:`literals`).
+- Because the asterisk is a non-alphanumeric character, the string to be matched must be enclosed in single or double quotes (see :ref:`storm-whitespace-literals`).
 - Because domains are reverse-indexed instead of prefix indexed, for **lift** operations, partial string matching can only occur based on the end (suffix) of a domain. It is not possible to lift by a string at the beginning of a domain. For example, ``inet:fqdn="yahoo*"`` and ``inet:fqdn^=yahoo`` are both invalid.
 - Domains can be **filtered** by prefix (``^=``). For example, ``inet:fqdn="*.biz" +inet:fqdn^=smtp`` is valid.
 - Domains cannot be filtered based on suffix matching (note that a "lift by suffix" is effectively a combined "lift and filter" operation).
@@ -623,7 +623,7 @@ Parsing
 
 An ``ival`` type is typically specified as two comma-separated time values enclosed in parentheses. Alternately, an ``ival`` can be specified as a single time value with no parentheses (see **Insertion** below for ``ival`` behavior when specifying a single time value).
 
-Single or double quotes are required in accordance with the standard rules for :ref:`whitespace` and :ref:`literals`. For example:
+Single or double quotes are required in accordance with the standard rules for using :ref:`storm-whitespace-literals`. For example:
 
 - ``.seen=("2017/03/24 12:13:27", "2017/08/05 17:23:46")``
 - ``+#sometag=(2018/09/15, "+24 hours")``
@@ -747,7 +747,7 @@ To appropriately represent the "city" element of the above location, an alternat
 - ``:loc = "us.fl.saint petersburg"``
 - ...etc.
 
-As an extension of the ``str`` type, ``loc`` types are subject to Synapse’s restrictions regarding :ref:`whitespace` and :ref:`literals`.
+As an extension of the ``str`` type, ``loc`` types are subject to Synapse’s restrictions regarding using :ref:`storm-whitespace-literals`.
 
 Insertion
 +++++++++
@@ -838,7 +838,7 @@ Parsing
 
 Some string types and string-derived types are normalized to all lowercase to facilitate pivoting across like values without case-sensitivity. For types that are normalized in this fashion, the string can be entered in mixed-case and will be automatically converted to lowercase.
 
-Strings are subject to Synapse’s restrictions regarding :ref:`whitespace` and :ref:`literals`.
+Strings are subject to Synapse’s restrictions regarding using :ref:`storm-whitespace-literals`.
 
 Insertion
 +++++++++
@@ -897,7 +897,7 @@ Components of a ``syn:tag`` value must be separated by the dot ( ``.`` ) charact
 
 ``syn:tag`` values can be input using any case (uppercase, lowercase, mixed case) but will be normalized to lowercase.
 
-As ``syn:tag`` values cannot contain whitespace (spaces) or escaped characters, the Synapse restrictions regarding  :ref:`whitespace` and :ref:`literals` do not apply.
+As ``syn:tag`` values cannot contain whitespace (spaces) or escaped characters, the Synapse restrictions regarding using :ref:`storm-whitespace-literals` do **not** apply.
 
 **Examples**
 
@@ -1086,7 +1086,7 @@ Parsing
 
 Despite storing ``time`` types as epoch millis, Storm does not accept millis format as direct input. For example, it is not possible to input a time value in the format ``1544953072324`` (Storm will attempt to interpret that as the string ``YYYYMMDDhhmmssmmmm`` and return an error).
 
-Standard rules regarding :ref:`whitespace` and :ref:`literals` apply. For example, ``"2018/12/16 09:37:52.324"`` needs to be entered in single or double quotes, but ``2018/12/16`` does not. Similarly, relative times and the special time value ``?`` need to be placed in single or double quotes.
+Standard rules regarding using :ref:`storm-whitespace-literals` apply. For example, ``"2018/12/16 09:37:52.324"`` needs to be entered in single or double quotes, but ``2018/12/16`` does not. Similarly, relative times and the special time value ``?`` need to be placed in single or double quotes.
 
 .. NOTE::
   Synapse does not support the storage of an explicit named time zone with a time value (i.e., PST, America/New_York). Synapse is intended to store time values in UTC for consistency, so users will need to convert date / time values to UTC before entering them and convert values to UTC during any automated ingest. Alternatively, the time zone can be provided in +/-hh:mm format, which will then be used to convert the time to UTC for storage.

--- a/docs/synapse/userguides/syn_tools_cmdr.rst
+++ b/docs/synapse/userguides/syn_tools_cmdr.rst
@@ -5,24 +5,34 @@
 Synapse Tools - cmdr
 ====================
 
-The Synapse command line interface (CLI) is a text-based interpreter used to communicate with a Synapse Cortex. The Synapse ``cmdr`` module is a command line tool used to connect and provide an interactive CLI to an existing local or remote Cortex. This section will cover the following Synapse CLI topics:
+The Synapse ``cmdr`` module is a command line tool used to connect and provide an interactive CLI to an existing local or remote Synapse Cortex.
+
+.. note::
+  
+  While the ``cmdr`` CLI is still supported, the Synapse storm tool (**Storm CLI**) is the preferred method for users to interact with a Synapse Cortex from the command line. The Storm CLI includes a native Storm interpreter that allows users to execute Storm queries and commands directly, without using the :ref:`syn-storm` command required by ``cmdr`` (see :ref:`syn-tools-storm`).
+
+This section will cover the following Synapse ``cmdr`` CLI topics:
 
 - `Obtaining a Command Line Interface`_
 - `Command Line Interface Basics`_
 
-See the :ref:`syn-ref-cmd` for a list of available Synapse commands.
+See the :ref:`syn-ref-cmd` for a list of Synapse commands available via ``cmdr``.
+
+.. note::
+  
+  ``cmdr`` commands are still supported, but the majority are being deprecated in favor of their Storm equivalents (see :ref:`storm-ref-cmd`).
 
 Obtaining a Command Line Interface
 ----------------------------------
 
-In order to obtain access to the Synapse CLI you must use the ``cmdr`` module connected to a local or remote Cortex. If you have access to an existing local or remote Cortex, proceed to `Connecting to an Existing Cortex`_ for instructions on how to connect to the Cortex. However, if you do not have access to an existing Cortex, proceed to `Connecting to a Temporary Cortex`_ for instructions on creating and connecting to a temporary Cortex on your local machine.
+The Synapse ``cmdr`` module can be used to obtain CLI access to a local or remote Synapse Cortex. If you have access to an existing Cortex, proceed to `Connecting to an Existing Cortex`_ for instructions on how to connect to the Cortex. However, if you do not have access to an existing Cortex, proceed to `Connecting to a Temporary Cortex`_ for instructions on creating and connecting to a temporary Cortex on your local machine via ``cmdr``.
 
 .. _cortex-connect:
 
 Connecting to an Existing Cortex
 ++++++++++++++++++++++++++++++++
 
-To connect to an existing local or remote Cortex, run the Synapse ``cmdr`` module by executing the following Python command from a terminal window, where the *<url>* parameter is the URL path to the Cortex.
+To connect to an existing local or remote Cortex using ``cmdr``, run the Synapse ``cmdr`` module by executing the following Python command from a terminal window, where the *<url>* parameter is the URL path to the Cortex.
 
 ``python -m synapse.tools.cmdr <url>``
 
@@ -36,23 +46,25 @@ or
 
 if authentication is used.
 
-.. NOTE::
-  The path to a storage Axon is specified in the same manner. That is:
-  
-    ``<scheme>://<server>:<port>/<axon>``
-
-or
-  
-    ``<scheme>://<user>:<password>@<server>:<port>/<axon>``
-
 **Example URL paths:**
 
 - ``tcp://synapse.woot.com:1234/cortex01``
 - ``ssl://synapse.woot.com:1234/cortex01``
 
-Once connected the Cortex, you will be presented with the following Synapse CLI command prompt:
+Once connected the Cortex, you will be presented with the following Synapse ``cmdr`` CLI command prompt:
 
 ``cli>``
+
+.. NOTE::
+  
+  The path to a storage Axon is specified in the same manner as the path to a data Cortex. That is:
+  
+    ``<scheme>://<server>:<port>/<axon>``
+  
+  or
+    
+    ``<scheme>://<user>:<password>@<server>:<port>/<axon>``
+
 
 .. _temporary:
 
@@ -68,6 +80,10 @@ To create and connect to a temporary local Cortex using the ``feed`` module, exe
 Once connected the Cortex, you will be presented with the following Synapse CLI command prompt:
 
 ``cli>``
+
+.. note::
+  
+  The Synapse Quickstart_ can be used to quickly set up and connect to a local Cortex using the preferred **Storm CLI** (:ref:`syn-tools-storm`).
 
 Command Line Interface Basics
 -----------------------------
@@ -160,3 +176,4 @@ The commands below demonstrate assignment and comparison operations that **requi
   
   ``cli> storm file:base = "windows,update.exe"``
 
+.. _Quickstart: https://github.com/vertexproject/synapse-quickstart

--- a/docs/synapse/userguides/syn_tools_feed.rst
+++ b/docs/synapse/userguides/syn_tools_feed.rst
@@ -30,7 +30,7 @@ Where:
   
 - ``--debug`` specifies to drop into an interactive prompt to inspect the state of the Cortex post-ingest. 
 
-  - See :ref:`_syn-ref-cmdr` for how to use the interactive prompt
+  - See :ref:`syn-tools-cmdr` and :ref:`syn-ref-cmd` for how to use the interactive prompt
   
 - ``FORMAT`` specifies the format of the input files. 
 
@@ -40,7 +40,7 @@ Where:
 - ``MODULES`` specifies a path to a Synapse CoreModule class that will be loaded into the temporary Cortex.
 
   - This option has no effect if the ``--test`` option is not specified
-  - For more on Core Modules, see :ref:`_dev_cortex_quickstart`
+  - For more on Core Modules, see :ref:`dev_cortex_quickstart`
 - ``CHUNKSIZE`` specifies how many lines or chunks of data to read at a time from the given files.
 
   - Defaults to 1000 if not specified

--- a/docs/synapse/userguides/syn_tools_storm.rst
+++ b/docs/synapse/userguides/syn_tools_storm.rst
@@ -1,0 +1,82 @@
+.. highlight:: none
+
+.. _syn-tools-storm:
+
+Synapse Tools - storm
+=====================
+
+The Synapse Storm tool (commonly referred to as the **Storm CLI**) is a text-based interpreter that leverages the Storm query language (see :ref:`storm-ref-intro`). The Storm CLI replaces the Synapse ``cmdr`` tool (see :ref:`syn-tools-cmdr`) as the preferred means for users to interact with a Synapse Cortex. Because the Storm CLI is a native Storm interpreter, users do not need to use the :ref:`syn-storm` command before entering and executing Storm queries or commands.
+
+- `Connecting to a Cortex with the Storm CLI`_
+- `Storm CLI Basics`_
+- `Accessing Synapse Tools from the Storm CLI`_
+
+Connecting to a Cortex with the Storm CLI
+-----------------------------------------
+
+To access the Storm CLI you must use the ``storm`` module to connect to a local or remote Synapse Cortex.
+
+.. note::
+
+  If you're just getting started with Synapse, you can use the Synapse Quickstart_ to quickly set up and connect to a local Cortex using the Storm CLI.
+
+To connect to a local or remote Synapse Cortex using the Storm CLI, simply run the Synapse ``storm`` module by executing the following Python command from a terminal window, where the *<url>* parameter is the URL path to the Synapse Cortex.
+
+``python -m synapse.tools.storm <url>``
+
+The URL has the following format:
+
+``<scheme>://<server>:<port>/<cortex>``
+
+or
+
+``<scheme>://<user>:<password>@<server>:<port>/<cortex>``
+
+if authentication is used.
+
+**Example URL paths:**
+
+- ``cell://vertex/storage`` (default if using Synapse Quickstart)
+- ``tcp://synapse.woot.com:1234/cortex01``
+- ``ssl://synapse.woot.com:1234/cortex01``
+
+Once connected, you will be presented with the following Storm CLI command prompt:
+
+``storm>``
+
+
+Storm CLI Basics
+----------------
+
+Once connected to a Synapse Cortex with the Storm CLI, you can execute any Storm queries or commands directly (i.e., without needing to precede them with the :ref:`syn-storm` command).
+
+For information on using the Storm query language to interact with data in a Synapse Cortex, see :ref:`storm-ref-intro` and related Storm documentation.
+
+To view a list of available Storm commands, type ``help`` from the Storm CLI prompt:
+
+``storm> help``
+
+For additional detail on Storm commands, see :ref:`storm-ref-cmd`.
+
+
+Accessing Synapse Tools from the Storm CLI
+------------------------------------------
+
+Most of the commands for working in and with a Synapse Cortex are native Storm commands that can be viewed using the ``help`` command and executed directly from the Storm CLI. 
+
+The Storm CLI also allows you to access a few external Synapse tools. Specifically, the Synapse ``pushfile`` and ``pullfile`` tools can be used to upload and download files from a Synapse storage :ref:`gloss-axon`. These tools can be accessed from the Storm CLI by preceding the command with a bang / exclamation point ( ``!``) character:
+
+``storm> !pushfile``
+
+``storm> !pullfile``
+
+Similarly, **help** for each tool can be viewed by entering ``-h`` or ``--help`` after each "bang" command:
+
+``storm> !pushfile -h``
+
+``storm> !pullfile --help``
+
+See :ref:`syn-tools-pushfile` and :ref:`syn-tools-pullfile` for additional detail on these tools.
+
+
+.. _Quickstart: https://github.com/vertexproject/synapse-quickstart


### PR DESCRIPTION
- Add doc for Storm CLI (syn_tools_storm).

- Update Storm Intro (storm_ref_intro) to:
  - reference Storm CLI vs cmdr
  - include discussion of whitespace / literals (previously part of cmdr docs)
  - reorder content (move Advanced Storm to end)
- Update type-specific doc (storm_ref_type_specific) to hyperlink to Storm whitespace docs vs cmdr
- Minor updates to cmdr doc (syn_tools_cmdr) to encourage Storm CLI use.
- Other minor fixes / cleanup
 