### PR TITLE
Genpkg / rapid powerup fixes (SYN-4492, SYN-4493)

### DIFF
--- a/docs/synapse/devguides/power-ups.rst
+++ b/docs/synapse/devguides/power-ups.rst
@@ -76,7 +76,7 @@ the **Storm Package** YAML file to locate their contents::
 
         modules/
             acme.hello.storm
-            acme.privsep.storm
+            acme.hello.privsep.storm
 
         commands/
             acme.hello.sayhi.storm

--- a/synapse/tests/test_tools_genpkg.py
+++ b/synapse/tests/test_tools_genpkg.py
@@ -41,6 +41,10 @@ class GenPkgTest(s_test.SynTest):
             ymlpath = s_common.genpath(dirname, 'files', 'stormpkg', 'nosuchfile.yaml')
             await s_genpkg.main((ymlpath,))
 
+        with self.raises(s_exc.NoSuchFile):
+            ymlpath = s_common.genpath(dirname, 'files', 'stormpkg', 'newpfile.yaml')
+            await s_genpkg.main((ymlpath,))
+
         with self.raises(s_exc.BadPkgDef):
             ymlpath = s_common.genpath(dirname, 'files', 'stormpkg', 'nopath.yaml')
             await s_genpkg.main((ymlpath,))

--- a/synapse/tools/genpkg.py
+++ b/synapse/tools/genpkg.py
@@ -106,6 +106,8 @@ def loadPkgProto(path, opticdir=None, no_docs=False, readonly=False):
 
     full = s_common.genpath(path)
     pkgdef = s_common.yamlload(full)
+    if pkgdef is None:
+        raise s_exc.NoSuchFile(mesg=f'File {full} does not exist or is empty.', path=full)
 
     version = pkgdef.get('version')
     if isinstance(version, (tuple, list)):


### PR DESCRIPTION
- genpkg raise error with nonexistent path
- fix powerup directory example 