### PR TITLE
Catch FileNotFoundError in healthcheck (SYN-4119)

### DIFF
--- a/synapse/tests/test_tools_healthcheck.py
+++ b/synapse/tests/test_tools_healthcheck.py
@@ -82,5 +82,5 @@ class HealthcheckTest(s_t_utils.SynTest):
             self.eq(retn, 1)
             resp = json.loads(str(outp))
             self.eq(resp.get('components')[0].get('name'), 'error')
-            m = 'Unable to connect to cell.'
-            self.eq(resp.get('components')[0].get('mesg'), m)
+            m = 'Unable to connect to cell'
+            self.isin(m, resp.get('components')[0].get('mesg'))

--- a/synapse/tools/healthcheck.py
+++ b/synapse/tools/healthcheck.py
@@ -9,6 +9,7 @@ import synapse.telepath as s_telepath
 import synapse.lib.cmd as s_cmd
 import synapse.lib.output as s_output
 import synapse.lib.health as s_health
+import synapse.lib.urlhelp as s_urlhelp
 
 def serialize(ret):
     s = json.dumps(ret, separators=(',', ':'))
@@ -34,11 +35,14 @@ async def main(argv, outp=s_output.stdout):
     except s_exc.ParserExit as e:  # pragma: no cover
         return e.get('status')
 
+    url = opts.cell
+    sanitized_url = s_urlhelp.sanitizeUrl(url)
+
     try:
-        prox = await asyncio.wait_for(s_telepath.openurl(opts.cell),
+        prox = await asyncio.wait_for(s_telepath.openurl(url),
                                       timeout=opts.timeout)
-    except (ConnectionError, socket.gaierror) as e:
-        mesg = 'Unable to connect to cell.'
+    except (FileNotFoundError, ConnectionError, socket.gaierror) as e:
+        mesg = f'Unable to connect to cell @ {sanitized_url}.'
         ret = {'status': 'failed',
                'iden': opts.cell,
                'components': [format_component(e, mesg)],


### PR DESCRIPTION
This can be raised if the connection to `cell:///vertex/storage` fails because the unix socket doesn't exist yet.