### PR TITLE
Update provisioning log levels (SYN-4269)

### DIFF
--- a/docker/images/synapse/Dockerfile
+++ b/docker/images/synapse/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM vertexproject/vtx-base-image:py38
 
-ENV SYN_LOG_LEVEL="WARNING"
+ENV SYN_LOG_LEVEL="INFO"
 
 COPY synapse /build/synapse/synapse
 COPY setup.py /build/synapse/setup.py

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -262,14 +262,14 @@ class ProvDmon(s_daemon.Daemon):
             anam = conf.get('aha:name')
             anet = conf.get('aha:network')
             mesg = f'Retrieved service provisioning info for {anam}.{anet} iden {name}'
-            logger.debug(mesg, extra=await self.aha.getLogExtra(iden=name, name=anam, netw=anet))
+            logger.info(mesg, extra=await self.aha.getLogExtra(iden=name, name=anam, netw=anet))
             return ProvApi(self.aha, provinfo)
 
         userinfo = await self.aha.getAhaUserEnroll(name)
         if userinfo is not None:
             unam = userinfo.get('name')
             mesg = f'Retrieved user provisioning info for {unam} iden {name}'
-            logger.debug(mesg, extra=await self.aha.getLogExtra(iden=name, name=unam))
+            logger.info(mesg, extra=await self.aha.getLogExtra(iden=name, name=unam))
             await self.aha.delAhaUserEnroll(name)
             return EnrollApi(self.aha, userinfo)
 
@@ -825,7 +825,7 @@ class AhaCell(s_cell.Cell):
 
         iden = await self._push('aha:svc:prov:add', provinfo)
 
-        logger.debug(f'Created service provisioning for {name}.{netw} with iden {iden}',
+        logger.info(f'Created service provisioning for {name}.{netw} with iden {iden}',
                      extra=await self.getLogExtra(iden=iden, name=name, netw=netw))
 
         return self._getProvClientUrl(iden)
@@ -904,7 +904,7 @@ class AhaCell(s_cell.Cell):
 
         iden = await self._push('aha:enroll:add', userinfo)
 
-        logger.debug(f'Created user provisioning for {name} with iden {iden}',
+        logger.info(f'Created user provisioning for {name} with iden {iden}',
                      extra=await self.getLogExtra(iden=iden, name=name))
 
         return self._getProvClientUrl(iden)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2810,7 +2810,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         if doneiden == providen:
             return
 
-        logger.debug(f'Provisioning {self.getCellType()} from AHA service.')
+        logger.info(f'Provisioning {self.getCellType()} from AHA service.')
 
         certdir = s_certdir.CertDir(path=(s_common.gendir(self.dirn, 'certs'),))
 
@@ -2841,7 +2841,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         with s_common.genfile(self.dirn, 'prov.done') as fd:
             fd.write(providen.encode())
 
-        logger.debug(f'Done provisioning {self.getCellType()} AHA service.')
+        logger.info(f'Done provisioning {self.getCellType()} AHA service.')
 
         return provconf
 


### PR DESCRIPTION
- Change the default SYN_LOG_LEVEL for vertexproject/synapse containers 
- Ensure basic provisioning related log messages are logged at info level