### PR TITLE
Add a test helper to mock out the certdir singleton behavior (SYN-3214)

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -745,9 +745,10 @@ def setlogging(mlogger, defval=None, structlog=None):
 
     return ret
 
+syndir_default = '~/.syn'
 syndir = os.getenv('SYN_DIR')
 if syndir is None:
-    syndir = '~/.syn'
+    syndir = syndir_default
 
 def envbool(name, defval='false'):
     '''

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1683,6 +1683,15 @@ class SynTest(unittest.TestCase):
             with self.setSynDir(dirn):
                 yield dirn
 
+    @contextlib.contextmanager
+    def getTestCertDir(self, dirn):
+        with mock.patch('synapse.lib.certdir.defdir', dirn):
+            # Use the default behavior of creating the certdir from defdir
+            # which was just patched
+            certdir = s_certdir.CertDir()
+            with mock.patch('synapse.lib.certdir.certdir', certdir):
+                yield certdir
+
     def eq(self, x, y, msg=None):
         '''
         Assert X is equal to Y

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1685,6 +1685,16 @@ class SynTest(unittest.TestCase):
 
     @contextlib.contextmanager
     def getTestCertDir(self, dirn):
+        '''
+        Patch the synapse.lib.certdir.certdir singleton and supporting functions
+        with a CertDir instance backed by the provided directory.
+
+        Args:
+            dirn (str): The directory used to back the new CertDir singleton.
+
+        Returns:
+            s_certdir.CertDir: The patched CertDir object that is the current singleton.
+        '''
         with mock.patch('synapse.lib.certdir.defdir', dirn):
             # Use the default behavior of creating the certdir from defdir
             # which was just patched


### PR DESCRIPTION
- This will isolate the certdir behavior to a known directory for testing.
- Add default references for `SYN_DIR` and `SYN_CERT_DIR` values.