### PR TITLE
Adjust names for storm types (SYN-5439)

### DIFF
--- a/docs/synapse/adminguide.rstorm
+++ b/docs/synapse/adminguide.rstorm
@@ -1525,7 +1525,7 @@ or view which is not yet provisioned or is currently offline.
 Once a mirrored layer is configured, it will need to stream down the entire history of events from the upstream
 layer.  During this process, the layer will be readable but writes will hang due to needing to await the write-back
 to be fully caught up to guarantee that edits are immediately observable like a normal layer.  During that process,
-you may track progress by calling the ``getMirrorStatus()`` API on the ``storm:layer`` object within the Storm runtime.
+you may track progress by calling the ``getMirrorStatus()`` API on the ``layer`` object within the Storm runtime.
 
 
 

--- a/docs/synapse/glossary.rst
+++ b/docs/synapse/glossary.rst
@@ -862,7 +862,7 @@ a third-party API along with the timestamp when the data was retrieved. If the s
 the same node within a specific time period, the Power-Up can use the cached node data instead of re-querying
 the API (helping to prevent using up any API query limits by re-querying the same data).
 
-Node data can be accessed using the `storm:node:data`_ type.
+Node data can be accessed using the `node:data`_ type.
 
 .. _gloss-node-def:
 
@@ -1671,6 +1671,6 @@ Workspaces Tool
 See :ref:`gloss-tool-workspaces`.
 
 
-.. _storm:node:data: https://synapse.docs.vertex.link/en/latest/synapse/autodocs/stormtypes_prims.html#storm-node-data
+.. _node:data: https://synapse.docs.vertex.link/en/latest/synapse/autodocs/stormtypes_prims.html#node-data
 
 .. _`Docker containers`: https://www.docker.com/resources/what-container/

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -22,7 +22,7 @@ class WebSocket(s_base.Base, s_stormtypes.StormType):
     '''
     Implements the Storm API for a Websocket.
     '''
-    _storm_typename = 'storm:http:socket'
+    _storm_typename = 'http:socket'
 
     _storm_locals = (
 
@@ -108,7 +108,7 @@ class LibHttp(s_stormtypes.Lib):
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
                   ),
-                  'returns': {'type': 'storm:http:resp', 'desc': 'The response object.'}}},
+                  'returns': {'type': 'http:resp', 'desc': 'The response object.'}}},
         {'name': 'post', 'desc': 'Post data to a given URL.',
          'type': {'type': 'function', '_funcname': '_httpPost',
                   'args': (
@@ -137,7 +137,7 @@ class LibHttp(s_stormtypes.Lib):
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
                   ),
-                  'returns': {'type': 'storm:http:resp', 'desc': 'The response object.'}}},
+                  'returns': {'type': 'http:resp', 'desc': 'The response object.'}}},
         {'name': 'head', 'desc': 'Get the HEAD response for a URL.',
          'type': {'type': 'function', '_funcname': '_httpEasyHead',
                   'args': (
@@ -156,7 +156,7 @@ class LibHttp(s_stormtypes.Lib):
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
                   ),
-                  'returns': {'type': 'storm:http:resp', 'desc': 'The response object.'}}},
+                  'returns': {'type': 'http:resp', 'desc': 'The response object.'}}},
         {'name': 'request', 'desc': 'Make an HTTP request using the given HTTP method to the url.',
          'type': {'type': 'function', '_funcname': '_httpRequest',
                    'args': (
@@ -186,7 +186,7 @@ class LibHttp(s_stormtypes.Lib):
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
                    ),
-                  'returns': {'type': 'storm:http:resp', 'desc': 'The response object.'}
+                  'returns': {'type': 'http:resp', 'desc': 'The response object.'}
                   }
          },
         {'name': 'connect', 'desc': 'Connect a web socket to tx/rx JSON messages.',
@@ -204,7 +204,7 @@ class LibHttp(s_stormtypes.Lib):
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
                   ),
-                  'returns': {'type': 'storm:http:socket', 'desc': 'A websocket object.'}}},
+                  'returns': {'type': 'http:socket', 'desc': 'A websocket object.'}}},
         {'name': 'urlencode', 'desc': '''
             Urlencode a text string.
 
@@ -467,7 +467,7 @@ class HttpResp(s_stormtypes.Prim):
                      }
         },
     )
-    _storm_typename = 'storm:http:resp'
+    _storm_typename = 'http:resp'
     def __init__(self, valu, path=None):
         super().__init__(valu, path=path)
         self.locls.update(self.getObjLocals())

--- a/synapse/lib/stormlib/gen.py
+++ b/synapse/lib/stormlib/gen.py
@@ -11,13 +11,13 @@ class LibGen(s_stormtypes.Lib):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the org.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'An ou:org node with the given name.'}}},
+                  'returns': {'type': 'node', 'desc': 'An ou:org node with the given name.'}}},
         {'name': 'orgHqByName', 'desc': 'Returns a ps:contact node for the ou:org, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the org.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A ps:contact node for the ou:org with the given name.'}}},
+                  'returns': {'type': 'node', 'desc': 'A ps:contact node for the ou:org with the given name.'}}},
         {'name': 'orgByFqdn', 'desc': 'Returns an ou:org node by FQDN, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
@@ -25,13 +25,13 @@ class LibGen(s_stormtypes.Lib):
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'An ou:org node with the given FQDN.'}}},
+                  'returns': {'type': 'node', 'desc': 'An ou:org node with the given FQDN.'}}},
         {'name': 'industryByName', 'desc': 'Returns an ou:industry by name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the industry.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'An ou:industry node with the given name.'}}},
+                  'returns': {'type': 'node', 'desc': 'An ou:industry node with the given name.'}}},
         {'name': 'newsByUrl', 'desc': 'Returns a media:news node by URL, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
@@ -39,13 +39,13 @@ class LibGen(s_stormtypes.Lib):
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A media:news node with the given URL.'}}},
+                  'returns': {'type': 'node', 'desc': 'A media:news node with the given URL.'}}},
         {'name': 'softByName', 'desc': 'Returns it:prod:soft node by name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the software.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'An it:prod:soft node with the given name.'}}},
+                  'returns': {'type': 'node', 'desc': 'An it:prod:soft node with the given name.'}}},
         {'name': 'vulnByCve', 'desc': 'Returns risk:vuln node by CVE, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
@@ -53,7 +53,7 @@ class LibGen(s_stormtypes.Lib):
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A risk:vuln node with the given CVE.'}}},
+                  'returns': {'type': 'node', 'desc': 'A risk:vuln node with the given CVE.'}}},
 
         {'name': 'riskThreat',
          'desc': 'Returns a risk:threat node based on the threat and reporter names, adding the node if it does not exist.',
@@ -62,7 +62,7 @@ class LibGen(s_stormtypes.Lib):
                       {'name': 'name', 'type': 'str', 'desc': 'The reported name of the threat cluster.'},
                       {'name': 'reporter', 'type': 'str', 'desc': 'The name of the organization which reported the threat cluster.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A risk:threat node.'}}},
+                  'returns': {'type': 'node', 'desc': 'A risk:threat node.'}}},
 
         {'name': 'riskToolSoftware',
          'desc': 'Returns a risk:tool:software node based on the tool and reporter names, adding the node if it does not exist.',
@@ -71,7 +71,7 @@ class LibGen(s_stormtypes.Lib):
                       {'name': 'name', 'type': 'str', 'desc': 'The reported name of the tool.'},
                       {'name': 'reporter', 'type': 'str', 'desc': 'The name of the organization which reported the tool.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A risk:tool:software node.'}}},
+                  'returns': {'type': 'node', 'desc': 'A risk:tool:software node.'}}},
 
         {'name': 'psContactByEmail', 'desc': 'Returns a ps:contact by deconflicting the type and email address.',
          'type': {'type': 'function', '_funcname': '_storm_query',
@@ -81,7 +81,7 @@ class LibGen(s_stormtypes.Lib):
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A ps:contact node.'}}},
+                  'returns': {'type': 'node', 'desc': 'A ps:contact node.'}}},
 
         {'name': 'polCountryByIso2', 'desc': 'Returns a pol:country node by deconflicting the :iso2 property.',
          'type': {'type': 'function', '_funcname': '_storm_query',
@@ -90,13 +90,13 @@ class LibGen(s_stormtypes.Lib):
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A pol:country node.'}}},
+                  'returns': {'type': 'node', 'desc': 'A pol:country node.'}}},
         {'name': 'langByName', 'desc': 'Returns a lang:language node by name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the language.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A lang:language node with the given name.'}}},
+                  'returns': {'type': 'node', 'desc': 'A lang:language node with the given name.'}}},
         {'name': 'langByCode', 'desc': 'Returns a lang:language node by language code, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
@@ -104,7 +104,7 @@ class LibGen(s_stormtypes.Lib):
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'A lang:language node with the given code.'}}},
+                  'returns': {'type': 'node', 'desc': 'A lang:language node with the given code.'}}},
     )
     _storm_lib_path = ('gen',)
 

--- a/synapse/lib/stormlib/imap.py
+++ b/synapse/lib/stormlib/imap.py
@@ -36,7 +36,7 @@ class ImapLib(s_stormtypes.Lib):
             Open a connection to an IMAP server.
 
             This method will wait for a "hello" response from the server
-            before returning the ``storm:imap:server`` instance.
+            before returning the ``imap:server`` instance.
             ''',
             'type': {
                 'type': 'function', '_funcname': 'connect',
@@ -51,8 +51,8 @@ class ImapLib(s_stormtypes.Lib):
                      'desc': 'Use SSL to connect to the IMAP server.'},
                 ),
                 'returns': {
-                    'type': 'storm:imap:server',
-                    'desc': 'A new ``storm:imap:server`` instance.'
+                    'type': 'imap:server',
+                    'desc': 'A new ``imap:server`` instance.'
                 },
             },
         },
@@ -138,7 +138,7 @@ class ImapServer(s_stormtypes.StormType):
                      'desc': 'The single message UID.'},
                 ),
                 'returns': {
-                    'type': 'storm:node',
+                    'type': 'node',
                     'desc': 'The file:bytes node representing the message.'
                 },
             },
@@ -263,7 +263,7 @@ class ImapServer(s_stormtypes.StormType):
             },
         },
     )
-    _storm_typename = 'storm:imap:server'
+    _storm_typename = 'imap:server'
 
     def __init__(self, runt, imap_cli, path=None):
         s_stormtypes.StormType.__init__(self, path=path)

--- a/synapse/lib/stormlib/infosec.py
+++ b/synapse/lib/stormlib/infosec.py
@@ -418,7 +418,7 @@ class CvssLib(s_stormtypes.Lib):
         {'name': 'calculate', 'desc': 'Calculate the CVSS score values for an input risk:vuln node.',
          'type': {'type': 'function', '_funcname': 'calculate',
                   'args': (
-                      {'name': 'node', 'type': 'storm:node',
+                      {'name': 'node', 'type': 'node',
                        'desc': 'A risk:vuln node from the Storm runtime.'},
                       {'name': 'save', 'type': 'boolean', 'default': True,
                        'desc': 'If true, save the computed scores to the node properties.'},
@@ -447,7 +447,7 @@ class CvssLib(s_stormtypes.Lib):
         {'name': 'saveVectToNode', 'desc': 'Parse a CVSS v3.1 vector and record properties on a risk:vuln node.',
          'type': {'type': 'function', '_funcname': 'saveVectToNode',
                   'args': (
-                      {'name': 'node', 'type': 'storm:node',
+                      {'name': 'node', 'type': 'node',
                        'desc': 'A risk:vuln node to record the CVSS properties on.'},
                       {'name': 'text', 'type': 'str', 'desc': 'A CVSS vector string.'},
                   ),

--- a/synapse/lib/stormlib/json.py
+++ b/synapse/lib/stormlib/json.py
@@ -27,7 +27,7 @@ class JsonSchema(s_stormtypes.StormType):
     '''
     A JsonSchema validation object for use in validating data structures in Storm.
     '''
-    _storm_typename = 'storm:json:schema'
+    _storm_typename = 'json:schema'
     _storm_locals = (
         {'name': 'schema',
          'desc': 'The schema belonging to this object.',
@@ -100,7 +100,7 @@ class JsonLib(s_stormtypes.Lib):
                       {'name': 'use_default', 'type': 'boolean', 'default': True,
                        'desc': 'Whether to insert default schema values into the validated data structure.'},
                   ),
-                  'returns': {'type': 'storm:json:schema',
+                  'returns': {'type': 'json:schema',
                               'desc': 'A validation object that can be used to validate data structures.'}}},
     )
     _storm_lib_path = ('json',)

--- a/synapse/lib/stormlib/model.py
+++ b/synapse/lib/stormlib/model.py
@@ -283,32 +283,32 @@ class LibModel(s_stormtypes.Lib):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the type to retrieve.', },
                   ),
-                  'returns': {'type': ['storm:model:type', 'null'],
-                              'desc': 'The ``storm:model:type`` instance if the type if present on the form or null.',
+                  'returns': {'type': ['model:type', 'null'],
+                              'desc': 'The ``model:type`` instance if the type if present on the form or null.',
                               }}},
         {'name': 'prop', 'desc': 'Get a prop object by name.',
          'type': {'type': 'function', '_funcname': '_methProp',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the prop to retrieve.', },
                   ),
-                  'returns': {'type': ['storm:model:property', 'null'],
-                              'desc': 'The ``storm:model:property`` instance if the type if present or null.',
+                  'returns': {'type': ['model:property', 'null'],
+                              'desc': 'The ``model:property`` instance if the type if present or null.',
                               }}},
         {'name': 'form', 'desc': 'Get a form object by name.',
          'type': {'type': 'function', '_funcname': '_methForm',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the form to retrieve.', },
                   ),
-                  'returns': {'type': ['storm:model:form', 'null'],
-                              'desc': 'The ``storm:model:form`` instance if the form is present or null.',
+                  'returns': {'type': ['model:form', 'null'],
+                              'desc': 'The ``model:form`` instance if the form is present or null.',
                               }}},
         {'name': 'tagprop', 'desc': 'Get a tag property object by name.',
          'type': {'type': 'function', '_funcname': '_methTagProp',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the tag prop to retrieve.', },
                   ),
-                  'returns': {'type': ['storm:model:tagprop', 'null'],
-                              'desc': 'The ``storm:model:tagprop`` instance if the tag prop if present or null.',
+                  'returns': {'type': ['model:tagprop', 'null'],
+                              'desc': 'The ``model:tagprop`` instance if the tag prop if present or null.',
                               }}},
     )
 
@@ -360,14 +360,14 @@ class ModelForm(s_stormtypes.Prim):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The property to retrieve.', },
                   ),
-                  'returns': {'type': ['storm:model:property', 'null'],
-                              'desc': 'The ``storm:model:property`` instance if the property if present on the form or null.'
+                  'returns': {'type': ['model:property', 'null'],
+                              'desc': 'The ``model:property`` instance if the property if present on the form or null.'
                               }}},
         {'name': 'type', 'desc': 'Get the Type for the form.',
          'type': {'type': 'ctor', '_ctorfunc': '_ctorFormType',
-                  'returns': {'type': 'storm:model:type'}}},
+                  'returns': {'type': 'model:type'}}},
     )
-    _storm_typename = 'storm:model:form'
+    _storm_typename = 'model:form'
     def __init__(self, form, path=None):
 
         s_stormtypes.Prim.__init__(self, form, path=path)
@@ -405,12 +405,12 @@ class ModelProp(s_stormtypes.Prim):
         {'name': 'full', 'desc': 'The full name of the Property.', 'type': 'str', },
         {'name': 'form', 'desc': 'Get the Form for the Property.',
          'type': {'type': 'ctor', '_ctorfunc': '_ctorPropForm',
-                  'returns': {'type': ['storm:model:form', 'null']}}},
+                  'returns': {'type': ['model:form', 'null']}}},
         {'name': 'type', 'desc': 'Get the Type for the Property.',
          'type': {'type': 'ctor', '_ctorfunc': '_ctorPropType',
-                  'returns': {'type': 'storm:model:type'}}},
+                  'returns': {'type': 'model:type'}}},
     )
-    _storm_typename = 'storm:model:property'
+    _storm_typename = 'model:property'
     def __init__(self, prop, path=None):
 
         s_stormtypes.Prim.__init__(self, prop, path=path)
@@ -444,9 +444,9 @@ class ModelTagProp(s_stormtypes.Prim):
         {'name': 'name', 'desc': 'The name of the Tag Property.', 'type': 'str', },
         {'name': 'type', 'desc': 'Get the Type for the Tag Property.',
          'type': {'type': 'ctor', '_ctorfunc': '_ctorTagPropType',
-                  'returns': {'type': 'storm:model:type'}}},
+                  'returns': {'type': 'model:type'}}},
     )
-    _storm_typename = 'storm:model:tagprop'
+    _storm_typename = 'model:tagprop'
     def __init__(self, tagprop, path=None):
 
         s_stormtypes.Prim.__init__(self, tagprop, path=path)
@@ -484,7 +484,7 @@ class ModelType(s_stormtypes.Prim):
                   ),
                   'returns': {'desc': 'A tuple of the normed value and its information dictionary.', 'type': 'list'}}},
     )
-    _storm_typename = 'storm:model:type'
+    _storm_typename = 'model:type'
 
     def __init__(self, valu, path=None):
         s_stormtypes.Prim.__init__(self, valu, path=path)

--- a/synapse/lib/stormlib/oauth.py
+++ b/synapse/lib/stormlib/oauth.py
@@ -31,7 +31,7 @@ class OAuthV1Lib(s_stormtypes.Lib):
                      'desc': 'Where to populate the signature (in the HTTP body, in the query parameters, or in the header)'},
                 ),
                 'returns': {
-                    'type': 'storm:oauth:v1:client',
+                    'type': 'oauth:v1:client',
                     'desc': 'An OAuthV1 client to be used to sign requests.',
                 }
             },
@@ -82,7 +82,7 @@ class OAuthV1Client(s_stormtypes.StormType):
             },
         },
     )
-    _storm_typename = 'storm:oauth:v1:client'
+    _storm_typename = 'oauth:v1:client'
 
     def __init__(self, runt, ckey, csecret, atoken, asecret, sigtype, path=None):
         s_stormtypes.StormType.__init__(self, path=path)

--- a/synapse/lib/stormlib/project.py
+++ b/synapse/lib/stormlib/project.py
@@ -17,7 +17,7 @@ class ProjectEpic(s_stormtypes.Prim):
          'type': {'type': ['gtor', 'stor'], '_storfunc': '_setEpicName', '_gtorfunc': '_getName',
                           'returns': {'type': ['str', 'null'], }}},
     )
-    _storm_typename = 'storm:project:epic'
+    _storm_typename = 'proj:epic'
 
     def __init__(self, proj, node):
         s_stormtypes.Prim.__init__(self, None)
@@ -59,13 +59,13 @@ class ProjectEpics(s_stormtypes.Prim):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name (or iden) of the ProjectEpic to get.'},
                   ),
-                  'returns': {'type': 'storm:project:epic', 'desc': 'The `storm:project:epic` object', }}},
+                  'returns': {'type': 'proj:epic', 'desc': 'The `proj:epic` object', }}},
         {'name': 'add', 'desc': 'Add an epic.',
          'type': {'type': 'function', '_funcname': '_addProjEpic',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name for the new ProjectEpic.'},
                   ),
-                  'returns': {'type': 'storm:project:epic', 'desc': 'The newly created `storm:project:epic` object', }}},
+                  'returns': {'type': 'proj:epic', 'desc': 'The newly created `proj:epic` object', }}},
         {'name': 'del', 'desc': 'Delete an epic by name.',
          'type': {'type': 'function', '_funcname': '_delProjEpic',
                   'args': (
@@ -73,7 +73,7 @@ class ProjectEpics(s_stormtypes.Prim):
                   ),
                   'returns': {'type': 'boolean', 'desc': 'True if the ProjectEpic can be found and deleted, otherwise False', }}}
     )
-    _storm_typename = 'storm:project:epics'
+    _storm_typename = 'proj:epics'
 
     def __init__(self, proj):
         s_stormtypes.Prim.__init__(self, None)
@@ -139,7 +139,7 @@ class ProjectTicketComment(s_stormtypes.Prim):
                   'returns': {'type': 'boolean', 'desc': 'True if the ProjectTicketComment was deleted'}}},
     )
 
-    _storm_typename = 'storm:project:ticket:comment'
+    _storm_typename = 'proj:comment'
 
     def __init__(self, ticket, node):
         s_stormtypes.Prim.__init__(self, None)
@@ -210,18 +210,18 @@ class ProjectTicketComments(s_stormtypes.Prim):
                   'args': (
                       {'name': 'guid', 'type': 'str', 'desc': 'The guid of the ProjectTicketComment to get.'},
                   ),
-                  'returns': {'type': 'storm:project:ticket:comment',
-                              'desc': 'The `storm:project:ticket:comment` object', }}},
+                  'returns': {'type': 'proj:comment',
+                              'desc': 'The `proj:comment` object', }}},
         {'name': 'add', 'desc': 'Add a comment to the ticket.',
          'type': {'type': 'function', '_funcname': '_addTicketComment',
                   'args': (
                       {'name': 'text', 'type': 'str', 'desc': 'The text for the new ProjectTicketComment.'},
                   ),
-                  'returns': {'type': 'storm:project:ticket:comment',
-                              'desc': 'The newly created `storm:project:ticketcomment` object', }}},
+                  'returns': {'type': 'proj:comment',
+                              'desc': 'The newly created `proj:comment` object', }}},
     )
 
-    _storm_typename = 'storm:project:ticket:comments'
+    _storm_typename = 'proj:comments'
 
     def __init__(self, ticket):
         s_stormtypes.Prim.__init__(self, None)
@@ -298,12 +298,12 @@ class ProjectTicket(s_stormtypes.Prim):
          'type': {'type': ['gtor', 'stor'], '_storfunc': '_setPriority', '_gtorfunc': '_getTicketPriority',
                           'returns': {'type': ['int', 'null'], }}},
         {'name': 'comments',
-         'desc': 'A ``storm:project:ticket:comments`` object that contains comments associated with the given ticket.',
+         'desc': 'A ``proj:comments`` object that contains comments associated with the given ticket.',
          'type': {'type': 'ctor', '_ctorfunc': '_ctorTicketComments',
-                  'returns': {'type': 'storm:project:ticket:comments', }}},
+                  'returns': {'type': 'proj:comments', }}},
     )
 
-    _storm_typename = 'storm:project:ticket'
+    _storm_typename = 'proj:ticket'
 
     def __init__(self, proj, node):
         s_stormtypes.Prim.__init__(self, None)
@@ -470,21 +470,21 @@ class ProjectTickets(s_stormtypes.Prim):
     associated with a project
     '''
 
-    _storm_typename = 'storm:project:tickets'
+    _storm_typename = 'proj:tickets'
     _storm_locals = (
         {'name': 'get', 'desc': 'Get a ticket by name.',
          'type': {'type': 'function', '_funcname': '_getProjTicket',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name (or iden) of the ProjectTicket to get.'},
                   ),
-                  'returns': {'type': 'storm:project:ticket', 'desc': 'The `storm:project:ticket` object', }}},
+                  'returns': {'type': 'proj:ticket', 'desc': 'The `proj:ticket` object', }}},
         {'name': 'add', 'desc': 'Add a ticket.',
          'type': {'type': 'function', '_funcname': '_addProjTicket',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name for the new ProjectTicket.'},
                       {'name': 'desc', 'type': 'str', 'desc': 'A description of the new ticket', 'default': ''},
                   ),
-                  'returns': {'type': 'storm:project:ticket', 'desc': 'The newly created `storm:project:ticket` object', }}},
+                  'returns': {'type': 'proj:ticket', 'desc': 'The newly created `proj:ticket` object', }}},
         {'name': 'del', 'desc': 'Delete a sprint by name.',
          'type': {'type': 'function', '_funcname': '_delProjTicket',
                   'args': (
@@ -582,7 +582,7 @@ class ProjectSprint(s_stormtypes.Prim):
                   'returns': {'type': 'generator', }}},
     )
 
-    _storm_typename = 'storm:project:sprint'
+    _storm_typename = 'proj:sprint'
 
     def __init__(self, proj, node):
         s_stormtypes.Prim.__init__(self, None)
@@ -659,7 +659,7 @@ class ProjectSprints(s_stormtypes.Prim):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name (or iden) of the ProjectSprint to get.'},
                   ),
-                  'returns': {'type': 'storm:project:sprint', 'desc': 'The `storm:project:sprint` object', }}},
+                  'returns': {'type': 'proj:sprint', 'desc': 'The `proj:sprint` object', }}},
         {'name': 'add', 'desc': 'Add a sprint.',
          'type': {'type': 'function', '_funcname': '_addProjSprint',
                   'args': (
@@ -667,7 +667,7 @@ class ProjectSprints(s_stormtypes.Prim):
                       {'name': 'period', 'type': 'ival', 'desc': 'The time interval the ProjectSprint runs for',
                        'default': None},
                   ),
-                  'returns': {'type': 'storm:project:sprint', 'desc': 'The newly created `storm:project:sprint` object', }}},
+                  'returns': {'type': 'proj:sprint', 'desc': 'The newly created `proj:sprint` object', }}},
         {'name': 'del', 'desc': 'Delete a sprint by name.',
          'type': {'type': 'function', '_funcname': '_delProjSprint',
                   'args': (
@@ -676,7 +676,7 @@ class ProjectSprints(s_stormtypes.Prim):
                   'returns': {'type': 'boolean', 'desc': 'True if the ProjectSprint can be found and deleted, otherwise False', }}}
     )
 
-    _storm_typename = 'storm:project:sprints'
+    _storm_typename = 'proj:sprints'
 
     def __init__(self, proj):
         s_stormtypes.Prim.__init__(self, None)
@@ -746,18 +746,18 @@ class Project(s_stormtypes.Prim):
         {'name': 'name', 'desc': 'The name of the project. This can also be used to set the name of the project.',
          'type': {'type': ['gtor', 'stor'], '_storfunc': '_setName', '_gtorfunc': '_getName',
                   'returns': {'type': ['str', 'null'], }}},
-        {'name': 'epics', 'desc': 'A `storm:project:epics` object that contains the epics associated with the given project.',
+        {'name': 'epics', 'desc': 'A `proj:epics` object that contains the epics associated with the given project.',
          'type': {'type': 'ctor', '_ctorfunc': '_ctorProjEpics',
-                 'returns': {'type': 'storm:project:epics', }}},
-        {'name': 'sprints', 'desc': 'A `storm:project:sprints` object that contains the sprints associated with the given project.',
+                 'returns': {'type': 'proj:epics', }}},
+        {'name': 'sprints', 'desc': 'A `proj:sprints` object that contains the sprints associated with the given project.',
          'type': {'type': 'ctor', '_ctorfunc': '_ctorProjSprints',
-                  'returns': {'type': 'storm:project:sprints', }}},
-        {'name': 'tickets', 'desc': 'A `storm:project:tickets` object that contains the tickets associated with the given project.',
+                  'returns': {'type': 'proj:sprints', }}},
+        {'name': 'tickets', 'desc': 'A `proj:tickets` object that contains the tickets associated with the given project.',
          'type': {'type': 'ctor', '_ctorfunc': '_ctorProjTickets',
-                  'returns': {'type': 'storm:project:tickets', }}},
+                  'returns': {'type': 'proj:tickets', }}},
     )
 
-    _storm_typename = 'storm:project'
+    _storm_typename = 'proj:project'
 
     def __init__(self, runt, node, path=None):
         s_stormtypes.Prim.__init__(self, None)
@@ -846,8 +846,8 @@ class LibProjects(s_stormtypes.Lib):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the Project to get'},
                   ),
-                  'returns': {'type': 'storm:project',
-                              'desc': 'The `storm:project `object, if it exists, otherwise null'}}},
+                  'returns': {'type': 'proj:project',
+                              'desc': 'The `proj:project `object, if it exists, otherwise null'}}},
 
         {'name': 'add', 'desc': 'Add a new project',
          'type': {'type': 'function', '_funcname': '_funcProjAdd',
@@ -855,7 +855,7 @@ class LibProjects(s_stormtypes.Lib):
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the Project to add'},
                       {'name': 'desc', 'type': 'str', 'desc': 'A description of the overall project', 'default': ''},
                   ),
-                  'returns': {'type': 'storm:project', 'desc': 'The newly created `storm:project` object'}}},
+                  'returns': {'type': 'proj:project', 'desc': 'The newly created `proj:project` object'}}},
         {'name': 'del', 'desc': 'Delete an existing project',
          'type': {'type': 'function', '_funcname': '_funcProjDel',
                   'args': (

--- a/synapse/lib/stormlib/smtp.py
+++ b/synapse/lib/stormlib/smtp.py
@@ -17,8 +17,8 @@ class SmtpLib(s_stormtypes.Lib):
     _storm_locals = (
         {'name': 'message', 'desc': 'Construct a new email message.',
          'type': {'type': 'function', '_funcname': 'message',
-                          'returns': {'type': 'storm:smtp:message',
-                                      'desc': 'The newly constructed storm:smtp:message.'}}},
+                          'returns': {'type': 'smtp:message',
+                                      'desc': 'The newly constructed smtp:message.'}}},
     )
     _storm_lib_path = ('inet', 'smtp',)
 
@@ -35,7 +35,7 @@ class SmtpMessage(s_stormtypes.StormType):
     '''
     An SMTP message to compose and send.
     '''
-    _storm_typename = 'storm:smtp:message'
+    _storm_typename = 'smtp:message'
 
     _storm_locals = (
 
@@ -154,7 +154,7 @@ class SmtpMessage(s_stormtypes.StormType):
 
         try:
             if self.bodytext is None and self.bodyhtml is None:
-                mesg = 'The storm:smtp:message has no HTML or text body.'
+                mesg = 'The smtp:message has no HTML or text body.'
                 raise s_exc.StormRuntimeError(mesg=mesg)
 
             host = await s_stormtypes.tostr(host)

--- a/synapse/lib/stormlib/stix.py
+++ b/synapse/lib/stormlib/stix.py
@@ -641,7 +641,7 @@ class LibStix(s_stormtypes.Lib):
                 'args': (
                     {'type': 'dict', 'name': 'bundle', 'desc': 'The STIX bundle to lift nodes from.'},
                 ),
-                'returns': {'name': 'Yields', 'type': 'storm:node', 'desc': 'Yields nodes'}
+                'returns': {'name': 'Yields', 'type': 'node', 'desc': 'Yields nodes'}
             }
         },
     )
@@ -850,7 +850,7 @@ class LibStixImport(s_stormtypes.Lib):
                     {'type': 'dict', 'name': 'bundle', 'desc': 'The STIX bundle to ingest.'},
                     {'type': 'dict', 'name': 'config', 'default': None, 'desc': 'An optional STIX ingest configuration.'},
                 ),
-                'returns': {'name': 'Yields', 'type': 'storm:node', 'desc': 'Yields nodes'}
+                'returns': {'name': 'Yields', 'type': 'node', 'desc': 'Yields nodes'}
             },
         },
     )
@@ -1093,7 +1093,7 @@ class LibStixExport(s_stormtypes.Lib):
                 'args': (
                     {'type': 'dict', 'name': 'config', 'default': None, 'desc': 'The STIX bundle export config to use.'},
                 ),
-                'returns': {'type': 'storm:stix:bundle', 'desc': 'A new ``storm:stix:bundle`` instance.'},
+                'returns': {'type': 'stix:bundle', 'desc': 'A new ``stix:bundle`` instance.'},
             },
         },
 
@@ -1203,7 +1203,7 @@ class StixBundle(s_stormtypes.Prim):
     Implements the Storm API for creating and packing a STIX bundle for v2.1
     '''
 
-    _storm_typename = 'storm:stix:bundle'
+    _storm_typename = 'stix:bundle'
     _storm_locals = (
 
         {'name': 'add', 'desc': '''

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -52,13 +52,13 @@ class StormTypesRegistry:
     base_undefined_types = (
         'any',
         'int',
+        'lib',  # lib.import
         'null',
         'time',
         'prim',
         'undef',
         'float',
         'integer',
-        'storm:lib',  # lib.import
         'generator',
     )
     undefined_types = set(base_undefined_types)
@@ -397,7 +397,7 @@ class StormType:
     '''
     _storm_locals = ()  # type: Any # To be overridden for deref constants that need documentation
     _ismutable = True
-    _storm_typename = 'storm:unknown'
+    _storm_typename = 'unknown'
 
     def __init__(self, path=None):
         self.path = path
@@ -477,7 +477,7 @@ class Lib(StormType):
     '''
     _ismutable = False
     _storm_query = None
-    _storm_typename = 'storm:lib'
+    _storm_typename = 'lib'
     _storm_lib_perms = ()
 
     def __init__(self, runt, name=()):
@@ -1139,7 +1139,7 @@ class LibBase(Lib):
                        'desc': 'An initial set of values to place in the Text. '
                                'These values are joined together with an empty string.', },
                   ),
-                  'returns': {'type': 'storm:text', 'desc': 'The new Text object.', }}},
+                  'returns': {'type': 'text', 'desc': 'The new Text object.', }}},
         {'name': 'cast', 'desc': 'Normalize a value as a Synapse Data Model Type.',
          'type': {'type': 'function', '_funcname': '_cast',
                   'args': (
@@ -1240,8 +1240,8 @@ class LibBase(Lib):
                       {'name': 'reqvers', 'type': 'str', 'default': None,
                        'desc': 'Version requirement for the imported module.', },
                   ),
-                  'returns': {'type': 'storm:lib',
-                              'desc': 'A ``storm:lib`` instance representing the imported package.', }}},
+                  'returns': {'type': 'lib',
+                              'desc': 'A ``lib`` instance representing the imported package.', }}},
 
         {'name': 'trycast', 'desc': '''
             Attempt to normalize a value and return status and the normalized value.
@@ -1806,7 +1806,7 @@ class LibAxon(Lib):
                       {'name': '*args', 'type': 'any', 'desc': 'Args from ``$lib.axon.wget()``.'},
                       {'name': '**kwargs', 'type': 'any', 'desc': 'Args from ``$lib.axon.wget()``.'},
                   ),
-                  'returns': {'type': ['storm:node', 'null'],
+                  'returns': {'type': ['node', 'null'],
                               'desc': 'The ``inet:urlfile`` node on success,  ``null`` on error.'}}},
         {'name': 'del', 'desc': '''
             Remove the bytes from the Cortex's Axon by sha256.
@@ -2319,7 +2319,7 @@ class LibLift(Lib):
                   'args': (
                       {'name': 'name', 'desc': 'The name to of the nodedata key to lift by.', 'type': 'str', },
                   ),
-                  'returns': {'name': 'Yields', 'type': 'storm:node',
+                  'returns': {'name': 'Yields', 'type': 'node',
                               'desc': 'Yields nodes to the pipeline. '
                                       'This must be used in conjunction with the ``yield`` keyword.', }}},
     )
@@ -2928,7 +2928,7 @@ class LibFeed(Lib):
                       {'name': 'name', 'type': 'str', 'desc': 'Name of the ingest function to send data too.', },
                       {'name': 'data', 'type': 'prim', 'desc': 'Data to send to the ingest function.', },
                   ),
-                  'returns': {'name': 'Yields', 'type': 'storm:node',
+                  'returns': {'name': 'Yields', 'type': 'node',
                               'desc': 'Yields Nodes as they are created by the ingest function.', }}},
         {'name': 'list', 'desc': 'Get a list of feed functions.',
          'type': {'type': 'function', '_funcname': '_libList',
@@ -3032,7 +3032,7 @@ class LibPipe(Lib):
                       {'name': 'size', 'type': 'int', 'default': 10000,
                        'desc': 'Maximum size of the pipe.', },
                   ),
-                  'returns': {'type': 'storm:pipe', 'desc': 'The pipe containing query results.', }}},
+                  'returns': {'type': 'pipe', 'desc': 'The pipe containing query results.', }}},
     )
 
     _storm_lib_path = ('pipe',)
@@ -3126,7 +3126,7 @@ class Pipe(StormType):
          'type': {'type': 'function', '_funcname': '_methPipeSize',
                   'returns': {'type': 'int', 'desc': 'The number of items in the Pipe.', }}},
     )
-    _storm_typename = 'storm:pipe'
+    _storm_typename = 'pipe'
 
     def __init__(self, runt, size):
         StormType.__init__(self)
@@ -3195,13 +3195,13 @@ class LibQueue(Lib):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the queue to add.', },
                   ),
-                  'returns': {'type': 'storm:queue', }}},
+                  'returns': {'type': 'queue', }}},
         {'name': 'gen', 'desc': 'Add or get a Storm Queue in a single operation.',
          'type': {'type': 'function', '_funcname': '_methQueueGen',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the Queue to add or get.', },
                   ),
-                  'returns': {'type': 'storm:queue', }}},
+                  'returns': {'type': 'queue', }}},
         {'name': 'del', 'desc': 'Delete a given named Queue.',
          'type': {'type': 'function', '_funcname': '_methQueueDel',
                   'args': (
@@ -3213,7 +3213,7 @@ class LibQueue(Lib):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the Queue to get.', },
                   ),
-                  'returns': {'type': 'storm:queue', 'desc': 'A ``storm:queue`` object.', }}},
+                  'returns': {'type': 'queue', 'desc': 'A ``queue`` object.', }}},
         {'name': 'list', 'desc': 'Get a list of the Queues in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methQueueList',
                   'returns': {'type': 'list',
@@ -3340,7 +3340,7 @@ class Queue(StormType):
          'type': {'type': 'function', '_funcname': '_methQueueSize',
                   'returns': {'type': 'int', 'desc': 'The number of items in the Queue.', }}},
     )
-    _storm_typename = 'storm:queue'
+    _storm_typename = 'queue'
     _ismutable = False
 
     def __init__(self, runt, name, info):
@@ -3447,7 +3447,7 @@ class LibTelepath(Lib):
                   'args': (
                       {'name': 'url', 'type': 'str', 'desc': 'The Telepath URL to connect to.', },
                   ),
-                  'returns': {'type': 'storm:proxy', 'desc': 'A object representing a Telepath Proxy.', }}},
+                  'returns': {'type': 'telepath:proxy', 'desc': 'A object representing a Telepath Proxy.', }}},
     )
     _storm_lib_path = ('telepath',)
     _storm_lib_perms = (
@@ -3494,7 +3494,7 @@ class Proxy(StormType):
         }
 
     '''
-    _storm_typename = 'storm:proxy'
+    _storm_typename = 'telepath:proxy'
 
     def __init__(self, runt, proxy, path=None):
         StormType.__init__(self, path=path)
@@ -3521,7 +3521,7 @@ class Proxy(StormType):
 # @registry.registerType
 class ProxyMethod(StormType):
 
-    _storm_typename = 'storm:proxy:method'
+    _storm_typename = 'telepath:proxy:method'
 
     def __init__(self, runt, meth, path=None):
         StormType.__init__(self, path=path)
@@ -3544,7 +3544,7 @@ class ProxyMethod(StormType):
 # @registry.registerType
 class ProxyGenrMethod(StormType):
 
-    _storm_typename = 'storm:proxy:genrmethod'
+    _storm_typename = 'telepath:proxy:genrmethod'
 
     def __init__(self, meth, path=None):
         StormType.__init__(self, path=path)
@@ -4246,7 +4246,7 @@ class CmdOpts(Dict):
     A dictionary like object that holds a reference to a command options namespace.
     ( This allows late-evaluation of command arguments rather than forcing capture )
     '''
-    _storm_typename = 'storm:cmdopts'
+    _storm_typename = 'cmdopts'
     _ismutable = False
 
     def __len__(self):
@@ -4849,9 +4849,9 @@ class LibUser(Lib):
                   'returns': {'type': 'boolean',
                               'desc': 'True if the user has the requested permission, false otherwise.', }}},
         {'name': 'vars', 'desc': "Get a Hive dictionary representing the current user's persistent variables.",
-         'type': 'storm:hive:dict', },
+         'type': 'hive:dict', },
         {'name': 'profile', 'desc': "Get a Hive dictionary representing the current user's profile information.",
-         'type': 'storm:hive:dict', },
+         'type': 'hive:dict', },
         {'name': 'iden', 'desc': 'The user GUID for the current storm user.', 'type': 'str'},
     )
     _storm_lib_path = ('user', )
@@ -5020,7 +5020,7 @@ class StormHiveDict(Prim):
          'type': {'type': 'function', '_funcname': '_list',
                   'returns': {'type': 'list', 'desc': 'A list of tuples containing key, value pairs.', }}},
     )
-    _storm_typename = 'storm:hive:dict'
+    _storm_typename = 'hive:dict'
     _ismutable = True
 
     def __init__(self, runt, info):
@@ -5234,7 +5234,7 @@ class NodeProps(Prim):
          'type': {'type': 'function', '_funcname': 'list',
                   'returns': {'type': 'list', 'desc': 'A list of (name, value) tuples.', }}},
     )
-    _storm_typename = 'storm:node:props'
+    _storm_typename = 'node:props'
     _ismutable = True
 
     def __init__(self, node, path=None):
@@ -5359,7 +5359,7 @@ class NodeData(Prim):
                   ),
                   'returns': {'type': 'null', }}},
     )
-    _storm_typename = 'storm:node:data'
+    _storm_typename = 'node:data'
     _ismutable = True
 
     def __init__(self, node, path=None):
@@ -5543,7 +5543,7 @@ class Node(Prim):
          'type': {'type': 'function', '_funcname': 'getStorNodes',
                   'returns': {'type': 'list', 'desc': 'List of storage node objects.', }}},
     )
-    _storm_typename = 'storm:node'
+    _storm_typename = 'node'
     _ismutable = False
 
     def __init__(self, node, path=None):
@@ -5734,7 +5734,7 @@ class PathMeta(Prim):
     '''
     Put the storm deref/setitem/iter convention on top of path meta information.
     '''
-    _storm_typename = 'storm:node:path:meta'
+    _storm_typename = 'node:path:meta'
     _ismutable = True
 
     def __init__(self, path):
@@ -5759,7 +5759,7 @@ class PathVars(Prim):
     '''
     Put the storm deref/setitem/iter convention on top of path variables.
     '''
-    _storm_typename = 'storm:node:path:vars'
+    _storm_typename = 'node:path:vars'
     _ismutable = True
 
     def __init__(self, path):
@@ -5791,8 +5791,8 @@ class Path(Prim):
     Implements the Storm API for the Path object.
     '''
     _storm_locals = (
-        {'name': 'vars', 'desc': 'The PathVars object for the Path.', 'type': 'storm:node:path:vars', },
-        {'name': 'meta', 'desc': 'The PathMeta object for the Path.', 'type': 'storm:node:path:meta', },
+        {'name': 'vars', 'desc': 'The PathVars object for the Path.', 'type': 'node:path:vars', },
+        {'name': 'meta', 'desc': 'The PathMeta object for the Path.', 'type': 'node:path:meta', },
         {'name': 'idens', 'desc': 'The list of Node idens which this Path has been forked from during pivot operations.',
          'type': {'type': 'function', '_funcname': '_methPathIdens',
                   'returns': {'type': 'list', 'desc': 'A list of node idens.', }}},
@@ -5801,7 +5801,7 @@ class Path(Prim):
                   'returns': {'type': 'list',
                               'desc': 'List of tuples containing the name and value of path variables.', }}},
     )
-    _storm_typename = 'storm:path'
+    _storm_typename = 'path'
     _ismutable = True
 
     def __init__(self, node, path=None):
@@ -5841,7 +5841,7 @@ class Text(Prim):
          'type': {'type': 'function', '_funcname': '_methTextStr',
                   'returns': {'desc': 'The current string of the text object.', 'type': 'str', }}},
     )
-    _storm_typename = 'storm:text'
+    _storm_typename = 'text'
     _ismutable = True
 
     def __init__(self, valu, path=None):
@@ -5872,7 +5872,7 @@ class LibStats(Lib):
     _storm_locals = (
         {'name': 'tally', 'desc': 'Get a Tally object.',
          'type': {'type': 'function', '_funcname': 'tally',
-                  'returns': {'type': 'storm:stat:tally', 'desc': 'A new tally object.', }}},
+                  'returns': {'type': 'stat:tally', 'desc': 'A new tally object.', }}},
     )
     _storm_lib_path = ('stats',)
 
@@ -5900,7 +5900,7 @@ class StatTally(Prim):
         }
 
     '''
-    _storm_typename = 'storm:stat:tally'
+    _storm_typename = 'stat:tally'
     _storm_locals = (
         {'name': 'inc', 'desc': 'Increment a given counter.',
          'type': {'type': 'function', '_funcname': 'inc',
@@ -5980,8 +5980,8 @@ class LibLayer(Lib):
                   'args': (
                       {'name': 'ldef', 'type': 'dict', 'desc': 'The layer definition dictionary.', 'default': None, },
                   ),
-                  'returns': {'type': 'storm:layer',
-                              'desc': 'A ``storm:layer`` object representing the new layer.', }}},
+                  'returns': {'type': 'layer',
+                              'desc': 'A ``layer`` object representing the new layer.', }}},
         {'name': 'del', 'desc': 'Delete a layer from the Cortex.',
          'type': {'type': 'function', '_funcname': '_libLayerDel',
                   'args': (
@@ -5995,10 +5995,10 @@ class LibLayer(Lib):
                        'desc': 'The iden of the layer to get. '
                                'If not set, this defaults to the top layer of the current View.', },
                   ),
-                  'returns': {'type': 'storm:layer', 'desc': 'The storm layer object.', }}},
+                  'returns': {'type': 'layer', 'desc': 'The storm layer object.', }}},
         {'name': 'list', 'desc': 'List the layers in a Cortex',
          'type': {'type': 'function', '_funcname': '_libLayerList',
-                  'returns': {'type': 'list', 'desc': 'List of ``storm:layer`` objects.', }}},
+                  'returns': {'type': 'list', 'desc': 'List of ``layer`` objects.', }}},
     )
 
     def getObjLocals(self):
@@ -6225,7 +6225,7 @@ class Layer(Prim):
                       {'name': 'propvalu', 'type': 'obj', 'desc': 'The value for the property.', 'default': None},
                       {'name': 'propcmpr', 'type': 'str', 'desc': 'The comparison operation to use on the value.', 'default': '='},
                   ),
-                  'returns': {'name': 'Yields', 'type': 'storm:node',
+                  'returns': {'name': 'Yields', 'type': 'node',
                               'desc': 'Yields nodes.', }}},
         {'name': 'liftByTag', 'desc': '''
             Lift and yield nodes with the tag set within the layer.
@@ -6245,7 +6245,7 @@ class Layer(Prim):
                       {'name': 'tagname', 'type': 'str', 'desc': 'The tag name to lift by.'},
                       {'name': 'formname', 'type': 'str', 'desc': 'The optional form to lift.', 'default': None},
                   ),
-                  'returns': {'name': 'Yields', 'type': 'storm:node',
+                  'returns': {'name': 'Yields', 'type': 'node',
                               'desc': 'Yields nodes.', }}},
 
         {'name': 'getEdges', 'desc': '''
@@ -6299,7 +6299,7 @@ class Layer(Prim):
                   'returns': {'name': 'Yields', 'type': 'list',
                               'desc': 'Yields (<verb>, <n1iden>) tuples', }}},
     )
-    _storm_typename = 'storm:layer'
+    _storm_typename = 'layer'
     _ismutable = False
 
     def __init__(self, runt, ldef, path=None):
@@ -6646,7 +6646,7 @@ class LibView(Lib):
                       {'name': 'layers', 'type': 'list', 'desc': 'A list of layer idens which make up the view.', },
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the view.', 'default': None, }
                   ),
-                  'returns': {'type': 'storm:view', 'desc': 'A ``storm:view`` object representing the new View.', }}},
+                  'returns': {'type': 'view', 'desc': 'A ``view`` object representing the new View.', }}},
         {'name': 'del', 'desc': 'Delete a View from the Cortex.',
          'type': {'type': 'function', '_funcname': '_methViewDel',
                   'args': (
@@ -6659,14 +6659,14 @@ class LibView(Lib):
                       {'name': 'iden', 'type': 'str', 'default': None,
                         'desc': 'The iden of the View to get. If not specified, returns the current View.', },
                   ),
-                  'returns': {'type': 'storm:view', 'desc': 'The storm view object.', }}},
+                  'returns': {'type': 'view', 'desc': 'The storm view object.', }}},
         {'name': 'list', 'desc': 'List the Views in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methViewList',
                   'args': (
                       {'name': 'deporder', 'type': 'bool', 'default': False,
                         'desc': 'Return the lists in bottom-up dependency order.', },
                   ),
-                  'returns': {'type': 'list', 'desc': 'List of ``storm:view`` objects.', }}},
+                  'returns': {'type': 'list', 'desc': 'List of ``view`` objects.', }}},
     )
 
     def getObjLocals(self):
@@ -6730,9 +6730,9 @@ class View(Prim):
     '''
     _storm_locals = (
         {'name': 'iden', 'desc': 'The iden of the View.', 'type': 'str', },
-        {'name': 'layers', 'desc': 'The ``storm:layer`` objects associated with the ``storm:view``.', 'type': 'list', },
+        {'name': 'layers', 'desc': 'The ``layer`` objects associated with the ``view``.', 'type': 'list', },
         {'name': 'parent', 'desc': 'The parent View. Will be ``$lib.null`` if the view is not a fork.', 'type': 'str'},
-        {'name': 'triggers', 'desc': 'The ``storm:trigger`` objects associated with the ``storm:view``.',
+        {'name': 'triggers', 'desc': 'The ``trigger`` objects associated with the ``view``.',
          'type': 'list', },
         {'name': 'set', 'desc': '''
             Set a view configuration option.
@@ -6780,7 +6780,7 @@ class View(Prim):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the new view.', 'default': None, },
                   ),
-                  'returns': {'type': 'storm:view', 'desc': 'The ``storm:view`` object for the new View.', }}},
+                  'returns': {'type': 'view', 'desc': 'The ``view`` object for the new View.', }}},
         {'name': 'pack', 'desc': 'Get the View definition.',
          'type': {'type': 'function', '_funcname': '_methViewPack',
                   'returns': {'type': 'dict', 'desc': 'Dictionary containing the View definition.', }}},
@@ -6811,7 +6811,7 @@ class View(Prim):
                       {'name': 'valu', 'type': 'prim', 'desc': 'The primary property value.'},
                       {'name': 'props', 'type': 'dict', 'desc': 'An optional dictionary of props.', 'default': None},
                   ),
-                  'returns': {'type': 'storm:node', 'desc': 'The storm:node if the view is the current view, otherwise null.', }}},
+                  'returns': {'type': 'node', 'desc': 'The node if the view is the current view, otherwise null.', }}},
         {'name': 'addNodeEdits', 'desc': 'Add NodeEdits to the view.',
          'type': {'type': 'function', '_funcname': '_methAddNodeEdits',
                   'args': (
@@ -6834,7 +6834,7 @@ class View(Prim):
                       {'type': 'dict',
                        'desc': "Dictionary containing form names and the count of the nodes in the View's Layers.", }}},
     )
-    _storm_typename = 'storm:view'
+    _storm_typename = 'view'
     _ismutable = False
 
     def __init__(self, runt, vdef, path=None):
@@ -7061,7 +7061,7 @@ class LibTrigger(Lib):
                   'args': (
                       {'name': 'tdef', 'type': 'dict', 'desc': 'A Trigger definition.', },
                   ),
-                  'returns': {'type': 'storm:trigger', 'desc': 'The new trigger.', }}},
+                  'returns': {'type': 'trigger', 'desc': 'The new trigger.', }}},
         {'name': 'del', 'desc': 'Delete a Trigger from the Cortex.',
          'type': {'type': 'function', '_funcname': '_methTriggerDel',
                   'args': (
@@ -7073,13 +7073,13 @@ class LibTrigger(Lib):
         {'name': 'list', 'desc': 'Get a list of Triggers in the current view.',
          'type': {'type': 'function', '_funcname': '_methTriggerList',
                   'returns': {'type': 'list',
-                              'desc': 'A list of ``storm:trigger`` objects the user is allowed to access.', }}},
+                              'desc': 'A list of ``trigger`` objects the user is allowed to access.', }}},
         {'name': 'get', 'desc': 'Get a Trigger in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methTriggerGet',
                   'args': (
                       {'name': 'iden', 'type': 'str', 'desc': 'The iden of the Trigger to get.', },
                   ),
-                  'returns': {'type': 'storm:trigger', 'desc': 'The requested ``storm:trigger`` object.', }}},
+                  'returns': {'type': 'trigger', 'desc': 'The requested ``trigger`` object.', }}},
         {'name': 'enable', 'desc': 'Enable a Trigger in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methTriggerEnable',
                   'args': (
@@ -7273,7 +7273,7 @@ class Trigger(Prim):
          'type': {'type': 'function', '_funcname': 'pack',
                   'returns': {'type': 'dict', 'desc': 'The definition.', }}},
     )
-    _storm_typename = 'storm:trigger'
+    _storm_typename = 'trigger'
     _ismutable = False
 
     def __init__(self, runt, tdef):
@@ -7444,8 +7444,8 @@ class LibUsers(Lib):
                       {'name': 'email', 'type': 'str', 'desc': "The user's email address.", 'default': None, },
                       {'name': 'iden', 'type': 'str', 'desc': 'The iden to use to create the user.', 'default': None, }
                   ),
-                  'returns': {'type': 'storm:auth:user',
-                              'desc': 'The ``storm:auth:user`` object for the new user.', }}},
+                  'returns': {'type': 'auth:user',
+                              'desc': 'The ``auth:user`` object for the new user.', }}},
         {'name': 'del', 'desc': 'Delete a User from the Cortex.',
          'type': {'type': 'function', '_funcname': '_methUsersDel',
                   'args': (
@@ -7454,21 +7454,21 @@ class LibUsers(Lib):
                   'returns': {'type': 'null', }}},
         {'name': 'list', 'desc': 'Get a list of Users in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methUsersList',
-                  'returns': {'type': 'list', 'desc': 'A list of ``storm:auth:user`` objects.', }}},
+                  'returns': {'type': 'list', 'desc': 'A list of ``auth:user`` objects.', }}},
         {'name': 'get', 'desc': 'Get a specific User by iden.',
          'type': {'type': 'function', '_funcname': '_methUsersGet',
                   'args': (
                       {'name': 'iden', 'type': 'str', 'desc': 'The iden of the user to retrieve.', },
                   ),
-                  'returns': {'type': ['null', 'storm:auth:user'],
-                              'desc': 'The ``storm:auth:user`` object, or none if the user does not exist.', }}},
+                  'returns': {'type': ['null', 'auth:user'],
+                              'desc': 'The ``auth:user`` object, or none if the user does not exist.', }}},
         {'name': 'byname', 'desc': 'Get a specific user by name.',
          'type': {'type': 'function', '_funcname': '_methUsersByName',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the user to retrieve.', },
                   ),
-                  'returns': {'type': ['null', 'storm:auth:user'],
-                              'desc': 'The ``storm:auth:user`` object, or none if the user does not exist.', }}},
+                  'returns': {'type': ['null', 'auth:user'],
+                              'desc': 'The ``auth:user`` object, or none if the user does not exist.', }}},
     )
     _storm_lib_path = ('auth', 'users')
     _storm_lib_perms = (
@@ -7529,7 +7529,7 @@ class LibRoles(Lib):
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the role.', },
                   ),
-                  'returns': {'type': 'storm:auth:role', 'desc': 'The new role object.', }}},
+                  'returns': {'type': 'auth:role', 'desc': 'The new role object.', }}},
         {'name': 'del', 'desc': 'Delete a Role from the Cortex.',
          'type': {'type': 'function', '_funcname': '_methRolesDel',
                   'args': (
@@ -7538,20 +7538,20 @@ class LibRoles(Lib):
                   'returns': {'type': 'null', }}},
         {'name': 'list', 'desc': 'Get a list of Roles in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methRolesList',
-                  'returns': {'type': 'list', 'desc': 'A list of ``storm:auth:role`` objects.', }}},
+                  'returns': {'type': 'list', 'desc': 'A list of ``auth:role`` objects.', }}},
         {'name': 'get', 'desc': 'Get a specific Role by iden.',
          'type': {'type': 'function', '_funcname': '_methRolesGet',
                   'args': (
                       {'name': 'iden', 'type': 'str', 'desc': 'The iden of the role to retrieve.', },
                   ),
-                  'returns': {'type': ['null', 'storm:auth:role'],
-                              'desc': 'The ``storm:auth:role`` object; or null if the role does not exist.', }}},
+                  'returns': {'type': ['null', 'auth:role'],
+                              'desc': 'The ``auth:role`` object; or null if the role does not exist.', }}},
         {'name': 'byname', 'desc': 'Get a specific Role by name.',
          'type': {'type': 'function', '_funcname': '_methRolesByName',
                   'args': (
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the role to retrieve.', },
                   ),
-                  'returns': {'type': ['null', 'storm:auth:role'],
+                  'returns': {'type': ['null', 'auth:role'],
                               'desc': 'The role by name, or null if it does not exist.', }}},
     )
     _storm_lib_path = ('auth', 'roles')
@@ -7609,11 +7609,11 @@ class LibGates(Lib):
                   'args': (
                       {'name': 'iden', 'type': 'str', 'desc': 'The iden of the gate to retrieve.', },
                   ),
-                  'returns': {'type': ['null', 'storm:auth:gate'],
-                              'desc': 'The ``storm:auth:gate`` if it exists, otherwise null.', }}},
+                  'returns': {'type': ['null', 'auth:gate'],
+                              'desc': 'The ``auth:gate`` if it exists, otherwise null.', }}},
         {'name': 'list', 'desc': 'Get a list of Gates in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methGatesList',
-                  'returns': {'type': 'list', 'desc': 'A list of ``storm:auth:gate`` objects.', }}},
+                  'returns': {'type': 'list', 'desc': 'A list of ``auth:gate`` objects.', }}},
     )
     _storm_lib_path = ('auth', 'gates')
 
@@ -7648,7 +7648,7 @@ class Gate(Prim):
         {'name': 'roles', 'desc': 'The role idens which are a member of the Authgate.', 'type': 'list', },
         {'name': 'users', 'desc': 'The user idens which are a member of the Authgate.', 'type': 'list', },
     )
-    _storm_typename = 'storm:auth:gate'
+    _storm_typename = 'auth:gate'
     _ismutable = False
 
     def __init__(self, runt, valu, path=None):
@@ -7890,7 +7890,7 @@ class UserProfile(Prim):
     '''
     The Storm deref/setitem/iter convention on top of User profile information.
     '''
-    _storm_typename = 'storm:auth:user:profile'
+    _storm_typename = 'auth:user:profile'
     _ismutable = True
 
     def __init__(self, runt, valu, path=None):
@@ -7925,7 +7925,7 @@ class UserJson(Prim):
     '''
     Implements per-user JSON storage.
     '''
-    _storm_typename = 'storm:auth:user:json'
+    _storm_typename = 'auth:user:json'
     _ismutable = False
     _storm_locals = (
         {'name': 'get', 'desc': 'Return a stored JSON object or object property for the user.',
@@ -8059,7 +8059,7 @@ class UserVars(Prim):
     '''
     The Storm deref/setitem/iter convention on top of User vars information.
     '''
-    _storm_typename = 'storm:auth:user:vars'
+    _storm_typename = 'auth:user:vars'
     _ismutable = True
 
     def __init__(self, runt, valu, path=None):
@@ -8098,7 +8098,7 @@ class User(Prim):
         {'name': 'roles', 'desc': 'Get the Roles for the User.',
          'type': {'type': 'function', '_funcname': '_methUserRoles',
                   'returns': {'type': 'list',
-                              'desc': 'A list of ``storm:auth:roles`` which the user is a member of.', }}},
+                              'desc': 'A list of ``auth:roles`` which the user is a member of.', }}},
         {'name': 'pack', 'desc': 'Get the packed version of the User.',
          'type': {'type': 'function', '_funcname': '_methUserPack', 'args': (),
                   'returns': {'type': 'dict', 'desc': 'The packed User definition.', }}},
@@ -8228,7 +8228,7 @@ class User(Prim):
          'type': {'type': 'function', '_funcname': 'gates',
                   'args': (),
                   'returns': {'type': 'list',
-                              'desc': 'A list of ``storm:auth:gates`` that the user has rules for.', }}},
+                              'desc': 'A list of ``auth:gates`` that the user has rules for.', }}},
         {'name': 'name', 'desc': '''
         A user's name. This can also be used to set a user's name.
 
@@ -8262,13 +8262,13 @@ class User(Prim):
                 $user=$lib.auth.users.byname(bob) $value = $user.profile.somekey
         ''',
         'type': {'type': ['ctor'], '_ctorfunc': '_ctorUserProfile',
-                 'returns': {'type': 'storm:auth:user:profile', }}},
+                 'returns': {'type': 'auth:user:profile', }}},
         {'name': 'vars',
          'desc': "Get a dictionary representing the user's persistent variables.",
          'type': {'type': ['ctor'], '_ctorfunc': '_ctorUserVars',
-                  'returns': {'type': 'storm:auth:user:vars'}}},
+                  'returns': {'type': 'auth:user:vars'}}},
     )
-    _storm_typename = 'storm:auth:user'
+    _storm_typename = 'auth:user'
     _ismutable = False
 
     def __init__(self, runt, valu, path=None):
@@ -8506,7 +8506,7 @@ class Role(Prim):
          'type': {'type': 'function', '_funcname': 'gates',
                   'args': (),
                   'returns': {'type': 'list',
-                              'desc': 'A list of ``storm:auth:gates`` that the role has rules for.', }}},
+                              'desc': 'A list of ``auth:gates`` that the role has rules for.', }}},
         {'name': 'addRule', 'desc': 'Add a rule to the Role',
          'type': {'type': 'function', '_funcname': '_methRoleAddRule',
                   'args': (
@@ -8559,7 +8559,7 @@ class Role(Prim):
          'type': {'type': 'stor', '_storfunc': '_setRoleName',
                   'returns': {'type': 'str', }}},
     )
-    _storm_typename = 'storm:auth:role'
+    _storm_typename = 'auth:role'
     _ismutable = False
 
     def __init__(self, runt, valu, path=None):
@@ -8669,13 +8669,13 @@ class LibCron(Lib):
                   'args': (
                       {'name': '**kwargs', 'type': 'any', 'desc': 'Key-value parameters used to add the cron job.', },
                   ),
-                  'returns': {'type': 'storm:cronjob', 'desc': 'The new Cron Job.', }}},
+                  'returns': {'type': 'cronjob', 'desc': 'The new Cron Job.', }}},
         {'name': 'add', 'desc': 'Add a recurring Cron Job to the Cortex.',
          'type': {'type': 'function', '_funcname': '_methCronAdd',
                   'args': (
                       {'name': '**kwargs', 'type': 'any', 'desc': 'Key-value parameters used to add the cron job.', },
                   ),
-                  'returns': {'type': 'storm:cronjob', 'desc': 'The new Cron Job.', }}},
+                  'returns': {'type': 'cronjob', 'desc': 'The new Cron Job.', }}},
         {'name': 'del', 'desc': 'Delete a CronJob from the Cortex.',
          'type': {'type': 'function', '_funcname': '_methCronDel',
                   'args': (
@@ -8691,14 +8691,14 @@ class LibCron(Lib):
                        'desc': 'A prefix to match in order to identify a cron job to get. '
                                'Only a single matching prefix will be retrieved.', },
                   ),
-                  'returns': {'type': 'storm:cronjob', 'desc': 'The requested cron job.', }}},
+                  'returns': {'type': 'cronjob', 'desc': 'The requested cron job.', }}},
         {'name': 'mod', 'desc': 'Modify the Storm query for a CronJob in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methCronMod',
                   'args': (
                       {'name': 'prefix', 'type': 'str',
                        'desc': 'A prefix to match in order to identify a cron job to modify. '
                                'Only a single matching prefix will be modified.', },
-                      {'name': 'query', 'type': ['str', 'storm:query'],
+                      {'name': 'query', 'type': ['str', 'query'],
                        'desc': 'The new Storm query for the Cron Job.', }
                   ),
                   'returns': {'type': 'str', 'desc': 'The iden of the CronJob which was modified.'}}},
@@ -8714,7 +8714,7 @@ class LibCron(Lib):
                   'returns': {'type': 'str', 'desc': 'The iden of the CronJob which was moved.'}}},
         {'name': 'list', 'desc': 'List CronJobs in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methCronList',
-                  'returns': {'type': 'list', 'desc': 'A list of ``storm:cronjob`` objects..', }}},
+                  'returns': {'type': 'list', 'desc': 'A list of ``cronjob`` objects..', }}},
         {'name': 'enable', 'desc': 'Enable a CronJob in the Cortex.',
          'type': {'type': 'function', '_funcname': '_methCronEnable',
                   'args': (
@@ -9172,7 +9172,7 @@ class CronJob(Prim):
                       {'name': 'name', 'type': 'str', 'desc': 'The name of the field being set', },
                       {'name': 'valu', 'type': 'any', 'desc': 'The value to set on the definition.', },
                   ),
-                  'returns': {'type': 'storm:cronjob', 'desc': 'The ``storm:cronjob``', }}},
+                  'returns': {'type': 'cronjob', 'desc': 'The ``cronjob``', }}},
         {'name': 'pack', 'desc': 'Get the Cronjob definition.',
          'type': {'type': 'function', '_funcname': '_methCronJobPack',
                   'returns': {'type': 'dict', 'desc': 'The definition.', }}},
@@ -9182,7 +9182,7 @@ class CronJob(Prim):
                       {'type': 'dict',
                        'desc': 'A dictionary containing structured data about a cronjob for display purposes.', }}},
     )
-    _storm_typename = 'storm:cronjob'
+    _storm_typename = 'cronjob'
     _ismutable = False
 
     def __init__(self, runt, cdef, path=None):

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -2318,7 +2318,7 @@ class AstTest(s_test.SynTest):
 
             q = '$view = $lib.view.get() $lib.print($view)'
             mesgs = await core.stormlist(q)
-            self.stormIsInPrint('storm:view', mesgs)
+            self.stormIsInPrint('view', mesgs)
 
             q = '''
                 $pipe = $lib.pipe.gen(${

--- a/synapse/tests/test_lib_stormlib_json.py
+++ b/synapse/tests/test_lib_stormlib_json.py
@@ -62,7 +62,7 @@ class JsonTest(s_test.SynTest):
             # Print a json schema obj
             q = "$schemaObj = $lib.json.schema($schema) $lib.print('schema={s}', s=$schemaObj)"
             msgs = await core.stormlist(q, opts=opts)
-            self.stormIsInPrint('storm:json:schema: {', msgs)
+            self.stormIsInPrint('json:schema: {', msgs)
 
             q = "$schemaObj = $lib.json.schema($schema) return ( $schemaObj.schema() )"
             schema = await core.callStorm(q, opts=opts)

--- a/synapse/tests/test_lib_stormlib_model.py
+++ b/synapse/tests/test_lib_stormlib_model.py
@@ -37,37 +37,37 @@ class StormlibModelTest(s_test.SynTest):
             self.true(await core.callStorm('return(($lib.model.prop(".created").form = $lib.null))'))
 
             mesgs = await core.stormlist('$lib.print($lib.model.form(ou:name))')
-            self.stormIsInPrint("storm:model:form: {'name': 'ou:name'", mesgs)
+            self.stormIsInPrint("model:form: {'name': 'ou:name'", mesgs)
 
             mesgs = await core.stormlist('$lib.pprint($lib.model.form(ou:name))')
             self.stormIsInPrint("{'name': 'ou:name'", mesgs)
 
             mesgs = await core.stormlist('$lib.print($lib.model.form(ou:name).type)')
-            self.stormIsInPrint("storm:model:type: ('ou:name'", mesgs)
+            self.stormIsInPrint("model:type: ('ou:name'", mesgs)
 
             mesgs = await core.stormlist('$lib.pprint($lib.model.form(ou:name).type)')
             self.stormIsInPrint("('ou:name'", mesgs)
 
             mesgs = await core.stormlist('$lib.print($lib.model.prop(ps:contact:orgname))')
-            self.stormIsInPrint("storm:model:property: {'name': 'orgname'", mesgs)
+            self.stormIsInPrint("model:property: {'name': 'orgname'", mesgs)
 
             mesgs = await core.stormlist('$lib.pprint($lib.model.prop(ps:contact:orgname))')
             self.stormIsInPrint("'type': ('ou:name'", mesgs)
 
             mesgs = await core.stormlist('$lib.print($lib.model.tagprop(score))')
-            self.stormIsInPrint("storm:model:tagprop: {'name': 'score'", mesgs)
+            self.stormIsInPrint("model:tagprop: {'name': 'score'", mesgs)
 
             mesgs = await core.stormlist('$lib.pprint($lib.model.tagprop(score))')
             self.stormIsInPrint("'name': 'score'", mesgs)
 
             mesgs = await core.stormlist('$lib.print($lib.model.type(int))')
-            self.stormIsInPrint("storm:model:type: ('int', ('base'", mesgs)
+            self.stormIsInPrint("model:type: ('int', ('base'", mesgs)
 
             mesgs = await core.stormlist("$item=$lib.model.tagprop('score') $lib.pprint($item.type)")
             self.stormIsInPrint("('int',\n ('base',", mesgs)
 
             mesgs = await core.stormlist("$item=$lib.model.tagprop('score') $lib.print($item.type)")
-            self.stormIsInPrint("storm:model:type: ('int', ('base'", mesgs)
+            self.stormIsInPrint("model:type: ('int', ('base'", mesgs)
 
     async def test_stormlib_model_edge(self):
 

--- a/synapse/tests/test_lib_stormsvc.py
+++ b/synapse/tests/test_lib_stormsvc.py
@@ -653,15 +653,15 @@ class StormSvcTest(s_test.SynTest):
                     # storm service permissions should use svcidens
                     await user.addRule((True, ('service', 'get', iden)))
                     msgs = await core.stormlist('$svc=$lib.service.get(fake) $lib.print($svc)', {'user': user.iden})
-                    self.stormIsInPrint('storm:proxy', msgs)
+                    self.stormIsInPrint('telepath:proxy', msgs)
                     self.len(0, [m for m in msgs if m[0] == 'warn'])
 
                     msgs = await core.stormlist(f'$svc=$lib.service.get({iden}) $lib.print($svc)', {'user': user.iden})
-                    self.stormIsInPrint('storm:proxy', msgs)
+                    self.stormIsInPrint('telepath:proxy', msgs)
                     self.len(0, [m for m in msgs if m[0] == 'warn'])
 
                     msgs = await core.stormlist(f'$svc=$lib.service.get(real) $lib.print($svc)', {'user': user.iden})
-                    self.stormIsInPrint('storm:proxy', msgs)
+                    self.stormIsInPrint('telepath:proxy', msgs)
                     self.len(0, [m for m in msgs if m[0] == 'warn'])
 
                     q = '$hasfoo=$lib.service.has($svc) if $hasfoo {$lib.print(yes)} else {$lib.print(no)}'

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -768,7 +768,7 @@ class StormTypesTest(s_test.SynTest):
             self.stormIsInPrint("Library $lib", mesgs)
 
             mesgs = await core.stormlist('$lib.print($lib.queue.add(testq))')
-            self.stormIsInPrint("storm:queue: testq", mesgs)
+            self.stormIsInPrint("queue: testq", mesgs)
 
             mesgs = await core.stormlist('$lib.pprint($lib.list(1,2,3))')
             self.stormIsInPrint("('1', '2', '3')", mesgs)
@@ -2174,7 +2174,7 @@ class StormTypesTest(s_test.SynTest):
             self.eq(core.auth.rootuser.iden, await core.callStorm('return($lib.user.iden)'))
 
             msgs = await core.stormlist('$lib.print($lib.auth.users.list().0)')
-            self.stormIsInPrint('storm:auth:user', msgs)
+            self.stormIsInPrint('auth:user', msgs)
             self.stormIsInPrint("'name': 'root'", msgs)
 
             await core.stormlist('auth.user.add visi')
@@ -2579,13 +2579,13 @@ class StormTypesTest(s_test.SynTest):
                 await core.nodes('$lib.telepath.open($url)._newp()', opts=opts)
 
             mesgs = await core.stormlist('$lib.print($lib.telepath.open($url))', opts=opts)
-            self.stormIsInPrint("storm:proxy: <synapse.telepath.Proxy object", mesgs)
+            self.stormIsInPrint("telepath:proxy: <synapse.telepath.Proxy object", mesgs)
 
             mesgs = await core.stormlist('$lib.print($lib.telepath.open($url).doit)', opts=opts)
-            self.stormIsInPrint("storm:proxy:method: <synapse.telepath.Method", mesgs)
+            self.stormIsInPrint("telepath:proxy:method: <synapse.telepath.Method", mesgs)
 
             mesgs = await core.stormlist('$lib.print($lib.telepath.open($url).fqdns)', opts=opts)
-            self.stormIsInPrint("storm:proxy:genrmethod: <synapse.telepath.GenrMethod", mesgs)
+            self.stormIsInPrint("telepath:proxy:genrmethod: <synapse.telepath.GenrMethod", mesgs)
 
             unfo = await core.addUser('lowuesr')
             user = unfo.get('iden')
@@ -5074,7 +5074,7 @@ class StormTypesTest(s_test.SynTest):
             self.len(3, await core.callStorm(f'return($lib.auth.users.list())'))
 
             msgs = await core.stormlist(f'$lib.print($lib.auth.roles.get({core.auth.allrole.iden}))')
-            self.stormIsInPrint('storm:auth:role', msgs)
+            self.stormIsInPrint('auth:role', msgs)
 
             visi = await core.callStorm('''
                 $visi = $lib.auth.users.byname(visi)

--- a/synapse/tests/test_tools_autodoc.py
+++ b/synapse/tests/test_tools_autodoc.py
@@ -175,5 +175,5 @@ class TestAutoDoc(s_t_utils.SynTest):
             with s_common.genfile(path, 'stormtypes_prims.rst') as fd:
                 primbuf = fd.read()
             primstext = primbuf.decode()
-            self.isin('.. _stormprims-storm-auth-user-f527:\n\n*****************\nstorm\\:auth\\:user\n*****************', primstext)
+            self.isin('.. _stormprims-auth-user-f527:\n\n**********\nauth\\:user\n**********', primstext)
             self.isin('iden\n====\n\nThe User iden.', primstext)


### PR DESCRIPTION
- Remove `storm:` prefix from everything except `storm:query`
- `storm:proxy` and related types are now `telepath:proxy`
- Adjust project types to match the names in the data model.