### PR TITLE
Change count behavior with --yield (SYN-3846)

### DIFF
--- a/docs/synapse/power_ups/rapid_power_ups.rst
+++ b/docs/synapse/power_ups/rapid_power_ups.rst
@@ -26,7 +26,6 @@ The following Rapid Power-Ups are available:
 - `Synapse-DomainIQ <https://synapse.docs.vertex.link/projects/rapid-powerups/en/latest/storm-packages/synapse-domainiq/index.html>`_
 - `Synapse-Etherscan <https://synapse.docs.vertex.link/projects/rapid-powerups/en/latest/storm-packages/synapse-etherscan/index.html>`_
 - `Synapse-Flashpoint <https://synapse.docs.vertex.link/projects/rapid-powerups/en/latest/storm-packages/synapse-flashpoint/index.html>`_
-- `Synapse-Google-CT <https://synapse.docs.vertex.link/projects/rapid-powerups/en/latest/storm-packages/synapse-google-ct/index.html>`_
 - `Synapse-Google-Search <https://synapse.docs.vertex.link/projects/rapid-powerups/en/latest/storm-packages/synapse-google-search/index.html>`_
 - `Synapse-GreyNoise <https://synapse.docs.vertex.link/projects/rapid-powerups/en/latest/storm-packages/synapse-greynoise/index.html>`_
 - `Synapse-HybridAnalysis <https://synapse.docs.vertex.link/projects/rapid-powerups/en/latest/storm-packages/synapse-hybridanalysis/index.html>`_

--- a/docs/synapse/userguides/storm_ref_cmd.rstorm
+++ b/docs/synapse/userguides/storm_ref_cmd.rstorm
@@ -184,7 +184,7 @@ See also :ref:`storm-parallel`.
 count
 -----
 
-The ``count`` command enumerates the number of nodes returned from a given Storm query and displays the resultant nodes and associated node count.
+The ``count`` command enumerates the number of nodes returned from a given Storm query and displays the final tally. The associated nodes can also be displayed with the --yield option.
 
 **Syntax:**
 

--- a/docs/synapse/userguides/storm_ref_cmd.rstorm
+++ b/docs/synapse/userguides/storm_ref_cmd.rstorm
@@ -200,16 +200,17 @@ The ``count`` command enumerates the number of nodes returned from a given Storm
 .. storm-pre:: [inet:ipv4=66.129.222.1 inet:ipv4=184.82.164.104 inet:ipv4=209.161.249.125 inet:ipv4=69.90.65.240 inet:ipv4=70.62.232.98 +#aka.feye.thr.apt1]
 .. storm-cli:: inet:ipv4#aka.feye.thr.apt1 | count
 
+- Count nodes from a lift and yield the output:
+
+
+.. storm-pre:: [inet:ipv4=66.129.222.1 inet:ipv4=184.82.164.104 inet:ipv4=209.161.249.125 inet:ipv4=69.90.65.240 inet:ipv4=70.62.232.98 +#aka.feye.thr.apt1]
+.. storm-cli:: inet:ipv4#aka.feye.thr.apt1 | count --yield
 
 - Count the number of DNS A records for the domain woot.com where the lift produces no results:
 
 
 .. storm-cli:: inet:dns:a:fqdn=woot.com | count
 
-
-**Usage Notes:**
-
-- ``count`` does not consume nodes, so Storm will stream the nodes being counted to the CLI output while the command executes. To count nodes without streaming the output, ``count`` can be piped to the `spin`_ command (i.e., *<query>* | count | spin). ``Spin`` consumes nodes and so will prevent nodes processed by the ``count`` command from streaming.
 
 .. _storm-cron:
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -3955,22 +3955,33 @@ class SpinCmd(Cmd):
 class CountCmd(Cmd):
     '''
     Iterate through query results, and print the resulting number of nodes
-    which were lifted. This does yield the nodes counted.
+    which were lifted. This does not yield the nodes counted, unless the
+    --yield switch is provided.
 
     Example:
 
-        foo:bar:size=20 | count
+        # Count the number of IPV4 nodes with a given ASN.
+        inet:ipv4:asn=20 | count
+
+        # Count the number of IPV4 nodes with a given ASN and yield them.
+        inet:ipv4:asn=20 | count --yield
 
     '''
     name = 'count'
     readonly = True
 
+    def getArgParser(self):
+        pars = Cmd.getArgParser(self)
+        pars.add_argument('-y', '--yield', default=False, action='store_true',
+                          dest='yieldnodes', help='Yield inbound nodes.')
+        return pars
+
     async def execStormCmd(self, runt, genr):
 
         i = 0
         async for item in genr:
-
-            yield item
+            if self.opts.yieldnodes:
+                yield item
             i += 1
 
         await runt.printf(f'Counted {i} nodes.')


### PR DESCRIPTION
- Storm `count` now consumes nodes by default. Use `--yield` to emit nodes.
- Update `count` User docs.
- Remove synapse-google-ct from the rapid powerup-ups list.
- Cleanup most use of core.eval() in test_lib_storm.py