### PR TITLE
Int - Use str value for valus outside of valid msgpack ranges when raising BadTypeValu (SYN-3354)

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -918,11 +918,11 @@ class Int(IntBase):
 
         if self.minval is not None and valu < self.minval:
             mesg = f'value is below min={self.minval}'
-            raise s_exc.BadTypeValu(valu=valu, name=self.name, mesg=mesg)
+            raise s_exc.BadTypeValu(valu=repr(valu), name=self.name, mesg=mesg)
 
         if self.maxval is not None and valu > self.maxval:
             mesg = f'value is above max={self.maxval}'
-            raise s_exc.BadTypeValu(valu=valu, name=self.name, mesg=mesg)
+            raise s_exc.BadTypeValu(valu=repr(valu), name=self.name, mesg=mesg)
 
         if self.enumrepr and valu not in self.enumrepr:
             mesg = 'Value is not a valid enum value.'

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -2030,7 +2030,7 @@ class CortexTest(s_t_utils.SynTest):
             warns = [msg for msg in mesgs if msg[0] == 'warn']
             self.len(1, warns)
             emesg = "BadTypeValu [10] during pivot: value is below min=20"
-            self.eq(warns[0][1], {'name': 'int', 'valu': 10,
+            self.eq(warns[0][1], {'name': 'int', 'valu': '10',
                                   'mesg': emesg})
             nodes = [msg for msg in mesgs if msg[0] == 'node']
             self.len(1, nodes)

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -292,9 +292,13 @@ class TypesTest(s_t_utils.SynTest):
 
         # test ranges
         self.nn(t.norm(-2**63))
-        self.raises(s_exc.BadTypeValu, t.norm, (-2**63) - 1)
+        with self.raises(s_exc.BadTypeValu) as cm:
+            t.norm((-2**63) - 1)
+        self.isinstance(cm.exception.get('valu'), str)
         self.nn(t.norm(2**63 - 1))
-        self.raises(s_exc.BadTypeValu, t.norm, 2**63)
+        with self.raises(s_exc.BadTypeValu) as cm:
+            t.norm(2**63)
+        self.isinstance(cm.exception.get('valu'), str)
 
         # test base types that Model snaps in...
         self.eq(t.norm('100')[0], 100)
@@ -400,6 +404,13 @@ class TypesTest(s_t_utils.SynTest):
         self.false(t.cmpr(-math.inf, '>', math.inf))
         self.false(t.cmpr(-math.nan, '<=', math.inf))
         self.true(t.cmpr('inf', '>=', '-0.0'))
+
+        with self.raises(s_exc.BadTypeValu) as cm:
+            t.norm((-2**63) - 1)
+        self.isinstance(cm.exception.get('valu'), str)
+        with self.raises(s_exc.BadTypeValu) as cm:
+            t.norm(2**63)
+        self.isinstance(cm.exception.get('valu'), str)
 
         async with self.getTestCore() as core:
             nodes = await core.nodes('[ test:float=42.0 ]')

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -405,13 +405,6 @@ class TypesTest(s_t_utils.SynTest):
         self.false(t.cmpr(-math.nan, '<=', math.inf))
         self.true(t.cmpr('inf', '>=', '-0.0'))
 
-        with self.raises(s_exc.BadTypeValu) as cm:
-            t.norm((-2**63) - 1)
-        self.isinstance(cm.exception.get('valu'), str)
-        with self.raises(s_exc.BadTypeValu) as cm:
-            t.norm(2**63)
-        self.isinstance(cm.exception.get('valu'), str)
-
         async with self.getTestCore() as core:
             nodes = await core.nodes('[ test:float=42.0 ]')
             self.len(1, nodes)


### PR DESCRIPTION
In Int type, in BadTypeValu, return the repr of the valu instead of the raw valu when we are outside of our min / max sizes.