### PR TITLE
Feat bump requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,13 +12,13 @@ aiosmtplib>=2.0.0,<2.1.0
 prompt-toolkit>=3.0.4,<3.1.0
 lark==1.1.5
 Pygments>=2.7.4,<2.16.0
-fastjsonschema>=2.16.3,<2.17.0
+fastjsonschema>=2.16.3,<2.18.0
 packaging>=20.0,<24.0
 stix2-validator>=3.0.0,<4.0.0
 vcrpy>=4.1.1,<4.3.0
 base58>=2.1.0,<2.2.0
 python-bitcoinlib>=0.11.0,<0.13.0
-pycryptodome>=3.11.0,<3.18.0
+pycryptodome>=3.11.0,<3.19.0
 typing-extensions>=3.7.4,<5.0.0  # synapse.vendor.xrpl req
 scalecodec>=1.0.2,<1.3.0  # synapse.vendor.substrateinterface req
 cbor2>=5.4.1,<5.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Pygments>=2.7.4,<2.16.0
 fastjsonschema>=2.16.3,<2.18.0
 packaging>=20.0,<24.0
 stix2-validator>=3.0.0,<4.0.0
-vcrpy>=4.1.1,<4.3.0
+vcrpy>=4.3.1,<4.4.0
 base58>=2.1.0,<2.2.0
 python-bitcoinlib>=0.11.0,<0.13.0
 pycryptodome>=3.11.0,<3.19.0
@@ -33,4 +33,3 @@ beautifulsoup4[html5lib]>=4.11.1,<5.0.0
 # have a minimum version bumped in the event of a OpenSSL vulnerability that
 # needs to be patched.
 cryptography>=39.0.1,<41.0.0
-requests<2.30.0  # temporary pin until https://github.com/kevin1024/vcrpy/issues/688 is resolved

--- a/setup.py
+++ b/setup.py
@@ -94,12 +94,12 @@ setup(
         'lark==1.1.5',
         'Pygments>=2.7.4,<2.16.0',
         'packaging>=20.0,<24.0',
-        'fastjsonschema>=2.16.3,<2.17.0',
+        'fastjsonschema>=2.16.3,<2.18.0',
         'stix2-validator>=3.0.0,<4.0.0',
         'vcrpy>=4.1.1,<4.3.0',
         'base58>=2.1.0,<2.2.0',
         'python-bitcoinlib>=0.11.0,<0.13.0',
-        'pycryptodome>=3.11.0,<3.18.0',
+        'pycryptodome>=3.11.0,<3.19.0',
         'typing-extensions>=3.7.4,<5.0.0',  # synapse.vendor.xrpl req
         'scalecodec>=1.0.2,<1.3.0',  # synapse.vendor.substrateinterface req
         'cbor2>=5.4.1,<5.4.7',

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         'packaging>=20.0,<24.0',
         'fastjsonschema>=2.16.3,<2.18.0',
         'stix2-validator>=3.0.0,<4.0.0',
-        'vcrpy>=4.1.1,<4.3.0',
+        'vcrpy>=4.3.1,<4.4.0',
         'base58>=2.1.0,<2.2.0',
         'python-bitcoinlib>=0.11.0,<0.13.0',
         'pycryptodome>=3.11.0,<3.19.0',
@@ -109,7 +109,7 @@ setup(
         'python-dateutil>=2.8,<3.0',
         'pytz>=2023.3,<2024.1',
         'beautifulsoup4[html5lib]>=4.11.1,<5.0',
-        'requests<2.30.0',  # temporary pin until https://github.com/kevin1024/vcrpy/issues/688 is resolved
+        # 'requests<2.30.0',  # temporary pin until https://github.com/kevin1024/vcrpy/issues/688 is resolved
     ],
 
     extras_require={

--- a/synapse/tests/test_lib_rstorm.py
+++ b/synapse/tests/test_lib_rstorm.py
@@ -104,7 +104,7 @@ multi_rst_in_http_opts = '''
 .. storm-vcr-opts:: {"record_mode": "none"}
 .. storm-vcr-callback:: synapse.tests.test_lib_rstorm.vcrcallbacktst
 .. storm-mock-http:: /this/path/does/not/exist.yaml
-.. storm:: $resp = $lib.inet.http.get("http://example.com") if $resp.body { $lib.print('unexpected results') } else { $lib.print($lib.str.concat('this', ' test', ' passed')) }
+.. storm:: $resp = $lib.inet.http.get("http://example.com") if $resp.body { $lib.print('unexpected results') } else { $lib.print('this test passed') }
 '''
 
 storm_http_sadpath_callback = '''


### PR DESCRIPTION
- fastjsonschema
- pycryptdome
- vcrpy, which allows us to remove requests pin and then update requests in our containers to avoid being flagged on GHSA-j8r2-6x86-q33q  / CVE-2023-32681

https://github.com/vertexproject/vtx-base-image/pull/370
https://github.com/vertexproject/vtx-base-image/pull/366
https://github.com/vertexproject/vtx-base-image/pull/364
https://github.com/vertexproject/vtx-base-image/pull/361
https://github.com/vertexproject/vtx-base-image/pull/355