### PR TITLE
Relax trigger schema validation (SYN-3613)

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -936,6 +936,8 @@ stormcmds = (
             $opts = $lib.copy($cmdopts)
             // Set valid tdef keys
             $opts.enabled = (not $opts.disabled)
+            $opts.help = $lib.undef
+            $opts.disabled = $lib.undef
             $trig = $lib.trigger.add($opts)
             $lib.print("Added trigger: {iden}", iden=$trig.iden)
         ''',

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -6533,7 +6533,7 @@ class LibTrigger(Lib):
     async def _methTriggerMod(self, prefix, query):
         useriden = self.runt.user.iden
         viewiden = self.runt.snap.view.iden
-
+        query = await tostr(query)
         trig = await self._matchIdens(prefix)
         iden = trig.iden
         gatekeys = ((useriden, ('trigger', 'set'), iden),)
@@ -6642,8 +6642,10 @@ class Trigger(Prim):
         viewiden = self.runt.snap.view.iden
 
         name = await tostr(name)
-        if name == 'async':
+        if name in ('async', 'enabled', ):
             valu = await tobool(valu)
+        if name in ('doc', 'name', 'storm', ):
+            valu = await tostr(valu)
 
         gatekeys = ((useriden, ('trigger', 'set'), viewiden),)
         todo = ('setTriggerInfo', (trigiden, name, valu), {})

--- a/synapse/lib/trigger.py
+++ b/synapse/lib/trigger.py
@@ -40,6 +40,7 @@ TrigSchema = {
         'tag': {'type': 'string', 'pattern': _tagre},
         'prop': {'type': 'string', 'pattern': _propre},
         'name': {'type': 'string', },
+        'doc': {'type': 'string', },
         'cond': {'enum': ['node:add', 'node:del', 'tag:add', 'tag:del', 'prop:set']},
         'storm': {'type': 'string'},
         'async': {'type': 'boolean'},
@@ -70,10 +71,10 @@ TrigSchema = {
         },
     ],
 }
-TrigSchemaKeys = tuple(TrigSchema.get('properties').keys())
+TrigSchemaValidator = s_config.getJsValidator(TrigSchema)
 
 def reqValidTdef(conf):
-    s_config.Config(TrigSchema, conf=conf).reqConfValid()
+    TrigSchemaValidator(conf)
 
 class Triggers:
     '''

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -895,20 +895,13 @@ class View(s_nexus.Pusher):  # type: ignore
 
         root = await self.core.auth.getUserByName('root')
 
-        _tdef = {}
-        for key in s_trigger.TrigSchemaKeys:
-            valu = tdef.get(key, s_common.novalu)
-            if valu is s_common.novalu:
-                continue
-            _tdef[key] = valu
+        tdef.setdefault('user', root.iden)
+        tdef.setdefault('async', False)
+        tdef.setdefault('enabled', True)
 
-        _tdef.setdefault('user', root.iden)
-        _tdef.setdefault('async', False)
-        _tdef.setdefault('enabled', True)
+        s_trigger.reqValidTdef(tdef)
 
-        s_trigger.reqValidTdef(_tdef)
-
-        return await self._push('trigger:add', _tdef)
+        return await self._push('trigger:add', tdef)
 
     @s_nexus.Pusher.onPush('trigger:add')
     async def _onPushAddTrigger(self, tdef):

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -270,7 +270,7 @@ class TrigTest(s_t_utils.SynTest):
             self.eq(pdef0.get('storm'), (await view.getTrigger(iden)).tdef.get('storm'))
 
             # Bad trigger parms
-            with self.raises(s_exc.BadConfValu):
+            with self.raises(s_exc.SchemaViolation):
                 await view.addTrigger({'cond': 'nocond', 'storm': 'test:int=4', 'form': 'test:str'})
 
             with self.raises(s_exc.BadSyntax):
@@ -279,21 +279,21 @@ class TrigTest(s_t_utils.SynTest):
             with self.raises(s_exc.BadOptValu):
                 await view.addTrigger({'cond': 'node:add', 'storm': 'test:int=4', 'form': 'test:str', 'tag': 'foo'})
 
-            with self.raises(s_exc.BadConfValu):
+            with self.raises(s_exc.SchemaViolation):
                 await view.addTrigger({'cond': 'prop:set', 'storm': 'test:int=4', 'form': 'test:str', 'prop': 'foo'})
 
-            with self.raises(s_exc.BadConfValu):
+            with self.raises(s_exc.SchemaViolation):
                 await view.addTrigger({'cond': 'tag:add', 'storm': '[ +#count test:str=$tag ]'})
 
             with self.raises(s_exc.BadOptValu):
                 tdef = {'cond': 'tag:add', 'storm': '[ +#count test:str=$tag ]', 'tag': 'foo', 'prop': 'test:str'}
                 await view.addTrigger(tdef)
 
-            with self.raises(s_exc.BadConfValu):
+            with self.raises(s_exc.SchemaViolation):
                 await view.addTrigger({'cond': 'node:add', 'storm': 'test:int=4', 'form': 'test:str', 'iden': 'foo'})
 
             # bad tagmatch
-            with self.raises(s_exc.BadConfValu):
+            with self.raises(s_exc.SchemaViolation):
                 await view.addTrigger({'cond': 'tag:add', 'storm': '[ +#count test:str=$tag ]', 'tag': 'foo&baz'})
 
             # Trigger list


### PR DESCRIPTION
Allow any values passed into the raw add apis, continue to validate those which we positively control the use of in mod / set apis.