### PR TITLE
Fix macro creator when creating macros (SYN-4668)

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1357,7 +1357,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         user.confirm(('storm', 'macro', 'add'), default=True)
 
-        mdef = self._initStormMacro(mdef)
+        mdef = self._initStormMacro(mdef, user=user)
 
         reqValidStormMacro(mdef)
 

--- a/synapse/tests/test_lib_stormlib_macro.py
+++ b/synapse/tests/test_lib_stormlib_macro.py
@@ -246,12 +246,17 @@ class MacroTest(s_test.SynTest):
 
             self.none(await core.callStorm('return($lib.macro.get(bar))'))
 
+            # Non-admin can create / delete their own macro
             msgs = await core.stormlist('macro.set vmac { $lib.print(woot) }', opts=asvisi)
             self.stormIsInPrint('Set macro: vmac', msgs)
 
             mdef = await core.callStorm('return( $lib.macro.get(vmac) )')
             self.eq(mdef.get('creator'), visi.iden)
 
+            await core.callStorm('return ( $lib.macro.del(vmac) )', opts=asvisi)
+            self.none(await core.callStorm('return( $lib.macro.get(vmac) )', opts=asvisi))
+
+            # Invalid macro names
             opts = {'vars': {'aaaa': 'A' * 512}}
             msgs = await core.stormlist('macro.set $aaaa {$lib.print(hi)}', opts=opts)
             self.stormIsInErr('Macro names may only be up to 491 chars.', msgs)

--- a/synapse/tests/test_lib_stormlib_macro.py
+++ b/synapse/tests/test_lib_stormlib_macro.py
@@ -148,6 +148,9 @@ class MacroTest(s_test.SynTest):
             msgs = await core.stormlist('macro.set foo {$lib.print(woot)}')
             self.stormHasNoWarnErr(msgs)
 
+            mdef = await core.callStorm('return( $lib.macro.get(foo) )')
+            self.eq(mdef.get('creator'), core.auth.rootuser.iden)
+
             msgs = await core.stormlist('macro.list', opts=asvisi)
             self.stormIsInPrint('foo', msgs)
 
@@ -242,6 +245,12 @@ class MacroTest(s_test.SynTest):
             self.stormHasNoWarnErr(msgs)
 
             self.none(await core.callStorm('return($lib.macro.get(bar))'))
+
+            msgs = await core.stormlist('macro.set vmac { $lib.print(woot) }', opts=asvisi)
+            self.stormIsInPrint('Set macro: vmac', msgs)
+
+            mdef = await core.callStorm('return( $lib.macro.get(vmac) )')
+            self.eq(mdef.get('creator'), visi.iden)
 
             opts = {'vars': {'aaaa': 'A' * 512}}
             msgs = await core.stormlist('macro.set $aaaa {$lib.print(hi)}', opts=opts)


### PR DESCRIPTION
- Add a missing user argument to the _initStormMacro in Cortex.addStormMacro
- Add test for non-admin user creating / deleting their own macro