### PR TITLE
Support layer wipe by generating node edits (SYN-3438)

### DIFF
--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1774,6 +1774,8 @@ class Layer(s_nexus.Pusher):
         Nuke all the contents in the layer, leaving an empty layer
         NOTE: This internal API is deprecated but is kept for Nexus event backward compatibility
         '''
+        s_common.deprecated('truncate')
+
         self.dirty.clear()
         self.buidcache.clear()
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -3991,3 +3991,62 @@ def getFlatEdits(nodeedits):
         addedits(buid, form, edits)
 
     return [(k[0], k[1], v) for (k, v) in editsbynode.items()]
+
+def getNodeEditPerms(nodeedits):
+    '''
+    Yields (offs, perm) tuples that can be used in user.allowed()
+    '''
+
+    for nodeoffs, (buid, form, edits) in enumerate(nodeedits):
+
+        for editoffs, (edit, info, _) in enumerate(edits):
+
+            permoffs = (nodeoffs, editoffs)
+
+            if edit == EDIT_NODE_ADD:
+                yield (permoffs, ('node', 'add', form))
+                continue
+
+            if edit == EDIT_NODE_DEL:
+                yield (permoffs, ('node', 'del', form))
+                continue
+
+            if edit == EDIT_PROP_SET:
+                yield (permoffs, ('node', 'prop', 'set', f'{form}:{info[0]}'))
+                continue
+
+            if edit == EDIT_PROP_DEL:
+                yield (permoffs, ('node', 'prop', 'del', f'{form}:{info[0]}'))
+                continue
+
+            if edit == EDIT_TAG_SET:
+                yield (permoffs, ('node', 'tag', 'add', *info[0].split('.')))
+                continue
+
+            if edit == EDIT_TAG_DEL:
+                yield (permoffs, ('node', 'tag', 'del', *info[0].split('.')))
+                continue
+
+            if edit == EDIT_TAGPROP_SET:
+                yield (permoffs, ('node', 'tag', 'add', *info[0].split('.')))
+                continue
+
+            if edit == EDIT_TAGPROP_DEL:
+                yield (permoffs, ('node', 'tag', 'del', *info[0].split('.')))
+                continue
+
+            if edit == EDIT_NODEDATA_SET:
+                yield (permoffs, ('node', 'data', 'set', info[0]))
+                continue
+
+            if edit == EDIT_NODEDATA_DEL:
+                yield (permoffs, ('node', 'data', 'pop', info[0]))
+                continue
+
+            if edit == EDIT_EDGE_ADD:
+                yield (permoffs, ('node', 'edge', 'add', info[0]))
+                continue
+
+            if edit == EDIT_EDGE_DEL:
+                yield (permoffs, ('node', 'edge', 'del', info[0]))
+                continue

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -664,7 +664,7 @@ class Snap(s_base.Base):
             await asyncio.sleep(0)
             return node
 
-        layrs = (layr for layr in self.layers if layr.iden not in cache)
+        layrs = [layr for layr in self.layers if layr.iden not in cache]
         if layrs:
             indx = 0
             newsodes = await self.core._getStorNodes(buid, layrs)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -902,9 +902,10 @@ stormcmds = (
 
             if $cmdopts.delete {
                 $layriden = $view.pack().layers.index(0).iden
-
                 $lib.view.del($view.iden)
                 $lib.layer.del($layriden)
+            } else {
+                $view.wipeLayer()
             }
             $lib.print("View merged: {iden}", iden=$cmdopts.iden)
         ''',

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -6215,9 +6215,6 @@ class View(Prim):
         useriden = self.runt.user.iden
         viewiden = self.valu.get('iden')
         view = self.runt.snap.core.getView(viewiden)
-
-        # ensure the user may make *any* node edits
-        self.runt.layerConfirm(('node',))
         await view.wipeLayer(useriden=useriden)
 
 @registry.registerLib

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -6003,6 +6003,9 @@ class View(Prim):
                   ),
                   'returns': {'name': 'Yields', 'type': 'list',
                               'desc': 'Yields tuples containing the source iden, verb, and destination iden.', }}},
+        {'name': 'wipeLayer', 'desc': 'Delete all nodes and nodedata from the write layer. Triggers will be run.',
+         'type': {'type': 'function', '_funcname': '_methWipeLayer',
+                  'returns': {'type': 'null', }}},
         {'name': 'addNode', 'desc': '''Transactionally add a single node and all it's properties. If any validation fails, no changes are made.''',
          'type': {'type': 'function', '_funcname': 'addNode',
                   'args': (
@@ -6060,6 +6063,7 @@ class View(Prim):
             'merge': self._methViewMerge,
             'addNode': self.addNode,
             'getEdges': self._methGetEdges,
+            'wipeLayer': self._methWipeLayer,
             'addNodeEdits': self._methAddNodeEdits,
             'getEdgeVerbs': self._methGetEdgeVerbs,
             'getFormCounts': self._methGetFormcount,
@@ -6203,6 +6207,18 @@ class View(Prim):
         viewiden = self.valu.get('iden')
         todo = s_common.todo('merge', useriden=useriden, force=force)
         await self.runt.dyncall(viewiden, todo)
+
+    async def _methWipeLayer(self):
+        '''
+        Delete nodes and nodedata from the view's write layer.
+        '''
+        useriden = self.runt.user.iden
+        viewiden = self.valu.get('iden')
+        view = self.runt.snap.core.getView(viewiden)
+
+        # ensure the user may make *any* node edits
+        self.runt.layerConfirm(('node',))
+        await view.wipeLayer(useriden=useriden)
 
 @registry.registerLib
 class LibTrigger(Lib):


### PR DESCRIPTION
- $lib.view.merge() no longer automatically deletes data from the fork view
- view.merge (without --delete) will generate del node edits that will be executed by any consumers