### PR TITLE
log cell startup errors and handle lmdb.LockError in lmdbslab (SYN-3412)

### DIFF
--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -261,3 +261,5 @@ class FatalErr(SynErr):
     Raised when a fatal error has occured which an application cannot recover from.
     '''
     pass
+
+class LmdbLock(SynErr): pass

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2362,7 +2362,11 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         s_coro.set_pool_logging(logger, logconf=conf['_log_conf'])
 
-        cell = await cls.anit(opts.dirn, conf=conf)
+        try:
+            cell = await cls.anit(opts.dirn, conf=conf)
+        except:
+            logger.exception(f'Error starting cell at {opts.dirn}')
+            raise
 
         try:
 

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -717,10 +717,11 @@ class Slab(s_base.Base):
             self.lenv = lmdb.open(str(path), **opts)
         except lmdb.LockError as e:  # pragma: no cover
             # This is difficult to test since it requires two processes to open the slab with
-            # the same pid. In practice this typically represents two docker containers running
-            # from different process namespaces, whose process pids are the same, opening the
-            # same lmdb database.
-            mesg = f'Unable to obtain lock on {path}. Another process may have this file locked. {e}'
+            # the same pid. In practice this typically occurs when there are two docker
+            # containers running from different process namespaces, whose process pids are
+            # the same, opening the same lmdb database. That isn't a supported configuration
+            # and we just need to catch that error.
+            mesg = f'Unable to obtain lock on {path}. Another process with {os.getpid()} may have this file locked. {e}'
             raise s_exc.LmdbLock(mesg=mesg, path=path) from None
 
         self.allslabs[path] = self

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -721,7 +721,7 @@ class Slab(s_base.Base):
             # containers running from different process namespaces, whose process pids are
             # the same, opening the same lmdb database. That isn't a supported configuration
             # and we just need to catch that error.
-            mesg = f'Unable to obtain lock on {path}. Another process with may have this file locked. {e}'
+            mesg = f'Unable to obtain lock on {path}. Another process may have this file locked. {e}'
             raise s_exc.LmdbLock(mesg=mesg, path=path) from None
 
         self.allslabs[path] = self

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -713,7 +713,12 @@ class Slab(s_base.Base):
 
         self._saveOptsFile()
 
-        self.lenv = lmdb.open(str(path), **opts)
+        try:
+            self.lenv = lmdb.open(str(path), **opts)
+        except lmdb.LockError as e:
+            mesg = f'Unable to obtain lmdblock on {path}. Another process may have this file locked. {e}'
+            raise s_exc.LmdbLock(mesg=mesg, path=path) from None
+
         self.allslabs[path] = self
 
         self.scans = set()

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -716,7 +716,7 @@ class Slab(s_base.Base):
         try:
             self.lenv = lmdb.open(str(path), **opts)
         except lmdb.LockError as e:
-            mesg = f'Unable to obtain lmdblock on {path}. Another process may have this file locked. {e}'
+            mesg = f'Unable to obtain lock on {path}. Another process may have this file locked. {e}'
             raise s_exc.LmdbLock(mesg=mesg, path=path) from None
 
         self.allslabs[path] = self

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -715,7 +715,11 @@ class Slab(s_base.Base):
 
         try:
             self.lenv = lmdb.open(str(path), **opts)
-        except lmdb.LockError as e:
+        except lmdb.LockError as e:  # pragma: no cover
+            # This is difficult to test since it requires two processes to open the slab with
+            # the same pid. In practice this typically represents two docker containers running
+            # from different process namespaces, whose process pids are the same, opening the
+            # same lmdb database.
             mesg = f'Unable to obtain lock on {path}. Another process may have this file locked. {e}'
             raise s_exc.LmdbLock(mesg=mesg, path=path) from None
 

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -721,7 +721,7 @@ class Slab(s_base.Base):
             # containers running from different process namespaces, whose process pids are
             # the same, opening the same lmdb database. That isn't a supported configuration
             # and we just need to catch that error.
-            mesg = f'Unable to obtain lock on {path}. Another process with {os.getpid()} may have this file locked. {e}'
+            mesg = f'Unable to obtain lock on {path}. Another process with may have this file locked. {e}'
             raise s_exc.LmdbLock(mesg=mesg, path=path) from None
 
         self.allslabs[path] = self

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -844,6 +844,17 @@ class CellTest(s_t_utils.SynTest):
                 self.isin(f'...cell API (telepath): cell://root@{dirn}:*', buf)
                 self.isin('...cell API (https): disabled', buf)
 
+    async def test_initargv_failure(self):
+        if not os.path.exists('/dev/null'):
+            self.skip('Test requires /dev/null to exist.')
+
+        with self.getAsyncLoggerStream('synapse.lib.cell',
+                                       'Error starting cell at /dev/null') as stream:
+            with self.raises(FileExistsError):
+                async with await s_cell.Cell.initFromArgv(['/dev/null']):
+                    pass
+            self.true(await stream.wait(timeout=6))
+
     async def test_cell_backup(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
* Catch, log and reraise cell startup errors in initFromArgv so clean tracebacks can be captured by the logger when errors occur on cell startup.
* Catch lmdb.LockError when opening a lmdb database and raise it with a clear error message.