### PR TITLE
Add support for handling timezones without colon seperators (SYN-2841)

### DIFF
--- a/synapse/lib/time.py
+++ b/synapse/lib/time.py
@@ -37,25 +37,25 @@ def _rawparse(text, base=None, chop=False):
     try:
         if tlen == 4:
             if parsed_tz:
-                raise s_exc.BadTypeValu(mesg='Not enouugh information to parse timezone properly.',
+                raise s_exc.BadTypeValu(mesg=f'Not enough information to parse timezone properly for {otext}.',
                                         valu=otext)
             dt = datetime.datetime.strptime(text, '%Y')
 
         elif tlen == 6:
             if parsed_tz:
-                raise s_exc.BadTypeValu(mesg='Not enouugh information to parse timezone properly.',
+                raise s_exc.BadTypeValu(mesg=f'Not enough information to parse timezone properly for {otext}.',
                                         valu=otext)
             dt = datetime.datetime.strptime(text, '%Y%m')
 
         elif tlen == 8:
             if parsed_tz:
-                raise s_exc.BadTypeValu(mesg='Not enouugh information to parse timezone properly.',
+                raise s_exc.BadTypeValu(mesg=f'Not enough information to parse timezone properly for {otext}.',
                                         valu=otext)
             dt = datetime.datetime.strptime(text, '%Y%m%d')
 
         elif tlen == 10:
             if parsed_tz:
-                raise s_exc.BadTypeValu(mesg='Not enouugh information to parse timezone properly.',
+                raise s_exc.BadTypeValu(mesg=f'Not enough information to parse timezone properly for {otext}.',
                                         valu=otext)
             dt = datetime.datetime.strptime(text, '%Y%m%d%H')
 
@@ -70,7 +70,7 @@ def _rawparse(text, base=None, chop=False):
 
         else:
             raise s_exc.BadTypeValu(valu=otext, name='time',
-                                    mesg='Unknown time format')
+                                    mesg=f'Unknown time format for {otext}')
     except ValueError as e:
         raise s_exc.BadTypeValu(mesg=str(e), valu=otext)
 

--- a/synapse/lib/time.py
+++ b/synapse/lib/time.py
@@ -27,9 +27,6 @@ def _rawparse(text, base=None, chop=False):
         if base != 0:
             parsed_tz = True
 
-    if parsed_tz:
-        logger.info(f'parsed tx for {otext} to {text}, {base=}')
-
     text = (''.join([c for c in text if c.isdigit()]))
 
     if chop:

--- a/synapse/tests/test_lib_time.py
+++ b/synapse/tests/test_lib_time.py
@@ -78,6 +78,12 @@ class TimeTest(s_t_utils.SynTest):
 
         # invalid shorthand times with timezones are invalid
         tvs = (
+            '2020+3:00',
+            '2020+300',
+            '2020-3:00',
+            '2020-300',
+            '2020+03:00',
+            '2020-03:00',
             '2020-07-04:00',
             '2020-07-07 +4:00',
             '2020-07-07 +04:01',

--- a/synapse/tests/test_lib_time.py
+++ b/synapse/tests/test_lib_time.py
@@ -49,17 +49,12 @@ class TimeTest(s_t_utils.SynTest):
         self.eq(s_time.parse('2020-07-07T16:29:53-04:00'), 1594153793000)
         self.eq(s_time.parse('2020-07-07T16:29:53-04:30'), 1594155593000)
         self.eq(s_time.parse('2020-07-07T16:29:53+02:00'), 1594132193000)
+        self.eq(s_time.parse('2020-07-07T16:29:53-0430'), 1594155593000)
+        self.eq(s_time.parse('2020-07-07T16:29:53+0200'), 1594132193000)
+        self.eq(s_time.parse('2021-11-03T08:32:14.506-0400'), 1635942734506)
         self.eq(s_time.parse('2020-07-07T16:29:53.234+02:00'), 1594132193234)
         self.eq(s_time.parse('2020-07-07T16:29:53.234567+02:00'), 1594132193234)
         self.eq(s_time.parse('2020-07-07T16:29:53.234567+10:00'), 1594103393234)
-
-        # shorthand
-        utc = s_time.parse('2020-07')
-        self.eq(s_time.parse('2020-07-04:00'), utc + 4 * s_time.onehour)
-
-        utc = s_time.parse('2020-07-07')
-        self.eq(s_time.parse('2020-07-07 +4:00'), utc - 4 * s_time.onehour)
-        self.eq(s_time.parse('2020-07-07 +04:00'), utc - 4 * s_time.onehour)
 
         utc = s_time.parse('2020-07-07 16:29')
         self.eq(s_time.parse('2020-07-07 16:29-06:00'), utc + 6 * s_time.onehour)
@@ -67,13 +62,34 @@ class TimeTest(s_t_utils.SynTest):
         self.eq(s_time.parse('20200707162953+00:00'), 1594139393000)
         self.eq(s_time.parse('20200707162953-04:00'), 1594153793000)
 
-        # A malformed timezone can still be parsed incorrectly
-        self.eq(s_time.parse('202007+04'), s_time.parse('20200704'))
-        self.eq(s_time.parse('20200707162953+04'), 1594139393040)
-        self.eq(s_time.parse('20200707162953+423'), 1594139393423)
+        self.eq(s_time.parse('20200707162953'), 1594139393000)
+        self.eq(s_time.parse('20200707162953+423'),
+                1594139393000 - s_time.onehour * 4 - s_time.onemin * 23)
 
-        # invalid
-        self.raises(s_exc.BadTypeValu, s_time.parse, '2020-07-07T16:29:53+36:00')
+        # This partial value is ignored and treated like a millisecond value
+        self.eq(s_time.parse('20200707162953+04'), 1594139393040)
+
+        # A partial time (without mm) is ignored as a timestamp.
+        self.eq(s_time.parse('202007+04'), s_time.parse('20200704'))
+
+        # invalid range
+        with self.raises(s_exc.BadTypeValu):
+            s_time.parse('2020-07-07T16:29:53+36:00')
+
+        # invalid shorthand times with timezones are invalid
+        tvs = (
+            '2020-07-04:00',
+            '2020-07-07 +4:00',
+            '2020-07-07 +04:01',
+            '2020-07-07 01 +04:01',
+            '2020-07-04:00',
+            '2020-07-07 -4:00',
+            '2020-07-07 -04:00',
+            '2020-07-07 01 -04:01',
+        )
+        for tv in tvs:
+            with self.raises(s_exc.BadTypeValu):
+                s_time.parse(tv)
 
     def test_time_toutc(self):
         tick = s_time.parse('2020-02-11 14:08:00.123')


### PR DESCRIPTION
Also drops timezone support for time strings which do not have minute or less precision.