### PR TITLE
Do not allow addFormProp to be called twice with the same form+prop (SYN-3171)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
           command: |
             . venv/bin/activate
             mkdir test-reports
-            circleci tests glob synapse/tests/test_cortex.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_stormlib*.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
+            circleci tests glob synapse/tests/test_cortex.py synapse/tests/test_lib_aha.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_stormlib*.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml ${COVERAGE_ARGS}
 
   test_steps_doc:
     description: "Documentation test steps"

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -397,22 +397,24 @@ class AhaTest(s_test.SynTest):
     async def test_lib_aha_bootstrap(self):
 
         with self.getTestDir() as dirn:
+            certdirn = s_common.gendir('certdir')
+            with self.getTestCertDir(certdirn):
 
-            conf = {
-                'aha:name': 'aha.do.vertex.link',
-                'aha:admin': 'root@do.vertex.link',
-                'aha:network': 'do.vertex.link',
-            }
+                conf = {
+                    'aha:name': 'aha.do.vertex.link',
+                    'aha:admin': 'root@do.vertex.link',
+                    'aha:network': 'do.vertex.link',
+                }
 
-            async with await s_aha.AhaCell.anit(dirn, conf=conf) as aha:
-                self.true(os.path.isfile(os.path.join(dirn, 'certs', 'cas', 'do.vertex.link.crt')))
-                self.true(os.path.isfile(os.path.join(dirn, 'certs', 'cas', 'do.vertex.link.key')))
-                self.true(os.path.isfile(os.path.join(dirn, 'certs', 'hosts', 'aha.do.vertex.link.crt')))
-                self.true(os.path.isfile(os.path.join(dirn, 'certs', 'hosts', 'aha.do.vertex.link.key')))
-                self.true(os.path.isfile(os.path.join(dirn, 'certs', 'users', 'root@do.vertex.link.crt')))
-                self.true(os.path.isfile(os.path.join(dirn, 'certs', 'users', 'root@do.vertex.link.key')))
+                async with await s_aha.AhaCell.anit(dirn, conf=conf) as aha:
+                    self.true(os.path.isfile(os.path.join(dirn, 'certs', 'cas', 'do.vertex.link.crt')))
+                    self.true(os.path.isfile(os.path.join(dirn, 'certs', 'cas', 'do.vertex.link.key')))
+                    self.true(os.path.isfile(os.path.join(dirn, 'certs', 'hosts', 'aha.do.vertex.link.crt')))
+                    self.true(os.path.isfile(os.path.join(dirn, 'certs', 'hosts', 'aha.do.vertex.link.key')))
+                    self.true(os.path.isfile(os.path.join(dirn, 'certs', 'users', 'root@do.vertex.link.crt')))
+                    self.true(os.path.isfile(os.path.join(dirn, 'certs', 'users', 'root@do.vertex.link.key')))
 
-                host, port = await aha.dmon.listen('ssl://127.0.0.1:0?hostname=aha.do.vertex.link&ca=do.vertex.link')
+                    host, port = await aha.dmon.listen('ssl://127.0.0.1:0?hostname=aha.do.vertex.link&ca=do.vertex.link')
 
-                async with await s_telepath.openurl(f'ssl://root@127.0.0.1:{port}?hostname=aha.do.vertex.link') as proxy:
-                    await proxy.getCellInfo()
+                    async with await s_telepath.openurl(f'ssl://root@127.0.0.1:{port}?hostname=aha.do.vertex.link') as proxy:
+                        await proxy.getCellInfo()

--- a/synapse/tests/test_lib_stormlib_modelext.py
+++ b/synapse/tests/test_lib_stormlib_modelext.py
@@ -2,7 +2,7 @@ import synapse.tests.utils as s_test
 
 import synapse.exc as s_exc
 
-class SynTest(s_test.SynTest):
+class StormtypesModelextTest(s_test.SynTest):
 
     async def test_lib_stormlib_modelext(self):
         async with self.getTestCore() as core:
@@ -27,6 +27,10 @@ class SynTest(s_test.SynTest):
             self.eq(nodes[0].get('tick'), 1609459200000)
             self.eq(nodes[0].get('._woot'), 30)
             self.eq(nodes[0].getTagProp('lol', 'score'), 99)
+
+            with self.raises(s_exc.DupPropName):
+                q = '''$lib.model.ext.addFormProp(_visi:int, tick, (time, $lib.dict()), $lib.dict())'''
+                await core.callStorm(q)
 
             await core.callStorm('_visi:int=10 | delnode')
             await core.callStorm('''


### PR DESCRIPTION
- Prevent reusing a name on a property
- Add aha to nexus replay test
- Isolate a test's use of TLS / certdir singleton