### PR TITLE
login and authdeny consistency (SYN-4870)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,12 +20,20 @@ Features and Enhancements
   storage for both size and performance. May also be set by environment
   variable ``SYN_<SERVICE>_ONBOOT_OPTIMIZE=1``
   (`#3001 <https://github.com/vertexproject/synapse/pull/3001>`_)
+- Ensure that ``AuthDeny`` exceptions include the user iden in the ``user``
+  key, and the name in the ``username`` field. Previously the ``AuthDeny``
+  exceptions had multiple identifiers for these fields.
+  (`#3035 <https://github.com/vertexproject/synapse/pull/3035>`_)
 
 Bugfixes
 --------
 - Fix an issue in the Storm grammar where part of a query could potentially
   be incorrectly parsed as an unquoted case statement.
   (`#3032 <https://github.com/vertexproject/synapse/pull/3032>`_)
+- Fix an issue where a locked user could login the a Synapse service on a TLS
+  Telepath connection if the connection presented a trusted client certificate
+  for the locked user.
+  (`#3035 <https://github.com/vertexproject/synapse/pull/3035>`_)
 
 v2.123.0 - 2023-02-22
 =====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,7 @@ Bugfixes
 - Fix an issue where a spawned process returning a non-pickleable exception
   would not be handled properly.
   (`#3036 <https://github.com/vertexproject/synapse/pull/3036>`_)
-- Fix an issue where a locked user could login the a Synapse service on a TLS
+- Fix an issue where a locked user could login to a Synapse service on a TLS
   Telepath connection if the connection presented a trusted client certificate
   for the locked user.
   (`#3035 <https://github.com/vertexproject/synapse/pull/3035>`_)

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -5045,7 +5045,10 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         if useriden is None:
             return self.auth.rootuser
 
-        user = self.auth.reqUser(useriden)
+        user = self.auth.user(useriden)
+        if user is None:
+            mesg = f'No user found with iden: {useriden}'
+            raise s_exc.NoSuchUser(mesg=mesg, user=useriden)
 
         return user
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1672,7 +1672,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         if gdef['scope'] == 'power-up' and level > s_cell.PERM_READ:
             mesg = 'Power-up graph projections may not be modified.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=user.iden, username=user.name)
 
         if user is not None:
             self._reqEasyPerm(gdef, user, level)
@@ -5045,10 +5045,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         if useriden is None:
             return self.auth.rootuser
 
-        user = self.auth.user(useriden)
-        if user is None:
-            mesg = f'No user found with iden: {useriden}'
-            raise s_exc.NoSuchUser(mesg, iden=useriden)
+        user = self.auth.reqUser(useriden)
 
         return user
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -3460,7 +3460,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
             if user.isLocked():
                 raise s_exc.AuthDeny(mesg=f'Anon user ({anonuser}) is locked.', username=anonuser,
-                                     user=anonuser.iden)
+                                     user=user.iden)
 
             return user
 

--- a/synapse/lib/hive.py
+++ b/synapse/lib/hive.py
@@ -419,7 +419,7 @@ class Hive(s_nexus.Pusher, s_telepath.Aware):
         # passwd None always fails...
         passwd = info.get('passwd')
         if not await user.tryPasswd(passwd):
-            raise s_exc.AuthDeny(mesg='Invalid password', user=user.name)
+            raise s_exc.AuthDeny(mesg='Invalid password', user=user.iden, username=user.name)
 
         return await HiveApi.anit(self, user)
 

--- a/synapse/lib/hiveauth.py
+++ b/synapse/lib/hiveauth.py
@@ -163,7 +163,7 @@ class Auth(s_nexus.Pusher):
         user = self.user(iden)
         if user is None:
             mesg = f'No user with iden {iden}.'
-            raise s_exc.NoSuchUser(mesg=mesg)
+            raise s_exc.NoSuchUser(mesg=mesg, user=iden)
         return user
 
     async def reqRole(self, iden):
@@ -178,7 +178,7 @@ class Auth(s_nexus.Pusher):
         user = await self.getUserByName(name)
         if user is None:
             mesg = f'No user named {name}.'
-            raise s_exc.NoSuchUser(mesg=mesg)
+            raise s_exc.NoSuchUser(mesg=mesg, username=name)
         return user
 
     async def reqUserByNameOrIden(self, name):
@@ -922,11 +922,11 @@ class HiveUser(HiveRuler):
         perm = '.'.join(perm)
         if gateiden is None:
             mesg = f'User {self.name!r} ({self.iden}) must have permission {perm}'
-            raise s_exc.AuthDeny(mesg=mesg, perm=perm, user=self.name)
+            raise s_exc.AuthDeny(mesg=mesg, perm=perm, user=self.iden, username=self.name)
 
         gate = self.auth.reqAuthGate(gateiden)
         mesg = f'User {self.name!r} ({self.iden}) must have permission {perm} on object {gate.iden} ({gate.type}).'
-        raise s_exc.AuthDeny(mesg=mesg, perm=perm, user=self.name)
+        raise s_exc.AuthDeny(mesg=mesg, perm=perm, user=self.iden, username=self.name)
 
     def getRoles(self):
         for iden in self.info.get('roles', ()):

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -1850,8 +1850,8 @@ class Runtime(s_base.Base):
         if self.user.allowed(('layer', 'read'), gateiden=layriden):
             return
 
-        mesg = 'User can not read layer.'
-        raise s_exc.AuthDeny(mesg=mesg)
+        mesg = f'User ({self.user.name}) can not read layer.'
+        raise s_exc.AuthDeny(mesg=mesg, user=self.user.iden, username=self.user.name)
 
     async def dyncall(self, iden, todo, gatekeys=()):
         # bypass all perms checks if we are running asroot
@@ -2740,7 +2740,7 @@ class PureCmd(Cmd):
         asroot = runt.allowed(perm)
         if self.asroot and not asroot:
             mesg = f'Command ({name}) elevates privileges.  You need perm: storm.asroot.cmd.{name}'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=runt.user.iden, username=runt.user.name)
 
         # if a command requires perms, check em!
         # ( used to create more intuitive perm boundaries )
@@ -2755,7 +2755,7 @@ class PureCmd(Cmd):
             if not allowed:
                 permtext = ' or '.join(('.'.join(p) for p in perms))
                 mesg = f'Command ({name}) requires permission: {permtext}'
-                raise s_exc.AuthDeny(mesg=mesg)
+                raise s_exc.AuthDeny(mesg=mesg, user=runt.user.iden, username=runt.user.name)
 
         text = self.cdef.get('storm')
         query = await runt.snap.core.getStormQuery(text)
@@ -3971,7 +3971,7 @@ class DelNodeCmd(Cmd):
         if self.opts.force:
             if runt.user is not None and not runt.user.isAdmin():
                 mesg = '--force requires admin privs.'
-                raise s_exc.AuthDeny(mesg=mesg)
+                raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         async for node, path in genr:
 
@@ -5514,7 +5514,7 @@ class RunAsCmd(Cmd):
     async def execStormCmd(self, runt, genr):
         if not runt.user.isAdmin():
             mesg = 'The runas command requires admin privileges.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         core = runt.snap.core
 

--- a/synapse/lib/stormlib/cell.py
+++ b/synapse/lib/stormlib/cell.py
@@ -160,7 +160,7 @@ class CellLib(s_stormtypes.Lib):
     async def _hotFixesApply(self):
         if not self.runt.isAdmin():
             mesg = '$lib.cell.stormFixesApply() requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         curv = await self.runt.snap.core.getStormVar(runtime_fixes_key, default=(0, 0, 0))
         for vers, info in hotfixes:
@@ -195,7 +195,7 @@ class CellLib(s_stormtypes.Lib):
     async def _hotFixesCheck(self):
         if not self.runt.isAdmin():
             mesg = '$lib.cell.stormFixesCheck() requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         curv = await self.runt.snap.core.getStormVar(runtime_fixes_key, default=(0, 0, 0))
 
@@ -213,32 +213,32 @@ class CellLib(s_stormtypes.Lib):
     async def _getCellInfo(self):
         if not self.runt.isAdmin():
             mesg = '$lib.cell.getCellInfo() requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
         return await self.runt.snap.core.getCellInfo()
 
     async def _getSystemInfo(self):
         if not self.runt.isAdmin():
             mesg = '$lib.cell.getSystemInfo() requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
         return await self.runt.snap.core.getSystemInfo()
 
     async def _getBackupInfo(self):
         if not self.runt.isAdmin():
             mesg = '$lib.cell.getBackupInfo() requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
         return await self.runt.snap.core.getBackupInfo()
 
     async def _getHealthCheck(self):
         if not self.runt.isAdmin():
             mesg = '$lib.cell.getHealthCheck() requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
         return await self.runt.snap.core.getHealthCheck()
 
     async def _getMirrorUrls(self, name=None):
 
         if not self.runt.isAdmin():
             mesg = '$lib.cell.getMirrorUrls() requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         name = await s_stormtypes.tostr(name, noneok=True)
 
@@ -256,7 +256,7 @@ class CellLib(s_stormtypes.Lib):
     async def _trimNexsLog(self, consumers=None, timeout=30):
         if not self.runt.isAdmin():
             mesg = '$lib.cell.trimNexsLog() requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         timeout = await s_stormtypes.toint(timeout, noneok=True)
 

--- a/synapse/lib/stormlib/notifications.py
+++ b/synapse/lib/stormlib/notifications.py
@@ -70,7 +70,7 @@ class NotifyLib(s_stormtypes.Lib):
         mesg = await self.runt.snap.core.getUserNotif(indx)
         if mesg[0] != self.runt.user.iden and not self.runt.isAdmin():
             mesg = 'You may only get notifications which belong to you.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
         return mesg
 
     async def _del(self, indx):
@@ -78,7 +78,7 @@ class NotifyLib(s_stormtypes.Lib):
         mesg = await self.runt.snap.core.getUserNotif(indx)
         if mesg[0] != self.runt.user.iden and not self.runt.isAdmin():
             mesg = 'You may only delete notifications which belong to you.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
         await self.runt.snap.core.delUserNotif(indx)
 
     async def list(self, size=None):

--- a/synapse/lib/stormlib/oauth.py
+++ b/synapse/lib/stormlib/oauth.py
@@ -261,25 +261,29 @@ class OAuthV2Lib(s_stormtypes.Lib):
 
     async def _addProvider(self, conf):
         if not self.runt.isAdmin():
-            raise s_exc.AuthDeny(mesg='addProvider() requires admin privs.')
+            raise s_exc.AuthDeny(mesg='addProvider() requires admin privs.',
+                                 user=self.runt.user.iden, username=self.runt.user.name)
         conf = await s_stormtypes.toprim(conf)
         await self.runt.snap.core.addOAuthProvider(conf)
 
     async def _delProvider(self, iden):
         if not self.runt.isAdmin():
-            raise s_exc.AuthDeny(mesg='delProvider() requires admin privs.')
+            raise s_exc.AuthDeny(mesg='delProvider() requires admin privs.',
+                                 user=self.runt.user.iden, username=self.runt.user.name)
         iden = await s_stormtypes.tostr(iden)
         return await self.runt.snap.core.delOAuthProvider(iden)
 
     async def _getProvider(self, iden):
         if not self.runt.isAdmin():
-            raise s_exc.AuthDeny(mesg='getProvider() requires admin privs.')
+            raise s_exc.AuthDeny(mesg='getProvider() requires admin privs.',
+                                 user=self.runt.user.iden, username=self.runt.user.name)
         iden = await s_stormtypes.tostr(iden)
         return await self.runt.snap.core.getOAuthProvider(iden)
 
     async def _listProviders(self):
         if not self.runt.isAdmin():
-            raise s_exc.AuthDeny(mesg='listProviders() requires admin privs.')
+            raise s_exc.AuthDeny(mesg='listProviders() requires admin privs.',
+                                 user=self.runt.user.iden, username=self.runt.user.name)
         return await self.runt.snap.core.listOAuthProviders()
 
     async def _setUserAuthCode(self, iden, authcode, code_verifier=None):

--- a/synapse/lib/stormlib/project.py
+++ b/synapse/lib/stormlib/project.py
@@ -437,7 +437,7 @@ class ProjectTicket(s_stormtypes.Prim):
         udef = await self.proj.runt.snap.core.getUserDefByName(strvalu)
         if udef is None:
             mesg = f'No user found by the name {strvalu}'
-            raise s_exc.NoSuchUser(mesg=mesg)
+            raise s_exc.NoSuchUser(mesg=mesg, username=strvalu)
         await self.node.set('assignee', udef['iden'])
         await self.node.set('updated', s_common.now())
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -1358,7 +1358,7 @@ class LibBase(Lib):
             if not asroot:
                 permtext = ' or '.join(('.'.join(p) for p in rootperms))
                 mesg = f'Module ({name}) requires permission: {permtext}'
-                raise s_exc.AuthDeny(mesg=mesg)
+                raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         else:
             perm = ('storm', 'asroot', 'mod') + tuple(name.split('.'))
@@ -1366,7 +1366,7 @@ class LibBase(Lib):
 
             if mdef.get('asroot', False) and not asroot:
                 mesg = f'Module ({name}) elevates privileges.  You need perm: storm.asroot.mod.{name}'
-                raise s_exc.AuthDeny(mesg=mesg)
+                raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         modr = await self.runt.getModRuntime(query, opts={'vars': {'modconf': modconf}})
         modr.asroot = asroot
@@ -1992,7 +1992,7 @@ class LibAxon(Lib):
         self.runt.confirm(('storm', 'lib', 'axon', 'wget'))
 
         if proxy is not None and not self.runt.isAdmin():
-            raise s_exc.AuthDeny(mesg=s_exc.proxy_admin_mesg)
+            raise s_exc.AuthDeny(mesg=s_exc.proxy_admin_mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         url = await tostr(url)
         method = await tostr(method)
@@ -2026,7 +2026,7 @@ class LibAxon(Lib):
         self.runt.confirm(('storm', 'lib', 'axon', 'wput'))
 
         if proxy is not None and not self.runt.isAdmin():
-            raise s_exc.AuthDeny(mesg=s_exc.proxy_admin_mesg)
+            raise s_exc.AuthDeny(mesg=s_exc.proxy_admin_mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         url = await tostr(url)
         sha256 = await tostr(sha256)
@@ -6280,7 +6280,7 @@ class Layer(Prim):
 
         if not self.runt.isAdmin(gateiden=layriden):
             mesg = '$layr.addPull() requires admin privs on the layer.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         scheme = url.split('://')[0]
         self.runt.confirm(('lib', 'telepath', 'open', scheme))
@@ -6305,7 +6305,7 @@ class Layer(Prim):
         layriden = self.valu.get('iden')
         if not self.runt.isAdmin(gateiden=layriden):
             mesg = '$layr.delPull() requires admin privs on the top layer.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         todo = s_common.todo('delLayrPull', layriden, iden)
         await self.runt.dyncall('cortex', todo)
@@ -6319,7 +6319,7 @@ class Layer(Prim):
 
         if not self.runt.isAdmin(gateiden=layriden):
             mesg = '$layer.addPush() requires admin privs on the layer.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         scheme = url.split('://')[0]
         self.runt.confirm(('lib', 'telepath', 'open', scheme))
@@ -6344,7 +6344,7 @@ class Layer(Prim):
 
         if not self.runt.isAdmin(gateiden=layriden):
             mesg = '$layer.delPush() requires admin privs on the layer.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         todo = s_common.todo('delLayrPush', layriden, iden)
         await self.runt.dyncall('cortex', todo)
@@ -6800,8 +6800,8 @@ class View(Prim):
                 self.runt.confirm(('layer', 'read'), gateiden=layr.iden)
 
             if not self.runt.isAdmin(gateiden=view.iden):
-                mesg = 'You must be an admin of the view to set the layers.'
-                raise s_exc.AuthDeny(mesg=mesg)
+                mesg = 'User must be an admin of the view to set the layers.'
+                raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
             await view.setLayers(layers)
             self.valu['layers'] = layers
@@ -7511,7 +7511,7 @@ class LibJsonStor(Lib):
 
         if not self.runt.isAdmin():
             mesg = '$lib.jsonstor.has() requires admin privileges.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         path = await toprim(path)
         if isinstance(path, str):
@@ -7524,7 +7524,7 @@ class LibJsonStor(Lib):
 
         if not self.runt.isAdmin():
             mesg = '$lib.jsonstor.get() requires admin privileges.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         path = await toprim(path)
         prop = await toprim(prop)
@@ -7543,7 +7543,7 @@ class LibJsonStor(Lib):
 
         if not self.runt.isAdmin():
             mesg = '$lib.jsonstor.set() requires admin privileges.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         path = await toprim(path)
         valu = await toprim(valu)
@@ -7564,7 +7564,7 @@ class LibJsonStor(Lib):
 
         if not self.runt.isAdmin():
             mesg = '$lib.jsonstor.del() requires admin privileges.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         path = await toprim(path)
         prop = await toprim(prop)
@@ -7584,7 +7584,7 @@ class LibJsonStor(Lib):
 
         if not self.runt.isAdmin():
             mesg = '$lib.jsonstor.iter() requires admin privileges.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         path = await toprim(path)
 
@@ -7601,7 +7601,7 @@ class LibJsonStor(Lib):
 
         if not self.runt.isAdmin():
             mesg = '$lib.jsonstor.cacheget() requires admin privileges.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         key = await toprim(key)
         path = await toprim(path)
@@ -7630,7 +7630,7 @@ class LibJsonStor(Lib):
 
         if not self.runt.isAdmin():
             mesg = '$lib.jsonstor.cacheset() requires admin privileges.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         key = await toprim(key)
         path = await toprim(path)
@@ -8040,7 +8040,7 @@ class User(Prim):
         mesgdata = await toprim(mesgdata)
         if not self.runt.isAdmin():
             mesg = '$user.notify() method requires admin privs.'
-            raise s_exc.AuthDeny(mesg=mesg)
+            raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
         return await self.runt.snap.core.addUserNotif(self.valu, mesgtype, mesgdata)
 
     async def _storUserName(self, name):

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -748,8 +748,8 @@ class View(s_nexus.Pusher):  # type: ignore
             return
 
         perm = '.'.join(perms)
-        mesg = f'User must have permission {perm} on write layer {layriden} of view {self.iden}'
-        raise s_exc.AuthDeny(mesg=mesg, perm=perm, user=user.name)
+        mesg = f'User ({user.name}) must have permission {perm} on write layer {layriden} of view {self.iden}'
+        raise s_exc.AuthDeny(mesg=mesg, perm=perm, user=user.iden, username=user.name)
 
     async def mergeAllowed(self, user=None, force=False):
         '''

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -167,6 +167,9 @@ class CellTest(s_t_utils.SynTest):
                     self.eq(ratm.get('name'), 'testrole')
                     self.eq(ratm.get('iden'), testrole.iden)
 
+                    with self.raises(s_exc.NoSuchUser):
+                        await proxy.getUserInfo('newp')
+
                     # User cannot get authinfo for other items since they are
                     # not an admin or do not have those roles.
                     await self.asyncraises(s_exc.AuthDeny, proxy.getUserInfo('root'))
@@ -320,6 +323,11 @@ class CellTest(s_t_utils.SynTest):
                 user = await prox.getCellUser()
                 self.eq('root', user.get('name'))
                 self.true(await prox.isCellActive())
+
+            with self.raises(s_exc.NoSuchUser):
+                url = f'cell://{core.dirn}/?user=newp'
+                async with await s_telepath.openurl(url) as prox:
+                    pass
 
         # Explicit use of the unix:// handler
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -432,8 +432,9 @@ class CellTest(s_t_utils.SynTest):
                     await prox.setCellUser(s_common.guid())
 
                 visi = await prox.addUser('visi')
+                visiiden = visi.get('iden')
 
-                self.true(await prox.setCellUser(visi['iden']))
+                self.true(await prox.setCellUser(visiiden))
                 self.eq('visi', (await prox.getCellUser())['name'])
 
                 # setCellUser propagates his change to the Daemon Sess object.
@@ -446,10 +447,10 @@ class CellTest(s_t_utils.SynTest):
                     await prox.setCellUser(s_common.guid())
 
             # Cannot change to a locked user
-            await cell.setUserLocked(visi.iden, True)
+            await cell.setUserLocked(visiiden, True)
             async with cell.getLocalProxy() as prox:
                 with self.raises(s_exc.AuthDeny):
-                    await prox.setCellUser(visi.iden)
+                    await prox.setCellUser(visiiden)
 
     async def test_cell_hiveboot(self):
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -445,6 +445,12 @@ class CellTest(s_t_utils.SynTest):
                 with self.raises(s_exc.AuthDeny):
                     await prox.setCellUser(s_common.guid())
 
+            # Cannot change to a locked user
+            await cell.setUserLocked(visi.iden, True)
+            async with cell.getLocalProxy() as prox:
+                with self.raises(s_exc.AuthDeny):
+                    await prox.setCellUser(visi.iden)
+
     async def test_cell_hiveboot(self):
 
         with self.getTestDir() as dirn:

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1106,7 +1106,19 @@ class CellTest(s_t_utils.SynTest):
                     url = f'ssl://newp@127.0.0.1:{port}?hostname=localhost'
                     async with await s_telepath.openurl(url) as proxy:
                         pass
-                self.eq(cm.exception.get('user'), 'newp@localhost')
+                self.eq(cm.exception.get('username'), 'newp@localhost')
+
+                # add newp
+                unfo = await cryo.addUser('newp@localhost')
+                async with await s_telepath.openurl(f'ssl://newp@127.0.0.1:{port}?hostname=localhost') as proxy:
+                    self.eq(cryo.iden, await proxy.getCellIden())
+
+                # Lock newp
+                await cryo.setUserLocked(unfo.get('iden'), True)
+                with self.raises(s_exc.AuthDeny) as cm:
+                    url = f'ssl://newp@127.0.0.1:{port}?hostname=localhost'
+                    async with await s_telepath.openurl(url) as proxy:
+                        pass
 
     async def test_cell_auth_ctor(self):
         conf = {

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -213,6 +213,8 @@ class StormTypesTest(s_test.SynTest):
             with self.raises(s_exc.AuthDeny):
                 await core.callStorm('return($lib.jsonstor.get(foo))', opts=asvisi)
             with self.raises(s_exc.AuthDeny):
+                await core.callStorm('return($lib.jsonstor.has(foo))', opts=asvisi)
+            with self.raises(s_exc.AuthDeny):
                 await core.callStorm('return($lib.jsonstor.set(foo, bar))', opts=asvisi)
             with self.raises(s_exc.AuthDeny):
                 await core.callStorm('return($lib.jsonstor.del(foo))', opts=asvisi)


### PR DESCRIPTION
- Ensure locked users cannot login with dmon SSL listeners
- AuthDeny errors now report the associated useriden in the `user` key, and the username in the `username` key. Previously this behavior was inconsistent.