### PR TITLE
Remove x-xss-protection header from default headers in httpapi (SYN-4641)

### DIFF
--- a/synapse/lib/httpapi.py
+++ b/synapse/lib/httpapi.py
@@ -80,7 +80,6 @@ class HandlerBase:
     def set_default_headers(self):
 
         self.clear_header('Server')
-        self.add_header('X-XSS-Protection', '1; mode=block')
         self.add_header('X-Content-Type-Options', 'nosniff')
 
         origin = self.request.headers.get('origin')

--- a/synapse/tests/test_lib_httpapi.py
+++ b/synapse/tests/test_lib_httpapi.py
@@ -1461,7 +1461,6 @@ class HttpApiTest(s_tests.SynTest):
                     result = await resp.json()
                     self.eq(result.get('status'), 'ok')
                     self.true(result['result']['active'])
-                    self.eq('1; mode=block', resp.headers.get('x-xss-protection'))
                     self.eq('nosniff', resp.headers.get('x-content-type-options'))
 
             await root.setPasswd('secret')


### PR DESCRIPTION
The x-xss-protection header is not supported by most browsers and is a non-standard header ( see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection ). This can be added to a service with the ``https:headers`` if a user needs it for a given deployment.