### PR TITLE
inet model bugfixes (SYN-4552, SYN-4561)

### DIFF
--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -192,11 +192,11 @@ class DnsModule(s_module.CoreModule):
                 )),
 
                 ('inet:dns:soa', {}, (
-                    ('fqdn', ('inet:fqdn', {}), {'ro': True,
+                    ('fqdn', ('inet:fqdn', {}), {
                          'doc': 'The domain queried for its SOA record.'}),
-                    ('ns', ('inet:fqdn', {}), {'ro': True,
+                    ('ns', ('inet:fqdn', {}), {
                          'doc': 'The domain (MNAME) returned in the SOA record.'}),
-                    ('email', ('inet:email', {}), {'ro': True,
+                    ('email', ('inet:email', {}), {
                          'doc': 'The email address (RNAME) returned in the SOA record.'}),
                 )),
 

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -199,7 +199,7 @@ class Email(s_types.Str):
         try:
             user, fqdn = valu.split('@', 1)
         except ValueError:
-            mesg = f'Cannot split the email user and fqdn for "{valu}"'
+            mesg = f'Email address expected in <user>@<fqdn> format, got "{valu}"'
             raise s_exc.BadTypeValu(valu=valu, name=self.name, mesg=mesg) from None
 
         try:

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -198,7 +198,11 @@ class Email(s_types.Str):
 
         try:
             user, fqdn = valu.split('@', 1)
+        except ValueError:
+            mesg = f'Cannot split the email user and fqdn for "{valu}"'
+            raise s_exc.BadTypeValu(valu=valu, name=self.name, mesg=mesg) from None
 
+        try:
             fqdnnorm, fqdninfo = self.modl.type('inet:fqdn').norm(fqdn)
             usernorm, userinfo = self.modl.type('inet:user').norm(user)
         except Exception as e:

--- a/synapse/tests/test_lib_snap.py
+++ b/synapse/tests/test_lib_snap.py
@@ -577,7 +577,7 @@ class SnapTest(s_t_utils.SynTest):
 
             self.len(1, await core.nodes('media:news -(pwns)> *'))
 
-            self.len(1, await core.nodes('[ inet:dns:soa=(lol,) :fqdn=vertex.link ]'))
-            self.len(1, await core.nodes('inet:dns:soa=(lol,) [ :fqdn=vertex.link ]'))
+            self.len(1, await core.nodes('[ test:ro=foo :writeable=hehe :readable=haha ]'))
+            self.len(1, await core.nodes('test:ro=foo [ :readable = haha ]'))
             with self.raises(s_exc.ReadOnlyProp):
-                await core.nodes('inet:dns:soa=(lol,) [ :fqdn=woot.com ]')
+                await core.nodes('test:ro=foo [ :readable=newp ]')

--- a/synapse/tests/test_model_dns.py
+++ b/synapse/tests/test_model_dns.py
@@ -237,6 +237,14 @@ class DnsModelTest(s_t_utils.SynTest):
                 self.eq(node.get('email'), 'pennywise@vertex.link')
                 self.eq(node.get('ns'), 'ns1.vertex.link')
 
+                # inet:dns:soa properties which previously were RO are now writeable
+                await node.set('ns', 'ns2.vertex.link')
+                await node.set('fqdn', 'hehe.vertex.link')
+                await node.set('email', 'bobgrey@vertex.link')
+                self.eq(node.get('ns'), 'ns2.vertex.link')
+                self.eq(node.get('fqdn'), 'hehe.vertex.link')
+                self.eq(node.get('email'), 'bobgrey@vertex.link')
+
                 # inet:dns:txt
                 node = await snap.addNode('inet:dns:txt', ('clowns.vertex.link', 'we all float down here'))
                 self.eq(node.ndef[1], ('clowns.vertex.link', 'we all float down here'))

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -385,6 +385,14 @@ class InetModelTest(s_t_utils.SynTest):
 
             valu = t.norm('bob\udcfesmith@woot.com')[0]
 
+            with self.raises(s_exc.BadTypeValu) as cm:
+                t.norm('hehe')
+            self.isin('Cannot split the email user and fqdn', cm.exception.get('mesg'))
+
+            with self.raises(s_exc.BadTypeValu) as cm:
+                t.norm('hehe@1.2.3.4')
+            self.isin('FQDN Got an IP address instead', cm.exception.get('mesg'))
+
             # Form Tests ======================================================
             valu = 'UnitTest@Vertex.link'
             expected_ndef = (formname, valu.lower())

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -387,7 +387,7 @@ class InetModelTest(s_t_utils.SynTest):
 
             with self.raises(s_exc.BadTypeValu) as cm:
                 t.norm('hehe')
-            self.isin('Cannot split the email user and fqdn', cm.exception.get('mesg'))
+            self.isin('Email address expected in <user>@<fqdn> format', cm.exception.get('mesg'))
 
             with self.raises(s_exc.BadTypeValu) as cm:
                 t.norm('hehe@1.2.3.4')

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -193,6 +193,7 @@ testmodel = {
 
         ('test:ival', ('ival', {}), {}),
 
+        ('test:ro', ('str', {}), {}),
         ('test:int', ('int', {}), {}),
         ('test:float', ('float', {}), {}),
         ('test:str', ('str', {}), {}),
@@ -361,6 +362,11 @@ testmodel = {
             ('lulz', ('str', {}), {}),
             ('newp', ('str', {}), {'doc': 'A stray property we never use in nodes.'}),
         )),
+
+        ('test:ro', {}, (
+            ('writeable', ('str', {}), {'doc': 'writeable property'}),
+            ('readable', ('str', {}), {'doc': 'ro property', 'ro': True}),
+        ))
 
     ),
 }


### PR DESCRIPTION
- `inet:dns:soa` properties are now writable.
- `inet:email` norm now catches a python ValueError during splitting and raises a BadTypeValu directly when that happens.