### PR TITLE
Update pyopenssl and cryptography requirements (SYN-4913)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,7 +77,7 @@ Features and Enhancements
   ``reason`` value populated.
   (`#3023 <https://github.com/vertexproject/synapse/pull/3023>`_)
 - Update the minimum version of the ``cryptography`` library to ``39.0.1`` and
-  the minimum version of the ``pyopenssl`` to ``23.0.0``.
+  the minimum version of the ``pyopenssl`` library to ``23.0.0``.
   (`#3022 <https://github.com/vertexproject/synapse/pull/3022>`_)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,6 +72,9 @@ Features and Enhancements
   was created. The ``_web_user`` value, which previously pointed to a heavy
   HiveUser object, is no longer populated by default.
   (`#3007 <https://github.com/vertexproject/synapse/pull/3007>`_)
+- Update the minimum versions of the ``cryptography`` and ``pyopenssl``
+  libraries.
+  (`#3022 <https://github.com/vertexproject/synapse/pull/3022>`_)
 
 Bugfixes
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyOpenSSL>=21.0.0,<23.0.0
+pyOpenSSL>=23.0.0,<24.0.0
 msgpack>=1.0.2,<1.1.0
 xxhash>=1.4.4,<3.1.0
 lmdb>=1.2.1,<1.4.0
@@ -28,7 +28,8 @@ idna==3.3
 python-dateutil>=2.8,<3.0
 pytz>=2021.3,<2022.2
 beautifulsoup4[html5lib]>=4.11.1,<5.0.0
-# Cryptography is a pyopenssl dependency which has no maximum version pinned.
-# They have a 3 major version's policy for deprecations, so we should be safe
-# that far out.
-cryptography>=36.0.0,<39.0.0
+# Cryptography is a pyopenssl dependency which has now has a maximum version
+# pin. Cryptography also vendors a copy of OpenSSL, so it needs to be able to
+# have a minimum version bumped in the event of a OpenSSL vulnerability that
+# needs to be patched.
+cryptography>=39.0.1,<40.0.0

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,8 @@ setup(
     include_package_data=True,
 
     install_requires=[
-        'pyOpenSSL>=21.0.0,<23.0.0',
-        'cryptography>=36.0.0,<39.0.0',
+        'pyOpenSSL>=23.0.0,<27.0.0',
+        'cryptography>=39.0.1,<40.0.0',
         'msgpack>=1.0.2,<1.1.0',
         'xxhash>=1.4.4,<3.1.0',
         'lmdb>=1.2.1,<1.4.0',

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -60,10 +60,6 @@ def _initTLSServerCiphers():
 
 TLS_SERVER_CIPHERS = _initTLSServerCiphers()
 
-# openssl X509_V_FLAG_PARTIAL_CHAIN flag. This allows a context to treat all loaded
-# certificates as trust anchors when doing verification.
-_X509_PARTIAL_CHAIN = 0x80000
-
 def _unpackContextError(e: crypto.X509StoreContextError) -> str:
     # account for backward incompatible change in pyopenssl v22.1.0
     if e.args:
@@ -119,7 +115,7 @@ class CRL:
         cacert = self.certdir.getCaCert(self.name)
         store = crypto.X509Store()
         store.add_cert(cacert)
-        store.set_flags(_X509_PARTIAL_CHAIN)
+        store.set_flags(crypto.X509StoreFlags.PARTIAL_CHAIN)
         ctx = crypto.X509StoreContext(store, cert,)
         try:
             ctx.verify_certificate()


### PR DESCRIPTION
Blocks the following updates:

https://github.com/vertexproject/vtx-base-image/pull/282
https://github.com/vertexproject/vtx-base-image/pull/296