### PR TITLE
Bug - mirror prov.done is incorrect (SYN-4275, SYN-4246)

### DIFF
--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2672,8 +2672,6 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         if not self._mustBootMirror():
             return
 
-        # Unpack the pnfo tuple
-
         async with s_telepath.loadTeleCell(self.dirn):
             await self._bootCellMirror(pnfo)
 
@@ -2944,6 +2942,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         # Overwrite the prov.done file that may have come from
         # the upstream backup.
         with s_common.genfile(self.dirn, 'prov.done') as fd:
+            fd.truncate(0)
             fd.write(providen.encode())
 
         logger.warning(f'Bootstrap mirror from: {murl} DONE!')

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2908,8 +2908,12 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
     async def _bootCellMirror(self, provconf):
         # this function must assume almost nothing is initialized
-        # but that's ok since it will only run rarely...
-        murl = self.conf.get('mirror')
+        # but that's ok since it will only run rarely.
+        # This does assume it was executed as a result of booting off
+        # of an aha:provision URL.
+        murl = self.conf.reqConfValu('mirror')
+        purl = self.conf.reqConfValu('aha:provision')
+        providen = s_telepath.chopurl(purl).get('path').strip('/')
         logger.warning(f'Bootstrap mirror from: {murl} (this could take a while!)')
 
         tarpath = s_common.genpath(self.dirn, 'tmp', 'bootstrap.tgz')
@@ -2935,6 +2939,11 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 os.unlink(tarpath)
 
         await self._bootProvConf(provconf)
+
+        # Overwrite the prov.done file that may have come from
+        # the upstream backup.
+        with s_common.genfile(self.dirn, 'prov.done') as fd:
+            fd.write(providen.encode())
 
         logger.warning(f'Bootstrap mirror from: {murl} DONE!')
 

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1334,13 +1334,11 @@ class SynTest(unittest.TestCase):
         waiter = aha.waiter(n, 'aha:svcadd')
 
         if dirn:
-            s_common.yamlsave(conf, dirn, 'cell.yaml')
             async with await ctor.anit(dirn, conf=conf) as svc:
                 self.len(n, await waiter.wait(timeout=12))
                 yield svc
         else:
             with self.getTestDir() as dirn:
-                s_common.yamlsave(conf, dirn, 'cell.yaml')
                 async with await ctor.anit(dirn, conf=conf) as svc:
                     self.len(n, await waiter.wait(timeout=12))
                     yield svc

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1315,6 +1315,10 @@ class SynTest(unittest.TestCase):
             conf (dict): Optional service conf.
             dirn (str): Optional directory.
             provinfo (dict)): Optional provisioning info.
+
+        Notes:
+            The config data for the cell is pushed into dirn/cell.yaml.
+            The cells are created with the ``ctor.anit()`` function.
         '''
         onetime = await aha.addAhaSvcProv(svcname, provinfo=provinfo)
 
@@ -1334,12 +1338,14 @@ class SynTest(unittest.TestCase):
         waiter = aha.waiter(n, 'aha:svcadd')
 
         if dirn:
-            async with await ctor.anit(dirn, conf=conf) as svc:
+            s_common.yamlsave(conf, dirn, 'cell.yaml')
+            async with await ctor.anit(dirn) as svc:
                 self.len(n, await waiter.wait(timeout=12))
                 yield svc
         else:
             with self.getTestDir() as dirn:
-                async with await ctor.anit(dirn, conf=conf) as svc:
+                s_common.yamlsave(conf, dirn, 'cell.yaml')
+                async with await ctor.anit(dirn) as svc:
                     self.len(n, await waiter.wait(timeout=12))
                     yield svc
 


### PR DESCRIPTION
Ensure we always write the prov.done file to the iden which we used to do provisioning when we boot from a mirror.