### PR TITLE
Inject the tag name into the BadTypeValu when norming a tag (SYN-3982, SYN-2923)

### DIFF
--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -32,7 +32,7 @@ class SynErr(Exception):
         return self.errinfo.get(name, defv)
 
     def set(self, name, valu):
-        self.errinfo.setdefault(name, valu)
+        self.errinfo[name] = valu
 
 class StormRaise(SynErr):
     def __init__(self, name, mesg, info):

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -31,6 +31,9 @@ class SynErr(Exception):
         '''
         return self.errinfo.get(name, defv)
 
+    def set(self, name, valu):
+        self.errinfo.setdefault(name, valu)
+
 class StormRaise(SynErr):
     def __init__(self, name, mesg, info):
         info['mesg'] = mesg

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -32,6 +32,9 @@ class SynErr(Exception):
         return self.errinfo.get(name, defv)
 
     def set(self, name, valu):
+        '''
+        Set a value in the errinfo dict.
+        '''
         self.errinfo[name] = valu
 
 class StormRaise(SynErr):

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -14,6 +14,15 @@ class SynErr(Exception):
         displ = ' '.join(['%s=%r' % (p, v) for (p, v) in props])
         return '%s: %s' % (self.__class__.__name__, displ)
 
+    def _setExcMesg(self):
+        '''Should be called when self.errinfo is modified.'''
+        self.args = (self._getExcMsg(),)
+
+    def __setstate__(self, state):
+        '''Pickle support.'''
+        super(SynErr, self).__setstate__(state)
+        self._setExcMesg()
+
     def items(self):
         return {k: v for k, v in self.errinfo.items()}
 
@@ -36,6 +45,7 @@ class SynErr(Exception):
         Set a value in the errinfo dict.
         '''
         self.errinfo[name] = valu
+        self._setExcMesg()
 
 class StormRaise(SynErr):
     def __init__(self, name, mesg, info):
@@ -220,10 +230,6 @@ class NoSuchVar(SynErr): pass
 class NoSuchView(SynErr): pass
 class NoSuchTagProp(SynErr): pass
 class NoSuchStormSvc(SynErr): pass
-
-class NoSuchStor(SynErr):
-    def __init__(self, name):
-        SynErr.__init__(self, mesg=f'No storage type found named {name!r}', name=name)
 
 class NotANumberCompared(SynErr): pass
 

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -47,6 +47,15 @@ class SynErr(Exception):
         self.errinfo[name] = valu
         self._setExcMesg()
 
+    def setdefault(self, name, valu):
+        '''
+        Set a value in errinfo dict if it is not already set.
+        '''
+        if name in self.errinfo:
+            return
+        self.errinfo[name] = valu
+        self._setExcMesg()
+
 class StormRaise(SynErr):
     def __init__(self, name, mesg, info):
         info['mesg'] = mesg

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -190,8 +190,10 @@ class ProtoNode:
             try:
                 valu, _ = self.ctx.snap.core.model.type('ival').norm(valu)
             except s_exc.BadTypeValu as e:
-                if self.ctx.snap.strict: raise e
-                return await self.ctx.snap.warn(f'Invalid Tag Value: {valu}.')
+                if self.ctx.snap.strict:
+                    e.set('tag', tagnode.valu)
+                    raise e
+                return await self.ctx.snap.warn(f'Invalid Tag Value: {tagnode.valu}={valu}.')
 
         tagup = tagnode.get('up')
         if tagup:

--- a/synapse/lib/snap.py
+++ b/synapse/lib/snap.py
@@ -147,7 +147,8 @@ class ProtoNode:
         try:
             s_common.reqjsonsafe(valu)
         except s_exc.MustBeJsonSafe as e:
-            if self.ctx.snap.strict: raise e
+            if self.ctx.snap.strict:
+                raise e
             return await self.ctx.snap.warn(str(e))
 
         self.nodedata[name] = valu
@@ -282,7 +283,8 @@ class ProtoNode:
                 e.errinfo['prop'] = prop.name
                 e.errinfo['form'] = prop.form.name
                 e.errinfo['mesg'] = f'Bad prop value {prop.full}={valu!r} : {oldm}'
-                if self.ctx.snap.strict: raise e
+                if self.ctx.snap.strict:
+                    raise e
                 await self.ctx.snap.warn(e)
                 return False
 

--- a/synapse/tests/test_exc.py
+++ b/synapse/tests/test_exc.py
@@ -1,0 +1,24 @@
+import logging
+
+import synapse.exc as s_exc
+
+import synapse.lib.parser as s_parser
+
+import synapse.tests.utils as s_t_utils
+
+logger = logging.getLogger(__name__)
+
+class ExcTest(s_t_utils.SynTest):
+    def test_basic(self):
+        e = s_exc.SynErr(mesg='words', foo='bar')
+        self.eq(e.get('foo'), 'bar')
+        self.eq("SynErr: foo='bar' mesg='words'", str(e))
+        e.set('hehe', 1234)
+        e.set('foo', 'words')
+        self.eq("SynErr: foo='words' hehe=1234 mesg='words'", str(e))
+
+    async def test_pickled_synerr(self):
+        with self.raises(s_exc.BadSyntax) as cm:
+            _ = await s_parser._forkedParseEval('| | | ')
+        self.isin('BadSyntax', str(cm.exception))
+        self.isin('Unexpected token', str(cm.exception))

--- a/synapse/tests/test_exc.py
+++ b/synapse/tests/test_exc.py
@@ -17,6 +17,12 @@ class ExcTest(s_t_utils.SynTest):
         e.set('foo', 'words')
         self.eq("SynErr: foo='words' hehe=1234 mesg='words'", str(e))
 
+        e.setdefault('defv', 1)
+        self.eq("SynErr: defv=1 foo='words' hehe=1234 mesg='words'", str(e))
+
+        e.setdefault('defv', 2)
+        self.eq("SynErr: defv=1 foo='words' hehe=1234 mesg='words'", str(e))
+
     async def test_pickled_synerr(self):
         with self.raises(s_exc.BadSyntax) as cm:
             _ = await s_parser._forkedParseEval('| | | ')

--- a/synapse/tests/test_lib_node.py
+++ b/synapse/tests/test_lib_node.py
@@ -415,6 +415,10 @@ class NodeTest(s_t_utils.SynTest):
             self.none(await node.getData('foo'))
             self.none(await node.getData('bar'))
 
+            # Add sad path for setting invalid node data
+            with self.raises(s_exc.MustBeJsonSafe):
+                await node.setData('newp', {1, 2, 3})
+
     async def test_node_tagprops(self):
         async with self.getTestCore() as core:
             await core.addTagProp('score', ('int', {}), {})


### PR DESCRIPTION
- Add set() and setdefault() apis on SynErr.
- Inject tag name into BadTypeValu when norming a tag ival.
- Fix issue with unpickling SynErr exceptions.