### PR TITLE
Expand the version range of typing-extensions that we allow (SYN-3058)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ vcrpy>=4.1.1,<4.2.0
 base58>=2.1.0,<2.2.0
 python-bitcoinlib==0.11.0
 pycryptodome>=3.11.0,<3.13.0
-typing-extensions==3.7.4  # synapse.vendor.xrpl req
+typing-extensions>=3.7.4,<5.0.0  # synapse.vendor.xrpl req
 scalecodec==1.0.2  # synapse.vendor.substrateinterface req
 cbor2>=5.4.1,<5.4.3
 bech32==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         'base58>=2.1.0,<2.2.0',
         'python-bitcoinlib==0.11.0',
         'pycryptodome>=3.11.0,<3.13.0',
-        'typing-extensions==3.7.4',  # synapse.vendor.xrpl req
+        'typing-extensions>=3.7.4,<5.0.0',  # synapse.vendor.xrpl req
         'scalecodec==1.0.2',  # synapse.vendor.substrateinterface req
         'cbor2>=5.4.1,<5.4.3',
         'bech32==1.2.0',


### PR DESCRIPTION
This project is moved to Semantic Versions since the 4.0.0 release, and keeping it pinned interferes with Synapse being mixed with other libraries who may use contemporary typing-extensions.