### PR TITLE
SYN-5812: storm dmons to start AFTER model migrations

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1224,7 +1224,6 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         self.onfini(self.stormdmons)
         self.agenda = await s_agenda.Agenda.anit(self)
         self.onfini(self.agenda)
-        await self._initStormDmons()
         await self._initStormGraphs()
 
         self.trigson = self.conf.get('trigger:enable')
@@ -1584,6 +1583,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         if self.isactive:
             await self._checkLayerModels()
 
+        await self._initStormDmons()
         await self._initStormSvcs()
 
         # share ourself via the cell dmon as "cortex"

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -23,6 +23,7 @@ import synapse.lib.layer as s_layer
 import synapse.lib.output as s_output
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.version as s_version
+import synapse.lib.modelrev as s_modelrev
 import synapse.lib.stormsvc as s_stormsvc
 
 import synapse.tools.backup as s_tools_backup
@@ -7293,3 +7294,41 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                 self.eq(1, data.count('deprecated properties unlocked'))
                 self.isin(f'Detected {count - 4} deprecated properties', data)
+
+    async def test_cortex_dmons_after_modelrev(self):
+        with self.getTestDir() as dirn:
+            async with self.getTestCore(dirn=dirn) as core:
+
+                # Add a dmon so something gets started
+                await core.callStorm('''
+                    $ddef = $lib.dmon.add(${
+                        $lib.print(hi)
+                        $lib.warn(omg)
+                        $s = $lib.str.format('Running {t} {i}', t=$auto.type, i=$auto.iden)
+                        $lib.log.info($s, ({"iden": $auto.iden}))
+                    })
+                ''')
+
+                # Create this so we can find the model rev version before the
+                # latest
+                mrev = s_modelrev.ModelRev(core)
+
+                # Add a layer and regress the version so it gets migrated on the
+                # next start
+                ldef = await core.addLayer()
+                layr = core.getLayer(ldef['iden'])
+                await layr.setModelVers(mrev.revs[-2][0])
+
+            with self.getLoggerStream('') as stream:
+                async with self.getTestCore(dirn=dirn) as core:
+                    pass
+
+            stream.seek(0)
+            data = stream.read()
+
+            # Check that the model migration happens before the dmons start
+            mrevstart = data.find('beginning model migration')
+            dmonstart = data.find('Starting Dmon')
+            self.ne(-1, mrevstart)
+            self.ne(-1, dmonstart)
+            self.lt(mrevstart, dmonstart)


### PR DESCRIPTION
- Move storm dmon init to be after model migration
- Add new tests to verify desired startup behavior

Resolves [SYN-5812]

[SYN-5812]: https://vertexproject.atlassian.net/browse/SYN-5812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ