### PR TITLE
Feat genpkg readonly (SYN-2959)

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -229,7 +229,7 @@ def reqpath(*paths):
     '''
     path = genpath(*paths)
     if not os.path.isfile(path):
-        raise s_exc.NoSuchFile(name=path)
+        raise s_exc.NoSuchFile(mesg=f'No such path {path}', path=path)
     return path
 
 def reqfile(*paths, **opts):
@@ -246,7 +246,7 @@ def reqfile(*paths, **opts):
     '''
     path = genpath(*paths)
     if not os.path.isfile(path):
-        raise s_exc.NoSuchFile(path=path)
+        raise s_exc.NoSuchFile(mesg=f'No such file {path}', path=path)
     opts.setdefault('mode', 'rb')
     return io.open(path, **opts)
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1926,10 +1926,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         sslctx.minimum_version = ssl.TLSVersion.TLSv1_2
 
         if not os.path.isfile(keypath):
-            raise s_exc.NoSuchFile(name=keypath)
+            raise s_exc.NoSuchFile(mesg=f'Missing TLS keypath {keypath}', path=keypath)
 
         if not os.path.isfile(certpath):
-            raise s_exc.NoSuchFile(name=certpath)
+            raise s_exc.NoSuchFile(mesg=f'Missing TLS certpath {certpath}', path=certpath)
 
         sslctx.load_cert_chain(certpath, keypath)
         return sslctx

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -249,7 +249,7 @@ class CertDir:
             raise s_exc.NoSuchFile(mesg='missing User cert', name=name)
 
         capath = self._getCaPath(ucert)
-        cacert = self._loadCertPath(capth)
+        cacert = self._loadCertPath(capath)
         if not cacert:
             raise s_exc.NoSuchFile(mesg='missing CA cert', path=capath)
 

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -246,15 +246,16 @@ class CertDir:
         '''
         ucert = self.getUserCert(name)
         if not ucert:
-            raise s_exc.NoSuchFile('missing User cert')
+            raise s_exc.NoSuchFile(mesg='missing User cert', name=name)
 
-        cacert = self._loadCertPath(self._getCaPath(ucert))
+        capath = self._getCaPath(ucert)
+        cacert = self._loadCertPath(capth)
         if not cacert:
-            raise s_exc.NoSuchFile('missing CA cert')
+            raise s_exc.NoSuchFile(mesg='missing CA cert', path=capath)
 
         ukey = self.getUserKey(name)
         if not ukey:
-            raise s_exc.NoSuchFile('missing User private key')
+            raise s_exc.NoSuchFile(mesg='missing User private key', name=name)
 
         ccert = crypto.PKCS12()
         ccert.set_friendlyname(name.encode('utf-8'))
@@ -679,7 +680,7 @@ class CertDir:
             None
         '''
         if not os.path.isfile(path):
-            raise s_exc.NoSuchFile('File does not exist')
+            raise s_exc.NoSuchFile(mesg='File does not exist', path=path)
 
         fname = os.path.split(path)[1]
         parts = fname.rsplit('.', 1)

--- a/synapse/lib/platforms/linux.py
+++ b/synapse/lib/platforms/linux.py
@@ -40,7 +40,7 @@ def getFileMappedRegion(filename):
                     largest = (start_addr, memlen)
 
     if largest is None:
-        raise s_exc.NoSuchFile(f'{filename} is not mapped into current process')
+        raise s_exc.NoSuchFile(mesg=f'{filename} is not mapped into current process', path=filename)
     return largest
 
 def getTotalMemory():

--- a/synapse/servers/stemcell.py
+++ b/synapse/servers/stemcell.py
@@ -30,7 +30,7 @@ def getStemCell(dirn):
         return ctor
 
     mesg = f'No such file: {cellyaml} and SYN_STEM_CELL_CTOR environmt variable is not set.'
-    raise s_exc.NoSuchFile(mesg=mesg)
+    raise s_exc.NoSuchFile(mesg=mesg, path=cellyaml)
 
 async def main(argv, outp=s_output.stdout):  # pragma: no cover
     ctor = getStemCell(argv[0])

--- a/synapse/tests/test_tools_genpkg.py
+++ b/synapse/tests/test_tools_genpkg.py
@@ -133,8 +133,8 @@ class GenPkgTest(s_test.SynTest):
         self.eq(pkg.get('docs'), [{'title': 'newp', 'path': 'docs/newp.md', 'content': ''}])
 
     def test_tools_readonly(self):
-        readonly_mode = stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH
         self.thisHostMustNot(platform='windows')
+        readonly_mode = stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH
         srcpath = s_common.genpath(dirname, 'files', 'stormpkg')
 
         with self.getTestDir(copyfrom=srcpath) as dirn:

--- a/synapse/tests/test_tools_genpkg.py
+++ b/synapse/tests/test_tools_genpkg.py
@@ -124,6 +124,11 @@ class GenPkgTest(s_test.SynTest):
         # Ensure it ran the fallback to do_docs=False
         self.eq(pkg.get('docs'), [{'title': 'newp', 'path': 'docs/newp.md', 'content': ''}])
 
+    def test_tools_readonly(self):
+        srcpath = s_common.genpath(dirname, 'files', 'stormpkg')
+        with self.getTestDir(copyfrom=srcpath) as dirn:
+            pass
+
     def test_files(self):
         assets = s_files.getAssets()
         self.isin('test.dat', assets)

--- a/synapse/tools/genpkg.py
+++ b/synapse/tools/genpkg.py
@@ -16,7 +16,7 @@ def chopSemVer(vers):
 
 def getStormStr(fn):
     if not os.path.isfile(fn):
-        raise ValueError('Storm file {} not found'.format(fn))
+        raise s_exc.NoSuchFile(mesg='Storm file {} not found'.format(fn), path=fn)
 
     with open(fn, 'rb') as f:
         return f.read().decode()
@@ -44,23 +44,25 @@ def loadOpticFiles(pkgdef, path):
                     'file': base64.b64encode(fd.read()).decode(),
                 }
 
-def tryLoadPkgProto(fp, opticdir=None):
+def tryLoadPkgProto(fp, opticdir=None, readonly=False):
     '''
     Try to get a Storm Package prototype from disk with or without inline documentation.
 
     Args:
         fp (str): Path to the package .yaml file on disk.
         opticdir (str): Path to optional Optic module code to add to the Storm Package.
+        readonly (bool): If set, open files in read-only mode. If files are missing, that will raise a NoSuchFile
+                         exception.
 
     Returns:
         dict: A Storm package definition.
     '''
     try:
-        return loadPkgProto(fp, opticdir=opticdir)
+        return loadPkgProto(fp, opticdir=opticdir, readonly=readonly)
     except s_exc.NoSuchFile:
-        return loadPkgProto(fp, opticdir=opticdir, no_docs=True)
+        return loadPkgProto(fp, opticdir=opticdir, no_docs=True, readonly=readonly)
 
-def loadPkgProto(path, opticdir=None, no_docs=False):
+def loadPkgProto(path, opticdir=None, no_docs=False, readonly=False):
     '''
     Get a Storm Package definition from disk.
 
@@ -120,8 +122,13 @@ def loadPkgProto(path, opticdir=None, no_docs=False):
 
     for mod in pkgdef.get('modules', ()):
         name = mod.get('name')
-        with s_common.genfile(protodir, 'storm', 'modules', name) as fd:
-            mod['storm'] = fd.read().decode()
+        mod_path = s_common.genpath(protodir, 'storm', 'modules', name)
+        if readonly:
+            storm = getStormStr(mod_path)
+        else:
+            with s_common.genfile(mod_path) as fd:
+                storm = fd.read().decode()
+        mod['storm'] = storm
 
     for extmod in pkgdef.get('external_modules', ()):
         fpth = extmod.get('file_path')
@@ -142,8 +149,13 @@ def loadPkgProto(path, opticdir=None, no_docs=False):
 
     for cmd in pkgdef.get('commands', ()):
         name = cmd.get('name')
-        with s_common.genfile(protodir, 'storm', 'commands', name) as fd:
-            cmd['storm'] = fd.read().decode()
+        cmd_path = s_common.genpath(protodir, 'storm', 'commands', name)
+        if readonly:
+            storm = getStormStr(mod_path)
+        else:
+            with s_common.genfile(cmd_path) as fd:
+                storm = fd.read().decode()
+        cmd['storm'] = storm
 
     for widen, wdef in pkgdef.get('optic', {}).get('workflows', {}).items():
         name = wdef.get('name')

--- a/synapse/tools/genpkg.py
+++ b/synapse/tools/genpkg.py
@@ -70,6 +70,8 @@ def loadPkgProto(path, opticdir=None, no_docs=False, readonly=False):
         fp (str): Path to the package .yaml file on disk.
         opticdir (str): Path to optional Optic module code to add to the Storm Package.
         no_docs (bool): If true, omit inline documentation content if it is not present on disk.
+        readonly (bool): If set, open files in read-only mode. If files are missing, that will raise a NoSuchFile
+                         exception.
 
     Returns:
         dict: A Storm package definition.

--- a/synapse/tools/genpkg.py
+++ b/synapse/tools/genpkg.py
@@ -124,11 +124,10 @@ def loadPkgProto(path, opticdir=None, no_docs=False, readonly=False):
         name = mod.get('name')
         mod_path = s_common.genpath(protodir, 'storm', 'modules', name)
         if readonly:
-            storm = getStormStr(mod_path)
+            mod['storm'] = getStormStr(mod_path)
         else:
             with s_common.genfile(mod_path) as fd:
-                storm = fd.read().decode()
-        mod['storm'] = storm
+                mod['storm'] = fd.read().decode()
 
     for extmod in pkgdef.get('external_modules', ()):
         fpth = extmod.get('file_path')
@@ -151,11 +150,10 @@ def loadPkgProto(path, opticdir=None, no_docs=False, readonly=False):
         name = cmd.get('name')
         cmd_path = s_common.genpath(protodir, 'storm', 'commands', name)
         if readonly:
-            storm = getStormStr(mod_path)
+            cmd['storm'] = getStormStr(cmd_path)
         else:
             with s_common.genfile(cmd_path) as fd:
-                storm = fd.read().decode()
-        cmd['storm'] = storm
+                cmd['storm'] = fd.read().decode()
 
     for widen, wdef in pkgdef.get('optic', {}).get('workflows', {}).items():
         name = wdef.get('name')


### PR DESCRIPTION
- Add a `readonly` flag to `synapse.tools.genpkg.loadPkgProto()` and  `synapse.tools.genpkg.tryLoadPkgProto()` APIs. If set to `True` this will open files in read only mode.
- Update several `synapse.exc.NoSuchFile` exceptions to include `mesg` and `path` arguments.