### PR TITLE
SYN-5600: Removing extended form does not properly remove all the props

### DIFF
--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -770,7 +770,7 @@ class Model:
 
         if newtype.deprecated and typeinfo.get('custom'):
             mesg = f'The type {typename} is based on a deprecated type {newtype.name} which ' \
-                   f'which which will be removed in 3.0.0.'
+                   f'will be removed in 3.0.0.'
             logger.warning(mesg)
 
         self.types[typename] = newtype
@@ -817,6 +817,12 @@ class Model:
         form = self.forms.get(formname)
         if form is None:
             return
+
+        formprops = [p for p in form.props.values() if p.univ is None]
+        if formprops:
+            propnames = ', '.join(prop.name for prop in formprops)
+            mesg = f'Form has extended properties: {propnames}'
+            raise s_exc.CantDelForm(mesg=mesg)
 
         if isinstance(form.type, s_types.Array):
             self.arraysbytype[form.type.arraytype.name].remove(form)

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -118,6 +118,10 @@ class DataModelTest(s_t_utils.SynTest):
         with self.raises(s_exc.CantDelType):
             modl.delType('bar')
 
+        with self.raises(s_exc.CantDelForm):
+            modl.delForm('foo:foo')
+
+        modl.delFormProp('foo:foo', 'bar')
         modl.delForm('foo:foo')
 
     async def test_datamodel_del_prop(self):

--- a/synapse/tests/test_lib_stormlib_modelext.py
+++ b/synapse/tests/test_lib_stormlib_modelext.py
@@ -61,7 +61,7 @@ class StormtypesModelextTest(s_test.SynTest):
             q = '$lib.model.ext.delForm(_visi:int)'
             with self.raises(s_exc.CantDelForm) as exc:
                 await core.callStorm(q)
-                self.eq('Form has extended properties: tick', exc.exception.get('mesg'))
+            self.eq('Form has extended properties: tick', exc.exception.get('mesg'))
 
             await core.callStorm('$lib.model.ext.addFormProp(_visi:int, tock, (time, $lib.dict()), $lib.dict())')
 
@@ -72,7 +72,7 @@ class StormtypesModelextTest(s_test.SynTest):
             q = '$lib.model.ext.delForm(_visi:int)'
             with self.raises(s_exc.CantDelForm) as exc:
                 await core.callStorm(q)
-                self.eq('Form has extended properties: tick, tock', exc.exception.get('mesg'))
+            self.eq('Form has extended properties: tick, tock', exc.exception.get('mesg'))
 
             await core.callStorm('''
                 $lib.model.ext.delFormProp(_visi:int, tick)

--- a/synapse/tests/test_lib_stormlib_modelext.py
+++ b/synapse/tests/test_lib_stormlib_modelext.py
@@ -6,7 +6,8 @@ class StormtypesModelextTest(s_test.SynTest):
 
     async def test_lib_stormlib_modelext(self):
         async with self.getTestCore() as core:
-            await core.callStorm('''
+
+            create = '''
                 $typeinfo = $lib.dict()
                 $forminfo = $lib.dict(doc="A test form doc.")
                 $lib.model.ext.addForm(_visi:int, int, $typeinfo, $forminfo)
@@ -19,7 +20,9 @@ class StormtypesModelextTest(s_test.SynTest):
 
                 $tagpropinfo = $lib.dict(doc="A test tagprop doc.")
                 $lib.model.ext.addTagProp(score, (int, $lib.dict()), $tagpropinfo)
-            ''')
+            '''
+
+            await core.callStorm(create)
 
             nodes = await core.nodes('[ _visi:int=10 :tick=20210101 ._woot=30 +#lol:score=99 ]')
             self.len(1, nodes)
@@ -48,6 +51,38 @@ class StormtypesModelextTest(s_test.SynTest):
             self.none(core.model.prop('._woot'))
             self.none(core.model.prop('_visi:int:tick'))
             self.none(core.model.tagprop('score'))
+
+            # Verify extended forms can't be deleted if they have associated extended props
+            await core.callStorm(create)
+
+            self.nn(core.model.form('_visi:int'))
+            self.nn(core.model.prop('_visi:int:tick'))
+
+            q = '$lib.model.ext.delForm(_visi:int)'
+            with self.raises(s_exc.CantDelForm) as exc:
+                await core.callStorm(q)
+                self.eq('Form has extended properties: tick', exc.exception.get('mesg'))
+
+            await core.callStorm('$lib.model.ext.addFormProp(_visi:int, tock, (time, $lib.dict()), $lib.dict())')
+
+            self.nn(core.model.form('_visi:int'))
+            self.nn(core.model.prop('_visi:int:tick'))
+            self.nn(core.model.prop('_visi:int:tock'))
+
+            q = '$lib.model.ext.delForm(_visi:int)'
+            with self.raises(s_exc.CantDelForm) as exc:
+                await core.callStorm(q)
+                self.eq('Form has extended properties: tick, tock', exc.exception.get('mesg'))
+
+            await core.callStorm('''
+                $lib.model.ext.delFormProp(_visi:int, tick)
+                $lib.model.ext.delFormProp(_visi:int, tock)
+                $lib.model.ext.delForm(_visi:int)
+            ''')
+
+            self.none(core.model.form('_visi:int'))
+            self.none(core.model.prop('_visi:int:tick'))
+            self.none(core.model.prop('_visi:int:tock'))
 
             # Underscores can exist in extended names but only at specific locations
             q = '''$l =$lib.list('str', $lib.dict()) $d=$lib.dict(doc="Foo")


### PR DESCRIPTION
- Update `synapse.datamodel.Model.delForm()` to check for extended properties on the form before deletion. If extended props are found, raise exception with names of properties.
- Update tests.

Resolves SYN-5600