### PR TITLE
Fix missing keyword argument in AxonApi.wput method SYN-3107

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -496,16 +496,18 @@ class AxonApi(s_cell.CellApi, s_share.Share):  # type: ignore
             dict: An information dictionary containing the results of the request.
         '''
         await self._reqUserAllowed(('axon', 'wget'))
-        return await self.cell.wget(url, params=params, headers=headers, json=json, body=body, method=method, ssl=ssl, timeout=timeout)
+        return await self.cell.wget(url, params=params, headers=headers, json=json, body=body, method=method, ssl=ssl,
+                                    timeout=timeout)
 
     async def postfiles(self, fields, url, params=None, headers=None, method='POST', ssl=True, timeout=None):
         await self._reqUserAllowed(('axon', 'wput'))
         return await self.cell.postfiles(fields, url, params=params, headers=headers,
                                          method=method, ssl=ssl, timeout=timeout)
 
-    async def wput(self, sha256, url, params=None, headers=None, ssl=True, timeout=None):
+    async def wput(self, sha256, url, params=None, headers=None, method='PUT', ssl=True, timeout=None):
         await self._reqUserAllowed(('axon', 'wput'))
-        return await self.cell.wput(sha256, url, params=params, headers=headers, ssl=ssl, timeout=timeout)
+        return await self.cell.wput(sha256, url, params=params, headers=headers, method=method, ssl=ssl,
+                                    timeout=timeout)
 
     async def metrics(self):
         '''
@@ -1124,7 +1126,8 @@ class Axon(s_cell.Cell):
                     'headers': dict(),
                 }
 
-    async def wput(self, sha256, url, params=None, headers=None, method='PUT', ssl=True, timeout=None, filename=None, filemime=None):
+    async def wput(self, sha256, url, params=None, headers=None, method='PUT', ssl=True, timeout=None,
+                   filename=None, filemime=None):
         '''
         Stream a blob from the axon as the body of an HTTP request.
         '''

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -562,7 +562,7 @@ class AxonTest(s_t_utils.SynTest):
 
             async with axon.getLocalProxy() as proxy:
 
-                resp = await proxy.wput(sha256, f'https://127.0.0.1:{port}/api/v1/pushfile', ssl=False)
+                resp = await proxy.wput(sha256, f'https://127.0.0.1:{port}/api/v1/pushfile', method='PUT', ssl=False)
                 self.eq(True, resp['ok'])
                 self.eq(200, resp['code'])
 


### PR DESCRIPTION
The method argument was missing after the headers argument.