### PR TITLE
Update pyopenssl / cryptography packages (SYN-2932)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyOpenSSL>=16.2.0,<20.0.0
+pyOpenSSL>=21.0.0,<22.0.0
 msgpack>=1.0.2,<1.1.0
 xxhash>=1.4.4,<2.0.0
 lmdb>=1.2.1,<1.3.0
@@ -26,3 +26,7 @@ bech32==1.2.0
 oauthlib>=3.1.1,<4.0.0
 idna==3.3
 python-dateutil>=2.8,<3.0
+# Cryptography is a pyopenssl dependency which has no maximum version pinned.
+# They have a 3 major version's policy for deprecations, so we should be safe
+# that far out.
+cryptography>=36.0.0,<39.0.0

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     include_package_data=True,
 
     install_requires=[
-        'pyOpenSSL>=21.0.0,<21.0.0',
+        'pyOpenSSL>=21.0.0,<22.0.0',
         'cryptography>=36.0.0,<39.0.0',
         'msgpack>=1.0.2,<1.1.0',
         'xxhash>=1.4.4,<2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ setup(
     include_package_data=True,
 
     install_requires=[
-        'pyOpenSSL>=16.2.0,<20.0.0',
+        'pyOpenSSL>=21.0.0,<21.0.0',
+        'cryptography>=36.0.0,<39.0.0',
         'msgpack>=1.0.2,<1.1.0',
         'xxhash>=1.4.4,<2.0.0',
         'lmdb>=1.2.1,<1.3.0',

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -1053,6 +1053,9 @@ class CertDir:
     def _loadP12Path(self, path):
         byts = self._getPathBytes(path)
         if byts:
+            # This API is deprecrated by PyOpenSSL and will need to be rewritten if pyopenssl is
+            # updated from v21.x.x. The APIs that use this are not directly exposed via the
+            # easycert tool currently.
             return crypto.load_pkcs12(byts)
 
     def _saveCertTo(self, cert, *paths):

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -1055,7 +1055,7 @@ class CertDir:
         if byts:
             # This API is deprecrated by PyOpenSSL and will need to be rewritten if pyopenssl is
             # updated from v21.x.x. The APIs that use this are not directly exposed via the
-            # easycert tool currently.
+            # easycert tool currently, and are only used in unit tests.
             return crypto.load_pkcs12(byts)
 
     def _saveCertTo(self, cert, *paths):


### PR DESCRIPTION
- Update pyopenssl to v21.0.0
- Add cryptography with a maximum version bound)
- Add a commend about a certdir API using a deprecated pyopenssl API