### PR TITLE
Skip beholder test under nexus replay

### DIFF
--- a/synapse/tests/test_lib_httpapi.py
+++ b/synapse/tests/test_lib_httpapi.py
@@ -737,6 +737,8 @@ class HttpApiTest(s_tests.SynTest):
                     self.eq('test.visi', mesg['data']['tag'])
 
     async def test_http_beholder(self):
+        self.skipIfNexusReplay()
+
         async with self.getTestCore() as core:
 
             visi = await core.auth.addUser('visi')

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -900,6 +900,16 @@ class SynTest(unittest.TestCase):
         if bool(int(os.getenv('SYN_TEST_SKIP_LONG', 0))):
             raise unittest.SkipTest('SYN_TEST_SKIP_LONG envar set')
 
+    def skipIfNexusReplay(self):
+        '''
+        Allow skipping a test if SYNDEV_NEXUS_REPLAY envar is set.
+
+        Raises:
+            unittest.SkipTest if SYNDEV_NEXUS_REPLAY envar is set to a integer greater than 1.
+        '''
+        if bool(int(os.getenv('SYNDEV_NEXUS_REPLAY', 0))):
+            raise unittest.SkipTest('SYNDEV_NEXUS_REPLAY envar set')
+
     def getTestOutp(self):
         '''
         Get a Output instance with a expects() function.

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -905,9 +905,9 @@ class SynTest(unittest.TestCase):
         Allow skipping a test if SYNDEV_NEXUS_REPLAY envar is set.
 
         Raises:
-            unittest.SkipTest if SYNDEV_NEXUS_REPLAY envar is set to a integer greater than 1.
+            unittest.SkipTest if SYNDEV_NEXUS_REPLAY envar is set to true value.
         '''
-        if bool(int(os.getenv('SYNDEV_NEXUS_REPLAY', 0))):
+        if s_common.envbool('SYNDEV_NEXUS_REPLAY'):
             raise unittest.SkipTest('SYNDEV_NEXUS_REPLAY envar set')
 
     def getTestOutp(self):

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1108,14 +1108,18 @@ class SynTest(unittest.TestCase):
         '''
         Patch so that the Nexus apply log is applied twice. Useful to verify idempotency.
 
+        Args:
+            replay (bool): Set the default value of resolving the existence of SYNDEV_NEXUS_REPLAY variable.
+                           This can be used to force the apply patch without using the environment variable.
+
         Notes:
             This is applied if the environment variable SYNDEV_NEXUS_REPLAY is set
-            or the replay argument is set to True.
+            to a non zero value or the replay argument is set to True.
 
         Returns:
             contextlib.ExitStack: An exitstack object.
         '''
-        replay = os.environ.get('SYNDEV_NEXUS_REPLAY', default=replay)
+        replay = s_common.envbool('SYNDEV_NEXUS_REPLAY', defval=str(replay))
 
         with contextlib.ExitStack() as stack:
             if replay:


### PR DESCRIPTION
`test_cortex_behold` in `test_cortex.py` doesn't demonstrate this same issue because the nexus handles associated with the events bail early if they see the view/cron already exists and fail to fire a new beholder message.