### PR TITLE
SYN-5827: inet:dns:answer:time

### DIFF
--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -286,7 +286,7 @@ class DnsModule(s_module.CoreModule):
                         'doc': 'The DNS TXT record returned by the lookup.'}),
 
                     ('time', ('time', {}), {
-                        'doc': 'The time that the DNS response was received.'}),
+                        'doc': 'The time that the DNS response was transmitted.'}),
                 )),
 
                 ('inet:dns:wild:a', {}, (

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -284,6 +284,9 @@ class DnsModule(s_module.CoreModule):
 
                     ('txt', ('inet:dns:txt', {}), {
                         'doc': 'The DNS TXT record returned by the lookup.'}),
+
+                    ('time', ('time', {}), {
+                        'doc': 'The time that the DNS response was received.'}),
                 )),
 
                 ('inet:dns:wild:a', {}, (

--- a/synapse/tests/test_model_dns.py
+++ b/synapse/tests/test_model_dns.py
@@ -300,6 +300,11 @@ class DnsModelTest(s_t_utils.SynTest):
                 node = await snap.addNode('inet:dns:answer', '*', props)
                 self.eq(node.get('txt'), (fqdn0, 'Oh my!'))
 
+                # Time prop
+                props = {'time': "2018"}
+                node = await snap.addNode('inet:dns:answer', '*', props)
+                self.eq(node.get('time'), 1514764800000)
+
     async def test_model_dns_wild(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
- Added `time` prop to `inet:dns:answer' form
- Update test to check new time prop

Resolves SYN-5827