### PR TITLE
Move the cell.guid copy into cell.py (SYN-5292)

### DIFF
--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1954,6 +1954,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
                 logger.debug('Starting backup process')
 
+                # Copy cell.guid first to ensure the backup can be deleted
+                dstdir = s_common.gendir(dirn)
+                shutil.copy(os.path.join(self.dirn, 'cell.guid'), os.path.join(dstdir, 'cell.guid'))
+
                 args = (child_pipe, self.dirn, dirn, paths, logconf)
 
                 def waitforproc1():

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1005,7 +1005,7 @@ class CellTest(s_t_utils.SynTest):
 
                     with mock.patch.object(s_cell.Cell, 'BACKUP_SPAWN_TIMEOUT', 0.1):
                         with mock.patch.object(s_cell.Cell, '_backupProc', staticmethod(_sleeperProc)):
-                            await self.asyncraises(s_exc.SynErr, proxy.runBackup())
+                            await self.asyncraises(s_exc.SynErr, proxy.runBackup('_sleeperProc'))
 
                     info = await proxy.getBackupInfo()
                     errinfo = info.get('lastexception')
@@ -1016,7 +1016,7 @@ class CellTest(s_t_utils.SynTest):
                     with mock.patch.object(s_cell.Cell, 'BACKUP_SPAWN_TIMEOUT', 8.0):
 
                         with mock.patch.object(s_cell.Cell, '_backupProc', staticmethod(_sleeper2Proc)):
-                            await self.asyncraises(s_exc.SynErr, proxy.runBackup())
+                            await self.asyncraises(s_exc.SynErr, proxy.runBackup('_sleeper2Proc'))
 
                         info = await proxy.getBackupInfo()
                         laststart2 = info['laststart']
@@ -1024,8 +1024,10 @@ class CellTest(s_t_utils.SynTest):
                         errinfo = info.get('lastexception')
                         self.eq(errinfo['err'], 'SynErr')
 
+                        return
+
                         with mock.patch.object(s_cell.Cell, '_backupProc', staticmethod(_exiterProc)):
-                            await self.asyncraises(s_exc.SpawnExit, proxy.runBackup())
+                            await self.asyncraises(s_exc.SpawnExit, proxy.runBackup('_exiterProc'))
 
                         info = await proxy.getBackupInfo()
                         laststart3 = info['laststart']

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1024,8 +1024,6 @@ class CellTest(s_t_utils.SynTest):
                         errinfo = info.get('lastexception')
                         self.eq(errinfo['err'], 'SynErr')
 
-                        return
-
                         with mock.patch.object(s_cell.Cell, '_backupProc', staticmethod(_exiterProc)):
                             await self.asyncraises(s_exc.SpawnExit, proxy.runBackup('_exiterProc'))
 
@@ -1043,6 +1041,10 @@ class CellTest(s_t_utils.SynTest):
                     slabpath = s_common.genpath(coredirn, 'randodirn', 'randoslab2')
                     async with await s_lmdbslab.Slab.anit(slabpath):
                         pass
+
+                    await proxy.delBackup('_sleeperProc')
+                    await proxy.delBackup('_sleeper2Proc')
+                    await proxy.delBackup('_exiterProc')
 
                     name = await proxy.runBackup()
                     self.eq((name,), await proxy.getBackups())

--- a/synapse/tools/backup.py
+++ b/synapse/tools/backup.py
@@ -88,9 +88,6 @@ def txnbackup(lmdbinfo, srcdir, dstdir, skipdirs=None):
     srcdir = s_common.reqdir(srcdir)
     dstdir = s_common.gendir(dstdir)
 
-    # Copy cell.guid first to ensure the backup can be deleted
-    shutil.copy(os.path.join(srcdir, 'cell.guid'), os.path.join(dstdir, 'cell.guid'))
-
     if skipdirs is None:
         skipdirs = []
 


### PR DESCRIPTION
ensure that the backup cell.guid file is made before we start the backup process