### PR TITLE
stormtypes - when encoding a str or decoding a byts, use surrogatepass errors handler (SYN-2869)

### DIFF
--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3649,7 +3649,7 @@ class Bytes(Prim):
         except struct.error as e:
             raise s_exc.BadArg(mesg=f'unpack() error: {e}')
 
-    async def _methDecode(self, encoding='utf8', ):
+    async def _methDecode(self, encoding='utf8'):
         try:
             return self.valu.decode(encoding, 'surrogatepass')
         except UnicodeDecodeError as e:

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3454,7 +3454,7 @@ class Str(Prim):
         try:
             return self.valu.encode(encoding, errors=errors)
         except UnicodeEncodeError as e:
-            raise s_exc.StormRuntimeError(mesg=str(e), valu=str(self.valu)[:1024]) from None
+            raise s_exc.StormRuntimeError(mesg=str(e), valu=self.valu[:1024]) from None
 
     async def _methStrSplit(self, text, maxsplit=-1):
         maxsplit = await toint(maxsplit)
@@ -3656,7 +3656,7 @@ class Bytes(Prim):
         try:
             return self.valu.decode(encoding, errors)
         except UnicodeDecodeError as e:
-            raise s_exc.StormRuntimeError(mesg=str(e), valu=self.valu) from None
+            raise s_exc.StormRuntimeError(mesg=str(e), valu=self.valu[:1024]) from None
 
     async def _methBunzip(self):
         return bz2.decompress(self.valu)

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3261,8 +3261,6 @@ class Str(Prim):
                   'args': (
                       {'name': 'encoding', 'type': 'str', 'desc': 'Encoding to use. Defaults to utf8.',
                        'default': 'utf8', },
-                      {'name': 'errors', 'type': 'str', 'desc': 'Error handling to use. Defaults to surrogatepass.',
-                       'default': 'surrogatepass', },
                   ),
                   'returns': {'type': 'bytes', 'desc': 'The encoded string.', }}},
         {'name': 'replace', 'desc': '''
@@ -3450,9 +3448,9 @@ class Str(Prim):
     async def _methStrSize(self):
         return len(self.valu)
 
-    async def _methEncode(self, encoding='utf8', errors='surrogatepass'):
+    async def _methEncode(self, encoding='utf8'):
         try:
-            return self.valu.encode(encoding, errors=errors)
+            return self.valu.encode(encoding, 'surrogatepass')
         except UnicodeEncodeError as e:
             raise s_exc.StormRuntimeError(mesg=str(e), valu=self.valu[:1024]) from None
 
@@ -3519,7 +3517,6 @@ class Bytes(Prim):
          'type': {'type': 'function', '_funcname': '_methDecode',
                   'args': (
                       {'name': 'encoding', 'type': 'str', 'desc': 'The encoding to use.', 'default': 'utf8', },
-                      {'name': 'errors', 'type': 'str', 'desc': 'Error handling to use.', 'default': 'surrogatepass', },
                   ),
                   'returns': {'type': 'str', 'desc': 'The decoded string.', }}},
         {'name': 'bunzip', 'desc': '''
@@ -3652,9 +3649,9 @@ class Bytes(Prim):
         except struct.error as e:
             raise s_exc.BadArg(mesg=f'unpack() error: {e}')
 
-    async def _methDecode(self, encoding='utf8', errors='surrogatepass'):
+    async def _methDecode(self, encoding='utf8', ):
         try:
-            return self.valu.decode(encoding, errors)
+            return self.valu.decode(encoding, 'surrogatepass')
         except UnicodeDecodeError as e:
             raise s_exc.StormRuntimeError(mesg=str(e), valu=self.valu[:1024]) from None
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -2454,6 +2454,13 @@ class StormTypesTest(s_test.SynTest):
                      },
                     {n.ndef[1] for n in nodes})
 
+            # Mismatch surrogates from real world data
+            surrogate_data = "FOO\ufffd\ufffd\ufffd\udfab\ufffd\ufffdBAR"
+            resp = await core.callStorm('$buf=$s.encode() return ( ($buf, $buf.decode() ) )',
+                                        opts={'vars': {'s': surrogate_data}})
+            self.eq(resp[0], surrogate_data.encode('utf-8', 'surrogatepass'))
+            self.eq(resp[1], surrogate_data)
+
             # Encoding/decoding errors are caught
             q = '$valu="valu" $valu.encode("utf16").decode()'
             msgs = await core.stormlist(q)


### PR DESCRIPTION
- This allows retaining the byte string / str that we most likely are going to get or receive when receiving a JSON API response when working with data that has odd encodings shoved into JSON responses.
- Truncate the valu in Bytes.decode() and Str.encode() error logging to 1024 characters prevent logging potentially huge values to logs.