### PR TITLE
synapse.lib.scope updates

### DIFF
--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -465,7 +465,7 @@ class Base:
 
         task = self.loop.create_task(coro)
 
-        s_scope.copy(task)
+        s_scope.clone(task)
 
         # In rare cases, (Like this function being triggered from call_soon_threadsafe), there's no task context
         if asyncio.current_task():

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -16,6 +16,7 @@ import synapse.exc as s_exc
 import synapse.glob as s_glob
 
 import synapse.lib.coro as s_coro
+import synapse.lib.scope as s_scope
 
 logger = logging.getLogger(__name__)
 
@@ -444,8 +445,12 @@ class Base:
         Schedules a free-running coroutine to run on this base's event loop.  Kills the coroutine if Base is fini'd.
         It does not pend on coroutine completion.
 
-        Precondition:
-            This function is *not* threadsafe and must be run on the Base's event loop
+        Args:
+            coro: The coroutine to schedule.
+
+        Notes:
+            This function is *not* threadsafe and must be run on the Base's event loop.
+            Tasks created by this function do inherit the synapse.lib.scope Scope from the current task.
 
         Returns:
             asyncio.Task: An asyncio.Task object.
@@ -459,6 +464,8 @@ class Base:
             assert s_threads.iden() == self.tid
 
         task = self.loop.create_task(coro)
+
+        s_scope.copy(task)
 
         # In rare cases, (Like this function being triggered from call_soon_threadsafe), there's no task context
         if asyncio.current_task():
@@ -492,6 +499,7 @@ class Base:
 
         Notes:
             This method may be called from outside of the event loop on a different thread.
+            This function will break any task scoping done with synapse.lib.scope.
 
         Returns:
             concurrent.futures.Future: A Future representing the eventual function execution.
@@ -508,6 +516,7 @@ class Base:
 
         Notes:
             This method may be run outside the event loop on a different thread.
+            This function will break any task scoping done with synapse.lib.scope.
 
         Returns:
             concurrent.futures.Future: A Future representing the eventual coroutine execution.

--- a/synapse/lib/scope.py
+++ b/synapse/lib/scope.py
@@ -1,4 +1,3 @@
-import os
 import asyncio
 import contextlib
 
@@ -22,7 +21,6 @@ class Scope:
 
     '''
     def __init__(self, *frames, **vals):
-        self.ctors = {}
         self.frames = list(frames)
         if vals:
             self.frames.append(vals)
@@ -68,13 +66,6 @@ class Scope:
             if valu != s_common.novalu:
                 return valu
 
-        task = self.ctors.get(name)
-        if task is not None:
-            func, args, kwargs = task
-            item = func(*args, **kwargs)
-            self.frames[-1][name] = item
-            return item
-
         return defval
 
     def add(self, name, *vals):
@@ -96,19 +87,6 @@ class Scope:
             obj: The scope variable value or None
         '''
         return self.frames[-1].pop(name, None)
-
-    def ctor(self, name, func, *args, **kwargs):
-        '''
-        Add a constructor to be called when a specific property is not present.
-
-        Example:
-
-            scope.ctor('foo',FooThing)
-            ...
-            foo = scope.get('foo')
-
-        '''
-        self.ctors[name] = (func, args, kwargs)
 
     def iter(self, name):
         '''
@@ -133,9 +111,9 @@ class Scope:
         '''
         return self.__class__(*[frame.copy() for frame in self.frames])
 
-# set up a global scope with env vars etc...
-envr = dict(os.environ)
-globscope = Scope(envr)
+# set up a global scope with an empty frame
+globscope = Scope(dict())
+
 
 def _task_scope() -> Scope:
     '''

--- a/synapse/lib/scope.py
+++ b/synapse/lib/scope.py
@@ -102,12 +102,12 @@ class Scope:
     def __setitem__(self, name, valu):
         self.frames[-1][name] = valu
 
-    def clone(self):
+    def copy(self):
         '''
         Create a shallow copy of the current Scope.
 
         Returns:
-            Scope: A new scope which is a clone of the current scope.
+            Scope: A new scope which is a copy of the current scope.
         '''
         return self.__class__(*[frame.copy() for frame in self.frames])
 
@@ -131,7 +131,7 @@ def _task_scope() -> Scope:
 
     # no need to lock because it's per-task...
     if scope is None:
-        scope = globscope.clone()
+        scope = globscope.copy()
         task._syn_scope = scope
 
     return scope
@@ -213,7 +213,7 @@ def clone(task: asyncio.Task) -> None:
 
         parent_scope = _task_scope()
 
-    scope = parent_scope.clone()
+    scope = parent_scope.copy()
     task._syn_scope = scope
     scope.enter()
 

--- a/synapse/lib/scope.py
+++ b/synapse/lib/scope.py
@@ -109,7 +109,7 @@ class Scope:
         Returns:
             Scope: A new scope which is a clone of the current scope.
         '''
-        return self.__class__(*[frame.clone() for frame in self.frames])
+        return self.__class__(*[frame.copy() for frame in self.frames])
 
 # set up a global scope with an empty frame
 globscope = Scope(dict())

--- a/synapse/tests/test_lib_scope.py
+++ b/synapse/tests/test_lib_scope.py
@@ -116,7 +116,7 @@ class ScopeTest(s_t_utils.SynTest):
             s_scope.set('foo', 'bar')
             s_scope.set('dict', {'hehe': 'haha'})
             t2 = asyncio.create_task(func2())
-            s_scope.copy(t2)
+            s_scope.clone(t2)
             await asyncio.sleep(0)
             await asyncio.wait_for(evt0.wait(), timeout=6)
             self.eq(s_scope.get('dict').get('beep'), 'boop')
@@ -130,17 +130,17 @@ class ScopeTest(s_t_utils.SynTest):
             return
 
         task = asyncio.create_task(func1())
-        s_scope.copy(task)
+        s_scope.clone(task)
         self.none(await task)
 
-    def test_scope_copy(self):
+    def test_scope_clone(self):
         scope00 = s_scope.Scope()
         scope00.enter()
         scope00.update(vals={'key': 'valu', 'dict': {'foo': 'bar'}})
         self.eq(scope00.get('key'), 'valu')
         self.eq(scope00.get('dict'), {'foo': 'bar'})
 
-        scope01 = scope00.copy()
+        scope01 = scope00.clone()
         scope01.enter()
         self.eq(scope01.get('key'), 'valu')
         scope01.set('s1', True)

--- a/synapse/tests/test_lib_scope.py
+++ b/synapse/tests/test_lib_scope.py
@@ -87,8 +87,8 @@ class ScopeTest(s_t_utils.SynTest):
             self.none(s_scope.get('hehe'))
             self.eq(s_scope.get('foo'), 'bar')
 
-    async def test_lib_scope_task_shallow(self):
-        # Ensure that scopes are shallow
+    async def test_lib_task_clone(self):
+        # Ensure that scope task clones are shallow
         evt0 = asyncio.Event()
         evt1 = asyncio.Event()
 
@@ -133,14 +133,17 @@ class ScopeTest(s_t_utils.SynTest):
         s_scope.clone(task)
         self.none(await task)
 
-    def test_scope_clone(self):
+    def test_scope_copy(self):
+        # Ensure scope copies are shallow copies
+        # Scope keys do not mutate in copies.
+        # Mutable data structures stored in scopes may change.
         scope00 = s_scope.Scope()
         scope00.enter()
         scope00.update(vals={'key': 'valu', 'dict': {'foo': 'bar'}})
         self.eq(scope00.get('key'), 'valu')
         self.eq(scope00.get('dict'), {'foo': 'bar'})
 
-        scope01 = scope00.clone()
+        scope01 = scope00.copy()
         scope01.enter()
         self.eq(scope01.get('key'), 'valu')
         scope01.set('s1', True)

--- a/synapse/tests/test_lib_scope.py
+++ b/synapse/tests/test_lib_scope.py
@@ -76,27 +76,89 @@ class ScopeTest(s_t_utils.SynTest):
                 raise ValueError('bad value')
         self.none(s_scope.get('foo'))
 
-        current_task = asyncio.current_task()
-        self.nn(current_task)
-        cscope = current_task._syn_scope  # type: s_scope.Scope
-        print(cscope)
-        print(cscope.frames, [f for f in cscope.frames])
-
         with s_scope.enter({'foo': 'bar'}):
-            print(cscope)
-            print(cscope.frames, [f for f in cscope.frames])
             self.eq(s_scope.get('foo'), 'bar')
-            print(cscope)
-            print(cscope.frames, [f for f in cscope.frames])
             with s_scope.enter({'hehe': 'haha'}):
-                print(cscope)
-                print(cscope.frames, [f for f in cscope.frames])
                 self.eq(s_scope.get('hehe'), 'haha')
                 self.eq(s_scope.get('foo'), 'bar')
                 with s_scope.enter({'foo': 'woah'}):
                     self.eq(s_scope.get('foo'), 'woah')
+                self.eq(s_scope.get('foo'), 'bar')
             self.none(s_scope.get('hehe'))
             self.eq(s_scope.get('foo'), 'bar')
+
+    async def test_lib_scope_task_shallow(self):
+        # Ensure that scopes are shallow
+        evt0 = asyncio.Event()
+        evt1 = asyncio.Event()
+
+        # Ensure the following rules are met with scope copies:
+        # 1. The frames of the scope.copy are shallow copies of the parent
+        #    scope.
+        # 2. Changes in the parent scope, after being copied, are not seen
+        #    by the child scope.
+        #    Example: In chained scopes ( example, three copied scopes ) a
+        #    member of he chain leaving scope does not affect subsequent
+        #    copies.
+        #
+
+        async def func2():
+            self.eq(s_scope.get('foo'), 'bar')
+            self.eq(s_scope.get('dict'), {'hehe': 'haha'})
+            s_scope.get('dict')['beep'] = 'boop'  # mutable object being modified
+            s_scope.set('f2', 'notseen')
+            evt0.set()
+            await asyncio.wait_for(evt1.wait(), timeout=6)
+            self.eq(s_scope.get('f2'), 'notseen')
+            return
+
+        async def func1():
+            s_scope.set('foo', 'bar')
+            s_scope.set('dict', {'hehe': 'haha'})
+            t2 = asyncio.create_task(func2())
+            s_scope.copy(t2)
+            await asyncio.sleep(0)
+            await asyncio.wait_for(evt0.wait(), timeout=6)
+            self.eq(s_scope.get('dict').get('beep'), 'boop')
+            self.none(s_scope.get('f2'))
+            s_scope.set('f2', 'setbyf1')
+            evt1.set()
+            self.eq(s_scope.get('f2'), 'setbyf1')
+            await t2
+            # change made in dict still is present
+            self.eq(s_scope.get('dict').get('beep'), 'boop')
+            return
+
+        task = asyncio.create_task(func1())
+        s_scope.copy(task)
+        self.none(await task)
+
+        evt0.clear()
+        evt1.clear()
+
+    def test_scope_copy(self):
+        scope00 = s_scope.Scope()
+        scope00.enter()
+        scope00.update(vals={'key': 'valu', 'dict': {'foo': 'bar'}})
+        self.eq(scope00.get('key'), 'valu')
+        self.eq(scope00.get('dict'), {'foo': 'bar'})
+
+        scope01 = scope00.copy()
+        scope01.enter()
+        self.eq(scope01.get('key'), 'valu')
+        scope01.set('s1', True)
+        scope01.get('dict')['hehe'] = 'haha'
+        self.none(scope00.get('s1'))
+        self.eq(scope00.get('dict').get('hehe'), 'haha')
+        scope00.set('key', 'newp')
+        self.eq(scope01.get('key'), 'valu')
+
+        # If an earlier scope leaves, it does not affect the copied scope.
+        scope00.leave()
+        self.none(scope00.get('key'))
+        self.eq(scope01.get('key'), 'valu')
+        self.eq(scope01.get('dict'), {'foo': 'bar', 'hehe': 'haha'})
+        scope01.leave()
 
     def test_lib_scope_get_defval(self):
         syms = {'foo': None, 'bar': 123}

--- a/synapse/tests/test_lib_scope.py
+++ b/synapse/tests/test_lib_scope.py
@@ -133,9 +133,6 @@ class ScopeTest(s_t_utils.SynTest):
         s_scope.copy(task)
         self.none(await task)
 
-        evt0.clear()
-        evt1.clear()
-
     def test_scope_copy(self):
         scope00 = s_scope.Scope()
         scope00.enter()


### PR DESCRIPTION
- Added a ``Scope.copy()`` method will now create a shallow copy of the current scope's frames.
- Added a ``synapse.lib.scope.clone(task)`` method which will copy the current task scope, or the default global copy, onto the ``asyncio.Task`` provided to it.
- coroutines executed via the ``synapse.lib.base.Base.schedCoro()`` method now inherit their parent task scope. The ``Base`` object docstrings have been updated regarding this task scope inheritance, as well as noting where that inheritance does not apply.
- Fixed a bug in ``Scope.enter()`` which did not properly clear the scope frame that it added.
- Removed ctor support from ``Scope``
- The global default scope, ``synapse.lib.scope.globscop``, no longer inherits os.environ values. This is a dangerous pattern to rely on and has never been used in production code.