### PR TITLE
Use replace option in cve type (SYN-3287)

### DIFF
--- a/synapse/lib/chop.py
+++ b/synapse/lib/chop.py
@@ -110,6 +110,7 @@ unicode_dashes = (
     '\u2013',  # endash
     '\u2014',  # emdash
 )
+unicode_dashes_replace = tuple([(char, '-') for char in unicode_dashes])
 
 def replaceUnicodeDashes(valu):
     '''

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -191,21 +191,6 @@ class SemVer(s_types.Int):
         valu = s_version.fmtVersion(major, minor, patch)
         return valu
 
-class CVE(s_types.Str):
-
-    def postTypeInit(self):
-        self.opts.update({
-            'lower': True,
-            'regex': r'(?i)^CVE-[0-9]{4}-[0-9]{4,}$',
-        })
-        s_types.Str.postTypeInit(self)
-
-    def _normPyStr(self, valu):
-
-        valu = s_chop.replaceUnicodeDashes(valu)
-
-        return s_types.Str._normPyStr(self, valu)
-
 loglevels = (
     (10, 'debug'),
     (20, 'info'),
@@ -315,10 +300,6 @@ class ItModule(s_module.CoreModule):
                 ('it:sec:cpe:v2_2', 'synapse.models.infotech.Cpe22Str', {}, {
                     'doc': 'A NIST CPE 2.2 Formatted String',
                 }),
-                ('it:sec:cve', 'synapse.models.infotech.CVE', {}, {
-                    'doc': 'A vulnerability as designated by a Common Vulnerabilities and Exposures (CVE) number.',
-                    'ex': 'cve-2012-0158'
-                }),
             ),
             'types': (
                 ('it:hostname', ('str', {'strip': True, 'lower': True}), {
@@ -352,6 +333,11 @@ class ItModule(s_module.CoreModule):
                 ('it:screenshot', ('guid', {}), {
                     'doc': 'A screenshot of a host.',
                     'interfaces': ('it:host:activity',),
+                }),
+                ('it:sec:cve', ('str', {'lower': True, 'replace': s_chop.unicode_dashes_replace,
+                                        'regex': r'(?i)^CVE-[0-9]{4}-[0-9]{4,}$'}), {
+                    'doc': 'A vulnerability as designated by a Common Vulnerabilities and Exposures (CVE) number.',
+                    'ex': 'cve-2012-0158'
                 }),
                 ('it:sec:cwe', ('str', {'regex': r'^CWE-[0-9]{1,8}$'}), {
                     'doc': 'NIST NVD Common Weaknesses Enumeration Specification',

--- a/synapse/tests/test_lib_scrape.py
+++ b/synapse/tests/test_lib_scrape.py
@@ -304,9 +304,6 @@ class ScrapeTest(s_t_utils.SynTest):
         ndefs = list(s_scrape.scrape('log4j vuln CVE-2021-44228 is pervasive'))
         self.eq(ndefs, (('it:sec:cve', 'CVE-2021-44228'),))
 
-        infos = list(s_scrape.contextScrape('endashs are a vulnerability  CVE\u20132022\u20131138 '))
-        self.eq(infos, [{'match': 'CVE–2022–1138', 'offset': 29, 'valu': 'CVE-2022-1138', 'form': 'it:sec:cve'}])
-
         nodes = set(s_scrape.scrape(data0))
 
         self.len(26, nodes)

--- a/synapse/tests/test_lib_scrape.py
+++ b/synapse/tests/test_lib_scrape.py
@@ -304,6 +304,9 @@ class ScrapeTest(s_t_utils.SynTest):
         ndefs = list(s_scrape.scrape('log4j vuln CVE-2021-44228 is pervasive'))
         self.eq(ndefs, (('it:sec:cve', 'CVE-2021-44228'),))
 
+        infos = list(s_scrape.contextScrape('endashs are a vulnerability  CVE\u20132022\u20131138 '))
+        self.eq(infos, [{'match': 'CVE–2022–1138', 'offset': 29, 'valu': 'CVE-2022-1138', 'form': 'it:sec:cve'}])
+
         nodes = set(s_scrape.scrape(data0))
 
         self.len(26, nodes)


### PR DESCRIPTION
Revert a portion of "Bug - scrape - allow endash when scraping CVE (SYN-3287) (#2644)".

Use a replace flag on str instead of a subclass of Str type.

This reverts commit 8b52ad8aea3b475d6ad2547d9ad69183666256d7.