### PR TITLE
Aha root user (SYN-4054, SYN-3953)

### DIFF
--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -401,17 +401,20 @@ class AhaCell(s_cell.Cell):
             if netw is not None:
 
                 if self.certdir.getCaCertPath(netw) is None:
+                    logger.info(f'Adding CA certificate for {netw}')
                     await self.genCaCert(netw)
 
                 name = self.conf.get('aha:name')
 
                 host = f'{name}.{netw}'
                 if self.certdir.getHostCertPath(host) is None:
+                    logger.info(f'Adding server certificate for {host}')
                     await self._genHostCert(host, signas=netw)
 
                 user = self._getAhaAdmin()
                 if user is not None:
                     if self.certdir.getUserCertPath(user) is None:
+                        logger.info(f'Adding user certificate for {user}@{netw}')
                         await self._genUserCert(user, signas=netw)
 
     async def initServiceNetwork(self):

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -773,6 +773,10 @@ class AhaCell(s_cell.Cell):
             mesg = 'AHA server has no configured aha:network.'
             raise s_exc.NeedConfValu(mesg=mesg)
 
+        if netw != mynetw:
+            mesg = f'Provisioning aha:network must be equal to the Aha servers network. Expected {mynetw}, got {netw}'
+            raise s_exc.BadConfValu(mesg=mesg, name='aha:network', expected=mynetw, got=netw)
+
         hostname = f'{name}.{netw}'
 
         conf.setdefault('aha:name', name)
@@ -804,16 +808,9 @@ class AhaCell(s_cell.Cell):
         if mirname is not None:
             conf['mirror'] = f'aha://{ahauser}@{mirname}.{netw}'
 
-        # If the provisioned aha network is our network, we can assume
-        # non-namespaced usernames.
-        if netw == mynetw:
-            username = ahauser
-        else:
-            username = f'{ahauser}@{netw}'
-
-        user = await self.auth.getUserByName(username)
+        user = await self.auth.getUserByName(ahauser)
         if user is None:
-            user = await self.auth.addUser(username)
+            user = await self.auth.addUser(ahauser)
 
         perms = [
             ('aha', 'service', 'get', netw),

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -414,6 +414,17 @@ class AhaCell(s_cell.Cell):
                     if self.certdir.getUserCertPath(user) is None:
                         await self._genUserCert(user, signas=netw)
 
+                # defprovuser = f'root@{netw}'
+                # user = await self.auth.getUserByName(defprovuser)
+                # if user is None:
+                #     await self._addAdminUser(defprovuser)
+                # else:
+                #     if not user.isAdmin():
+                #         await user.setAdmin(True, logged=False)
+                #
+                #     if user.isLocked():
+                #         await user.setLocked(False, logged=False)
+
     async def initServiceNetwork(self):
 
         await s_cell.Cell.initServiceNetwork(self)

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -550,7 +550,8 @@ class Base:
         Helper function to setup signal handlers for this base as the main object.
         ( use base.waitfini() to block )
 
-        NOTE: This API may only be used when the ioloop is *also* the main thread.
+        Note:
+            This API may only be used when the ioloop is *also* the main thread.
         '''
         await self.addSignalHandlers()
         return await self.waitfini()
@@ -565,7 +566,7 @@ class Base:
 
             waiter = base.waiter(10,'foo:bar')
 
-            # .. fire thread that will cause foo:bar events
+            # .. fire task that will cause foo:bar events
 
             events = await waiter.wait(timeout=3)
 
@@ -575,11 +576,12 @@ class Base:
             for event in events:
                 # parse the events if you need...
 
-        NOTE: use with caution... it's easy to accidentally construct
-              race conditions with this mechanism ;)
+        Note:
+            Use this with caution. It's easy to accidentally construct
+            race conditions with this mechanism ;)
 
         '''
-        return Waiter(self, count, self.loop, *names)
+        return Waiter(self, count, *names)
 
 class Waiter:
     '''

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2860,9 +2860,6 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         # check for a TLS client cert
         username = link.getTlsPeerCn()
         if username is not None:
-            user = await self.auth.getUserByName(username)
-            if user is not None:
-                return user
 
             if username.find('@') != -1:
                 userpart, hostpart = username.split('@', 1)
@@ -2870,6 +2867,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                     user = await self.auth.getUserByName(userpart)
                     if user is not None:
                         return user
+
+            user = await self.auth.getUserByName(username)
+            if user is not None:
+                return user
 
             raise s_exc.NoSuchUser(mesg=f'TLS client cert User not found: {username}', user=username)
 

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -959,7 +959,7 @@ class CertDir:
 
         certfile = self.getHostCertPath(hostname)
         if certfile is None:
-            mesg = f'Missing TLS certificate file for host: {hostname} {self.certdirs} {self.pathrefs}'
+            mesg = f'Missing TLS certificate file for host: {hostname}'
             raise s_exc.NoCertKey(mesg=mesg)
 
         keyfile = self.getHostKeyPath(hostname)

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -959,7 +959,7 @@ class CertDir:
 
         certfile = self.getHostCertPath(hostname)
         if certfile is None:
-            mesg = f'Missing TLS certificate file for host: {hostname}'
+            mesg = f'Missing TLS certificate file for host: {hostname} {self.certdirs} {self.pathrefs}'
             raise s_exc.NoCertKey(mesg=mesg)
 
         keyfile = self.getHostKeyPath(hostname)

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -8,6 +8,7 @@ import synapse.common as s_common
 import synapse.telepath as s_telepath
 
 import synapse.lib.aha as s_aha
+import synapse.lib.cell as s_cell
 import synapse.lib.output as s_output
 
 import synapse.tools.backup as s_tools_backup
@@ -24,25 +25,19 @@ async def mockaddsvc(self, name, info, network=None):
         raise s_exc.SynErr(mesg='newp')
     return await realaddsvc(self, name, info, network=network)
 
-import contextlib
+class ExecTeleCallerApi(s_cell.CellApi):
+    async def exectelecall(self, url, meth, *args, **kwargs):
+        return await self.cell.exectelecall(url, meth, *args, **kwargs)
 
-import synapse.cortex as s_cortex
-import synapse.lib.jsonstor as s_jsonstor
-import synapse.lib.cell as s_cell
+class ExecTeleCaller(s_cell.Cell):
+    cellapi = ExecTeleCallerApi
 
-class SvcConnectorApi(s_cell.CellApi):
-    async def tstGetSvcInfo(self, url):
-        return await self.cell.tstGetSvcInfo(url)
-
-class SvcConnector(s_cell.Cell):
-    cellapi = SvcConnectorApi
-
-    async def tstGetSvcInfo(self, url):
+    async def exectelecall(self, url, meth, *args, **kwargs):
 
         async with await s_telepath.openurl(url) as prox:
-
-            return await prox.getSystemInfo()
-            # return await prox.getCellInfo()
+            meth = getattr(prox, meth)
+            resp = await meth(*args, **kwargs)
+            return resp
 
 class AhaTest(s_test.SynTest):
     aha_ctor = s_aha.AhaCell.anit
@@ -777,121 +772,15 @@ class AhaTest(s_test.SynTest):
                         self.eq(info.get('status'), 'err')
                         self.eq(info.get('code'), 'AuthDeny')
 
-    @contextlib.asynccontextmanager
-    async def getTestAhaProv(self, conf=None
-                                ):
-
-        bconf = {
-            'aha:name': 'aha',
-            'aha:network': 'loop.vertex.link',
-            'provision:listen': 'ssl://aha.loop.vertex.link:0'
-        }
-
-        if conf is None:
-            conf = bconf
-        else:
-            for k, v in bconf.items():
-                conf.setdefault(k, v)
-
-        name = conf.get('aha:name')
-        netw = conf.get('aha:network')
-        dnsname = f'{name}.{netw}'
-
-        with self.getTestDir() as dirn:
-
-            ahapath = s_common.gendir(dirn, 'aha')
-
-            async with self.getTestAha(conf=conf, dirn=ahapath) as aha:
-
-                addr, port = aha.provdmon.addr
-                # update the config to reflect the dynamically bound port
-                aha.conf['provision:listen'] = f'ssl://{dnsname}:{port}'
-
-                # do this config ex-post-facto due to port binding...
-                host, ahaport = await aha.dmon.listen(
-                    f'ssl://0.0.0.0:0?hostname={dnsname}&ca={netw}')
-                aha.conf['aha:urls'] = f'ssl://{dnsname}:{ahaport}'
-
-                yield aha
-
-    @contextlib.asynccontextmanager
-    async def addSvcToAha(self, aha, svcname, ctor, conf=None, dirn=None):
-        '''
-        Add a service to an Aha network via the provisioning API.
-
-        This assumes the Aha cell has a provision:listen and aha:urls set.
-
-        Args:
-            aha:
-            svcname:
-            ctor:
-            conf:
-            dirn:
-
-        Returns:
-
-        '''
-        onetime = await aha.addAhaSvcProv(svcname)
-
-        if conf is None:
-            conf = {}
-
-        conf['aha:provision'] = onetime
-
-        if dirn:
-
-            s_common.yamlsave(conf, dirn, 'cell.yaml')
-            async with await ctor.anit(dirn, conf=conf) as svc:
-                yield svc
-        else:
-            with self.getTestDir() as dirn:
-                s_common.yamlsave(conf, dirn, 'cell.yaml')
-                async with await ctor.anit(dirn, conf=conf) as svc:
-                    yield svc
-
-    async def test_aha_auto_prov(self):
-
-        import asyncio
-
+    async def test_aha_root_acct(self):
         async with self.getTestAhaProv() as aha:  # type: s_aha.AhaCell
-            async with self.addSvcToAha(aha, '00.axon', s_axon.Axon) as axon:
-                async with self.addSvcToAha(aha, '00.jsonstor', s_jsonstor.JsonStorCell) as jsonstor:
-                    conf = {
-                        'axon': 'aha://axon...',
-                        'jsonstor': 'aha://jsonstor...',
-                    }
-                    async with self.addSvcToAha(aha, '00.cortex', s_cortex.Cortex, conf=conf) as core:
+            user = await aha.auth.getUserByName(f'root@{aha.conf.get("aha:network")}')
+            self.true(user.isAdmin())
 
-                        async with self.addSvcToAha(aha, 'connector', SvcConnector) as conn:
-                            await asyncio.sleep(0.5)
-                            from pprint import pprint
-                            async for svc in aha.getAhaSvcs():
-                                pprint(svc)
+            async with self.addSvcToAha(aha, '00.exec', ExecTeleCaller) as conn:
 
-                            ahaurl = aha.conf.get('aha:urls')  # Assumes aha:urls is a single item.
-                            # opts = {'vars': {'ahaurl': ahaurl}}
-                            # q = '''
-                            # $lib.print($ahaurl)
-                            # $lahaurl=ssl://root@aha.loop.vertex.link:45967
-                            # $prox=$lib.telepath.open($ahaurl)
-                            # $info=$prox.getCellInfo()
-                            # $lib.print($info)
-                            # '''
-                            #
-                            # msgs = await core.stormlist(q, opts=opts)
-                            # for m in msgs:
-                            #     print(m)
-                            #
+                ahaurl = aha.conf.get('aha:urls')[0]
+                ahaurl = s_telepath.modurl(ahaurl, user='root')
 
-                            ahaurl = aha.conf.get('aha:urls')  # Assumes aha:urls is a single item.
-                            ahaurl = s_telepath.modurl(ahaurl, user='root')
-                            print(ahaurl)
-
-                            r = await conn.tstGetSvcInfo(ahaurl)
-                            pprint(r)
-
-                        await asyncio.sleep(1)
-                    await asyncio.sleep(1)
-                await asyncio.sleep(1)
-            await asyncio.sleep(1)
-        await asyncio.sleep(1)
+                # This fails if root@loop.vertex.link is not an admin
+                await conn.exectelecall(ahaurl, 'getNexsIndx')

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -780,5 +780,6 @@ class AhaTest(s_test.SynTest):
                 ahaurl = aha.conf.get('aha:urls')[0]
                 ahaurl = s_telepath.modurl(ahaurl, user='root')
 
-                # This adminapi fails if root@loop.vertex.link is not an admin
+                # This adminapi fails if the ssl://root@aha.loop.vertex.link
+                # session is not an admin user.
                 await conn.exectelecall(ahaurl, 'getNexsIndx')

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -772,15 +772,13 @@ class AhaTest(s_test.SynTest):
                         self.eq(info.get('status'), 'err')
                         self.eq(info.get('code'), 'AuthDeny')
 
-    async def test_aha_root_acct(self):
+    async def test_aha_connect_back(self):
         async with self.getTestAhaProv() as aha:  # type: s_aha.AhaCell
-            user = await aha.auth.getUserByName(f'root@{aha.conf.get("aha:network")}')
-            self.true(user.isAdmin())
 
             async with self.addSvcToAha(aha, '00.exec', ExecTeleCaller) as conn:
 
                 ahaurl = aha.conf.get('aha:urls')[0]
                 ahaurl = s_telepath.modurl(ahaurl, user='root')
 
-                # This fails if root@loop.vertex.link is not an admin
+                # This adminapi fails if root@loop.vertex.link is not an admin
                 await conn.exectelecall(ahaurl, 'getNexsIndx')

--- a/synapse/tools/aha/enroll.py
+++ b/synapse/tools/aha/enroll.py
@@ -14,7 +14,7 @@ Use a one-time use key to initialize your AHA user enrivonment.
 
 Examples:
 
-    python -m synapse.tools.aha.register tcp://aha.loop.vertex.link:27272/b751e6c3e6fc2dad7a28d67e315e1874
+    python -m synapse.tools.aha.enroll tcp://aha.loop.vertex.link:27272/b751e6c3e6fc2dad7a28d67e315e1874
 
 '''
 


### PR DESCRIPTION
invert user lookup for the cell to prefer `aha:network` prefixed usernames over the given username.
only add aha users during provisioning if the user (by name) does not exist and does not have perms to register connections.
add aha test helpers for provisioning services.
fix call error in Base.waiter()
fix typos in tools