### PR TITLE
Update packaging, pycryptome, scalecodec packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ commands:
           command: |
             python3 -m venv --copies venv
             . venv/bin/activate
-            python3 -m pip install -U wheel pip pytest pytest-cov pycodestyle
+            python3 -m pip install -U wheel pip
+            python3 -m pip install -U -r requirements_dev.txt
 
       - run:
           name: install synapse

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,14 @@ prompt-toolkit>=3.0.4,<3.1.0
 lark-parser==0.11.2
 Pygments>=2.7.4,<2.8.0
 fastjsonschema>=2.14.3,<2.15
-packaging>=20.0,<21.0
+packaging>=20.0,<22.0
 stix2-validator>=3.0.0,<4.0.0
 vcrpy>=4.1.1,<4.2.0
 base58>=2.1.0,<2.2.0
 python-bitcoinlib==0.11.0
-pycryptodome>=3.11.0,<3.13.0
+pycryptodome>=3.11.0,<3.14.0
 typing-extensions>=3.7.4,<5.0.0  # synapse.vendor.xrpl req
-scalecodec==1.0.2  # synapse.vendor.substrateinterface req
+scalecodec>=1.0.2,<1.0.29  # synapse.vendor.substrateinterface req
 cbor2>=5.4.1,<5.4.3
 bech32==1.2.0
 oauthlib>=3.1.1,<4.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,6 @@ pytest-cov>=3.0.0,<4.0.0
 pycodestyle>=2.8.0,<3.0.0
 bump2version>=1.0.1,<1.1.0
 pytest-xdist>=2.4.0,<3.0.0
+# Remporary until https://github.com/nedbat/coveragepy/issues/1310 is resolved.
+coverage>=6.2,<6.3
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,6 @@ pytest-cov>=3.0.0,<4.0.0
 pycodestyle>=2.8.0,<3.0.0
 bump2version>=1.0.1,<1.1.0
 pytest-xdist>=2.4.0,<3.0.0
-# Remporary until https://github.com/nedbat/coveragepy/issues/1310 is resolved.
+# Temporary until https://github.com/nedbat/coveragepy/issues/1310 is resolved.
 coverage>=6.2,<6.3
 

--- a/setup.py
+++ b/setup.py
@@ -93,15 +93,15 @@ setup(
         'prompt-toolkit>=3.0.4,<3.1.0',
         'lark-parser==0.11.2',
         'Pygments>=2.7.4,<2.8.0',
-        'packaging>=20.0,<21.0',
+        'packaging>=20.0,<22.0',
         'fastjsonschema>=2.14.3,<2.15',
         'stix2-validator>=3.0.0,<4.0.0',
         'vcrpy>=4.1.1,<4.2.0',
         'base58>=2.1.0,<2.2.0',
         'python-bitcoinlib==0.11.0',
-        'pycryptodome>=3.11.0,<3.13.0',
+        'pycryptodome>=3.11.0,<3.14.0',
         'typing-extensions>=3.7.4,<5.0.0',  # synapse.vendor.xrpl req
-        'scalecodec==1.0.2',  # synapse.vendor.substrateinterface req
+        'scalecodec>=1.0.2,<1.0.29',  # synapse.vendor.substrateinterface req
         'cbor2>=5.4.1,<5.4.3',
         'bech32==1.2.0',
         'oauthlib>=3.1.1,<4.0.0',

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
             'pycodestyle>=2.8.0,<3.0.0',
             'bump2version>=1.0.1,<1.1.0',
             'pytest-xdist>=2.4.0,<3.0.0',
+            'coverage>=6.2,<6.3',
         ],
     },
 


### PR DESCRIPTION
We don't have a reason to keep the upper bounds on these pinned at their current values and the APIs being used are currently stable.

- https://github.com/vertexproject/vtx-base-image/pull/6
- https://github.com/vertexproject/vtx-base-image/pull/8
- https://github.com/vertexproject/vtx-base-image/pull/14