### PR TITLE
Stormpkg improvements (SYN-4396, SYN-4395)

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2109,7 +2109,7 @@ class Cortex(s_cell.Cell):  # type: ignore
         await self.feedBeholder('pkg:del', {'name': name}, gates=gates, perms=perms)
 
     async def getStormPkg(self, name):
-        return self.stormpkgs.get(name)
+        return copy.deepcopy(self.stormpkgs.get(name))
 
     async def getStormPkgs(self):
         return list(self.pkghive.values())
@@ -2318,9 +2318,13 @@ class Cortex(s_cell.Cell):  # type: ignore
             async def _onload():
                 try:
                     async for mesg in self.storm(onload):
-                        if mesg[0] in ('print', 'warn'):
-                            logger.warning(f'onload output: {mesg}')
-                            await asyncio.sleep(0)
+                        if mesg[0] == 'print':
+                            logger.info(f'{name} onload output: {mesg[1].get("mesg")}')
+                        if mesg[0] == 'warn':
+                            logger.warning(f'{name} onload output: {mesg[1].get("mesg")}')
+                        if mesg[0] == 'err':
+                            logger.error(f'{name} onload output: {mesg[1]}')
+                        await asyncio.sleep(0)
                 except asyncio.CancelledError:  # pragma: no cover
                     raise
                 except Exception:  # pragma: no cover

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2112,7 +2112,7 @@ class Cortex(s_cell.Cell):  # type: ignore
         return copy.deepcopy(self.stormpkgs.get(name))
 
     async def getStormPkgs(self):
-        return list(self.pkghive.values())
+        return copy.deepcopy(list(self.pkghive.values()))
 
     async def getStormMods(self):
         return self.stormmods

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1788,7 +1788,7 @@ class StormTest(s_t_utils.SynTest):
                     'storm': 'function x() { return((0)) }',
                 },
             ),
-            'onload': f'[ ps:contact={cont} ] $lib.print(teststring) return($path.vars.newp)'
+            'onload': f'[ ps:contact={cont} ] $lib.print(teststring) $lib.warn(testwarn, key=valu) return($path.vars.newp)'
         }
         class PkgHandler(s_httpapi.Handler):
 
@@ -1816,15 +1816,18 @@ class StormTest(s_t_utils.SynTest):
             msgs = await core.stormlist(f'pkg.load --ssl-noverify https://127.0.0.1:{port}/api/v1/pkgtest/notok')
             self.stormIsInWarn('pkg.load got JSON error: FooBar', msgs)
 
-            with self.getAsyncLoggerStream('synapse.cortex',
-                                      "{'mesg': 'teststring'}") as stream:
+            with self.getAsyncLoggerStream('synapse.cortex') as stream:
                 msgs = await core.stormlist(f'pkg.load --ssl-noverify https://127.0.0.1:{port}/api/v1/pkgtest/yep')
                 self.stormIsInPrint('testload @0.3.0', msgs)
 
                 msgs = await core.stormlist(f'pkg.load --ssl-noverify --raw https://127.0.0.1:{port}/api/v1/pkgtestraw/yep')
                 self.stormIsInPrint('testload @0.3.0', msgs)
-                self.true(await stream.wait(6))
 
+            stream.seek(0)
+            buf = stream.read()
+            self.isin("testload onload output: teststring", buf)
+            self.isin("testload onload output: testwarn", buf)
+            self.isin("No var with name: newp", buf)
             self.len(1, await core.nodes(f'ps:contact={cont}'))
 
     async def test_storm_tree(self):


### PR DESCRIPTION
- Make Core.getStormPkg and getStormPkgs return pkg definitions which are copies of the stored packages (SYN-4396)
- Ensure print/warn/err messages are all printed in onload handler with their pkgname (SYN-4395)