### PR TITLE
Inet:url norm updates (SYN-3260 SYN-3360 SYN-3392)

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -850,6 +850,11 @@ class Url(s_types.Str):
             if port is not None:
                 hostparts = f'{hostparts}:{port}'
 
+        if proto != 'file':
+            if not subs.get('fqdn') and not subs.get('ipv4') and not subs.get('ipv6'):
+                raise s_exc.BadTypeValu(valu=orig, name=self.name,
+                                        mesg='Missing address/url') from None
+
         base = f'{proto}://{hostparts}{pathpart}'
         subs['base'] = base
         norm = f'{base}{parampart}'

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -716,7 +716,7 @@ class Url(s_types.Str):
         hostparts = ''
         pathpart = ''
         parampart = ''
-        isUnc = False
+        isUNC = False
 
         # Protocol
         for splitter in ('://///', ':////'):
@@ -724,7 +724,7 @@ class Url(s_types.Str):
                 proto, valu = orig.split(splitter, 1)
                 proto = proto.lower()
                 assert proto == 'file'
-                isUnc = True
+                isUNC = True
                 break
             except Exception:
                 continue
@@ -842,7 +842,7 @@ class Url(s_types.Str):
         if authparts:
             hostparts = f'{authparts}@'
 
-        if isUnc:
+        if isUNC:
             hostparts += '//'
 
         if host is not None:

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -717,6 +717,7 @@ class Url(s_types.Str):
         pathpart = ''
         parampart = ''
         isUNC = False
+        prep = False
 
         # Protocol
         for splitter in ('://///', ':////'):
@@ -727,7 +728,7 @@ class Url(s_types.Str):
                 isUNC = True
                 break
             except Exception:
-                continue
+                proto = valu = ''
 
         if not proto:
             try:
@@ -737,17 +738,25 @@ class Url(s_types.Str):
                 pass
 
         if not proto:
-            for splitter in (':/', ':'):
-                try:
-                    proto, valu = orig.split(splitter, 1)
-                    proto = proto.lower()
-                    assert proto == 'file'
-                    valu = '/' + valu
-                    break
-                except Exception:
-                    pass
+            try:
+                proto, valu = orig.split(':/', 1)
+                proto = proto.lower()
+                assert proto == 'file'
+                prep = True
+            except Exception:
+                proto = valu = ''
 
         if not proto:
+            try:
+                proto, valu = orig.split(':', 1)
+                proto = proto.lower()
+                assert proto == 'file'
+                assert valu
+                prep = True
+            except Exception:
+                proto = valu = ''
+
+        if not proto or not valu:
             raise s_exc.BadTypeValu(valu=orig, name=self.name,
                                     mesg='Invalid/Missing protocol') from None
 
@@ -758,7 +767,19 @@ class Url(s_types.Str):
             valu, queryrem = valu.split('?', 1)
             # TODO break out query params separately
 
+        # Optional User/Password
+        parts = valu.rsplit('@', 1)
+        if len(parts) == 2:
+            authparts, valu = parts
+            prep = False
+            userpass = authparts.split(':', 1)
+            subs['user'] = userpass[0]
+            if len(userpass) == 2:
+                subs['passwd'] = userpass[1]
+
         # Resource Path
+        if prep:
+            valu = f'/{valu}'
         parts = valu.split('/', 1)
         subs['path'] = ''
         if len(parts) == 2:
@@ -773,16 +794,6 @@ class Url(s_types.Str):
         if queryrem:
             parampart = f'?{queryrem}'
         subs['params'] = parampart
-
-        # Optional User/Password
-        parts = valu.rsplit('@', 1)
-        if len(parts) == 2:
-            authparts, valu = parts
-
-            userpass = authparts.split(':', 1)
-            subs['user'] = userpass[0]
-            if len(userpass) == 2:
-                subs['passwd'] = userpass[1]
 
         # Host (FQDN, IPv4, or IPv6)
         host = None

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -743,7 +743,7 @@ class Url(s_types.Str):
         subs['params'] = parampart
 
         # Optional User/Password
-        parts = valu.split('@', 1)
+        parts = valu.rsplit('@', 1)
         if len(parts) == 2:
             authparts, valu = parts
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -850,11 +850,11 @@ class Url(s_types.Str):
                 subs['port'] = self.modl.type('inet:port').norm(defport)[0]
 
         # Set up Normed URL
-        if authparts:
-            hostparts = f'{authparts}@'
-
         if isUNC:
             hostparts += '//'
+
+        if authparts:
+            hostparts = f'{authparts}@'
 
         if host is not None:
             hostparts = f'{hostparts}{host}'

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -886,6 +886,16 @@ class StormTest(s_t_utils.SynTest):
                 bytag = await subcore.nodes('#foo.bar')
                 self.len(0, bytag)
 
+                url = await subcore.nodes('inet:url')
+                self.len(1, url)
+                url = url[0]
+                self.eq('https', url.props['proto'])
+                self.eq('/api/v1/exptest/neat', url.props['path'])
+                self.eq('', url.props['params'])
+                self.eq(2130706433, url.props['ipv4'])
+                self.eq(f'https://127.0.0.1:{port}/api/v1/exptest/neat', url.props['base'])
+                self.eq(port, url.props['port'])
+
                 # now test that param works
                 byyield = await subcore.nodes(f'nodes.import --no-ssl-verify https://127.0.0.1:{port}/api/v1/exptest/kewl')
                 self.len(count, byyield)

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -1273,7 +1273,17 @@ class InetModelTest(s_t_utils.SynTest):
             self.raises(s_exc.BadTypeValu, t.norm, 'wat')  # No Protocol
 
             self.raises(s_exc.BadTypeValu, t.norm, 'www.google\udcfesites.com/hehe.asp')
-            valu = t.norm('http://www.googlesites.com/hehe\udcfestuff.asp')[0]
+            valu = t.norm('http://www.googlesites.com/hehe\udcfestuff.asp')
+            url = 'http://www.googlesites.com/hehe\udcfestuff.asp'
+            expected = (url, {'subs': {
+                'proto': 'http',
+                'path': '/hehe\udcfestuff.asp',
+                'port': 80,
+                'params': '',
+                'fqdn': 'www.googlesites.com',
+                'base': url
+            }})
+            self.eq(valu, expected)
 
             # Form Tests ======================================================
             async with await core.snap() as snap:
@@ -1701,6 +1711,14 @@ class InetModelTest(s_t_utils.SynTest):
             async with await core.snap() as snap:
                 node = await snap.addNode(formname, valu)
                 self.checkNode(node, (expected_ndef, expected_props))
+            url = await core.nodes('inet:url')
+            self.len(1, url)
+            url = url[0]
+            self.eq(443, url.props['port'])
+            self.eq('', url.props['params'])
+            self.eq('vertex.link', url.props['fqdn'])
+            self.eq('https', url.props['proto'])
+            self.eq('https://vertex.link/a_cool_program.exe', url.props['base'])
 
     async def test_url_mirror(self):
         url0 = 'http://vertex.link'

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -1269,7 +1269,7 @@ class InetModelTest(s_t_utils.SynTest):
 
             # Type Tests ======================================================
             t = core.model.type(formname)
-
+            self.raises(s_exc.BadTypeValu, t.norm, 'http:///wat')
             self.raises(s_exc.BadTypeValu, t.norm, 'wat')  # No Protocol
 
             self.raises(s_exc.BadTypeValu, t.norm, 'www.google\udcfesites.com/hehe.asp')

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -1373,6 +1373,54 @@ class InetModelTest(s_t_utils.SynTest):
         }})
         self.eq(t.norm(url), expected)
 
+        # Userinfo user with @ in it
+        url = f'lando://visi@vertex.link@{host_port}:40000/auth/gateway'
+        expected = (f'lando://visi@vertex.link@{repr_host_port}:40000/auth/gateway', {'subs': {
+            'proto': 'lando', 'path': '/auth/gateway',
+            'user': 'visi@vertex.link',
+            'base': f'lando://visi@vertex.link@{repr_host_port}:40000/auth/gateway',
+            'port': 40000,
+            'params': '',
+            htype: norm_host,
+        }})
+        self.eq(t.norm(url), expected)
+
+        # Userinfo password with @
+        url = f'balthazar://root:foo@@@bar@{host_port}:1234/'
+        expected = (f'balthazar://root:foo@@@bar@{repr_host_port}:1234/', {'subs': {
+            'proto': 'balthazar', 'path': '/',
+            'user': 'root', 'passwd': 'foo@@@bar',
+            'base': f'balthazar://root:foo@@@bar@{repr_host_port}:1234/',
+            'port': 1234,
+            'params': '',
+            htype: norm_host,
+        }})
+        self.eq(t.norm(url), expected)
+
+        # rfc3986 compliant Userinfo with @ properly encoded
+        url = f'calrissian://visi%40vertex.link:surround%40@{host_port}:44343'
+        expected = (f'calrissian://visi%40vertex.link:surround%40@{repr_host_port}:44343', {'subs': {
+            'proto': 'calrissian', 'path': '',
+            'user': 'visi%40vertex.link', 'passwd': 'surround%40',
+            'base': f'calrissian://visi%40vertex.link:surround%40@{repr_host_port}:44343',
+            'port': 44343,
+            'params': '',
+            htype: norm_host,
+        }})
+        self.eq(t.norm(url), expected)
+
+        # unencoded query params are handled nicely
+        url = f'https://visi@vertex.link:neato@burrito@{host}/?q=@foobarbaz'
+        expected = (f'https://visi@vertex.link:neato@burrito@{repr_host}/?q=@foobarbaz', {'subs': {
+            'proto': 'https', 'path': '/',
+            'user': 'visi@vertex.link', 'passwd': 'neato@burrito',
+            'base': f'https://visi@vertex.link:neato@burrito@{repr_host}/',
+            'port': 443,
+            'params': '?q=@foobarbaz',
+            htype: norm_host,
+        }})
+        self.eq(t.norm(url), expected)
+
         # URL with no port, but default port valu.
         # Port should be in subs, but not normed URL.
         url = f'https://user:password@{host}/a/b/c/?foo=bar&baz=faz'

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -1360,7 +1360,6 @@ class InetModelTest(s_t_utils.SynTest):
             }})
             self.eq(t.norm(url), expected)
 
-            # technically incorrect, but seen often enough that we should handle it.
             url = 'file://somehost/path/to/foo.txt'
             expected = (url, {'subs': {
                 'proto': 'file',
@@ -1443,6 +1442,7 @@ class InetModelTest(s_t_utils.SynTest):
             }})
             self.eq(t.norm(url), expected)
 
+            # https://datatracker.ietf.org/doc/html/rfc8089#appendix-E.3.2
             url = 'file:////host.vertex.link/SharedDir/Unc/FilePath'
             expected = ('file:////host.vertex.link/SharedDir/Unc/FilePath', {'subs': {
                 'proto': 'file',


### PR DESCRIPTION
* Don't require host for inet:url
* Support `file:` URIs from RFC-8089 in inet:url construction.