### PR TITLE
SYN-5692, SYN-5609: vectToScore returns normalized vector

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,13 +7,6 @@ Synapse Changelog
 NEXTVERS - 2023-XX-XX
 =====================
 
-Features and Enhancements
--------------------------
-- `$lib.infosec.cvss.vectToScore` now returns a `normalized` entry in the return
-  dict which contains the normalized vector string. Also updated to return more
-  useful error messages.
-  (`#3211 <https://github.com/vertexproject/synapse/pull/3211>`_)
-
 Bugfixes
 --------
 - Fix bug with regular expression comparisons for some types.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@
 Synapse Changelog
 *****************
 
+NEXTVERS - 2023-XX-XX
+=====================
+
+Features and Enhancements
+-------------------------
+- `$lib.infosec.cvss.vectToScore` now returns a `normalized` entry in the return
+  dict which contains the normalized vector string. Also updated to return more
+  useful error messages.
+  (`#3211 <https://github.com/vertexproject/synapse/pull/3211>`_)
 
 v2.140.0 - 2023-06-30
 =====================

--- a/synapse/lib/chop.py
+++ b/synapse/lib/chop.py
@@ -7,6 +7,8 @@ import synapse.common as s_common
 
 import synapse.lib.cache as s_cache
 
+import synapse.lookup.cvss as s_cvss
+
 TagMatchRe = regex.compile(r'([\w*]+\.)*[\w*]+')
 
 '''
@@ -127,3 +129,113 @@ def replaceUnicodeDashes(valu):
     for dash in unicode_dashes:
         valu = valu.replace(dash, '-')
     return valu
+
+def cvss2_normalize(vect):
+    '''
+    Helper function to normalize CVSS2 vectors
+    '''
+    vdict = cvss_validate(vect, s_cvss.cvss2)
+    return cvss_normalize(vdict, s_cvss.cvss2)
+
+def cvss3x_normalize(vect):
+    '''
+    Helper function to normalize CVSS3.X vectors
+    '''
+    vdict = cvss_validate(vect, s_cvss.cvss3_1)
+    return cvss_normalize(vdict, s_cvss.cvss3_1)
+
+def cvss_normalize(vdict, vers):
+    '''
+    Normalize CVSS vectors
+    '''
+    metrics = s_cvss.metrics[vers]
+    undefined = s_cvss.undefined[vers]
+
+    vals = []
+    for key in metrics:
+        if key in vdict and vdict[key] != undefined:
+            vals.append(f'{key}:{vdict[key]}')
+
+    return '/'.join(vals)
+
+def cvss_validate(vect, vers):
+    '''
+    Validate (as best as possible) the CVSS vector string. Look for issues such as:
+        - No duplicated metrics
+        - Invalid metrics
+        - Invalid metric values
+        - Missing mandatory metrics
+
+    Returns a dictionary with the parsed metric:value pairs.
+    '''
+
+    missing = []
+    badvals = []
+    invalid = []
+
+    tag = s_cvss.tags[vers]
+    METRICS = s_cvss.metrics[vers]
+
+    # Do some canonicalization of the vector for easier parsing
+    _vect = vect
+    _vect = _vect.strip('(')
+    _vect = _vect.strip(')')
+
+    if _vect.startswith(tag):
+        _vect = _vect[len(tag):]
+
+    try:
+        # Parse out metrics
+        mets_vals = [k.split(':') for k in _vect.split('/')]
+
+        # Convert metrics into a dictionary
+        vdict = dict(mets_vals)
+
+    except ValueError:
+        raise s_exc.BadDataValu(mesg=f'Provided vector {vect} malformed')
+
+    # Check that each metric is only specified once
+    if len(mets_vals) != len(set(k[0] for k in mets_vals)):
+        seen = []
+        repeated = []
+
+        for met, val in mets_vals:
+            if met in seen:
+                repeated.append(met)
+
+            seen.append(met)
+
+        repeated = ', '.join(repeated)
+        raise s_exc.BadDataValu(mesg=f'Provided vectors {vect} contains duplicate metrics: {repeated}')
+
+    invalid = []
+    for metric in vdict:
+        # Check that provided metrics are valid
+        if metric not in METRICS:
+            invalid.append(metric)
+
+    if invalid:
+        invalid = ', '.join(invalid)
+        raise s_exc.BadDataValu(mesg=f'Provided vector {vect} contains invalid metrics: {invalid}')
+
+    missing = []
+    badvals = []
+    for metric, (valids, mandatory, _) in METRICS.items():
+        # Check for mandatory metrics
+        if mandatory and metric not in vdict:
+            missing.append(metric)
+
+        # Check if metric value is valid
+        val = vdict.get(metric, None)
+        if metric in vdict and val not in valids:
+            badvals.append(f'{metric}:{val}')
+
+    if missing:
+        missing = ', '.join(missing)
+        raise s_exc.BadDataValu(mesg=f'Provided vector {vect} missing mandatory metric(s): {missing}')
+
+    if badvals:
+        badvals = ', '.join(badvals)
+        raise s_exc.BadDataValu(mesg=f'Provided vector {vect} contains invalid metric value(s): {badvals}')
+
+    return vdict

--- a/synapse/lib/chop.py
+++ b/synapse/lib/chop.py
@@ -153,8 +153,9 @@ def cvss_normalize(vdict, vers):
 
     vals = []
     for key in metrics:
-        if key in vdict and vdict[key] != undefined:
-            vals.append(f'{key}:{vdict[key]}')
+        valu = vdict.get(key, undefined)
+        if valu != undefined:
+            vals.append(f'{key}:{valu}')
 
     return '/'.join(vals)
 

--- a/synapse/lib/stormlib/infosec.py
+++ b/synapse/lib/stormlib/infosec.py
@@ -492,10 +492,20 @@ class CvssLib(s_stormtypes.Lib):
                   ),
                   'returns': {'type': 'dict',
                               'desc': '''
-                                A dictionary with the detected version, base
-                                score, temporal score, and environmental score. Example:
+                                A dictionary with the detected version, base score, temporal score,
+                                environmental score, overall score, and normalized vector string.
+                                The normalized vector string will have metrics ordered in
+                                specification order and metrics with undefined values will be
+                                removed. Example:
 
-                                    { 'version': '3.1', 'base': 5.0, 'temporal': 4.4, 'environmental': 4.3 }
+                                    {
+                                        'version': '3.1',
+                                        'score': 4.3,
+                                        'base': 5.0,
+                                        'temporal': 4.4,
+                                        'environmental': 4.3,
+                                        'normalized': 'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L'
+                                    }
                               '''}
         }},
     )
@@ -735,9 +745,9 @@ class CvssLib(s_stormtypes.Lib):
         return {
             'version': detected,
             'score': overall,
-            'normalized': s_chop.cvss_normalize(vdict, detected),
 
             'base': base,
             'temporal': temporal,
-            'environmental': environmental
+            'environmental': environmental,
+            'normalized': s_chop.cvss_normalize(vdict, detected)
         }

--- a/synapse/lookup/cvss.py
+++ b/synapse/lookup/cvss.py
@@ -1,0 +1,89 @@
+cvss2 = '2'
+cvss3_0 = '3.0'
+cvss3_1 = '3.1'
+
+versions = [
+    cvss2,
+    cvss3_0,
+    cvss3_1,
+]
+
+tags = {
+    cvss2: 'CVSS2#',
+    cvss3_0: 'CVSS:3.0/',
+    cvss3_1: 'CVSS:3.1/',
+}
+
+# Note: Metrics (the keys) of these dictionaries are ordered based on the order
+# they should appear in the normalized vector string. If you add a new CVSS
+# version, make sure the metrics are ordered as you want them to be normalized.
+metrics = {
+    cvss2: {
+        # ID,   valid values,                       reqd?   values
+
+        # Base metrics
+        'AV': (('L', 'A', 'N'), True, {'L': 0.395, 'A': 0.646, 'N': 1.0}),
+        'AC': (('H', 'M', 'L'), True, {'H': 0.35, 'M': 0.61, 'L': 0.71}),
+        'Au': (('M', 'S', 'N'), True, {'M': 0.45, 'S': 0.56, 'N': 0.704}),
+        'C': (('N', 'P', 'C'), True, {'N': 0.0, 'P': 0.275, 'C': 0.660}),
+        'I': (('N', 'P', 'C'), True, {'N': 0.0, 'P': 0.275, 'C': 0.660}),
+        'A': (('N', 'P', 'C'), True, {'N': 0.0, 'P': 0.275, 'C': 0.660}),
+
+        # Temporal metrics
+        'E': (('U', 'POC', 'F', 'H', 'ND'), False, {'U': 0.85, 'POC': 0.9, 'F': 0.95, 'H': 1.0, 'ND': 1.0}),
+        'RL': (('OF', 'TF', 'W', 'U', 'ND'), False, {'OF': 0.87, 'TF': 0.90, 'W': 0.95, 'U': 1.0, 'ND': 1.0}),
+        'RC': (('UC', 'UR', 'C', 'ND'), False, {'UC': 0.90, 'UR': 0.95, 'C': 1.0, 'ND': 1.0}),
+
+        # Environmental metrics
+        'CDP': (('N', 'L', 'LM', 'MH', 'H', 'ND'), False, {'N': 0.0, 'L': 0.1, 'LM': 0.3, 'MH': 0.4, 'H': 0.5, 'ND': 0.0}),
+        'TD': (('N', 'L', 'M', 'H', 'ND'), False, {'N': 0.0, 'L': 0.25, 'M': 0.75, 'H': 1.0, 'ND': 1.0}),
+        'CR': (('L', 'M', 'H', 'ND'), False, {'L': 0.5, 'M': 1.0, 'H': 1.51, 'ND': 1.0}),
+        'IR': (('L', 'M', 'H', 'ND'), False, {'L': 0.5, 'M': 1.0, 'H': 1.51, 'ND': 1.0}),
+        'AR': (('L', 'M', 'H', 'ND'), False, {'L': 0.5, 'M': 1.0, 'H': 1.51, 'ND': 1.0}),
+    },
+
+    cvss3_0: {
+        # ID,   valid values,               reqd?   values
+
+        # Base metrics
+        'AV': (('N', 'A', 'L', 'P'), True, {'N': 0.85, 'A': 0.62, 'L': 0.55, 'P': 0.2}),
+        'AC': (('L', 'H'), True, {'H': 0.44, 'L': 0.77}),
+        'PR': (('N', 'L', 'H'), True, {'U': {'N': 0.85, 'L': 0.62, 'H': 0.27}, # If Scope is Unchanged
+                                       'C': {'N': 0.85, 'L': 0.68, 'H': 0.5}}), # If Scope is Changed
+        'UI': (('N', 'R'), True, {'N': 0.85, 'R': 0.62}),
+        'S': (('U', 'C'), True, {'U': 6.42, 'C': 7.52}),
+        'C': (('H', 'L', 'N'), True, {'N': 0.0, 'L': 0.22, 'H': 0.56}),
+        'I': (('H', 'L', 'N'), True, {'N': 0.0, 'L': 0.22, 'H': 0.56}),
+        'A': (('H', 'L', 'N'), True, {'N': 0.0, 'L': 0.22, 'H': 0.56}),
+
+        # Temporal metrics
+        'E': (('X', 'H', 'F', 'P', 'U'), False, {'X': 1.0, 'U': 0.91, 'P': 0.94, 'F': 0.97, 'H': 1.0}),
+        'RL': (('X', 'U', 'W', 'T', 'O'), False, {'X': 1.0, 'O': 0.95, 'T': 0.96, 'W': 0.97, 'U': 1.0}),
+        'RC': (('X', 'C', 'R', 'U'), False, {'X': 1.0, 'U': 0.92, 'R': 0.96, 'C': 1.0}),
+
+        # Environmental metrics
+        'CR': (('X', 'H', 'M', 'L'), False, {'X': 1.0, 'L': 0.5, 'M': 1.0, 'H': 1.5}),
+        'IR': (('X', 'H', 'M', 'L'), False, {'X': 1.0, 'L': 0.5, 'M': 1.0, 'H': 1.5}),
+        'AR': (('X', 'H', 'M', 'L'), False, {'X': 1.0, 'L': 0.5, 'M': 1.0, 'H': 1.5}),
+        'MAV': (('X', 'N', 'A', 'L', 'P'), False, {'X': 1.0, 'N': 0.85, 'A': 0.62, 'L': 0.55, 'P': 0.2}),
+        'MAC': (('X', 'L', 'H'), False, {'X': 1.0, 'H': 0.44, 'L': 0.77}),
+        'MPR': (('X', 'N', 'L', 'H'), False, {'U': {'N': 0.85, 'L': 0.62, 'H': 0.27}, # If Scope is Unchanged
+                                              'C': {'N': 0.85, 'L': 0.68, 'H': 0.5}}), # If Scope is Changed
+        'MUI': (('X', 'N', 'R'), False, {'X': 1.0, 'N': 0.85, 'R': 0.62}),
+        'MS': (('X', 'U', 'C'), False, {'X': 1.0, 'U': 6.42, 'C': 7.52}),
+        'MC': (('X', 'N', 'L', 'H'), False, {'X': 1.0, 'N': 0.0, 'L': 0.22, 'H': 0.56}),
+        'MI': (('X', 'N', 'L', 'H'), False, {'X': 1.0, 'N': 0.0, 'L': 0.22, 'H': 0.56}),
+        'MA': (('X', 'N', 'L', 'H'), False, {'X': 1.0, 'N': 0.0, 'L': 0.22, 'H': 0.56}),
+    },
+
+    cvss3_1: {},
+}
+
+# Copy the CVSS3.0 metrics to the CVSS3.1 key
+metrics[cvss3_1] = metrics[cvss3_0]
+
+undefined = {
+    cvss2: 'ND',
+    cvss3_0: 'X',
+    cvss3_1: 'X',
+}

--- a/synapse/tests/test_lib_chop.py
+++ b/synapse/tests/test_lib_chop.py
@@ -91,3 +91,12 @@ class ChopTest(s_t_utils.SynTest):
                 s_chop.replaceUnicodeDashes('a\u2011b\u2012c\u2013d-\u2014e'))
         self.eq('a-b-c', s_chop.replaceUnicodeDashes('a-b-c'))
         self.eq('asdf', s_chop.replaceUnicodeDashes('asdf'))
+
+    def test_chop_cvss(self):
+        # Just basic tests here to mop up coverage, full coverage tests are in
+        # test_lib_stormlib_infosec.py
+        vect = '(AV:N/AC:M/Au:N/C:C/I:C/A:C/RC:ND/CR:ND/AR:ND)'
+        self.eq('AV:N/AC:M/Au:N/C:C/I:C/A:C', s_chop.cvss2_normalize(vect))
+
+        vect = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H/RL:X/CR:X/IR:X/AR:X'
+        self.eq('AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H', s_chop.cvss3x_normalize(vect))

--- a/synapse/tests/test_lib_stormlib_infosec.py
+++ b/synapse/tests/test_lib_stormlib_infosec.py
@@ -495,5 +495,4 @@ class InfoSecTest(s_test.SynTest):
             # test for vector normalization
             for vect, norm in VECTORS_UNNORMAL:
                 valu = await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': None}})
-                # self.eq(norm, valu.get('normalized'))
-                print(valu.get('normalized'))
+                self.eq(norm, valu.get('normalized'))

--- a/synapse/tests/test_lib_stormlib_infosec.py
+++ b/synapse/tests/test_lib_stormlib_infosec.py
@@ -1,5 +1,7 @@
 import synapse.exc as s_exc
 
+import synapse.lookup.cvss as s_cvss
+
 import synapse.tests.utils as s_test
 
 res0 = {'ok': True, 'version': '3.1', 'score': None, 'scores': {
@@ -147,41 +149,49 @@ VECTORS = [
 ]
 
 VECTORS_BAD_VERSION = [
-    ('CVSS2#AV:L/AC:L/C:P/I:C/A:N', '3.1'),
-    ('(AV:L/AC:L/Au:M/I:C/A:N)', '3.1'),
-    ('AV:L/AC:L/Au:M/C:P/A:N', '3.1'),
-    ('CVSS:3.0/AV:N/AC:H/UI:R/S:U/C:L/I:L/A:L', '2'),
-    ('CVSS:3.1/AV:N/AC:H/PR:L/S:U/C:L/I:L/A:L', '2'),
-    ('(AV:N/AC:H/PR:L/UI:R/S:U/I:L/A:L)', '2'),
-    ('AV:N/PR:L/UI:R/S:U/C:L/I:L/A:L', '2'),
+    ('CVSS2#AV:L/Au:L/C:P/I:C/A:N', '3.1', 'Provided vector CVSS2#AV:L/Au:L/C:P/I:C/A:N contains invalid metrics: CVSS2#AV, Au'),
+    ('(AV:L/AC:L/Au:M/I:C/A:N)', '3.1', 'Provided vector (AV:L/AC:L/Au:M/I:C/A:N) contains invalid metrics: Au'),
+    ('AV:L/AC:L/Au:M/C:P/A:N', '3.1', 'Provided vector AV:L/AC:L/Au:M/C:P/A:N contains invalid metrics: Au'),
+    ('CVSS:3.0/AV:N/AC:H/UI:R/S:U/C:L/I:L/A:L', '2', 'Provided vector CVSS:3.0/AV:N/AC:H/UI:R/S:U/C:L/I:L/A:L contains invalid metrics: CVSS, UI, S'),
+    ('CVSS:3.1/AV:N/AC:H/PR:L/S:U/C:L/I:L/A:L', '2', 'Provided vector CVSS:3.1/AV:N/AC:H/PR:L/S:U/C:L/I:L/A:L contains invalid metrics: CVSS, PR, S'),
+    ('(AV:N/AC:H/PR:L/UI:R/S:U/I:L/A:L)', '2', 'Provided vector (AV:N/AC:H/PR:L/UI:R/S:U/I:L/A:L) contains invalid metrics: PR, UI, S'),
+    ('AV:N/PR:L/UI:R/S:U/C:L/I:L/A:L', '2', 'Provided vector AV:N/PR:L/UI:R/S:U/C:L/I:L/A:L contains invalid metrics: PR, UI, S'),
 ]
 
 VECTORS_MISSING_MANDATORY = [
-    'CVSS2#AV:L/AC:L/C:P/I:C/A:N',
-    '(AV:L/AC:L/Au:M/I:C/A:N)',
-    'AV:L/AC:L/Au:M/C:P/A:N',
-    'CVSS:3.0/AV:N/AC:H/UI:R/S:U/C:L/I:L/A:L',
-    'CVSS:3.1/AV:N/AC:H/PR:L/S:U/C:L/I:L/A:L',
-    '(AV:N/AC:H/PR:L/UI:R/S:U/I:L/A:L)',
-    'AV:N/PR:L/UI:R/S:U/C:L/I:L/A:L',
+    ('CVSS2#AV:L/Au:L/C:P/I:C/A:N', 'AC'),
+    ('(AV:L/AC:L/Au:M/I:C/A:N)', 'C'),
+    ('AV:L/AC:L/Au:M/C:P/A:N', 'I'),
+    ('CVSS:3.0/AV:N/AC:H/UI:R/S:U/C:L/I:L/A:L', 'PR'),
+    ('CVSS:3.1/AV:N/AC:H/PR:L/S:U/C:L/I:L/A:L', 'UI'),
+    ('(AV:N/AC:H/PR:L/UI:R/S:U/I:L/A:L)', 'C'),
+    ('AV:N/PR:L/UI:R/S:U/C:L/I:L/A:L', 'AC'),
+    ('PR:L/UI:R/S:U/C:L/I:L/A:L', 'AV, AC'),
+    ('UI:R/S:U/C:L/I:L/A:L', 'AV, AC, PR'),
 ]
+
 VECTORS_INVALID_VALUE = [
-    'CVSS2#AV:L/AC:L/Au:Z/C:P/I:C/A:N',
-    '(AV:L/AC:L/Au:M/C:Z/I:C/A:N)',
-    'AV:L/AC:L/Au:M/C:P/I:Z/A:N',
-    'CVSS:3.0/AV:N/AC:H/PR:Z/UI:R/S:U/C:L/I:L/A:L',
-    'CVSS:3.1/AV:N/AC:Z/PR:L/UI:R/S:U/C:L/I:L/A:L',
-    '(AV:N/AC:H/PR:L/UI:Z/S:U/C:L/I:L/A:L)',
-    'AV:N/AC:H/PR:L/UI:R/S:Z/C:L/I:L/A:L',
+    ('CVSS2#AV:L/AC:L/Au:Z/C:P/I:C/A:N', 'Au:Z'),
+    ('(AV:L/AC:L/Au:M/C:Z/I:C/A:N)', 'C:Z'),
+    ('AV:L/AC:L/Au:M/C:P/I:Z/A:N', 'I:Z'),
+    ('CVSS:3.0/AV:N/AC:H/PR:Z/UI:R/S:U/C:L/I:L/A:L', 'PR:Z'),
+    ('CVSS:3.1/AV:N/AC:Z/PR:L/UI:R/S:U/C:L/I:L/A:L', 'AC:Z'),
+    ('(AV:N/AC:H/PR:L/UI:Z/S:U/C:L/I:L/A:L)', 'UI:Z'),
+    ('AV:N/AC:H/PR:L/UI:R/S:Z/C:L/I:L/A:L', 'S:Z'),
+    ('AV:N/AC:H/PR:L/UI:R/S:Z/C:Z/I:L/A:L', 'S:Z, C:Z'),
+    ('AV:N/AC:H/PR:L/UI:R/S:Z/C:Z/I:Z/A:L', 'S:Z, C:Z, I:Z'),
 ]
+
 VECTORS_DUPLICATE_METRIC = [
-    'CVSS2#AV:L/AC:L/Au:M/Au:M/C:P/I:C/A:N',
-    '(AV:L/AC:L/Au:M/C:P/C:P/I:C/A:N)',
-    'AV:L/AC:L/Au:M/C:P/I:C/I:C/A:N',
-    'CVSS:3.0/AV:N/AC:H/PR:L/PR:L/UI:R/S:U/C:L/I:L/A:L',
-    'CVSS:3.1/AV:N/AC:H/PR:L/UI:R/UI:R/S:U/C:L/I:L/A:L',
-    '(AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L/A:L)',
-    'AV:N/AC:H/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L',
+    ('CVSS2#AV:L/AC:L/Au:M/Au:M/C:P/I:C/A:N', 'Au'),
+    ('(AV:L/AC:L/Au:M/C:P/C:P/I:C/A:N)', 'C'),
+    ('AV:L/AC:L/Au:M/C:P/I:C/I:C/A:N', 'I'),
+    ('CVSS:3.0/AV:N/AC:H/PR:L/PR:L/UI:R/S:U/C:L/I:L/A:L', 'PR'),
+    ('CVSS:3.1/AV:N/AC:H/PR:L/UI:R/UI:R/S:U/C:L/I:L/A:L', 'UI'),
+    ('(AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L/A:L)', 'A'),
+    ('AV:N/AC:H/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L', 'AC'),
+    ('AV:N/AC:H/AC:H/PR:L/PR:L/UI:R/S:U/C:L/I:L/A:L', 'AC, PR'),
+    ('AV:N/AC:H/AC:H/PR:L/PR:L/UI:R/UI:R/S:U/C:L/I:L/A:L', 'AC, PR, UI'),
 ]
 
 VECTORS_MALFORMED = [
@@ -220,6 +230,73 @@ VECTORS_MALFORMED = [
     'CVSS:3.1/AV:N/AC:H/PR:L/UIR/S:U/C:L/I:L/A:L',
     '(AV:N/AC:H/PR:L/UI:R/S:U/C:L/IL/A:L)',
     'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/AL',
+]
+
+VECTORS_UNNORMAL = [
+    (
+        'S:C/C:H/I:N/A:L/E:P/RL:T/AV:A/AC:L/PR:H/UI:R/RC:U/CR:H/IR:L/AR:M/MAV:X/MAC:H/MPR:L/MUI:N/MS:U/MC:H/MI:L/MA:N',
+        'AV:A/AC:L/PR:H/UI:R/S:C/C:H/I:N/A:L/E:P/RL:T/RC:U/CR:H/IR:L/AR:M/MAC:H/MPR:L/MUI:N/MS:U/MC:H/MI:L/MA:N'
+    ),
+    (
+        'AV:A/AC:L/PR:H/UI:R/S:U/RC:U/CR:H/IR:L/AR:M/MAV:X/C:H/I:N/A:L/E:P/RL:T/MAC:H/MPR:L/MUI:N/MS:C/MC:H/MI:L/MA:N',
+        'AV:A/AC:L/PR:H/UI:R/S:U/C:H/I:N/A:L/E:P/RL:T/RC:U/CR:H/IR:L/AR:M/MAC:H/MPR:L/MUI:N/MS:C/MC:H/MI:L/MA:N'
+    ),
+    (
+        'MAV:X/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L/CR:L/IR:X/AR:X',
+        'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L/CR:L'
+    ),
+    (
+        'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L/E:U/RL:O/RC:U/CR:L/IR:X/AR:X/MAV:X/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X',
+        'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L/E:U/RL:O/RC:U/CR:L'
+    ),
+    (
+        '(AV:L/AC:L/Au:M/C:P/I:C/A:N/E:ND/RL:TF/RC:ND/CDP:N/TD:ND/CR:ND/IR:ND/AR:ND)',
+        'AV:L/AC:L/Au:M/C:P/I:C/A:N/RL:TF/CDP:N'
+    ),
+    (
+        '(AV:L/AC:L/Au:M/C:P/I:C/A:N/E:ND/RL:OF/RC:ND/CDP:N/TD:ND/CR:ND/IR:ND/AR:ND)',
+        'AV:L/AC:L/Au:M/C:P/I:C/A:N/RL:OF/CDP:N'
+    ),
+    (
+        '(AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:H)',
+        'AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:H'
+    ),
+    (
+        'CVSS2#AV:L/AC:L/Au:M/C:P/I:C/A:N',
+        'AV:L/AC:L/Au:M/C:P/I:C/A:N'
+    ),
+    (
+        '(AV:L/AC:L/Au:M/I:C/C:P/A:N)',
+        'AV:L/AC:L/Au:M/C:P/I:C/A:N'
+    ),
+    (
+        'A:N/I:C/C:P/Au:M/AC:L/AV:L/IR:ND',
+        'AV:L/AC:L/Au:M/C:P/I:C/A:N'
+    ),
+    (
+        'A:N/I:C/C:P/Au:M/AC:L/AV:L',
+        'AV:L/AC:L/Au:M/C:P/I:C/A:N'
+    ),
+    (
+        'CVSS:3.0/AV:N/AC:H/PR:L/A:L/UI:R/S:U/C:L/I:L',
+        'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L'
+    ),
+    (
+        'CVSS:3.1/AV:N/AC:H/PR:L/A:L/UI:R/S:U/C:L/I:L',
+        'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L'
+    ),
+    (
+        '(AV:N/AC:H/UI:R/PR:L/S:U/C:L/I:L/A:L)',
+        'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L'
+    ),
+    (
+        'AV:N/AC:H/UI:R/PR:L/S:U/C:L/I:L/A:L',
+        'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L'
+    ),
+    (
+        '(AV:N/AC:L/Au:N/C:C/I:N/A:N/E:POC/RL:ND/RC:ND)',
+        'AV:N/AC:L/Au:N/C:C/I:N/A:N/E:POC'
+    )
 ]
 
 class InfoSecTest(s_test.SynTest):
@@ -373,38 +450,50 @@ class InfoSecTest(s_test.SynTest):
 
         async with self.getTestCore() as core:
 
-            cmd = 'return($lib.infosec.cvss.vectToScore($vect))'
-            vercmd = 'return($lib.infosec.cvss.vectToScore($vect, $vers))'
+            cmd = 'return($lib.infosec.cvss.vectToScore($vect, $vers))'
 
             for vect, score in VECTORS:
-                valu = await core.callStorm(cmd, opts={'vars': {'vect': vect}})
+                valu = await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': None}})
+                valu.pop('normalized')
                 self.eq(score, valu)
 
             # test for invalid version being specified
-            with self.raises(s_exc.BadArg):
-                await core.callStorm(vercmd, opts={'vars': {'vect': 'DOESNT_MATTER', 'vers': '1.0'}})
+            with self.raises(s_exc.BadArg) as exc:
+                await core.callStorm(cmd, opts={'vars': {'vect': 'DOESNT_MATTER', 'vers': '1.0'}})
+            self.isin(f'Valid values for vers are: {s_cvss.versions + [None]}, got 1.0', exc.exception.get('mesg'))
 
             # test for vector/version mismatches
-            for vect, vers in VECTORS_BAD_VERSION:
+            for vect, vers, mesg in VECTORS_BAD_VERSION:
                 with self.raises(s_exc.BadDataValu) as exc:
-                    await core.callStorm(vercmd, opts={'vars': {'vect': vect, 'vers': vers}})
+                    await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': vers}})
+                self.isin(mesg, exc.exception.get('mesg'))
 
             # test for missing mandatory metrics
-            for vect in VECTORS_MISSING_MANDATORY:
-                with self.raises(s_exc.BadDataValu):
-                    await core.callStorm(cmd, opts={'vars': {'vect': vect}})
+            for vect, err in VECTORS_MISSING_MANDATORY:
+                with self.raises(s_exc.BadDataValu) as exc:
+                    await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': None}})
+                self.isin(f'Provided vector {vect} missing mandatory metric(s): {err}', exc.exception.get('mesg'))
 
             # test for invalid metric values
-            for vect in VECTORS_INVALID_VALUE:
-                with self.raises(s_exc.BadDataValu):
-                    await core.callStorm(cmd, opts={'vars': {'vect': vect}})
+            for vect, err in VECTORS_INVALID_VALUE:
+                with self.raises(s_exc.BadDataValu) as exc:
+                    await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': None}})
+                self.isin(f'Provided vector {vect} contains invalid metric value(s): {err}', exc.exception.get('mesg'))
 
             # test for duplicate metrics
-            for vect in VECTORS_DUPLICATE_METRIC:
-                with self.raises(s_exc.BadDataValu):
-                    await core.callStorm(cmd, opts={'vars': {'vect': vect}})
+            for vect, err in VECTORS_DUPLICATE_METRIC:
+                with self.raises(s_exc.BadDataValu) as exc:
+                    await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': None}})
+                self.isin(f'Provided vectors {vect} contains duplicate metrics: {err}', exc.exception.get('mesg'))
 
             # test for malformed vector string
             for vect in VECTORS_MALFORMED:
-                with self.raises(s_exc.BadDataValu):
-                    await core.callStorm(cmd, opts={'vars': {'vect': vect}})
+                with self.raises(s_exc.BadDataValu) as exc:
+                    await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': None}})
+                self.isin(f'Provided vector {vect} malformed', exc.exception.get('mesg'))
+
+            # test for vector normalization
+            for vect, norm in VECTORS_UNNORMAL:
+                valu = await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': None}})
+                # self.eq(norm, valu.get('normalized'))
+                print(valu.get('normalized'))

--- a/synapse/tests/test_lib_stormlib_infosec.py
+++ b/synapse/tests/test_lib_stormlib_infosec.py
@@ -149,13 +149,13 @@ VECTORS = [
 ]
 
 VECTORS_BAD_VERSION = [
-    ('CVSS2#AV:L/Au:L/C:P/I:C/A:N', '3.1', 'Provided vector CVSS2#AV:L/Au:L/C:P/I:C/A:N contains invalid metrics: CVSS2#AV, Au'),
-    ('(AV:L/AC:L/Au:M/I:C/A:N)', '3.1', 'Provided vector (AV:L/AC:L/Au:M/I:C/A:N) contains invalid metrics: Au'),
-    ('AV:L/AC:L/Au:M/C:P/A:N', '3.1', 'Provided vector AV:L/AC:L/Au:M/C:P/A:N contains invalid metrics: Au'),
-    ('CVSS:3.0/AV:N/AC:H/UI:R/S:U/C:L/I:L/A:L', '2', 'Provided vector CVSS:3.0/AV:N/AC:H/UI:R/S:U/C:L/I:L/A:L contains invalid metrics: CVSS, UI, S'),
-    ('CVSS:3.1/AV:N/AC:H/PR:L/S:U/C:L/I:L/A:L', '2', 'Provided vector CVSS:3.1/AV:N/AC:H/PR:L/S:U/C:L/I:L/A:L contains invalid metrics: CVSS, PR, S'),
-    ('(AV:N/AC:H/PR:L/UI:R/S:U/I:L/A:L)', '2', 'Provided vector (AV:N/AC:H/PR:L/UI:R/S:U/I:L/A:L) contains invalid metrics: PR, UI, S'),
-    ('AV:N/PR:L/UI:R/S:U/C:L/I:L/A:L', '2', 'Provided vector AV:N/PR:L/UI:R/S:U/C:L/I:L/A:L contains invalid metrics: PR, UI, S'),
+    ('CVSS2#AV:L/Au:L/C:P/I:C/A:N', '3.1', 'CVSS2#AV, Au'),
+    ('(AV:L/AC:L/Au:M/I:C/A:N)', '3.1', 'Au'),
+    ('AV:L/AC:L/Au:M/C:P/A:N', '3.1', 'Au'),
+    ('CVSS:3.0/AV:N/AC:H/UI:R/S:U/C:L/I:L/A:L', '2', 'CVSS, UI, S'),
+    ('CVSS:3.1/AV:N/AC:H/PR:L/S:U/C:L/I:L/A:L', '2', 'CVSS, PR, S'),
+    ('(AV:N/AC:H/PR:L/UI:R/S:U/I:L/A:L)', '2', 'PR, UI, S'),
+    ('AV:N/PR:L/UI:R/S:U/C:L/I:L/A:L', '2', 'PR, UI, S'),
 ]
 
 VECTORS_MISSING_MANDATORY = [
@@ -463,10 +463,10 @@ class InfoSecTest(s_test.SynTest):
             self.isin(f'Valid values for vers are: {s_cvss.versions + [None]}, got 1.0', exc.exception.get('mesg'))
 
             # test for vector/version mismatches
-            for vect, vers, mesg in VECTORS_BAD_VERSION:
+            for vect, vers, err in VECTORS_BAD_VERSION:
                 with self.raises(s_exc.BadDataValu) as exc:
                     await core.callStorm(cmd, opts={'vars': {'vect': vect, 'vers': vers}})
-                self.isin(mesg, exc.exception.get('mesg'))
+                self.isin(f'Provided vector {vect} contains invalid metrics: {err}', exc.exception.get('mesg'))
 
             # test for missing mandatory metrics
             for vect, err in VECTORS_MISSING_MANDATORY:


### PR DESCRIPTION
- Update vectToScore to return normalized vector
- Update CVSS validate function with better errors that return detailed info
- Create synapse.lookup.cvss and move a bunch of the CVSS constants into it.
- Move CVSS validate function into synapse.lib.chop
- Add CVSS normalize function in synapse.lib.chop
- Update tests

Addresses SYN-5692 and SYN-5609. Prepares for SYN-5701 model updates.