### PR TITLE
WIP SYN-5418: scrape support for finding ipv6 addresses

### DIFF
--- a/synapse/lib/scrape.py
+++ b/synapse/lib/scrape.py
@@ -73,6 +73,21 @@ def fqdn_check(match: regex.Match):
             return None, {}
     return valu, {}
 
+def inet_server_check(match: regex.Match):
+    mnfo = match.groupdict()
+    valu = mnfo.get('valu')
+    port = mnfo.get('port')
+
+    try:
+        port = int(port)
+    except ValueError:
+        return None, {}
+
+    if port < 1 or port > 2**16 - 1:
+        return None, {}
+
+    return valu, {}
+
 def cve_check(match: regex.Match):
     mnfo = match.groupdict()
     valu = mnfo.get('valu')  # type: str
@@ -81,13 +96,49 @@ def cve_check(match: regex.Match):
     valu = s_chop.replaceUnicodeDashes(valu)
     return valu, cbfo
 
+# This excellent IPV6 regex comes from RFC3986. Slightly modified to not capture
+# '::' (any-address)
+ipaddr_define = r'''
+(?(DEFINE)
+  (?<OCTET>25[0-5]|2[0-4]\d|[01]?\d\d?)
+  (?<IPV4>(?:(?&OCTET)\.){3}(?&OCTET))
+  (?<H16>[0-9a-fA-F]{1,4})
+  (?<LS32>(?&H16):(?&H16)|(?&IPV4))
+  (?<IPV6>
+    (?:                                 (?:(?&H16):){6}(?&LS32)) |
+    (?:                              :: (?:(?&H16):){5}(?&LS32)) |
+    (?:(?:                 (?&H16))? :: (?:(?&H16):){4}(?&LS32)) |
+    (?:(?:(?:(?&H16):){0,1}(?&H16))? :: (?:(?&H16):){3}(?&LS32)) |
+    (?:(?:(?:(?&H16):){0,2}(?&H16))? :: (?:(?&H16):){2}(?&LS32)) |
+    (?:(?:(?:(?&H16):){0,3}(?&H16))? :: (?:(?&H16):){1}(?&LS32)) |
+    (?:(?:(?:(?&H16):){0,4}(?&H16))? ::                (?&LS32)) |
+    (?:(?:(?:(?&H16):){0,5}(?&H16))? ::                 (?&H16)) |
+    (?:(?:(?:(?&H16):){0,6}(?&H16))  ::                        )
+  )
+
+  (?<IPV4_ADDR>
+    (?<!\d|\d\.|[0-9a-fA-F:]:)
+    (?&IPV4)
+    (?!\d|\d\.|\.\d)
+  )
+
+  (?<IPV6_ADDR>
+    (?<![0-9a-fA-F]:|:[0-9a-fA-F]|::|\d\.)
+    (?&IPV6)
+    (?![0-9a-fA-F:]|\d\.|\.\d)
+  )
+)
+'''
+
 # these must be ordered from most specific to least specific to allow first=True to work
 scrape_types = [  # type: ignore
     ('inet:url', r'(?P<prefix>[\\{<\(\[]?)(?P<valu>[a-zA-Z][a-zA-Z0-9]*://(?(?=[,.]+[ \'\"\t\n\r\f\v])|[^ \'\"\t\n\r\f\v])+)',
      {'callback': fqdn_prefix_check}),
     ('inet:email', r'(?=(?:[^a-z0-9_.+-]|^)(?P<valu>[a-z0-9_\.\-+]{1,256}@(?:[a-z0-9_-]{1,63}\.){1,10}(?:%s))(?:[^a-z0-9_.-]|[.\s]|$))' % tldcat, {}),
-    ('inet:server', r'(?P<valu>(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?):[0-9]{1,5})', {}),
-    ('inet:ipv4', r'(?P<valu>(?<!\d|\d\.)(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?!\d|\.\d))', {}),
+    ('inet:server', ipaddr_define + r'(?P<valu>(?:(?<!\d|\d\.|[0-9a-fA-F:]:)(?P<addr>(?&IPV4)):(?P<port>\d{1,5})(?!\d|\d\.|\.\d)) | (?:\[(?P<addr>(?&IPV6))\]:(?P<port>\d{1,5})(?!\d|\d\.|\.\d)))',
+     {'callback': inet_server_check}),
+    ('inet:ipv4', ipaddr_define + r'(?P<valu>(?&IPV4_ADDR))', {}),
+    ('inet:ipv6', ipaddr_define + r'(?P<valu>(?&IPV6_ADDR))', {}),
     ('inet:fqdn', r'(?=(?:[^\p{L}\p{M}\p{N}\p{S}\u3002\uff0e\uff61_.-]|^|[' + idna_disallowed + '])(?P<valu>(?:((?![' + idna_disallowed + r'])[\p{L}\p{M}\p{N}\p{S}_-]){1,63}[\u3002\uff0e\uff61\.]){1,10}(?:' + tldcat + r'))(?:[^\p{L}\p{M}\p{N}\p{S}\u3002\uff0e\uff61_.-]|[\u3002\uff0e\uff61.]([\p{Z}\p{Cc}]|$)|$|[' + idna_disallowed + r']))', {'callback': fqdn_check}),
     ('hash:md5', r'(?=(?:[^A-Za-z0-9]|^)(?P<valu>[A-Fa-f0-9]{32})(?:[^A-Za-z0-9]|$))', {}),
     ('hash:sha1', r'(?=(?:[^A-Za-z0-9]|^)(?P<valu>[A-Fa-f0-9]{40})(?:[^A-Za-z0-9]|$))', {}),
@@ -116,7 +167,7 @@ scrape_types = [  # type: ignore
 
 _regexes = collections.defaultdict(list)
 for (name, rule, opts) in scrape_types:
-    blob = (regex.compile(rule, regex.IGNORECASE), opts)
+    blob = (regex.compile(rule, regex.IGNORECASE | regex.VERBOSE), opts)
     _regexes[name].append(blob)
 
 def getForms():

--- a/synapse/tests/test_lib_scrape.py
+++ b/synapse/tests/test_lib_scrape.py
@@ -32,6 +32,7 @@ and BOB@WOOT.COM is another
 
     aa:bb:cc:dd:ee:ff
 
+    # GOOD IPV4 ADDRESSES
     1.2.3.4
 
     5.6.7.8:16
@@ -40,13 +41,102 @@ and BOB@WOOT.COM is another
 
     Typo no space after sentence.211.212.213.214 is the address..
 
-    # Bad IP addresses:
+    The IP address is:2.3.4.5.
+
+    # GOOD IPV6 ADDRESSES
+
+    fff0::1
+    ::1
+    ::1010
+    ff::
+    0::1
+    0:0::1
+    ff:fe:fd::1
+    ffff:ffe:fd:c::1
+    111::333:222
+    111:222::333
+
+    1:2:3:4:5:6:7:8
+
+    1:2:3:4:5:6::7
+    1:2:3:4:5::6
+    1:2:3:4::5
+    1:2:3::4
+    1:2::3
+
+    1::2
+    1::2:3:4:5:6:7
+    1::2:3:4:5:6
+    1::2:3:4:5
+    1::2:3:4
+    1::2:3
+
+    a:2::3:4:5:6:7
+    a:2::3:4:5:6
+    a:2::3:4:5
+    a:2::3:4
+    a:2::3
+
+    2001:db8:3333:4444:5555:6666:4.3.2.1
+
+    ::3.4.5.6
+    ::ffff:4.3.2.2
+    ::FFFF:4.3.2.3
+    ::ffff:0000:4.3.2.4
+    ::1:2:3:4:4.3.2.5
+    ::1:2:3:4.3.2.6
+    ::1:2:3:4:5:4.3.2.7
+    ::ffff:255.255.255.255
+    ::ffff:111.222.33.44
+    1:2::3:4.3.2.8
+
+    1:2:3:4:5:6:7:9%eth0
+    1:2:3:4:5:6:7:a%s10
+    1:2:3:4:5:6:7:b%lo
+    1::a%eth0
+    1::a:3%lo
+    1:a::3%eth1
+
+    The IP address is:a:b:c:d:e::6.
+
+    # BAD IPV6 ADDRESSES
+    ::
+    0::0::1
+    1:2:3:4
+    1:2:3:4:5
+    1:2:3:4:5:6
+    1:2:3:4:5:6:7
+    ::ffff:4.3.2.a.5
+    ::1.3.3.4.5:4.3.2.b
+    ::1:2:3:4:5:6:4.3.2.c
+    ::1:2:3:4:5:6:7:4.3.2.d
+
+    # Bad IPV4 addresses:
     6.7.8.900
     6.7.8.9750
     1236.7.8.9
     0126.7.8.9
     6.7.8.9.6.7.8.9
     6.7.8.9.6
+
+    # GOOD INET:SERVER
+    1.2.3.4:123
+    1.2.3.4:65535
+    1.2.3.4:12346.
+    1.2.3.4:12347:
+    [::1]:123
+    [1:2:3:4:5:6:7:8]:123
+
+    # BAD INET:SERVER
+    1.2.3.4:0
+    1.2.3.4:65536
+    1.2.3.4:1.2.3.5
+    1.2.3.4:123456
+    1.2.3.4:
+    0.1.2.3.4:12345
+    1.2.3:123
+    [::1].123
+    [::1]:123.1234
 
     faß.de
 
@@ -334,9 +424,10 @@ class ScrapeTest(s_t_utils.SynTest):
 
         nodes = set(s_scrape.scrape(data0))
 
-        self.len(31, nodes)
+        self.len(83, nodes)
         nodes.remove(('hash:md5', 'a' * 32))
         nodes.remove(('inet:ipv4', '1.2.3.4'))
+        nodes.remove(('inet:ipv4', '2.3.4.5'))
         nodes.remove(('inet:ipv4', '5.6.7.8'))
         nodes.remove(('inet:ipv4', '201.202.203.204'))
         nodes.remove(('inet:ipv4', '211.212.213.214'))
@@ -362,10 +453,61 @@ class ScrapeTest(s_t_utils.SynTest):
         nodes.remove(('inet:fqdn', 'tilde.com'))
         nodes.remove(('inet:fqdn', 'fxp.com'))
         nodes.remove(('inet:server', '5.6.7.8:16'))
+        nodes.remove(('inet:server', '1.2.3.4:123'))
+        nodes.remove(('inet:server', '1.2.3.4:65535'))
+        nodes.remove(('inet:server', '1.2.3.4:12346'))
+        nodes.remove(('inet:server', '1.2.3.4:12347'))
+        nodes.remove(('inet:server', '[::1]:123'))
+        nodes.remove(('inet:server', '[1:2:3:4:5:6:7:8]:123'))
         nodes.remove(('inet:email', 'BOB@WOOT.COM'))
         nodes.remove(('inet:email', 'visi@vertex.link'))
         nodes.remove(('it:sec:cwe', 'CWE-1'))
         nodes.remove(('it:sec:cwe', 'CWE-12345678'))
+        nodes.remove(('inet:ipv6', 'fff0::1'))
+        nodes.remove(('inet:ipv6', '::1'))
+        nodes.remove(('inet:ipv6', '::1010'))
+        nodes.remove(('inet:ipv6', 'ff::'))
+        nodes.remove(('inet:ipv6', '0::1'))
+        nodes.remove(('inet:ipv6', '0:0::1'))
+        nodes.remove(('inet:ipv6', 'ff:fe:fd::1'))
+        nodes.remove(('inet:ipv6', 'ffff:ffe:fd:c::1'))
+        nodes.remove(('inet:ipv6', '111::333:222'))
+        nodes.remove(('inet:ipv6', '111:222::333'))
+        nodes.remove(('inet:ipv6', '1:2:3:4:5:6:7:8'))
+        nodes.remove(('inet:ipv6', '1:2:3:4:5:6::7'))
+        nodes.remove(('inet:ipv6', '1:2:3:4:5::6'))
+        nodes.remove(('inet:ipv6', '1:2:3:4::5'))
+        nodes.remove(('inet:ipv6', '1:2:3::4'))
+        nodes.remove(('inet:ipv6', '1:2::3'))
+        nodes.remove(('inet:ipv6', '1::2'))
+        nodes.remove(('inet:ipv6', '1::2:3:4:5:6:7'))
+        nodes.remove(('inet:ipv6', '1::2:3:4:5:6'))
+        nodes.remove(('inet:ipv6', '1::2:3:4:5'))
+        nodes.remove(('inet:ipv6', '1::2:3:4'))
+        nodes.remove(('inet:ipv6', '1::2:3'))
+        nodes.remove(('inet:ipv6', 'a:2::3:4:5:6:7'))
+        nodes.remove(('inet:ipv6', 'a:2::3:4:5:6'))
+        nodes.remove(('inet:ipv6', 'a:2::3:4:5'))
+        nodes.remove(('inet:ipv6', 'a:2::3:4'))
+        nodes.remove(('inet:ipv6', 'a:2::3'))
+        nodes.remove(('inet:ipv6', '2001:db8:3333:4444:5555:6666:4.3.2.1'))
+        nodes.remove(('inet:ipv6', '::3.4.5.6'))
+        nodes.remove(('inet:ipv6', '::ffff:4.3.2.2'))
+        nodes.remove(('inet:ipv6', '::FFFF:4.3.2.3'))
+        nodes.remove(('inet:ipv6', '::ffff:0000:4.3.2.4'))
+        nodes.remove(('inet:ipv6', '::1:2:3:4:4.3.2.5'))
+        nodes.remove(('inet:ipv6', '::1:2:3:4.3.2.6'))
+        nodes.remove(('inet:ipv6', '::1:2:3:4:5:4.3.2.7'))
+        nodes.remove(('inet:ipv6', '::ffff:255.255.255.255'))
+        nodes.remove(('inet:ipv6', '::ffff:111.222.33.44'))
+        nodes.remove(('inet:ipv6', '1:2::3:4.3.2.8'))
+        nodes.remove(('inet:ipv6', '1:2:3:4:5:6:7:9'))
+        nodes.remove(('inet:ipv6', '1:2:3:4:5:6:7:a'))
+        nodes.remove(('inet:ipv6', '1:2:3:4:5:6:7:b'))
+        nodes.remove(('inet:ipv6', '1::a'))
+        nodes.remove(('inet:ipv6', '1::a:3'))
+        nodes.remove(('inet:ipv6', '1:a::3'))
+        nodes.remove(('inet:ipv6', 'a:b:c:d:e::6'))
         self.len(0, nodes)
 
         nodes = set(s_scrape.scrape(data0, 'inet:email'))


### PR DESCRIPTION
- Added IPv6 regexes to `synapse.lib.scrape`
- Updated `inet:server` regex to support IPV6 `[addr]:port` patterns
- Updated scrape tests with good and bad `inet:ipv6` and `inet:server` examples