### PR TITLE
Storm $lib.inet.http updates (SYN-5792, SYN-5730)

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1459,7 +1459,7 @@ class Axon(s_cell.Cell):
 
                 {
                     'ok': <boolean> - False if there were exceptions retrieving the URL.
-                    'err': <str> - Tuple of the error type and information if an exception occurred.
+                    'err': <tuple> - Tuple of the error type and information if an exception occurred.
                     'url': <str> - The URL retrieved (which could have been redirected)
                     'code': <int> - The response code.
                     'body': <bytes> - The response body.

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1540,8 +1540,6 @@ class Axon(s_cell.Cell):
                 else:
                     reason = f'Exception occurred during request: {err[0]}'
 
-                print(f'{reason=}')
-
                 return {
                     'ok': False,
                     'err': err,

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1459,10 +1459,11 @@ class Axon(s_cell.Cell):
 
                 {
                     'ok': <boolean> - False if there were exceptions retrieving the URL.
-                    'err': <str> - An error message if there was an exception when retrieving the URL.
+                    'err': <str> - Tuple of the error type and information if an exception occurred.
                     'url': <str> - The URL retrieved (which could have been redirected)
                     'code': <int> - The response code.
                     'body': <bytes> - The response body.
+                    'reason': <str> - The reason phrase for the HTTP status code.
                     'headers': <dict> - The response headers as a dictionary.
                 }
 
@@ -1522,6 +1523,7 @@ class Axon(s_cell.Cell):
                         'url': str(resp.url),
                         'code': resp.status,
                         'body': await resp.read(),
+                        'reason': s_common.httpcodereason(resp.status),
                         'headers': dict(resp.headers),
                     }
                     return info
@@ -1531,19 +1533,22 @@ class Axon(s_cell.Cell):
 
             except Exception as e:
                 logger.exception(f'Error POSTing files to [{s_urlhelp.sanitizeUrl(url)}]')
-                exc = s_common.excinfo(e)
-                errmsg = exc.get('errmsg')
+                err = s_common.err(e)
+                errmsg = err[1].get('mesg')
                 if errmsg:
-                    mesg = f"{exc.get('err')}: {exc.get('errmsg')}"
+                    reason = f'Exception occurred during request: {err[0]}: {errmsg}'
                 else:
-                    mesg = exc.get('err')
+                    reason = f'Exception occurred during request: {err[0]}'
+
+                print(f'{reason=}')
 
                 return {
                     'ok': False,
-                    'err': mesg,
+                    'err': err,
                     'url': url,
                     'body': b'',
                     'code': -1,
+                    'reason': reason,
                     'headers': dict(),
                 }
 

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -3,6 +3,7 @@ import os
 import ssl
 import sys
 import json
+import http
 import stat
 import time
 import heapq
@@ -1155,3 +1156,21 @@ class aclosing(contextlib.AbstractAsyncContextManager):
         return self.thing
     async def __aexit__(self, exc, cls, tb):
         await self.thing.aclose()
+
+def httpcodereason(code):
+    '''
+    Get the reason for an HTTP status code.
+
+    Args:
+        code (int): The code.
+
+    Note:
+        If the status code is unknown, a string indicating it is unknonwn is returned.
+
+    Returns:
+        str: A string describing the status code.
+    '''
+    try:
+        return http.HTTPStatus(code).phrase
+    except ValueError:
+        return f'Unknown HTTP status code {code}'

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -1165,7 +1165,7 @@ def httpcodereason(code):
         code (int): The code.
 
     Note:
-        If the status code is unknown, a string indicating it is unknonwn is returned.
+        If the status code is unknown, a string indicating it is unknown is returned.
 
     Returns:
         str: A string describing the status code.

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -2096,11 +2096,7 @@ class LibAxon(Lib):
         code = resp.get('code')
 
         if code != 200:
-            if code is None:
-                mesg = f'$lib.axon.urlfile(): {resp.get("mesg")}'
-            else:
-                mesg = f'$lib.axon.urlfile(): HTTP code {code} != 200'
-
+            mesg = f'$lib.axon.urlfile(): HTTP code {code}: {resp.get("reason")}'
             await self.runt.warn(mesg, log=False)
             return
 

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -979,7 +979,7 @@ bar baz",vv
             opts = {'vars': {'sha256': s_common.ehex(s_common.buid()), 'bytes': ''}}
             resp = await core.callStorm(q, opts=opts)
             self.false(resp['ok'])
-            self.isin('Axon does not contain the requested file.', resp.get('err'))
+            self.isin('Axon does not contain the requested file.', resp.get('reason'))
 
             async with axon.getLocalProxy() as proxy:
                 resp = await proxy.postfiles(fields, f'https://127.0.0.1:{port}/api/v1/pushfile', ssl=False)
@@ -1000,7 +1000,7 @@ bar baz",vv
             async with axon.getLocalProxy() as proxy:
                 resp = await proxy.postfiles(fields, f'https://127.0.0.1:{port}/api/v1/pushfile', ssl=False)
                 self.false(resp.get('ok'))
-                self.isin('connect to proxy 127.0.0.1:1', resp.get('err', ''))
+                self.isin('connect to proxy 127.0.0.1:1', resp.get('reason'))
 
             resp = await proxy.wput(sha256, 'vertex.link')
             self.false(resp.get('ok'))
@@ -1008,7 +1008,7 @@ bar baz",vv
 
             resp = await proxy.postfiles(fields, 'vertex.link')
             self.false(resp.get('ok'))
-            self.isin('InvalidURL: vertex.link', resp.get('err', ''))
+            self.isin('InvalidURL: vertex.link', resp.get('reason'))
 
             # Bypass the Axon proxy configuration from Storm
             url = axon.getLocalUrl()
@@ -1020,7 +1020,7 @@ bar baz",vv
                 '''
                 resp = await core.callStorm(q, opts={'vars': {'fields': fields}})
                 self.false(resp.get('ok'))
-                self.isin('connect to proxy 127.0.0.1:1', resp.get('err', ''))
+                self.isin('connect to proxy 127.0.0.1:1', resp.get('reason'))
 
                 q = f'''
                 $resp = $lib.inet.http.post("https://127.0.0.1:{port}/api/v1/pushfile",

--- a/synapse/tests/test_axon.py
+++ b/synapse/tests/test_axon.py
@@ -1068,7 +1068,7 @@ bar baz",vv
 
                 resp = await axon.postfiles(fields, url)
                 self.false(resp.get('ok'))
-                self.isin('unable to get local issuer certificate', resp.get('err'))
+                self.isin('unable to get local issuer certificate', resp.get('reason'))
 
             conf = {'auth:passwd': 'root', 'tls:ca:dir': tlscadir}
             async with self.getTestAxon(dirn=dirn, conf=conf) as axon:

--- a/synapse/tests/test_lib_stormhttp.py
+++ b/synapse/tests/test_lib_stormhttp.py
@@ -132,17 +132,19 @@ class StormHttpTest(s_test.SynTest):
             '''
             code, reason, (errname, _) = await core.callStorm(q, opts=opts)
             self.eq(code, -1)
-            self.eq(reason, 'Exception occurred during request')
+            self.isin('Exception occurred during request: ', reason)
+            self.isin('Invalid query type', reason)
             self.eq('TypeError', errname)
 
-            # SSL Verify enabled results in a aiohttp.ClientConnectorCertificateError
+            # SSL Verify enabled results in an aiohttp.ClientConnectorCertificateError
             q = '''
             $params=((foo, bar), (key, valu))
             $resp = $lib.inet.http.get($url, params=$params)
-            return ( ($resp.code, $resp.err) )
+            return ( ($resp.code, $resp.reason, $resp.err) )
             '''
-            code, (errname, _) = await core.callStorm(q, opts=opts)
+            code, reason, (errname, _) = await core.callStorm(q, opts=opts)
             self.eq(code, -1)
+            self.isin('certificate verify failed', reason)
             self.eq('ClientConnectorCertificateError', errname)
 
             retn = await core.callStorm('return($lib.inet.http.urlencode("http://go ogle.com"))')

--- a/synapse/tests/test_lib_stormhttp.py
+++ b/synapse/tests/test_lib_stormhttp.py
@@ -442,8 +442,8 @@ class StormHttpTest(s_test.SynTest):
             return($lib.inet.http.post($url, ssl_verify=$lib.false, fields=$fields))
             '''
             resp = await core.callStorm(q, opts=opts)
-            experr = "BadArg: BadArg: mesg=\'Each field requires a \"name\" key with a string value: None\' name=None"
-            self.eq(experr, resp['err'])
+            self.eq(resp.get('code'), -1)
+            self.isin('BadArg: Each field requires a "name" key with a string value: None', resp.get('reason'))
 
             q = '''
             $buf = $lib.hex.decode(deadb33f)


### PR DESCRIPTION
-  Add exception information to the reason field when an handling an exception
- Update the axon.postfiles response to include the reason code 
- Fix the axon.postfiles response to use the same err tufo that is used in stormhttp
- Centralize http status code lookup