### PR TITLE
synapse.lib.coro.spawn logging update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -841,7 +841,6 @@ workflows:
             branches:
               only:
                 - master
-                - dev_libcoro_spawn
 
       - push_docker_branch:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -841,6 +841,7 @@ workflows:
             branches:
               only:
                 - master
+                - dev_libcoro_spawn
 
       - push_docker_branch:
           requires:

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1323,7 +1323,7 @@ class Axon(s_cell.Cell):
         todo = s_common.todo(_spawn_readlines, sock00)
         async with await s_base.Base.anit() as scope:
 
-            scope.schedCoro(s_coro.spawn(todo))
+            scope.schedCoro(s_coro.spawn(todo, log_conf=await self._getSpawnLogConf()))
             scope.schedCoro(self._sha256ToLink(sha256, link00))
 
             try:
@@ -1354,7 +1354,7 @@ class Axon(s_cell.Cell):
         todo = s_common.todo(_spawn_readrows, sock00, dialect, fmtparams)
         async with await s_base.Base.anit() as scope:
 
-            scope.schedCoro(s_coro.spawn(todo))
+            scope.schedCoro(s_coro.spawn(todo, log_conf=await self._getSpawnLogConf()))
             scope.schedCoro(self._sha256ToLink(sha256, link00))
 
             try:

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -751,7 +751,7 @@ def normLogLevel(valu):
             return normLogLevel(valu)
     raise s_exc.BadArg(mesg=f'Unknown log level type: {type(valu)} {valu}', valu=valu)
 
-def setlogging(mlogger, defval=None, structlog=None):
+def setlogging(mlogger, defval=None, structlog=None, log_setup=True):
     '''
     Configure synapse logging.
 
@@ -782,7 +782,8 @@ def setlogging(mlogger, defval=None, structlog=None):
             logging.basicConfig(level=log_level, handlers=(handler,))
         else:
             logging.basicConfig(level=log_level, format=s_const.LOG_FORMAT)
-        mlogger.info('log level set to %s', s_const.LOG_LEVEL_INVERSE_CHOICES.get(log_level))
+        if log_setup:
+            mlogger.info('log level set to %s', s_const.LOG_LEVEL_INVERSE_CHOICES.get(log_level))
 
     return ret
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2433,9 +2433,11 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
     async def _getSpawnLogConf(self):
         conf = self.conf.get('_log_conf')
-        if conf:
-            return conf
-        return s_common._getLogConfFromEnv()
+        if not conf:
+            conf = s_common._getLogConfFromEnv()
+        conf = conf.copy()
+        conf.update('log_setup', False)
+        return conf
 
     def modCellConf(self, conf):
         '''

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2433,10 +2433,11 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
     async def _getSpawnLogConf(self):
         conf = self.conf.get('_log_conf')
-        if not conf:
+        if conf:
+            conf = conf.copy()
+        else:
             conf = s_common._getLogConfFromEnv()
-        conf = conf.copy()
-        conf.update('log_setup', False)
+        conf['log_setup'] = False
         return conf
 
     def modCellConf(self, conf):

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -174,7 +174,7 @@ def genrhelp(f):
 
 def _exectodo(que, evt, todo, logconf):
     # This is a new process: configure logging
-    s_common.setlogging(logger, log_setup=False, **logconf)
+    s_common.setlogging(logger, **logconf)
     func, args, kwargs = todo
     evt.set()
     try:

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -191,7 +191,7 @@ async def spawn(todo, timeout=None, ctx=None, log_conf=None):
         todo (tuple): A tuple of function, ``*args``, and ``**kwargs``.
         timeout (int): The timeout to wait for the todo function to finish.
         ctx (multiprocess.Context): A optional multiprocessing context object.
-        log_conf (dict): A optional set of logging configuration for the spawned process.
+        log_conf (dict): An optional logging configuration for the spawned process.
 
     Notes:
         The contents of the todo tuple must be able to be pickled for execution.

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -174,16 +174,16 @@ def genrhelp(f):
 
 def _exectodo(que, lock, evt, todo, logconf):
     # This is a new process: configure logging
-    s_common.setlogging(logger, **logconf)
+    s_common.setlogging(logger, log_setup=False, **logconf)
     func, args, kwargs = todo
-    with lock:
-        try:
-            evt.set()
-            ret = func(*args, **kwargs)
-            que.put(ret)
-        except Exception as e:
-            logger.exception(f'Error executing spawn function {func}')
-            que.put(e)
+    # with lock:
+    try:
+        evt.set()
+        ret = func(*args, **kwargs)
+        que.put(ret)
+    except Exception as e:
+        logger.exception(f'Error executing spawn function {func}')
+        que.put(e)
 
 async def spawn(todo, timeout=None, ctx=None, log_conf=None):
     '''
@@ -223,22 +223,36 @@ async def spawn(todo, timeout=None, ctx=None, log_conf=None):
         if started is False:
             raise s_exc.TimeOut(mesg=f'Timeout waiting to start coro for {todo[0]} after {start_timeout} seconds.')
 
-        # Now we try to get the lock - once we get the lock, we know
-        # proc has finished its work or exited prematurely.
-        with lock:
-            while True:
-                try:
-                    # we have to block/wait on the queue because the sender
-                    # could need to stream the return value in multiple chunks
-                    retn = que.get(timeout=1)
-                    # now that we've retrieved the response, it should have exited.
+        # Restore original implementation for now.
+        while True:
+            try:
+                # we have to block/wait on the queue because the sender
+                # could need to stream the return value in multiple chunks
+                retn = que.get(timeout=1)
+                # now that we've retrieved the response, it should have exited.
+                proc.join()
+                return retn
+            except queue.Empty:
+                if not proc.is_alive():
                     proc.join()
-                    return retn
-                except queue.Empty:
-                    if not proc.is_alive():
-                        # The process likely exited prematurely.
-                        proc.join()
-                        raise s_exc.SpawnExit(code=proc.exitcode)
+                    raise s_exc.SpawnExit(code=proc.exitcode)
+
+        # # Now we try to get the lock - once we get the lock, we know
+        # # proc has finished its work or exited prematurely.
+        # with lock:
+        #     while True:
+        #         try:
+        #             # we have to block/wait on the queue because the sender
+        #             # could need to stream the return value in multiple chunks
+        #             retn = que.get(timeout=1)
+        #             # now that we've retrieved the response, it should have exited.
+        #             proc.join()
+        #             return retn
+        #         except queue.Empty:
+        #             if not proc.is_alive():
+        #                 # The process likely exited prematurely.
+        #                 proc.join()
+        #                 raise s_exc.SpawnExit(code=proc.exitcode)
 
     try:
 

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -218,7 +218,8 @@ async def spawn(todo, timeout=None, ctx=None, log_conf=None):
 
         # Wait to start - the spawn proc has gotten the lock.
         start_timeout = 60
-        started = evt.wait(timeout)
+        # FIXME reconcile this start_timeout with timeout
+        started = evt.wait(start_timeout)
         if started is False:
             raise s_exc.TimeOut(mesg=f'Timeout waiting to start coro for {todo[0]} after {start_timeout} seconds.')
 

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -180,7 +180,6 @@ def _exectodo(que, lock, evt, todo, logconf):
         try:
             evt.set()
             ret = func(*args, **kwargs)
-            logger.debug(f'putting {ret=}')
             que.put(ret)
         except Exception as e:
             logger.exception(f'Error executing spawn function {func}')

--- a/synapse/lib/httpapi.py
+++ b/synapse/lib/httpapi.py
@@ -300,7 +300,8 @@ class Handler(HandlerBase, t_web.RequestHandler):
         self.task = asyncio.current_task()
 
     def on_connection_close(self):
-        self.task.cancel()
+        if hasattr(self, 'task'):
+            self.task.cancel()
 
     async def _reqValidOpts(self, opts):
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1671,6 +1671,8 @@ class Runtime(s_base.Base):
 
         self.query = query
 
+        self.spawn_log_conf = await self.snap.core._getSpawnLogConf()
+
         self.readonly = opts.get('readonly', False)  # EXPERIMENTAL: Make it safe to run untrusted queries
         self.model = snap.core.getDataModel()
 

--- a/synapse/lib/stormlib/json.py
+++ b/synapse/lib/stormlib/json.py
@@ -68,8 +68,9 @@ class JsonSchema(s_stormtypes.StormType):
     async def _validate(self, item):
         item = await s_stormtypes.toprim(item)
 
+        todo = (runJsSchema, (self.schema, item), {'use_default': self.use_default})
         try:
-            result = await s_coro.spawn((runJsSchema, (self.schema, item), {'use_default': self.use_default}))
+            result = await s_coro.spawn(todo, log_conf=self.runt.spawn_log_conf)
         except s_exc.SchemaViolation as e:
             return False, {'mesg': e.get('mesg')}
         else:
@@ -132,8 +133,9 @@ class JsonLib(s_stormtypes.Lib):
         schema = await s_stormtypes.toprim(schema)
         use_default = await s_stormtypes.tobool(use_default)
         # We have to ensure that we have a valid schema for making the object.
+        todo = (compileJsSchema, (schema,), {'use_default': use_default})
         try:
-            await s_coro.spawn((compileJsSchema, (schema,), {'use_default': use_default}))
+            await s_coro.spawn(todo, self.runt.spawn_log_conf)
         except asyncio.CancelledError:  # pragma: no cover
             raise
         except Exception as e:

--- a/synapse/lib/stormlib/json.py
+++ b/synapse/lib/stormlib/json.py
@@ -135,7 +135,7 @@ class JsonLib(s_stormtypes.Lib):
         # We have to ensure that we have a valid schema for making the object.
         todo = (compileJsSchema, (schema,), {'use_default': use_default})
         try:
-            await s_coro.spawn(todo, self.runt.spawn_log_conf)
+            await s_coro.spawn(todo, log_conf=self.runt.spawn_log_conf)
         except asyncio.CancelledError:  # pragma: no cover
             raise
         except Exception as e:

--- a/synapse/lib/stormlib/mime.py
+++ b/synapse/lib/stormlib/mime.py
@@ -34,4 +34,4 @@ class LibMimeHtml(s_stormtypes.Lib):
     async def totext(self, html):
         html = await s_stormtypes.tostr(html)
         todo = s_common.todo(htmlToText, html)
-        return await s_coro.spawn(todo)
+        return await s_coro.spawn(todo, log_conf=self.runt.spawn_log_conf)

--- a/synapse/lib/stormlib/stix.py
+++ b/synapse/lib/stormlib/stix.py
@@ -608,7 +608,8 @@ class LibStix(s_stormtypes.Lib):
 
     async def validateBundle(self, bundle):
         bundle = await s_stormtypes.toprim(bundle)
-        return await s_coro.spawn((validateStix, (bundle,), {}))
+        todo = (validateStix, (bundle,), {})
+        return await s_coro.spawn(todo, log_conf=self.runt.spawn_log_conf)
 
     async def liftBundle(self, bundle):
         bundle = await s_stormtypes.toprim(bundle)

--- a/synapse/lib/stormlib/xml.py
+++ b/synapse/lib/stormlib/xml.py
@@ -91,7 +91,7 @@ class LibXml(s_stormtypes.Lib):
         valu = await s_stormtypes.tostr(valu)
         try:
             todo = (xml_et.fromstring, (valu,), {})
-            root = await s_coro.spawn(todo)
+            root = await s_coro.spawn(todo, log_conf=self.runt.spawn_log_conf)
             return XmlElement(self.runt, root)
         except xml_et.ParseError as e:
             raise s_exc.BadArg(mesg=f'Invalid XML text: {str(e)}')


### PR DESCRIPTION
- Add optional logging setup to s_coro.spawn() calls, this includes logging exceptions that happen during the handling of the target function.
- Use the new logging for mainline spawn calls.
- For HTTPAPI stream handlers, don't tear down the associated task if it hasn't been set on the handler instance.