### PR TITLE
telepath.loadTeleCell() issue (SYN-4975)

### DIFF
--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -263,7 +263,8 @@ async def loadTeleCell(dirn):
     ahaurl = None
     if os.path.isfile(confpath):
         conf = s_common.yamlload(confpath)
-        ahaurl = conf.get('aha:registry')
+        if conf is not None:
+            ahaurl = conf.get('aha:registry')
 
     if usecerts:
         s_certdir.addCertPath(certpath)


### PR DESCRIPTION
Account for loadTeleCell to read a config file which exists but does't return data. That would cause an attribute errror.