### PR TITLE
Address Python deprecations.

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -649,7 +649,7 @@ def firethread(f):
 
 def worker(meth, *args, **kwargs):
     thr = threading.Thread(target=meth, args=args, kwargs=kwargs)
-    thr.setDaemon(True)
+    thr.daemon = True
     thr.start()
     return thr
 

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -648,8 +648,7 @@ def firethread(f):
     return callmeth
 
 def worker(meth, *args, **kwargs):
-    thr = threading.Thread(target=meth, args=args, kwargs=kwargs)
-    thr.daemon = True
+    thr = threading.Thread(target=meth, args=args, kwargs=kwargs, daemon=True)
     thr.start()
     return thr
 

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -334,11 +334,11 @@ class Daemon(s_base.Base):
 
         finis = [sess.fini() for sess in list(self.sessions.values())]
         if finis:
-            await asyncio.wait(finis)
+            await asyncio.gather(*finis, return_exceptions=True)
 
         finis = [link.fini() for link in self.links]
         if finis:
-            await asyncio.wait(finis)
+            await asyncio.gather(*finis, return_exceptions=True)
 
         for _, share in self.shared.items():
             if isinstance(share, s_base.Base):

--- a/synapse/glob.py
+++ b/synapse/glob.py
@@ -58,7 +58,7 @@ def initloop():
             setGreedCoro(_glob_loop)
 
             _glob_thrd = threading.Thread(target=_glob_loop.run_forever, name='SynLoop')
-            _glob_thrd.setDaemon(True)
+            _glob_thrd.daemon = True
             _glob_thrd.start()
 
     return _glob_loop
@@ -72,7 +72,7 @@ def setGreedCoro(loop: asyncio.AbstractEventLoop):
 
 def iAmLoop():
     initloop()
-    return threading.currentThread() == _glob_thrd
+    return threading.current_thread() == _glob_thrd
 
 def sync(coro, timeout=None):
     '''

--- a/synapse/glob.py
+++ b/synapse/glob.py
@@ -57,8 +57,7 @@ def initloop():
             _glob_loop = asyncio.new_event_loop()
             setGreedCoro(_glob_loop)
 
-            _glob_thrd = threading.Thread(target=_glob_loop.run_forever, name='SynLoop')
-            _glob_thrd.daemon = True
+            _glob_thrd = threading.Thread(target=_glob_loop.run_forever, name='SynLoop', daemon=True)
             _glob_thrd.start()
 
     return _glob_loop

--- a/synapse/lib/threads.py
+++ b/synapse/lib/threads.py
@@ -7,4 +7,4 @@ def current():
     return threading.currentThread()
 
 def iden():
-    return threading.currentThread().ident
+    return threading.current_thread().ident


### PR DESCRIPTION
- `setDaemon()` is deprecated in 3.10 and the same behavior can be achieved by passing a daemon argument.
- `current_thread` was added in 2.6 to replace `currentThread`.
- Passing coroutines (and not tasks) to `asyncio.wait()` was deprecated in 3.8.