### PR TITLE
Replay test updates (SYN-4225)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ commands:
             if [ -n "${RUN_SYNTAX}" ]; then pycodestyle synapse; fi;
             if [ -n "${RUN_SYNTAX}" ]; then pycodestyle scripts; fi;
 
-      - do_replay_test_execution
+      - do_test_execution
       - do_report_coverage
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,16 +61,6 @@ commands:
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py synapse/vendor/*/tests/test_*.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml -o junit_family=xunit1 ${COVERAGE_ARGS}
 
-  do_replay_test_execution:
-    description: "Execute unit tests via pytest"
-    steps:
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            mkdir test-reports
-            circleci tests glob synapse/tests/test_axon.py synapes/tests/test_lib_jsonstor.py synapse/tests/test_cortex.py synapse/tests/test_lib_aha.py synapse/tests/test_lib_modelrev.py synapse/tests/test_lib_nexus.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_stormlib_cell.py  synapse/tests/test_lib_stormlib*.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml -o junit_family=xunit1 ${COVERAGE_ARGS}
-
   test_steps_doc:
     description: "Documentation test steps"
     steps:
@@ -140,43 +130,6 @@ commands:
             if [ -n "${RUN_SYNTAX}" ]; then pycodestyle synapse; fi;
             if [ -n "${RUN_SYNTAX}" ]; then pycodestyle scripts; fi;
 
-
-      - do_test_execution
-      - do_report_coverage
-
-      - store_test_results:
-          path: test-reports
-
-      - store_artifacts:
-          path: test-reports
-
-  test_steps_python_replay:
-    description: "Python test steps"
-    steps:
-      - checkout
-
-      - run:
-          name: checkout regression repo
-          command: |
-            git clone https://github.com/vertexproject/synapse-regression ~/git/synapse-regression
-
-      - restore_cache:
-          keys:
-            - v3-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
-
-      - do_venv_setup
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v2-venv-{{ .Environment.CIRCLE_STAGE }}-{{ .Branch }}-{{ checksum "setup.py" }}
-
-      - run:
-          name: syntax
-          command: |
-            . venv/bin/activate
-            if [ -n "${RUN_SYNTAX}" ]; then pycodestyle synapse; fi;
-            if [ -n "${RUN_SYNTAX}" ]; then pycodestyle scripts; fi;
 
       - do_test_execution
       - do_report_coverage
@@ -543,7 +496,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - test_steps_python_replay
+      - test_steps_python
 
   python38_replay:
     parallelism: 6
@@ -560,7 +513,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - test_steps_python_replay
+      - test_steps_python
 
   python310_replay:
     parallelism: 6
@@ -577,7 +530,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - test_steps_python_replay
+      - test_steps_python
 
   doctests:
     parallelism: 1
@@ -917,9 +870,7 @@ workflows:
     jobs:
       - doctests
       - python38
-      - python38_replay
       - python310
-      - python310_replay
 
   weekly:
     triggers:
@@ -933,3 +884,5 @@ workflows:
       - osx38
       - python37
       - python37_replay
+      - python38_replay
+      - python310_replay

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
           command: |
             . venv/bin/activate
             mkdir test-reports
-            circleci tests glob synapse/tests/test_axon.py synapes/tests/test_lib_jsonstor.py synapse/tests/test_cortex.py synapse/tests/test_lib_aha.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_stormlib*.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml -o junit_family=xunit1 ${COVERAGE_ARGS}
+            circleci tests glob synapse/tests/test_axon.py synapes/tests/test_lib_jsonstor.py synapse/tests/test_cortex.py synapse/tests/test_lib_aha.py synapse/tests/test_lib_modelrev.py synapse/tests/test_lib_nexus.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_stormlib_cell.py  synapse/tests/test_lib_stormlib*.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml -o junit_family=xunit1 ${COVERAGE_ARGS}
 
   test_steps_doc:
     description: "Documentation test steps"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
           command: |
             . venv/bin/activate
             mkdir test-reports
-            circleci tests glob synapse/tests/test_cortex.py synapse/tests/test_lib_aha.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_stormlib*.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml -o junit_family=xunit1 ${COVERAGE_ARGS}
+            circleci tests glob synapse/tests/test_axon.py synapes/tests/test_lib_jsonstor.py synapse/tests/test_cortex.py synapse/tests/test_lib_aha.py synapse/tests/test_lib_storm.py synapse/tests/test_lib_stormtypes.py synapse/tests/test_lib_stormlib*.py synapse/tests/test_lib_view.py synapse/tests/test_lib_hiveauth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_layer.py | circleci tests split --split-by=timings | xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml -o junit_family=xunit1 ${COVERAGE_ARGS}
 
   test_steps_doc:
     description: "Documentation test steps"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,6 +769,7 @@ workflows:
             branches:
               only:
                 - master
+                - feat_test_utils_replay
 
       - python310_replay:
           filters:
@@ -777,6 +778,7 @@ workflows:
             branches:
               only:
                 - master
+                - feat_test_utils_replay
 
       - python_package_smoketest:
           filters:

--- a/synapse/lib/jsonstor.py
+++ b/synapse/lib/jsonstor.py
@@ -505,9 +505,13 @@ class JsonStorCell(s_cell.Cell):
         await self.multique.rem(name)
         return True
 
-    @s_nexus.Pusher.onPushAuto('q:puts')
-    async def putsQueue(self, name, items, reqid=None):
-        return await self.multique.puts(name, items, reqid=reqid)
+    async def putsQueue(self, name, items):
+        return await self._push('q:puts', name, items)
+
+    @s_nexus.Pusher.onPush('q:puts', passitem=True)
+    async def _putsQueue(self, name, items, nexsitem):
+        nexsoff, nexsmesg = nexsitem
+        return await self.multique.puts(name, items, reqid=nexsoff)
 
     @s_nexus.Pusher.onPushAuto('q:cull')
     async def cullQueue(self, name, offs):

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -56,7 +56,7 @@ class CortexTest(s_t_utils.SynTest):
                 'aha:network': 'newp',
                 'provision:listen': 'tcp://127.0.0.1:0',
             }
-            async with await s_aha.AhaCell.anit(ahadir, conf=conf) as aha:
+            async with self.getTestAha(dirn=ahadir, conf=conf) as aha:
 
                 provaddr, provport = aha.provdmon.addr
                 aha.conf['provision:listen'] = f'tcp://127.0.0.1:{provport}'

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -5340,7 +5340,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                     url2 = core01.getLocalUrl()
 
                     core02conf = {'mirror': url2}
-                    async with self.getTestCore(dirn=path01, conf=core02conf) as core02:
+                    async with self.getTestCore(dirn=path02, conf=core02conf) as core02:
 
                         await core00.nodes('[ inet:fqdn=vertex.link ]')
                         await core00.nodes('queue.add visi')

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -219,13 +219,13 @@ class CortexTest(s_t_utils.SynTest):
             path00 = os.path.join(dirn, 'core00')
             path01 = os.path.join(dirn, 'core01')
             conf00 = {'nexslog:en': True}
-            async with await s_cortex.Cortex.anit(path00, conf=conf00) as core00:
-                pass
+            async with self.getTestCore(dirn=path00, conf=conf00) as core00:
+                self.true(core00.isactive)
 
             s_tools_backup.backup(path00, path01)
-            async with await s_cortex.Cortex.anit(path00, conf=conf00) as core00:
+            async with self.getTestCore(dirn=path00, conf=conf00) as core00:
                 conf01 = {'nexslog:en': True, 'mirror': core00.getLocalUrl()}
-                async with await s_cortex.Cortex.anit(path01, conf=conf01) as core01:
+                async with self.getTestCore(dirn=path01, conf=conf01) as core01:
                     await testCoreJson(core01)
                     self.eq(await core00.getJsonObj('foo/bar'), 'zoinks')
                     self.eq(await core01.getJsonObj('foo/bar'), 'zoinks')
@@ -235,13 +235,13 @@ class CortexTest(s_t_utils.SynTest):
             path00 = os.path.join(dirn, 'core00')
             path01 = os.path.join(dirn, 'core01')
             conf00 = {'nexslog:en': True}
-            async with await s_cortex.Cortex.anit(path00, conf=conf00) as core00:
-                pass
+            async with self.getTestCore(dirn=path00, conf=conf00) as core00:
+                self.true(core00.isactive)
 
             s_tools_backup.backup(path00, path01)
-            async with await s_cortex.Cortex.anit(path00, conf=conf00) as core00:
+            async with self.getTestCore(dirn=path00, conf=conf00) as core00:
                 conf01 = {'nexslog:en': True, 'mirror': core00.getLocalUrl()}
-                async with await s_cortex.Cortex.anit(path01, conf=conf01) as core01:
+                async with self.getTestCore(dirn=path01, conf=conf01) as core01:
                     await testCoreJson(core00)
                     await core01.sync()
                     self.eq(await core00.getJsonObj('foo/bar'), 'zoinks')
@@ -358,11 +358,11 @@ class CortexTest(s_t_utils.SynTest):
 
         with self.getTestDir() as dirn:
 
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
                 self.nn(await core.cellinfo.pop('cortex:version'))
 
             with self.raises(s_exc.BadStorageVersion):
-                async with await s_cortex.Cortex.anit(dirn) as core:
+                async with self.getTestCore(dirn=dirn) as core:
                     pass
 
     async def test_cortex_stormiface(self):
@@ -1525,7 +1525,7 @@ class CortexTest(s_t_utils.SynTest):
 
         with self.getTestDir() as dirn:
 
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
 
                 async with core.getLocalProxy() as prox:
 
@@ -1553,7 +1553,7 @@ class CortexTest(s_t_utils.SynTest):
                         nodes = await core.nodes(q)
 
             # make sure it's still loaded...
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
 
                 async with core.getLocalProxy() as prox:
 
@@ -5079,12 +5079,12 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                 core01conf = {'nexslog:en': False, 'mirror': url}
                 with self.raises(s_exc.BadConfValu):
-                    async with await s_cortex.Cortex.anit(dirn=path01, conf=core01conf) as core01:
+                    async with self.getTestCore(dirn=path01, conf=core01conf) as core01:
                         self.fail('Should never get here.')
 
                 core01conf = {'mirror': url}
 
-                async with await s_cortex.Cortex.anit(dirn=path01, conf=core01conf) as core01:
+                async with self.getTestCore(dirn=path01, conf=core01conf) as core01:
 
                     await core00.nodes('[ inet:fqdn=vertex.link ]')
                     await core00.nodes('queue.add visi')
@@ -5122,7 +5122,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                 await core00.nodes('[ inet:ipv4=5.5.5.5 ]')
 
                 # test what happens when we go down and come up again...
-                async with await s_cortex.Cortex.anit(dirn=path01, conf=core01conf) as core01:
+                async with self.getTestCore(dirn=path01, conf=core01conf) as core01:
 
                     # check that startup does not create any events
                     self.eq(nexusind, core01.nexsroot.nexslog.index())
@@ -5139,9 +5139,9 @@ class CortexBasicTest(s_t_utils.SynTest):
                     self.none(ddef)
 
             # now lets start up in the opposite order...
-            async with await s_cortex.Cortex.anit(dirn=path01, conf=core01conf) as core01:
+            async with self.getTestCore(dirn=path01, conf=core01conf) as core01:
 
-                async with await s_cortex.Cortex.anit(dirn=path00) as core00:
+                async with self.getTestCore(dirn=path00) as core00:
 
                     self.len(1, await core00.nodes('[ inet:ipv4=6.6.6.6 ]'))
 
@@ -5150,7 +5150,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                     self.len(1, await core01.nodes('inet:ipv4=6.6.6.6'))
 
                 # what happens if *he* goes down and comes back up again?
-                async with await s_cortex.Cortex.anit(dirn=path00) as core00:
+                async with self.getTestCore(dirn=path00) as core00:
 
                     await core00.nodes('[ inet:ipv4=7.7.7.7 ]')
 
@@ -5163,7 +5163,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                     await self.asyncraises(s_exc.LinkErr, core01.nodes('[inet:ipv4=7.7.7.8]'))
 
                 # Bring the leader back up and try again
-                async with await s_cortex.Cortex.anit(dirn=path00) as core00:
+                async with self.getTestCore(dirn=path00) as core00:
                     self.len(1, await core01.nodes('[ inet:ipv4=7.7.7.8 ]'))
 
                 # remove the mirrorness from the Cortex and ensure that we can
@@ -5175,7 +5175,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                 self.len(1, await core01.nodes('[inet:ipv4=9.9.9.8]'))
                 new_url = core01.getLocalUrl()
                 new_conf = {'mirror': new_url}
-                async with await s_cortex.Cortex.anit(dirn=path00, conf=new_conf) as core00:
+                async with self.getTestCore(dirn=path00, conf=new_conf) as core00:
                     await core00.sync()
                     self.len(1, await core00.nodes('inet:ipv4=9.9.9.8'))
 
@@ -5336,11 +5336,11 @@ class CortexBasicTest(s_t_utils.SynTest):
                 url = core00.getLocalUrl()
 
                 core01conf = {'mirror': url}
-                async with await s_cortex.Cortex.anit(dirn=path01, conf=core01conf) as core01:
+                async with self.getTestCore(dirn=path01, conf=core01conf) as core01:
                     url2 = core01.getLocalUrl()
 
                     core02conf = {'mirror': url2}
-                    async with await s_cortex.Cortex.anit(dirn=path02, conf=core02conf) as core02:
+                    async with self.getTestCore(dirn=path01, conf=core02conf) as core02:
 
                         await core00.nodes('[ inet:fqdn=vertex.link ]')
                         await core00.nodes('queue.add visi')
@@ -5364,7 +5364,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                         self.len(1, await core02.nodes('inet:fqdn=test2.vertex.link'))
 
                         # Bring up a sibling mirror to the bottom
-                        async with await s_cortex.Cortex.anit(dirn=path02a, conf=core02conf) as core02a:
+                        async with self.getTestCore(dirn=path02a, conf=core02conf) as core02a:
                             self.len(1, await core02a.nodes('[ inet:fqdn=test3.vertex.link ]'))
                             self.len(1, await core02a.nodes('inet:fqdn=test2.vertex.link'))
 
@@ -5667,7 +5667,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
         with self.getTestDir() as dirn:
 
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
 
                 with self.raises(s_exc.BadFormDef):
                     await core.addForm('inet:ipv4', 'int', {}, {})
@@ -5712,7 +5712,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                 # manually edit in a borked form entry
                 await core.extforms.set('_hehe:bork', ('_hehe:bork', None, None, None))
 
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
 
                 self.none(core.model.form('_hehe:bork'))
 

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -82,7 +82,8 @@ class AhaTest(s_test.SynTest):
 
                     wait00 = aha0.waiter(1, 'aha:svcdown')
                     await aha0.setAhaSvcDown('test', iden, network='example.net')
-                    self.len(1, await wait00.wait(timeout=6))
+                    self.isin(len(await wait00.wait(timeout=6)), (1, 2))
+
                     await aha1.sync()
                     mnfo = await aha1.getAhaSvc('test.example.net')
                     self.notin('online', mnfo)
@@ -106,8 +107,8 @@ class AhaTest(s_test.SynTest):
                     'aha:registry': f'tcp://root:secret@127.0.0.1:{port}',
                     'dmon:listen': 'tcp://0.0.0.0:0/',
                 }
-                async with self.getTestCryo(dirn=cryo0_dirn, conf=cryo_conf.copy()) as cryo:
-                    self.len(1, await wait00.wait(timeout=6))
+                async with self.getTestCryo(dirn=cryo0_dirn, conf=cryo_conf) as cryo:
+                    self.isin(len(await wait00.wait(timeout=6)), (1, 2))
 
                     svc = await aha.getAhaSvc('0.cryo.mynet')
                     linkiden = svc.get('svcinfo', {}).get('online')

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -346,8 +346,7 @@ class AhaTest(s_test.SynTest):
 
     async def test_lib_aha_finid_cell(self):
 
-        with self.getTestDir() as dirn:
-            async with await self.aha_ctor(dirn) as aha:
+        async with self.getTestAha() as aha:
 
                 cryo0_dirn = s_common.gendir(aha.dirn, 'cryo0')
 
@@ -384,11 +383,9 @@ class AhaTest(s_test.SynTest):
 
     async def test_lib_aha_onlink_fail(self):
 
-        with self.getTestDir() as dirn:
+        with mock.patch('synapse.lib.aha.AhaCell.addAhaSvc', mockaddsvc):
 
-            with mock.patch('synapse.lib.aha.AhaCell.addAhaSvc', mockaddsvc):
-
-                async with await self.aha_ctor(dirn) as aha:
+            async with self.getTestAha() as aha:
 
                     cryo0_dirn = s_common.gendir(aha.dirn, 'cryo0')
 
@@ -437,7 +434,7 @@ class AhaTest(s_test.SynTest):
                     'aha:network': 'do.vertex.link',
                 }
 
-                async with await s_aha.AhaCell.anit(dirn, conf=conf) as aha:
+                async with self.getTestAha(dirn=dirn, conf=conf) as aha:
                     self.true(os.path.isfile(os.path.join(dirn, 'certs', 'cas', 'do.vertex.link.crt')))
                     self.true(os.path.isfile(os.path.join(dirn, 'certs', 'cas', 'do.vertex.link.key')))
                     self.true(os.path.isfile(os.path.join(dirn, 'certs', 'hosts', 'aha.do.vertex.link.crt')))
@@ -452,9 +449,7 @@ class AhaTest(s_test.SynTest):
 
     async def test_lib_aha_noconf(self):
 
-        with self.getTestDir() as dirn:
-
-            async with await self.aha_ctor(dirn) as aha:
+        async with self.getTestAha() as aha:
 
                 with self.raises(s_exc.NeedConfValu):
                     await aha.addAhaSvcProv('hehe')
@@ -487,7 +482,7 @@ class AhaTest(s_test.SynTest):
                 'aha:network': 'loop.vertex.link',
                 'provision:listen': 'ssl://aha.loop.vertex.link:0'
             }
-            async with await self.aha_ctor(dirn, conf=conf) as aha:
+            async with self.getTestAha(dirn=dirn, conf=conf) as aha:
 
                 addr, port = aha.provdmon.addr
                 # update the config to reflect the dynamically bound port
@@ -712,14 +707,13 @@ class AhaTest(s_test.SynTest):
                           cm.exception.get('mesg'))
 
     async def test_aha_httpapi(self):
-        with self.getTestDir() as dirn:
 
-            conf = {
-                'aha:name': 'aha',
-                'aha:network': 'loop.vertex.link',
-                'provision:listen': 'ssl://aha.loop.vertex.link:0'
-            }
-            async with await self.aha_ctor(dirn, conf=conf) as aha:
+        conf = {
+            'aha:name': 'aha',
+            'aha:network': 'loop.vertex.link',
+            'provision:listen': 'ssl://aha.loop.vertex.link:0'
+        }
+        async with self.getTestAha(conf=conf) as aha:
 
                 await aha.auth.rootuser.setPasswd('secret')
 

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -40,7 +40,6 @@ class ExecTeleCaller(s_cell.Cell):
             return resp
 
 class AhaTest(s_test.SynTest):
-    aha_ctor = s_aha.AhaCell.anit
 
     async def test_lib_aha_mirrors(self):
 
@@ -349,38 +348,38 @@ class AhaTest(s_test.SynTest):
 
         async with self.getTestAha() as aha:
 
-                cryo0_dirn = s_common.gendir(aha.dirn, 'cryo0')
+            cryo0_dirn = s_common.gendir(aha.dirn, 'cryo0')
 
-                host, port = await aha.dmon.listen('tcp://127.0.0.1:0')
-                await aha.auth.rootuser.setPasswd('hehehaha')
+            host, port = await aha.dmon.listen('tcp://127.0.0.1:0')
+            await aha.auth.rootuser.setPasswd('hehehaha')
 
-                wait00 = aha.waiter(1, 'aha:svcadd')
-                conf = {
-                    'aha:name': '0.cryo.mynet',
-                    'aha:admin': 'root@cryo.mynet',
-                    'aha:registry': [f'tcp://root:hehehaha@127.0.0.1:{port}',
-                                     f'tcp://root:hehehaha@127.0.0.1:{port}'],
-                    'dmon:listen': 'tcp://0.0.0.0:0/',
-                }
-                async with self.getTestCryo(dirn=cryo0_dirn, conf=conf) as cryo:
+            wait00 = aha.waiter(1, 'aha:svcadd')
+            conf = {
+                'aha:name': '0.cryo.mynet',
+                'aha:admin': 'root@cryo.mynet',
+                'aha:registry': [f'tcp://root:hehehaha@127.0.0.1:{port}',
+                                 f'tcp://root:hehehaha@127.0.0.1:{port}'],
+                'dmon:listen': 'tcp://0.0.0.0:0/',
+            }
+            async with self.getTestCryo(dirn=cryo0_dirn, conf=conf) as cryo:
 
-                    await cryo.auth.rootuser.setPasswd('secret')
+                await cryo.auth.rootuser.setPasswd('secret')
 
-                    ahaadmin = await cryo.auth.getUserByName('root@cryo.mynet')
-                    self.nn(ahaadmin)
-                    self.true(ahaadmin.isAdmin())
+                ahaadmin = await cryo.auth.getUserByName('root@cryo.mynet')
+                self.nn(ahaadmin)
+                self.true(ahaadmin.isAdmin())
 
-                    await wait00.wait(timeout=2)
+                await wait00.wait(timeout=2)
+
+                async with await s_telepath.openurl('aha://root:secret@0.cryo.mynet') as proxy:
+                    self.nn(await proxy.getCellIden())
+
+                await aha.fini()
+
+                with self.raises(s_exc.IsFini):
 
                     async with await s_telepath.openurl('aha://root:secret@0.cryo.mynet') as proxy:
-                        self.nn(await proxy.getCellIden())
-
-                    await aha.fini()
-
-                    with self.raises(s_exc.IsFini):
-
-                        async with await s_telepath.openurl('aha://root:secret@0.cryo.mynet') as proxy:
-                            self.fail('Should never reach a connection.')
+                        self.fail('Should never reach a connection.')
 
     async def test_lib_aha_onlink_fail(self):
 
@@ -388,40 +387,40 @@ class AhaTest(s_test.SynTest):
 
             async with self.getTestAha() as aha:
 
-                    cryo0_dirn = s_common.gendir(aha.dirn, 'cryo0')
+                cryo0_dirn = s_common.gendir(aha.dirn, 'cryo0')
 
-                    host, port = await aha.dmon.listen('tcp://127.0.0.1:0')
-                    await aha.auth.rootuser.setPasswd('secret')
+                host, port = await aha.dmon.listen('tcp://127.0.0.1:0')
+                await aha.auth.rootuser.setPasswd('secret')
 
-                    aha.testerr = True
+                aha.testerr = True
 
-                    wait00 = aha.waiter(1, 'aha:svcadd')
-                    conf = {
-                        'aha:name': '0.cryo.mynet',
-                        'aha:admin': 'root@cryo.mynet',
-                        'aha:registry': f'tcp://root:secret@127.0.0.1:{port}',
-                        'dmon:listen': 'tcp://0.0.0.0:0/',
-                    }
-                    async with self.getTestCryo(dirn=cryo0_dirn, conf=conf) as cryo:
+                wait00 = aha.waiter(1, 'aha:svcadd')
+                conf = {
+                    'aha:name': '0.cryo.mynet',
+                    'aha:admin': 'root@cryo.mynet',
+                    'aha:registry': f'tcp://root:secret@127.0.0.1:{port}',
+                    'dmon:listen': 'tcp://0.0.0.0:0/',
+                }
+                async with self.getTestCryo(dirn=cryo0_dirn, conf=conf) as cryo:
 
-                        await cryo.auth.rootuser.setPasswd('secret')
+                    await cryo.auth.rootuser.setPasswd('secret')
 
-                        self.none(await wait00.wait(timeout=2))
+                    self.none(await wait00.wait(timeout=2))
 
-                        svc = await aha.getAhaSvc('0.cryo.mynet')
-                        self.none(svc)
+                    svc = await aha.getAhaSvc('0.cryo.mynet')
+                    self.none(svc)
 
-                        wait01 = aha.waiter(1, 'aha:svcadd')
-                        aha.testerr = False
+                    wait01 = aha.waiter(1, 'aha:svcadd')
+                    aha.testerr = False
 
-                        self.nn(await wait01.wait(timeout=2))
+                    self.nn(await wait01.wait(timeout=2))
 
-                        svc = await aha.getAhaSvc('0.cryo.mynet')
-                        self.nn(svc)
-                        self.nn(svc.get('svcinfo', {}).get('online'))
+                    svc = await aha.getAhaSvc('0.cryo.mynet')
+                    self.nn(svc)
+                    self.nn(svc.get('svcinfo', {}).get('online'))
 
-                        async with await s_telepath.openurl('aha://root:secret@0.cryo.mynet') as proxy:
-                            self.nn(await proxy.getCellIden())
+                    async with await s_telepath.openurl('aha://root:secret@0.cryo.mynet') as proxy:
+                        self.nn(await proxy.getCellIden())
 
     async def test_lib_aha_bootstrap(self):
 
@@ -452,27 +451,27 @@ class AhaTest(s_test.SynTest):
 
         async with self.getTestAha() as aha:
 
-                with self.raises(s_exc.NeedConfValu):
-                    await aha.addAhaSvcProv('hehe')
-
-                aha.conf['aha:urls'] = 'tcp://127.0.0.1:0/'
-
-                with self.raises(s_exc.NeedConfValu):
-                    await aha.addAhaSvcProv('hehe')
-
-                with self.raises(s_exc.NeedConfValu):
-                    await aha.addAhaUserEnroll('hehe')
-
-                aha.conf['provision:listen'] = 'tcp://127.0.0.1:27272'
-
-                with self.raises(s_exc.NeedConfValu):
-                    await aha.addAhaSvcProv('hehe')
-
-                with self.raises(s_exc.NeedConfValu):
-                    await aha.addAhaUserEnroll('hehe')
-
-                aha.conf['aha:network'] = 'haha'
+            with self.raises(s_exc.NeedConfValu):
                 await aha.addAhaSvcProv('hehe')
+
+            aha.conf['aha:urls'] = 'tcp://127.0.0.1:0/'
+
+            with self.raises(s_exc.NeedConfValu):
+                await aha.addAhaSvcProv('hehe')
+
+            with self.raises(s_exc.NeedConfValu):
+                await aha.addAhaUserEnroll('hehe')
+
+            aha.conf['provision:listen'] = 'tcp://127.0.0.1:27272'
+
+            with self.raises(s_exc.NeedConfValu):
+                await aha.addAhaSvcProv('hehe')
+
+            with self.raises(s_exc.NeedConfValu):
+                await aha.addAhaUserEnroll('hehe')
+
+            aha.conf['aha:network'] = 'haha'
+            await aha.addAhaSvcProv('hehe')
 
     async def test_lib_aha_provision(self):
 
@@ -715,105 +714,102 @@ class AhaTest(s_test.SynTest):
             'provision:listen': 'ssl://aha.loop.vertex.link:0'
         }
         async with self.getTestAha(conf=conf) as aha:
+            await aha.auth.rootuser.setPasswd('secret')
 
-                await aha.auth.rootuser.setPasswd('secret')
+            addr, port = aha.provdmon.addr
+            # update the config to reflect the dynamically bound port
+            aha.conf['provision:listen'] = f'ssl://aha.loop.vertex.link:{port}'
 
-                addr, port = aha.provdmon.addr
-                # update the config to reflect the dynamically bound port
-                aha.conf['provision:listen'] = f'ssl://aha.loop.vertex.link:{port}'
+            # do this config ex-post-facto due to port binding...
+            host, ahaport = await aha.dmon.listen('ssl://0.0.0.0:0?hostname=aha.loop.vertex.link&ca=loop.vertex.link')
+            aha.conf['aha:urls'] = f'ssl://aha.loop.vertex.link:{ahaport}'
 
-                # do this config ex-post-facto due to port binding...
-                host, ahaport = await aha.dmon.listen('ssl://0.0.0.0:0?hostname=aha.loop.vertex.link&ca=loop.vertex.link')
-                aha.conf['aha:urls'] = f'ssl://aha.loop.vertex.link:{ahaport}'
+            host, httpsport = await aha.addHttpsPort(0)
+            url = f'https://localhost:{httpsport}/api/v1/aha/provision/service'
 
-                host, httpsport = await aha.addHttpsPort(0)
-                url = f'https://localhost:{httpsport}/api/v1/aha/provision/service'
+            async with self.getHttpSess(auth=('root', 'secret'), port=httpsport) as sess:
+                # Simple request works
+                async with sess.post(url, json={'name': '00.foosvc'}) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'ok')
+                    result = info.get('result')
+                    provurl = result.get('url')
 
-                async with self.getHttpSess(auth=('root', 'secret'), port=httpsport) as sess:
+                async with await s_telepath.openurl(provurl) as prox:
+                    provconf = await prox.getProvInfo()
+                    self.isin('iden', provconf)
+                    conf = provconf.get('conf')
+                    self.eq(conf.get('aha:user'), 'root')
+                    dmon_listen = conf.get('dmon:listen')
+                    parts = s_telepath.chopurl(dmon_listen)
+                    self.eq(parts.get('port'), 0)
+                    self.none(conf.get('https:port'))
 
-                    # Simple request works
-                    async with sess.post(url, json={'name': '00.foosvc'}) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'ok')
-                        result = info.get('result')
-                        provurl = result.get('url')
-
-                    async with await s_telepath.openurl(provurl) as prox:
-                        provconf = await prox.getProvInfo()
-                        self.isin('iden', provconf)
-                        conf = provconf.get('conf')
-                        self.eq(conf.get('aha:user'), 'root')
-                        dmon_listen = conf.get('dmon:listen')
-                        parts = s_telepath.chopurl(dmon_listen)
-                        self.eq(parts.get('port'), 0)
-                        self.none(conf.get('https:port'))
-
-                    # Full api works as well
-                    data = {'name': '01.foosvc',
-                            'provinfo': {
-                                'dmon:port': 12345,
-                                'https:port': 8443,
-                                'mirror': 'foosvc',
-                                'conf': {
-                                    'aha:user': 'test',
-                                }
+                # Full api works as well
+                data = {'name': '01.foosvc',
+                        'provinfo': {
+                            'dmon:port': 12345,
+                            'https:port': 8443,
+                            'mirror': 'foosvc',
+                            'conf': {
+                                'aha:user': 'test',
                             }
-                    }
-                    async with sess.post(url, json=data) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'ok')
-                        result = info.get('result')
-                        provurl = result.get('url')
-                    async with await s_telepath.openurl(provurl) as prox:
-                        provconf = await prox.getProvInfo()
-                        conf = provconf.get('conf')
-                        self.eq(conf.get('aha:user'), 'test')
-                        dmon_listen = conf.get('dmon:listen')
-                        parts = s_telepath.chopurl(dmon_listen)
-                        self.eq(parts.get('port'), 12345)
-                        self.eq(conf.get('https:port'), 8443)
+                        }
+                        }
+                async with sess.post(url, json=data) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'ok')
+                    result = info.get('result')
+                    provurl = result.get('url')
+                async with await s_telepath.openurl(provurl) as prox:
+                    provconf = await prox.getProvInfo()
+                    conf = provconf.get('conf')
+                    self.eq(conf.get('aha:user'), 'test')
+                    dmon_listen = conf.get('dmon:listen')
+                    parts = s_telepath.chopurl(dmon_listen)
+                    self.eq(parts.get('port'), 12345)
+                    self.eq(conf.get('https:port'), 8443)
 
-                    # Sad path
-                    async with sess.post(url) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'err')
-                        self.eq(info.get('code'), 'SchemaViolation')
-                    async with sess.post(url, json={}) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'err')
-                        self.eq(info.get('code'), 'SchemaViolation')
-                    async with sess.post(url, json={'name': 1234}) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'err')
-                        self.eq(info.get('code'), 'SchemaViolation')
-                    async with sess.post(url, json={'name': ''}) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'err')
-                        self.eq(info.get('code'), 'SchemaViolation')
-                    async with sess.post(url, json={'name': '00.newp', 'provinfo': 5309}) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'err')
-                        self.eq(info.get('code'), 'SchemaViolation')
-                    async with sess.post(url, json={'name': '00.newp', 'provinfo': {'dmon:port': -1}}) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'err')
-                        self.eq(info.get('code'), 'SchemaViolation')
+                # Sad path
+                async with sess.post(url) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'err')
+                    self.eq(info.get('code'), 'SchemaViolation')
+                async with sess.post(url, json={}) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'err')
+                    self.eq(info.get('code'), 'SchemaViolation')
+                async with sess.post(url, json={'name': 1234}) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'err')
+                    self.eq(info.get('code'), 'SchemaViolation')
+                async with sess.post(url, json={'name': ''}) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'err')
+                    self.eq(info.get('code'), 'SchemaViolation')
+                async with sess.post(url, json={'name': '00.newp', 'provinfo': 5309}) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'err')
+                    self.eq(info.get('code'), 'SchemaViolation')
+                async with sess.post(url, json={'name': '00.newp', 'provinfo': {'dmon:port': -1}}) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'err')
+                    self.eq(info.get('code'), 'SchemaViolation')
 
-                    # Break the Aha cell - not will provision after this.
-                    _network = aha.conf.pop('aha:network')
-                    async with sess.post(url, json={'name': '00.newp'}) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'err')
-                        self.eq(info.get('code'), 'NeedConfValu')
+                # Break the Aha cell - not will provision after this.
+                _network = aha.conf.pop('aha:network')
+                async with sess.post(url, json={'name': '00.newp'}) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'err')
+                    self.eq(info.get('code'), 'NeedConfValu')
 
-                # Not an admin
-                await aha.addUser('lowuser', passwd='lowuser')
-                async with self.getHttpSess(auth=('lowuser', 'lowuser'), port=httpsport) as sess:
-
-                    async with sess.post(url, json={'name': '00.newp'}) as resp:
-                        info = await resp.json()
-                        self.eq(info.get('status'), 'err')
-                        self.eq(info.get('code'), 'AuthDeny')
+            # Not an admin
+            await aha.addUser('lowuser', passwd='lowuser')
+            async with self.getHttpSess(auth=('lowuser', 'lowuser'), port=httpsport) as sess:
+                async with sess.post(url, json={'name': '00.newp'}) as resp:
+                    info = await resp.json()
+                    self.eq(info.get('status'), 'err')
+                    self.eq(info.get('code'), 'AuthDeny')
 
     async def test_aha_connect_back(self):
         async with self.getTestAhaProv() as aha:  # type: s_aha.AhaCell

--- a/synapse/tests/test_lib_httpapi.py
+++ b/synapse/tests/test_lib_httpapi.py
@@ -737,6 +737,7 @@ class HttpApiTest(s_tests.SynTest):
                     self.eq('test.visi', mesg['data']['tag'])
 
     async def test_http_beholder(self):
+        self.skip('Temporary skip')
         async with self.getTestCore() as core:
 
             visi = await core.auth.addUser('visi')

--- a/synapse/tests/test_lib_jsonstor.py
+++ b/synapse/tests/test_lib_jsonstor.py
@@ -7,44 +7,42 @@ class JsonStorTest(s_test.SynTest):
 
     async def test_lib_jsonstor_popprop(self):
 
-        with self.getTestDir() as dirn:
-            async with await s_jsonstor.JsonStorCell.anit(dirn) as jsonstor:
-                async with jsonstor.getLocalProxy() as prox:
-                    await prox.setPathObj('foo/bar', {'foo': 'bar', 'baz': 'faz'})
-                    self.eq('faz', await prox.popPathObjProp('foo/bar', 'baz'))
-                    self.none(await prox.getPathObjProp('foo/bar', 'baz'))
+        async with self.getTestJsonStor() as jsonstor:
+            async with jsonstor.getLocalProxy() as prox:
+                await prox.setPathObj('foo/bar', {'foo': 'bar', 'baz': 'faz'})
+                self.eq('faz', await prox.popPathObjProp('foo/bar', 'baz'))
+                self.none(await prox.getPathObjProp('foo/bar', 'baz'))
 
-                    self.none(await prox.popPathObjProp('foo/bar', 'baz'))
-                    self.none(await prox.popPathObjProp('newp/newp', 'baz'))
+                self.none(await prox.popPathObjProp('foo/bar', 'baz'))
+                self.none(await prox.popPathObjProp('newp/newp', 'baz'))
 
-                    # coverage for the loop'd get
-                    await prox.setPathObj('hehe', {'foo': {'bar': 'baz'}})
-                    self.eq('baz', await prox.popPathObjProp('hehe', 'foo/bar'))
-                    self.none(await prox.popPathObjProp('hehe', 'foo/newp'))
+                # coverage for the loop'd get
+                await prox.setPathObj('hehe', {'foo': {'bar': 'baz'}})
+                self.eq('baz', await prox.popPathObjProp('hehe', 'foo/bar'))
+                self.none(await prox.popPathObjProp('hehe', 'foo/newp'))
 
     async def test_lib_jsonstor_has(self):
 
-        with self.getTestDir() as dirn:
-            async with await s_jsonstor.JsonStorCell.anit(dirn) as jsonstor:
-                async with jsonstor.getLocalProxy() as prox:
-                    await prox.setPathObj('foo/bar', 'asdf')
-                    self.true(await prox.hasPathObj('foo/bar'))
+        async with self.getTestJsonStor() as jsonstor:
+            async with jsonstor.getLocalProxy() as prox:
+                await prox.setPathObj('foo/bar', 'asdf')
+                self.true(await prox.hasPathObj('foo/bar'))
 
     async def test_lib_jsonstor_copy(self):
 
-        with self.getTestDir() as dirn:
-            async with await s_jsonstor.JsonStorCell.anit(dirn) as jsonstor:
-                async with jsonstor.getLocalProxy() as prox:
-                    await prox.setPathObj('foo/bar', 'asdf')
-                    await prox.copyPathObj('foo/bar', 'foo/baz')
-                    self.eq('asdf', await prox.getPathObj('foo/baz'))
+        async with self.getTestJsonStor() as jsonstor:
+            async with jsonstor.getLocalProxy() as prox:
+                await prox.setPathObj('foo/bar', 'asdf')
+                await prox.copyPathObj('foo/bar', 'foo/baz')
+                self.eq('asdf', await prox.getPathObj('foo/baz'))
 
-                    await prox.copyPathObjs((('foo/bar', 'foo/faz'),))
-                    self.eq('asdf', await prox.getPathObj('foo/faz'))
+                await prox.copyPathObjs((('foo/bar', 'foo/faz'),))
+                self.eq('asdf', await prox.getPathObj('foo/faz'))
 
     async def test_lib_jsonstor_basics(self):
+
         with self.getTestDir() as dirn:
-            async with await s_jsonstor.JsonStorCell.anit(dirn) as jsonstor:
+            async with self.getTestJsonStor(dirn=dirn) as jsonstor:
                 async with jsonstor.getLocalProxy() as prox:
 
                     await prox.setPathObj('foo/bar', {'hehe': 'haha', 'mooz': 'zoom'})
@@ -104,7 +102,7 @@ class JsonStorTest(s_test.SynTest):
                     self.none(await prox.getPathObjProp('newp/newp', 'newp'))
                     self.false(await prox.setPathObjProp('newp/newp', 'newp', 'newp'))
 
-            async with await s_jsonstor.JsonStorCell.anit(dirn) as jsonstor:
+            async with self.getTestJsonStor(dirn=dirn) as jsonstor:
                 async with jsonstor.getLocalProxy() as prox:
                     self.eq({'hehe': 'haha', 'zip': {'zop': True}}, await prox.getPathObj('foo/bar'))
                     self.eq({'hehe': 'haha', 'zip': {'zop': True}}, await prox.getPathObj('foo/baz'))

--- a/synapse/tests/test_lib_modelrev.py
+++ b/synapse/tests/test_lib_modelrev.py
@@ -13,14 +13,14 @@ class ModelRevTest(s_tests.SynTest):
 
         with self.getTestDir(mirror='testcore') as dirn:
 
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
                 layr = core.getLayer()
                 self.true(layr.fresh)
                 self.eq(s_modelrev.maxvers, await layr.getModelVers())
 
             # no longer "fresh", but lets mark a layer as read only
             # and test the bail condition for layers which we cant update
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
 
                 layr = core.getLayer()
                 layr.canrev = False
@@ -33,7 +33,7 @@ class ModelRevTest(s_tests.SynTest):
                     await mrev.revCoreLayers()
 
             # no longer "fresh"
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
 
                 layr = core.getLayer()
                 self.false(layr.fresh)
@@ -136,13 +136,13 @@ class ModelRevTest(s_tests.SynTest):
 
                 conf00 = {'nexslog:en': True}
 
-                async with await s_cortex.Cortex.anit(regrdir00, conf=conf00) as core00:
+                async with self.getTestCore(dirn=regrdir00, conf=conf00) as core00:
 
                     self.true(await core00.getLayer().getModelVers() >= (0, 2, 7))
 
                     conf01 = {'nexslog:en': True, 'mirror': core00.getLocalUrl()}
 
-                async with await s_cortex.Cortex.anit(regrdir01, conf=conf01) as core01:
+                async with self.getTestCore(dirn=regrdir01, conf=conf01) as core01:
 
                     self.eq(await core01.getLayer().getModelVers(), (0, 2, 6))
 
@@ -154,8 +154,8 @@ class ModelRevTest(s_tests.SynTest):
                     self.eq(node.props.get('._hugearray'), ('3.45', '10E-21'))
                     self.eq(node.props.get('._hugearray'), ('3.45', '10E-21'))
 
-                async with await s_cortex.Cortex.anit(regrdir00, conf=conf00) as core00:
-                    async with await s_cortex.Cortex.anit(regrdir01, conf=conf01) as core01:
+                async with self.getTestCore(dirn=regrdir00, conf=conf00) as core00:
+                    async with self.getTestCore(dirn=regrdir01, conf=conf01) as core01:
 
                         await core01.sync()
 

--- a/synapse/tests/test_lib_nexus.py
+++ b/synapse/tests/test_lib_nexus.py
@@ -156,7 +156,7 @@ class NexusTest(s_t_utils.SynTest):
     async def test_nexus_migration(self):
         with self.getRegrDir('cortexes', 'reindex-byarray3') as regrdirn:
             slabsize00 = s_common.getDirSize(regrdirn)
-            async with await s_cortex.Cortex.anit(regrdirn) as core00:
+            async with self.getTestCore(dirn=regrdirn) as core00:
                 slabsize01 = s_common.getDirSize(regrdirn)
                 # Ensure that realsize hasn't grown wildly. That would be indicative
                 # of a sparse file copy and not a directory move.

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -481,10 +481,10 @@ class StormSvcTest(s_test.SynTest):
         }
         with self.getTestDir() as dirn:
 
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
                 await core.addStormPkg(pkg)
 
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
                 nodes = await core.nodes('foobar')
                 self.eq(nodes[0].ndef, ('inet:asn', 30))
 
@@ -504,7 +504,7 @@ class StormSvcTest(s_test.SynTest):
                 lurl = f'tcp://127.0.0.1:{port}/real'
                 murl = f'tcp://127.0.0.1:{port}/ncreate'
 
-                async with await s_cortex.Cortex.anit(dirn) as core:
+                async with self.getTestCore(dirn=dirn) as core:
 
                     await core.nodes(f'service.add real {lurl}')
                     await core.nodes(f'service.add ncreate {murl}')
@@ -772,7 +772,7 @@ class StormSvcTest(s_test.SynTest):
     async def test_storm_svc_restarts(self):
 
         with self.getTestDir() as dirn:
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
                 with self.getTestDir() as svcd:
                     async with await ChangingService.anit(svcd) as chng:
                         chng.dmon.share('chng', chng)
@@ -827,7 +827,7 @@ class StormSvcTest(s_test.SynTest):
             # This test verifies that storm commands loaded from a previously connected service are still available,
             # even if the service is not available now
             with self.getLoggerStream('synapse.lib.nexus') as stream:
-                async with await s_cortex.Cortex.anit(dirn) as core:
+                async with self.getTestCore(dirn=dirn) as core:
                     self.nn(core.getStormCmd('newcmd'))
                     self.nn(core.getStormCmd('new.baz'))
                     self.nn(core.getStormCmd('old.bar'))
@@ -904,7 +904,7 @@ class StormSvcTest(s_test.SynTest):
                     url = core00.getLocalUrl()
 
                     conf = {'mirror': url}
-                    async with await s_cortex.Cortex.anit(dirn=path01, conf=conf) as core01:
+                    async with self.getTestCore(dirn=path01, conf=conf) as core01:
 
                         await core01.sync()
 

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -97,8 +97,7 @@ class TrigTest(s_t_utils.SynTest):
 
                 url = core00.getLocalUrl()
                 core01conf = {'mirror': url}
-
-                async with await s_cortex.Cortex.anit(dirn=path01, conf=core01conf) as core01:
+                async with self.getTestCore(dirn=path01, conf=core01conf) as core01:
                     # ensure sync by forcing node construction
                     await core01.nodes('[ou:org=*]')
                     self.nn(await core00.callStorm('return($lib.queue.gen(foo).pop(wait=$lib.true))'))

--- a/synapse/tests/test_model_syn.py
+++ b/synapse/tests/test_model_syn.py
@@ -299,7 +299,7 @@ class SynModelTest(s_t_utils.SynTest):
         # Ensure that the model runts are re-populated after a model load has occurred.
         with self.getTestDir() as dirn:
 
-            async with self.getTestCore(dirn=dirn) as core:
+            async with await s_cortex.Cortex.anit(dirn) as core:
 
                 # Lift nodes
                 nodes = await core.nodes('syn:form=syn:tag')

--- a/synapse/tests/test_model_syn.py
+++ b/synapse/tests/test_model_syn.py
@@ -299,7 +299,7 @@ class SynModelTest(s_t_utils.SynTest):
         # Ensure that the model runts are re-populated after a model load has occurred.
         with self.getTestDir() as dirn:
 
-            async with await s_cortex.Cortex.anit(dirn) as core:
+            async with self.getTestCore(dirn=dirn) as core:
 
                 # Lift nodes
                 nodes = await core.nodes('syn:form=syn:tag')

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -870,15 +870,17 @@ class SynTest(unittest.TestCase):
 
     @contextlib.asynccontextmanager
     async def getRegrCore(self, vers, conf=None):
-        with self.getRegrDir('cortexes', vers) as dirn:
-            async with await s_cortex.Cortex.anit(dirn, conf=conf) as core:
-                yield core
+        with self.withNexusReplay():
+            with self.getRegrDir('cortexes', vers) as dirn:
+                async with await s_cortex.Cortex.anit(dirn, conf=conf) as core:
+                    yield core
 
     @contextlib.asynccontextmanager
     async def getRegrAxon(self, vers, conf=None):
-        with self.getRegrDir('axons', vers) as dirn:
-            async with await s_axon.Axon.anit(dirn, conf=conf) as axon:
-                yield axon
+        with self.withNexusReplay():
+            with self.getRegrDir('axons', vers) as dirn:
+                async with await s_axon.Axon.anit(dirn, conf=conf) as axon:
+                    yield axon
 
     def skipIfNoInternet(self):  # pragma: no cover
         '''
@@ -1200,15 +1202,16 @@ class SynTest(unittest.TestCase):
             conf = {}
         conf = copy.deepcopy(conf)
 
-        if dirn is not None:
-            async with await s_cryotank.CryoCell.anit(dirn, conf=conf) as cryo:
-                yield cryo
+        with self.withNexusReplay():
+            if dirn is not None:
+                async with await s_cryotank.CryoCell.anit(dirn, conf=conf) as cryo:
+                    yield cryo
 
-            return
+                return
 
-        with self.getTestDir() as dirn:
-            async with await s_cryotank.CryoCell.anit(dirn, conf=conf) as cryo:
-                yield cryo
+            with self.getTestDir() as dirn:
+                async with await s_cryotank.CryoCell.anit(dirn, conf=conf) as cryo:
+                    yield cryo
 
     @contextlib.asynccontextmanager
     async def getTestCryoAndProxy(self, dirn=None):

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -946,15 +946,21 @@ class SynTest(unittest.TestCase):
         Returns:
             s_axon.Axon: A Axon object.
         '''
-        if dirn is not None:
-            async with await s_axon.Axon.anit(dirn, conf) as axon:
-                yield axon
 
-            return
+        if conf is None:
+            conf = {}
+        conf = copy.deepcopy(conf)
 
-        with self.getTestDir() as dirn:
-            async with await s_axon.Axon.anit(dirn, conf) as axon:
-                yield axon
+        with self.withNexusReplay():
+            if dirn is not None:
+                async with await s_axon.Axon.anit(dirn, conf) as axon:
+                    yield axon
+
+                return
+
+            with self.getTestDir() as dirn:
+                async with await s_axon.Axon.anit(dirn, conf) as axon:
+                    yield axon
 
     @contextlib.contextmanager
     def withTestCmdr(self, cmdg):
@@ -1165,10 +1171,22 @@ class SynTest(unittest.TestCase):
                 yield core, prox
 
     @contextlib.asynccontextmanager
-    async def getTestJsonStor(self):
-        with self.getTestDir() as dirn:
-            async with await s_jsonstor.JsonStorCell.anit(dirn) as jsonstor:
-                yield jsonstor
+    async def getTestJsonStor(self, dirn=None, conf=None):
+
+        if conf is None:
+            conf = {}
+        conf = copy.deepcopy(conf)
+
+        with self.withNexusReplay():
+            if dirn is not None:
+                async with await s_jsonstor.JsonStorCell.anit(dirn, conf) as jsonstor:
+                    yield jsonstor
+
+                return
+
+            with self.getTestDir() as dirn:
+                async with await s_jsonstor.JsonStorCell.anit(dirn, conf) as jsonstor:
+                    yield jsonstor
 
     @contextlib.asynccontextmanager
     async def getTestCryo(self, dirn=None, conf=None):
@@ -1221,16 +1239,17 @@ class SynTest(unittest.TestCase):
 
         conf = copy.deepcopy(conf)
 
-        if dirn is not None:
+        with self.withNexusReplay():
+            if dirn is not None:
 
-            async with await ctor.anit(dirn, conf=conf) as cell:
-                yield cell
+                async with await ctor.anit(dirn, conf=conf) as cell:
+                    yield cell
 
-            return
+                return
 
-        with self.getTestDir() as dirn:
-            async with await ctor.anit(dirn, conf=conf) as cell:
-                yield cell
+            with self.getTestDir() as dirn:
+                async with await ctor.anit(dirn, conf=conf) as cell:
+                    yield cell
 
     @contextlib.asynccontextmanager
     async def getTestCoreProxSvc(self, ssvc, ssvc_conf=None, core_conf=None):
@@ -1253,13 +1272,19 @@ class SynTest(unittest.TestCase):
 
     @contextlib.asynccontextmanager
     async def getTestAha(self, conf=None, dirn=None):
-        if dirn:
-            async with await s_aha.AhaCell.anit(dirn, conf=conf) as aha:
-                yield aha
-        else:
-            with self.getTestDir() as dirn:
+
+        if conf is None:
+            conf = {}
+        conf = copy.deepcopy(conf)
+
+        with self.withNexusReplay():
+            if dirn:
                 async with await s_aha.AhaCell.anit(dirn, conf=conf) as aha:
                     yield aha
+            else:
+                with self.getTestDir() as dirn:
+                    async with await s_aha.AhaCell.anit(dirn, conf=conf) as aha:
+                        yield aha
 
     @contextlib.asynccontextmanager
     async def getTestAhaProv(self, conf=None, dirn=None):
@@ -1340,13 +1365,13 @@ class SynTest(unittest.TestCase):
         if dirn:
             s_common.yamlsave(conf, dirn, 'cell.yaml')
             async with await ctor.anit(dirn) as svc:
-                self.len(n, await waiter.wait(timeout=12))
+                self.ge(len(await waiter.wait(timeout=12)), n)
                 yield svc
         else:
             with self.getTestDir() as dirn:
                 s_common.yamlsave(conf, dirn, 'cell.yaml')
                 async with await ctor.anit(dirn) as svc:
-                    self.len(n, await waiter.wait(timeout=12))
+                    self.ge(len(await waiter.wait(timeout=12)), n)
                     yield svc
 
     async def addSvcToCore(self, svc, core, svcname='svc'):

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1196,6 +1196,10 @@ class SynTest(unittest.TestCase):
         Returns:
             s_cryotank.CryoCell: Test cryocell.
         '''
+        if conf is None:
+            conf = {}
+        conf = copy.deepcopy(conf)
+
         if dirn is not None:
             async with await s_cryotank.CryoCell.anit(dirn, conf=conf) as cryo:
                 yield cryo


### PR DESCRIPTION
- Add withNexusReplay calls to our SynTest helpers that construct cells which did not previously have that in their call stacks.
- Make SynTest.addSvcToAha more robust when used with the nexus double apply patch.
- Fix bug with JsonStor `q:puts` message being double applied.
- Replace most direct cell construction in unit tests with test helpers, to ensure more coverage is available for withNexusReplay.
- Make master and tag build replay tests run the entire test suite as opposed to a subset of tests. Move nightly replay tests to weekly tests.