### PR TITLE
Require field name in postfiles (SYN-5560)

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1498,7 +1498,8 @@ class Axon(s_cell.Cell):
 
                     name = field.get('name')
                     if not isinstance(name, str):
-                        raise s_exc.BadArg(mesg=f'Field name must be a string', name=name)
+                        mesg = f'Each field requires a "name" key with a string value: {name}'
+                        raise s_exc.BadArg(mesg=mesg, name=name)
 
                     sha256 = field.get('sha256')
                     if sha256:

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1495,6 +1495,11 @@ class Axon(s_cell.Cell):
                 data._is_multipart = True
 
                 for field in fields:
+
+                    name = field.get('name')
+                    if not isinstance(name, str):
+                        raise s_exc.BadArg(mesg=f'Field name must be a string', name=name)
+
                     sha256 = field.get('sha256')
                     if sha256:
                         valu = self.get(s_common.uhex(sha256))
@@ -1503,7 +1508,7 @@ class Axon(s_cell.Cell):
                         if not isinstance(valu, (bytes, str)):
                             valu = json.dumps(valu)
 
-                    data.add_field(field.get('name'),
+                    data.add_field(name,
                                    valu,
                                    content_type=field.get('content_type'),
                                    filename=field.get('filename'),

--- a/synapse/tests/test_lib_stormhttp.py
+++ b/synapse/tests/test_lib_stormhttp.py
@@ -420,6 +420,15 @@ class StormHttpTest(s_test.SynTest):
             data = resp.get('result')
             self.eq(data.get('params'), {'foo': ('bar', 'bar2'), 'baz': ('cool',)})
 
+            q = '''
+            $fields = ([
+                {"forgot": "name", "sha256": "newp"},
+            ])
+            return($lib.inet.http.post($url, ssl_verify=$lib.false, fields=$fields))
+            '''
+            resp = await core.callStorm(q, opts=opts)
+            self.eq("BadArg: BadArg: mesg='Field name must be a string' name=None", resp['err'])
+
     async def test_storm_http_post_file(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_stormhttp.py
+++ b/synapse/tests/test_lib_stormhttp.py
@@ -427,7 +427,8 @@ class StormHttpTest(s_test.SynTest):
             return($lib.inet.http.post($url, ssl_verify=$lib.false, fields=$fields))
             '''
             resp = await core.callStorm(q, opts=opts)
-            self.eq("BadArg: BadArg: mesg='Field name must be a string' name=None", resp['err'])
+            experr = "BadArg: BadArg: mesg=\'Each field requires a \"name\" key with a string value: None\' name=None"
+            self.eq(experr, resp['err'])
 
     async def test_storm_http_post_file(self):
 


### PR DESCRIPTION
Prevents opaque python exception from leaking through