### PR TITLE
test_stormlib_crypto_hmac test stability

### DIFF
--- a/synapse/tests/test_lib_stormlib_hashes.py
+++ b/synapse/tests/test_lib_stormlib_hashes.py
@@ -74,7 +74,7 @@ class CryptoHashesTest(s_test.SynTest):
 
             # A few sad paths
             # bad mode
-            mode = 'md4'
+            mode = 'newp'
             opts = {'vars': {'key': key, 'mesg': data, 'mode': mode}}
             with self.raises(s_exc.BadArg):
                 await core.callStorm(q, opts=opts)


### PR DESCRIPTION
Update test_stormlib_crypto_hmac to be stable across additional environments with different openssl bindings.