### PR TITLE
Use iso3166 type rather than more generic str type

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -2718,7 +2718,7 @@ class InetModule(s_module.CoreModule):
                         ('contacts', ('array', {'type': 'inet:whois:ipcontact', 'uniq': True, 'sorted': True}), {
                             'doc': 'Additional contacts from the record.',
                         }),
-                        ('country', ('str', {'lower': True, 'regex': '^[a-z]{2}$'}), {
+                        ('country', ('iso:3166:cc', {}), {
                             'doc': 'The two-letter ISO 3166 country code.'
                         }),
                         ('status', ('str', {'lower': True}), {


### PR DESCRIPTION
Avoid using a generic string type with an extra regex constraint when a type is available. 

I'm unsure that https://github.com/ancailliau/synapse/blob/fix-flag-code/synapse/models/inet.py#L2564 should also have its type updated.