### PR TITLE
Move getPermDef/getPermDefs to Cell (SYN-4291)

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -936,18 +936,6 @@ class CoreApi(s_cell.CellApi):
                                                     startvalu=startvalu):
             yield item
 
-    async def getPermDef(self, perm):
-        '''
-        Return a perm definition if it is present in getPermDefs() output.
-        '''
-        return await self.cell.getPermDef(perm)
-
-    async def getPermDefs(self):
-        '''
-        Return a non-comprehensive list of perm definitions.
-        '''
-        return await self.cell.getPermDefs()
-
     async def getAxonUpload(self):
         self.user.confirm(('axon', 'upload'))
         await self.cell.axready.wait()

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -236,7 +236,6 @@ class CellApi(s_base.Base):
         '''
         return await self.cell.getPermDefs()
 
-
     @adminapi()
     def getNexsIndx(self):
         return self.cell.getNexsIndx()

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -224,6 +224,19 @@ class CellApi(s_base.Base):
         '''
         return await self.cell.isCellActive()
 
+    async def getPermDef(self, perm):
+        '''
+        Return a perm definition if it is present in getPermDefs() output.
+        '''
+        return await self.cell.getPermDef(perm)
+
+    async def getPermDefs(self):
+        '''
+        Return a non-comprehensive list of perm definitions.
+        '''
+        return await self.cell.getPermDefs()
+
+
     @adminapi()
     def getNexsIndx(self):
         return self.cell.getNexsIndx()
@@ -2152,6 +2165,12 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
     async def reqGateKeys(self, gatekeys):
         for useriden, perm, gateiden in gatekeys:
             (await self.auth.reqUser(useriden)).confirm(perm, gateiden=gateiden)
+
+    async def getPermDef(self, perm): # pragma: no cover
+        pass
+
+    async def getPermDefs(self): # pragma: no cover
+        pass
 
     async def feedBeholder(self, name, info, gates=None, perms=None):
         '''

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -226,7 +226,7 @@ class CellApi(s_base.Base):
 
     async def getPermDef(self, perm):
         '''
-        Return a perm definition if it is present in getPermDefs() output.
+        Return a perm definition if it is present in getPermDefs() output, otherwise None.
         '''
         return await self.cell.getPermDef(perm)
 
@@ -2166,10 +2166,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             (await self.auth.reqUser(useriden)).confirm(perm, gateiden=gateiden)
 
     async def getPermDef(self, perm): # pragma: no cover
-        pass
+        return
 
     async def getPermDefs(self): # pragma: no cover
-        pass
+        return []
 
     async def feedBeholder(self, name, info, gates=None, perms=None):
         '''


### PR DESCRIPTION
So beholder always has the API that it can call.