### PR TITLE
Axon and Storm wget improvements (SYN-4675)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,25 +12,25 @@ Features and Enhancements
 - Add ``synapse.utils.stormcov``, a Coverage.py plugin for measuring code
   coverage of Storm files.
   (`#2961 <https://github.com/vertexproject/synapse/pull/2961>`_)
-- The ``Axon.wget()`` API node includes HTTP request history, which is added
-  when the API encounters redirects. The ``$lib.axon.wget()`` Storm API now
-  includes information about the original request URL. This data is now used
-  to create ``inet:urlredir`` nodes, such as when the Storm ``wget`` command
-  is used to retreive a file.
+- The ``Axon.wget()`` API response now includes HTTP request history, which is
+  added when the API request encounters redirects. The ``$lib.axon.wget()``
+  Storm API now includes information about the original request URL. This data
+  is now used to create ``inet:urlredir`` nodes, such as when the Storm
+  ``wget`` command is used to retrieve a file.
   (`#3011 <https://github.com/vertexproject/synapse/pull/3011>`_)
 
 Bugfixes
 --------
 - The Storm ``wget`` command created ``inet:urlfile`` nodes with the ``url``
   property of the resolved URL from ``aiohttp``. This made it so that a user
-  could not pivot from a ``inet:url`` node which had an URL encoded  parameter
+  could not pivot from an ``inet:url`` node which had a URL encoded parameter
   string to the resulting ``inet:urlfile`` node. The ``inet:urlfile`` nodes
   are now made with the original request URL to allow that pivoting to occur.
   (`#3011 <https://github.com/vertexproject/synapse/pull/3011>`_)
 - The ``Axon.wget()`` and ``$lib.axon.wget()`` APIs returned URLs in the
-  ``url`` field of their responses which did contain fragment identifiers.
-  These API responses now include the fragment identifier if it was present
-  in the resolved URL.
+  ``url`` field of their responses which did not contain fragment identifiers.
+  These API responses now include the fragment identifier if it was present in
+  the resolved URL.
   (`#3011 <https://github.com/vertexproject/synapse/pull/3011>`_)
 - The Storm ``tree`` command did not properly handle Storm query arguments
   which were declared as ``storm:query`` types.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,10 +9,21 @@ NEXTVERS - YYYY-MM-DD
 
 Features and Enhancements
 -------------------------
-- TBD
+- The ``Axon.wget()`` and ``$lib.axon.wget()`` APIs now include information
+  about the original request and URL redirect history in their response data.
+  The Storm ``wget`` command now creates ``inet:urlredir`` nodes based on the
+  redirect history when that is present.
+  (`#3011 <https://github.com/vertexproject/synapse/pull/3011>`_)
 
 Bugfixes
 --------
+- The Storm ``wget`` command created ``inet:urlfile`` nodes with the ``url``
+  property of the resolved URL from ``aiohttp``. This broke made it so that
+  a user could not pivot from a ``inet:url`` node which had a URL encoded
+  parameter strin to the resulting ``inet:urlfile`` node. The
+  ``inet:urlfile`` nodes are now made with the original request URL to allow
+  that pivoting to occur.
+  (`#3011 <https://github.com/vertexproject/synapse/pull/3011>`_)
 - The Storm ``tree`` command did not properly handle Storm query arguments
   which were declared as ``storm:query`` types.
   (`#3012 <https://github.com/vertexproject/synapse/pull/3012>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,20 +9,25 @@ NEXTVERS - YYYY-MM-DD
 
 Features and Enhancements
 -------------------------
-- The ``Axon.wget()`` and ``$lib.axon.wget()`` APIs now include information
-  about the original request and URL redirect history in their response data.
-  The Storm ``wget`` command now creates ``inet:urlredir`` nodes based on the
-  redirect history when that is present.
+- The ``Axon.wget()`` API node includes HTTP request history, which is added
+  when the API encounters redirects. The ``$lib.axon.wget()`` Storm API now
+  includes information about the original request URL. This data is now used
+  to create ``inet:urlredir`` nodes, such as when the Storm ``wget`` command
+  is used to retreive a file.
   (`#3011 <https://github.com/vertexproject/synapse/pull/3011>`_)
 
 Bugfixes
 --------
 - The Storm ``wget`` command created ``inet:urlfile`` nodes with the ``url``
-  property of the resolved URL from ``aiohttp``. This broke made it so that
-  a user could not pivot from a ``inet:url`` node which had a URL encoded
-  parameter strin to the resulting ``inet:urlfile`` node. The
-  ``inet:urlfile`` nodes are now made with the original request URL to allow
-  that pivoting to occur.
+  property of the resolved URL from ``aiohttp``. This made it so that a user
+  could not pivot from a ``inet:url`` node which had an URL encoded  parameter
+  string to the resulting ``inet:urlfile`` node. The ``inet:urlfile`` nodes
+  are now made with the original request URL to allow that pivoting to occur.
+  (`#3011 <https://github.com/vertexproject/synapse/pull/3011>`_)
+- The ``Axon.wget()`` and ``$lib.axon.wget()`` APIs returned URLs in the
+  ``url`` field of their responses which did contain fragment identifiers.
+  These API responses now include the fragment identifier if it was present
+  in the resolved URL.
   (`#3011 <https://github.com/vertexproject/synapse/pull/3011>`_)
 - The Storm ``tree`` command did not properly handle Storm query arguments
   which were declared as ``storm:query`` types.

--- a/docs/synapse/httpapi.rst
+++ b/docs/synapse/httpapi.rst
@@ -85,7 +85,7 @@ Both of the Python examples use session managers which manage the session cookie
 
         url = 'https://localhost:4443/api/v1/login'
         info = {'user': 'visi', 'passwd': 'secret'}
-        resp = sess.post(url, json=info)
+        resp = sess.post(url, json=info, verify=ssl)
         item = resp.json()
 
         if item.get('status') != 'ok':

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -611,7 +611,7 @@ class AxonApi(s_cell.CellApi, s_share.Share):  # type: ignore
 
                 {
                     'ok': <boolean> - False if there were exceptions retrieving the URL.
-                    'url': <str> - The URL retrieved (which could have been redirected)
+                    'url': <str> - The URL retrieved (which could have been redirected). This is a url-decoded string.
                     'code': <int> - The response code.
                     'mesg': <str> - An error message if there was an exception when retrieving the URL.
                     'headers': <dict> - The response headers as a dictionary.
@@ -621,7 +621,13 @@ class AxonApi(s_cell.CellApi, s_share.Share):  # type: ignore
                         'sha1': <str> - The SHA1 hash of the response body.
                         'sha256': <str> - The SHA256 hash of the response body.
                         'sha512': <str> - The SHA512 hash of the response body.
+                    },
+                    'request': {
+                        'url': The request URL. This is a url-decoded string.
+                        'headers': The request headers.
+                        'method': The request method.
                     }
+                    'history': A sequence of response bodies to track any redirects, not including hashes.
                 }
 
         Returns:
@@ -1574,6 +1580,47 @@ class Axon(s_cell.Cell):
                     'mesg': mesg,
                 }
 
+    async def _flatten_clientresponse(self,
+                                      resp: aiohttp.ClientResponse,
+                                      toplevel=True,
+                                      ) -> dict:
+        info = {
+            'ok': True,
+            'url': str(resp.url),
+            'code': resp.status,
+            'headers': dict(resp.headers),
+            'request': {
+                'url': str(resp.request_info.url),
+                'headers': dict(resp.request_info.headers),
+                'method': str(resp.request_info.method),
+            }
+        }
+
+        hashset = s_hashset.HashSet()
+
+        if toplevel:
+            async with await self.upload() as upload:
+                async for byts in resp.content.iter_chunked(CHUNK_SIZE):
+                    await upload.write(byts)
+                    hashset.update(byts)
+
+                size, _ = await upload.save()
+
+            info['size'] = size
+            info['hashes'] = dict([(n, s_common.ehex(h)) for (n, h) in hashset.digests()])
+
+        info['request'] = {
+            'url': str(resp.request_info.url),
+            'real_url': str(resp.request_info.real_url),
+            'headers': dict(resp.request_info.headers),
+            'method': str(resp.request_info.method),
+        }
+
+        if toplevel and resp.history:
+            info['history'] = [await self._flatten_clientresponse(hist, toplevel=False) for hist in resp.history]
+
+        return info
+
     async def wget(self, url, params=None, headers=None, json=None, body=None, method='GET', ssl=True, timeout=None, proxy=None):
         '''
         Stream a file download directly into the Axon.
@@ -1597,7 +1644,7 @@ class Axon(s_cell.Cell):
 
                 {
                     'ok': <boolean> - False if there were exceptions retrieving the URL.
-                    'url': <str> - The URL retrieved (which could have been redirected)
+                    'url': <str> - The URL retrieved (which could have been redirected). This is a url-decoded string.
                     'code': <int> - The response code.
                     'mesg': <str> - An error message if there was an exception when retrieving the URL.
                     'headers': <dict> - The response headers as a dictionary.
@@ -1607,7 +1654,13 @@ class Axon(s_cell.Cell):
                         'sha1': <str> - The SHA1 hash of the response body.
                         'sha256': <str> - The SHA256 hash of the response body.
                         'sha512': <str> - The SHA512 hash of the response body.
+                    },
+                    'request': {
+                        'url': The request URL. This is a url-decoded string.
+                        'headers': The request headers.
+                        'method': The request method.
                     }
+                    'history': A sequence of response bodies to track any redirects, not including hashes.
                 }
 
         Returns:
@@ -1637,30 +1690,8 @@ class Axon(s_cell.Cell):
         async with aiohttp.ClientSession(connector=connector, timeout=atimeout) as sess:
 
             try:
-
                 async with sess.request(method, url, headers=headers, params=params, json=json, data=body, ssl=ssl) as resp:
-
-                    info = {
-                        'ok': True,
-                        'url': str(resp.url),
-                        'code': resp.status,
-                        'headers': dict(resp.headers),
-                    }
-
-                    hashset = s_hashset.HashSet()
-
-                    async with await self.upload() as upload:
-
-                        async for byts in resp.content.iter_chunked(CHUNK_SIZE):
-                            await upload.write(byts)
-                            hashset.update(byts)
-
-                        size, _ = await upload.save()
-
-                    info['size'] = size
-                    info['hashes'] = dict([(n, s_common.ehex(h)) for (n, h) in hashset.digests()])
-
-                    return info
+                    return await self._flatten_clientresponse(resp)
 
             except asyncio.CancelledError:
                 raise

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -2066,8 +2066,7 @@ class LibAxon(Lib):
 
         now = self.runt.model.type('time').norm('now')[0]
 
-        # Account for older axon implementations
-        original_url = resp.get('original_url', resp.get('url'))
+        original_url = resp.get('original_url')
         hashes = resp.get('hashes')
         sha256 = hashes.get('sha256')
         props = {

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -2016,8 +2016,10 @@ class LibAxon(Lib):
             kwargs['proxy'] = proxy
 
         axon = self.runt.snap.core.axon
-        return await axon.wget(url, headers=headers, params=params, method=method, ssl=ssl, body=body, json=json,
+        resp = await axon.wget(url, headers=headers, params=params, method=method, ssl=ssl, body=body, json=json,
                                timeout=timeout, **kwargs)
+        resp['original_url'] = url
+        return resp
 
     async def wput(self, sha256, url, headers=None, params=None, method='PUT', ssl=True, timeout=None, proxy=None):
 
@@ -2062,27 +2064,53 @@ class LibAxon(Lib):
             await self.runt.warn(mesg, log=False)
             return
 
-        url = resp.get('url')
+        now = self.runt.model.type('time').norm('now')[0]
+
+        # Account for older axon implementations
+        original_url = resp.get('original_url', resp.get('url'))
         hashes = resp.get('hashes')
+        sha256 = hashes.get('sha256')
         props = {
             'size': resp.get('size'),
             'md5': hashes.get('md5'),
             'sha1': hashes.get('sha1'),
-            'sha256': hashes.get('sha256'),
-            '.seen': 'now',
+            'sha256': sha256,
+            '.seen': now,
         }
 
-        sha256 = hashes.get('sha256')
         filenode = await self.runt.snap.addNode('file:bytes', sha256, props=props)
 
         if not filenode.get('name'):
-            info = s_urlhelp.chopurl(url)
+            info = s_urlhelp.chopurl(original_url)
             base = info.get('path').strip('/').split('/')[-1]
             if base:
                 await filenode.set('name', base)
 
-        props = {'.seen': 'now'}
-        urlfile = await self.runt.snap.addNode('inet:urlfile', (url, sha256), props=props)
+        props = {'.seen': now}
+        urlfile = await self.runt.snap.addNode('inet:urlfile', (original_url, sha256), props=props)
+
+        history = resp.get('history')
+        if history is not None:
+            redirs = []
+            src = original_url
+
+            # We skip the first entry in history, since that URL is the original URL
+            # having been redirected. The second+ history item represents the
+            # requested URL. We then capture the last part of the chain in our list.
+            # The recorded URLs after the original_url are all the resolved URLS,
+            # since Location headers may be partial paths and this avoids needing to
+            # do url introspection that has already been done by the Axon.
+
+            for info in history[1:]:
+                url = info.get('url')
+                redirs.append((src, url))
+                src = url
+
+            redirs.append((src, resp.get('url')))
+
+            for valu in redirs:
+                props = {'.seen': now}
+                await self.runt.snap.addNode('inet:urlredir', valu, props=props)
 
         return urlfile
 

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -251,31 +251,31 @@ class DnsModule(s_module.CoreModule):
                     ('ttl', ('int', {}), {}),
                     ('request', ('inet:dns:request', {}), {}),
 
-                    ('a', ('inet:dns:a', {}), {'ro': True,
+                    ('a', ('inet:dns:a', {}), {
                         'doc': 'The DNS A record returned by the lookup.',
                     }),
-                    ('ns', ('inet:dns:ns', {}), {'ro': True,
+                    ('ns', ('inet:dns:ns', {}), {
                         'doc': 'The DNS NS record returned by the lookup.',
                     }),
-                    ('rev', ('inet:dns:rev', {}), {'ro': True,
+                    ('rev', ('inet:dns:rev', {}), {
                         'doc': 'The DNS PTR record returned by the lookup.',
                     }),
-                    ('aaaa', ('inet:dns:aaaa', {}), {'ro': True,
+                    ('aaaa', ('inet:dns:aaaa', {}), {
                         'doc': 'The DNS AAAA record returned by the lookup.',
                     }),
-                    ('rev6', ('inet:dns:rev6', {}), {'ro': True,
+                    ('rev6', ('inet:dns:rev6', {}), {
                         'doc': 'The DNS PTR record returned by the lookup of an IPv6 address.',
                     }),
-                    ('cname', ('inet:dns:cname', {}), {'ro': True,
+                    ('cname', ('inet:dns:cname', {}), {
                         'doc': 'The DNS CNAME record returned by the lookup.',
                     }),
-                    ('mx', ('inet:dns:mx', {}), {'ro': True,
+                    ('mx', ('inet:dns:mx', {}), {
                         'doc': 'The DNS MX record returned by the lookup.',
                     }),
-                    ('soa', ('inet:dns:soa', {}), {'ro': True,
+                    ('soa', ('inet:dns:soa', {}), {
                         'doc': 'The domain queried for its SOA record.',
                     }),
-                    ('txt', ('inet:dns:txt', {}), {'ro': True,
+                    ('txt', ('inet:dns:txt', {}), {
                         'doc': 'The DNS TXT record returned by the lookup.',
                     }),
                 )),

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -2,6 +2,7 @@ import json
 import asyncio
 import datetime
 import itertools
+import urllib.parse as u_parse
 
 import synapse.exc as s_exc
 import synapse.common as s_common
@@ -1723,6 +1724,32 @@ class StormTest(s_t_utils.SynTest):
             resp = await _getRespFromSha(core, mesgs)
             data = resp.get('result')
             self.eq(data.get('params'), {'key': ('valu',), 'foo': ('bar',)})
+
+            # URL encoded data plays nicely
+            params = (('foo', 'bar'), ('baz', 'faz'))
+            url = f'https://root:root@127.0.0.1:{port}/api/v0/test?{u_parse.urlencode(params)}'
+            q = '[inet:url=$url] | wget --no-ssl-verify | -> *'
+            msgs = await core.stormlist(q, opts={'vars': {'url': url}})
+            podes = [m[1] for m in msgs if m[0] == 'node']
+            self.isin(('inet:url', url), [pode[0] for pode in podes])
+
+            # Redirects still record the destination address
+            durl = f'https://127.0.0.1:{port}/api/v1/active'
+            params = (('redirect', durl),)
+            url = f'https://127.0.0.1:{port}/api/v0/test?{u_parse.urlencode(params)}'
+            # Redirect again...
+            url = f'https://127.0.0.1:{port}/api/v0/test?{u_parse.urlencode((("redirect", url),))}'
+
+            q = '[inet:url=$url] | wget --no-ssl-verify | -> *'
+            msgs = await core.stormlist(q, opts={'vars': {'url': url}})
+            podes = [m[1] for m in msgs if m[0] == 'node']
+            self.isin(('inet:url', url), [pode[0] for pode in podes])
+
+            # $lib.axon.urlfile makes redirect nodes for the chain, starting from
+            # the original request URL to the final URL
+            q = 'inet:url=$url -> inet:urlredir | tree { :dst -> inet:urlredir:src }'
+            nodes = await core.nodes(q, opts={'vars': {'url': url}})
+            self.len(2, nodes)
 
     async def test_storm_vars_fini(self):
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1725,6 +1725,13 @@ class StormTest(s_t_utils.SynTest):
             data = resp.get('result')
             self.eq(data.get('params'), {'key': ('valu',), 'foo': ('bar',)})
 
+            # URL fragments are preserved.
+            url = f'https://root:root@127.0.0.1:{port}/api/v0/test#fragmented-bits'
+            q = '[inet:url=$url] | wget --no-ssl-verify | -> *'
+            msgs = await core.stormlist(q, opts={'vars': {'url': url}})
+            podes = [m[1] for m in msgs if m[0] == 'node']
+            self.isin(('inet:url', url), [pode[0] for pode in podes])
+
             # URL encoded data plays nicely
             params = (('foo', 'bar'), ('baz', 'faz'))
             url = f'https://root:root@127.0.0.1:{port}/api/v0/test?{u_parse.urlencode(params)}'

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1733,7 +1733,7 @@ class StormTest(s_t_utils.SynTest):
             podes = [m[1] for m in msgs if m[0] == 'node']
             self.isin(('inet:url', url), [pode[0] for pode in podes])
 
-            # Redirects still record the destination address
+            # Redirects still record the original address
             durl = f'https://127.0.0.1:{port}/api/v1/active'
             params = (('redirect', durl),)
             url = f'https://127.0.0.1:{port}/api/v0/test?{u_parse.urlencode(params)}'

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1327,10 +1327,10 @@ class StormTest(s_t_utils.SynTest):
             newn = await core.nodes('ou:name=readonly2', opts=altview)
             self.eq(oldn[0].props['.created'], newn[0].props['.created'])
 
-            await core.nodes('[ inet:dns:answer=(bad,) :a=(vertex.link, 1.2.3.4) ]', opts=altview)
-            await core.nodes('[ inet:dns:answer=(bad,) :a=(vertex.link, 5.6.7.8) ]')
+            await core.nodes('[ test:ro=bad :readable=foo ]', opts=altview)
+            await core.nodes('[ test:ro=bad :readable=bar ]')
 
-            msgs = await core.stormlist('inet:dns:answer | merge', opts=altview)
+            msgs = await core.stormlist('test:ro | merge', opts=altview)
             self.stormIsInWarn("Cannot merge read only property with conflicting value", msgs)
 
     async def test_storm_merge_opts(self):

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -708,6 +708,12 @@ class HttpReflector(s_httpapi.Handler):
             sleep = int(sleep[0])
             await asyncio.sleep(sleep)
 
+        redirect = params.get('redirect')
+        if redirect:
+            self.add_header('Redirected', '1')
+            self.redirect(redirect[0])
+            return
+
         self.sendRestRetn(resp)
 
     async def post(self):


### PR DESCRIPTION
- Axon.wget() now includes the request and redirect history information
- $lib.axon.wget now includes the original URL in its response
- Storm wget / $lib.axon.urlfile now makes inet:urlfile nodes based on the original request URL to preserve pivoting 1:1 from a URL to the urlfile node.
- Storm wget / $lib.axon.urlfile now makes inet:urlredir nodes based on the redirect history information. The first node in the chain uses the original request url to preserve pivoting 1:1 from the url to the redirection chain.
