### PR TITLE
SYN-5719: Only log depr prop warning in prod

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1649,7 +1649,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         return retn
 
     async def _warnDeprLocks(self):
-        if __debug__ and not s_common.envbool('SYN_CORTEX_WARN_DEPRLOCKS'):
+        if __debug__ and not s_common.envbool('SYNDEV_WARN_DEPRLOCKS'):
             return
 
         # Check for deprecated properties which are unused and unlocked

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1649,6 +1649,9 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         return retn
 
     async def _warnDeprLocks(self):
+        if __debug__ and not s_common.envbool('SYN_CORTEX_WARN_DEPRLOCKS'):
+            return
+
         # Check for deprecated properties which are unused and unlocked
         deprs = await self.getDeprLocks()
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -7267,7 +7267,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
         with self.getTestDir() as dirn:
             with self.getLoggerStream('synapse.cortex') as stream:
-                with self.setTstEnvars(SYN_CORTEX_WARN_DEPRLOCKS=1):
+                with self.setTstEnvars(SYNDEV_WARN_DEPRLOCKS=1):
 
                     # Do something that triggers a log message
                     async with self.getTestCore(conf=conf, dirn=dirn) as core:


### PR DESCRIPTION
- Updated `synapse.cortex.Cortex._warnDeprLocks()` to return early if in test and the test env var is not set
- Updated tests to set env var and check for no warnings in regular test mode