### PR TITLE
Update the minimum version of oauthlib (SYN-4163)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ typing-extensions>=3.7.4,<5.0.0  # synapse.vendor.xrpl req
 scalecodec>=1.0.2,<1.0.38  # synapse.vendor.substrateinterface req
 cbor2>=5.4.1,<5.4.3
 bech32==1.2.0
-oauthlib>=3.1.1,<4.0.0
+oauthlib>=3.2.1,<4.0.0
 idna==3.3
 python-dateutil>=2.8,<3.0
 pytz>=2021.3,<2022.2

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         'scalecodec>=1.0.2,<1.0.38',  # synapse.vendor.substrateinterface req
         'cbor2>=5.4.1,<5.4.3',
         'bech32==1.2.0',
-        'oauthlib>=3.1.1,<4.0.0',
+        'oauthlib>=3.2.1,<4.0.0',
         'idna==3.3',
         'python-dateutil>=2.8,<3.0',
         'pytz>=2021.3,<2022.2',


### PR DESCRIPTION
We're already building with 3.2.1 so this is just enforcing that.

Avoids issues with code related to CVE-2022-36087 being allowed.