### PR TITLE
Add a error message to storm commands when the help flag is given alongside extra arguments (SYN-3103)

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2144,8 +2144,11 @@ class Parser:
                 return
 
         # check for help before processing other args
-        if opts.get('help'):
-            self.help()
+        if opts.pop('help', None):
+            mesg = None
+            if opts or posargs:
+                mesg = f'Extra arguments and flags are not supported with the help flag: {self.prog} {" ".join(argv)}'
+            self.help(mesg)
             return
 
         # process positional arguments

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -2394,6 +2394,12 @@ class StormTest(s_t_utils.SynTest):
         self.isin('Arguments:', pars.mesgs)
         self.isin('  <hehe>                      : No help available', pars.mesgs)
 
+        pars = s_storm.Parser(prog='hehe')
+        pars.add_argument('hehe')
+        opts = pars.parse_args(['newp', '-h'])
+        self.none(opts)
+        self.isin('ERROR: Extra arguments and flags are not supported with the help flag: hehe newp -h', pars.mesgs)
+
         pars = s_storm.Parser()
         pars.add_argument('--no-foo', default=True, action='store_false')
         opts = pars.parse_args(['--no-foo'])


### PR DESCRIPTION
Add a error message to storm commands when the help flag is given alongside extra arguments (SYN-3103)