### PR TITLE
WIP SYN-5922: Respect default allow permissions

### DIFF
--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -379,7 +379,7 @@ class LibHttp(s_stormtypes.Lib):
 
         if fields:
             if any(['sha256' in field for field in fields]):
-                self.runt.confirm(('storm', 'lib', 'axon', 'wput'))
+                await self.runt.confirm(('storm', 'lib', 'axon', 'wput'))
                 axon = self.runt.snap.core.axon
                 info = await axon.postfiles(fields, url, headers=headers, params=params,
                                             method=meth, ssl=ssl_verify, timeout=timeout, proxy=proxy)

--- a/synapse/lib/stormlib/imap.py
+++ b/synapse/lib/stormlib/imap.py
@@ -66,7 +66,7 @@ class ImapLib(s_stormtypes.Lib):
 
     async def connect(self, host, port=993, timeout=30, ssl=True):
 
-        self.runt.confirm(('storm', 'inet', 'imap', 'connect'))
+        await self.runt.confirm(('storm', 'inet', 'imap', 'connect'))
 
         ssl = await s_stormtypes.tobool(ssl)
         host = await s_stormtypes.tostr(host)

--- a/synapse/lib/stormlib/log.py
+++ b/synapse/lib/stormlib/log.py
@@ -137,7 +137,7 @@ class LoggerLib(s_stormtypes.Lib):
 
     @s_stormtypes.stormfunc(readonly=True)
     async def _logDebug(self, mesg, extra=None):
-        self.runt.confirm(('storm', 'lib', 'log', 'debug'))
+        await self.runt.confirm(('storm', 'lib', 'log', 'debug'))
         mesg = await s_stormtypes.tostr(mesg)
         extra = await self._getExtra(extra)
         stormlogger.debug(mesg, extra=extra)
@@ -145,7 +145,7 @@ class LoggerLib(s_stormtypes.Lib):
 
     @s_stormtypes.stormfunc(readonly=True)
     async def _logInfo(self, mesg, extra=None):
-        self.runt.confirm(('storm', 'lib', 'log', 'info'))
+        await self.runt.confirm(('storm', 'lib', 'log', 'info'))
         mesg = await s_stormtypes.tostr(mesg)
         extra = await self._getExtra(extra)
         stormlogger.info(mesg, extra=extra)
@@ -153,7 +153,7 @@ class LoggerLib(s_stormtypes.Lib):
 
     @s_stormtypes.stormfunc(readonly=True)
     async def _logWarning(self, mesg, extra=None):
-        self.runt.confirm(('storm', 'lib', 'log', 'warning'))
+        await self.runt.confirm(('storm', 'lib', 'log', 'warning'))
         mesg = await s_stormtypes.tostr(mesg)
         extra = await self._getExtra(extra)
         stormlogger.warning(mesg, extra=extra)
@@ -161,7 +161,7 @@ class LoggerLib(s_stormtypes.Lib):
 
     @s_stormtypes.stormfunc(readonly=True)
     async def _logError(self, mesg, extra=None):
-        self.runt.confirm(('storm', 'lib', 'log', 'error'))
+        await self.runt.confirm(('storm', 'lib', 'log', 'error'))
         mesg = await s_stormtypes.tostr(mesg)
         extra = await self._getExtra(extra)
         stormlogger.error(mesg, extra=extra)

--- a/synapse/lib/stormlib/model.py
+++ b/synapse/lib/stormlib/model.py
@@ -248,7 +248,7 @@ class LibModelTags(s_stormtypes.Lib):
 
     async def _delTagModel(self, tagname):
         tagname = await s_stormtypes.tostr(tagname)
-        self.runt.confirm(('model', 'tag', 'set'))
+        await self.runt.confirm(('model', 'tag', 'set'))
         return await self.runt.snap.core.delTagModel(tagname)
 
     async def _getTagModel(self, tagname):
@@ -261,14 +261,14 @@ class LibModelTags(s_stormtypes.Lib):
     async def _popTagModel(self, tagname, propname):
         tagname = await s_stormtypes.tostr(tagname)
         propname = await s_stormtypes.tostr(propname)
-        self.runt.confirm(('model', 'tag', 'set'))
+        await self.runt.confirm(('model', 'tag', 'set'))
         return await self.runt.snap.core.popTagModel(tagname, propname)
 
     async def _setTagModel(self, tagname, propname, propvalu):
         tagname = await s_stormtypes.tostr(tagname)
         propname = await s_stormtypes.tostr(propname)
         propvalu = await s_stormtypes.toprim(propvalu)
-        self.runt.confirm(('model', 'tag', 'set'))
+        await self.runt.confirm(('model', 'tag', 'set'))
         await self.runt.snap.core.setTagModel(tagname, propname, propvalu)
 
 @s_stormtypes.registry.registerLib

--- a/synapse/lib/stormlib/smtp.py
+++ b/synapse/lib/stormlib/smtp.py
@@ -150,7 +150,7 @@ class SmtpMessage(s_stormtypes.StormType):
 
     async def send(self, host, port=25, user=None, passwd=None, usetls=False, starttls=False, timeout=60):
 
-        self.runt.confirm(('storm', 'inet', 'smtp', 'send'))
+        await self.runt.confirm(('storm', 'inet', 'smtp', 'send'))
 
         try:
             if self.bodytext is None and self.bodyhtml is None:

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -41,11 +41,11 @@ class Undef:
 
 undef = Undef()
 
-def confirm(perm, gateiden=None):
-    s_scope.get('runt').confirm(perm, gateiden=gateiden)
+async def confirm(perm, gateiden=None):
+    await s_scope.get('runt').confirm(perm, gateiden=gateiden)
 
-def allowed(perm, gateiden=None):
-    return s_scope.get('runt').allowed(perm, gateiden=gateiden)
+async def allowed(perm, gateiden=None):
+    return await s_scope.get('runt').allowed(perm, gateiden=gateiden)
 
 class StormTypesRegistry:
     # The following types are currently undefined.
@@ -3275,7 +3275,7 @@ class LibQueue(Lib):
         qlist = await self.dyncall('cortex', todo)
 
         for queue in qlist:
-            if not allowed(('queue', 'get'), f"queue:{queue['name']}"):
+            if not await allowed(('queue', 'get'), f"queue:{queue['name']}"):
                 continue
 
             retn.append(queue)
@@ -5017,7 +5017,7 @@ class LibGlobals(Lib):
         todo = ('itemsStormVar', (), {})
 
         async for key, valu in self.runt.dyniter('cortex', todo):
-            if allowed(('globals', 'get', key)):
+            if await allowed(('globals', 'get', key)):
                 ret.append((key, valu))
         return ret
 
@@ -5318,12 +5318,12 @@ class NodeProps(Prim):
         gateiden = self.valu.snap.wlyr.iden
 
         if valu is undef:
-            confirm(('node', 'prop', 'del', formprop.full), gateiden=gateiden)
+            await confirm(('node', 'prop', 'del', formprop.full), gateiden=gateiden)
             await self.valu.pop(name, None)
             return
 
         valu = await toprim(valu)
-        confirm(('node', 'prop', 'set', formprop.full), gateiden=gateiden)
+        await confirm(('node', 'prop', 'set', formprop.full), gateiden=gateiden)
         return await self.valu.set(name, valu)
 
     async def iter(self):
@@ -5456,7 +5456,7 @@ class NodeData(Prim):
     async def _setNodeData(self, name, valu):
         name = await tostr(name)
         gateiden = self.valu.snap.wlyr.iden
-        confirm(('node', 'data', 'set', name), gateiden=gateiden)
+        await confirm(('node', 'data', 'set', name), gateiden=gateiden)
         valu = await toprim(valu)
         s_common.reqjsonsafe(valu)
         return await self.valu.setData(name, valu)
@@ -5464,7 +5464,7 @@ class NodeData(Prim):
     async def _popNodeData(self, name):
         name = await tostr(name)
         gateiden = self.valu.snap.wlyr.iden
-        confirm(('node', 'data', 'pop', name), gateiden=gateiden)
+        await confirm(('node', 'data', 'pop', name), gateiden=gateiden)
         return await self.valu.popData(name)
 
     @stormfunc(readonly=True)
@@ -5655,7 +5655,7 @@ class Node(Prim):
         iden = await tobuidhex(iden)
 
         gateiden = self.valu.snap.wlyr.iden
-        confirm(('node', 'edge', 'add', verb), gateiden=gateiden)
+        await confirm(('node', 'edge', 'add', verb), gateiden=gateiden)
 
         await self.valu.addEdge(verb, iden)
 
@@ -5664,7 +5664,7 @@ class Node(Prim):
         iden = await tobuidhex(iden)
 
         gateiden = self.valu.snap.wlyr.iden
-        confirm(('node', 'edge', 'del', verb), gateiden=gateiden)
+        await confirm(('node', 'edge', 'del', verb), gateiden=gateiden)
 
         await self.valu.delEdge(verb, iden)
 
@@ -7184,7 +7184,7 @@ class LibTrigger(Lib):
                     mesg = 'Provided iden matches more than one trigger.'
                     raise s_exc.StormRuntimeError(mesg=mesg, iden=prefix)
 
-                if not allowed(('trigger', 'get'), gateiden=iden):
+                if not await allowed(('trigger', 'get'), gateiden=iden):
                     continue
 
                 match = trig
@@ -7265,7 +7265,7 @@ class LibTrigger(Lib):
         triggers = []
 
         for iden, trig in await view.listTriggers():
-            if not allowed(('trigger', 'get'), gateiden=iden):
+            if not await allowed(('trigger', 'get'), gateiden=iden):
                 continue
             triggers.append(Trigger(self.runt, trig.pack()))
 
@@ -8817,7 +8817,7 @@ class LibCron(Lib):
         for cron in crons:
             iden = cron.get('iden')
 
-            if iden.startswith(prefix) and allowed(perm, gateiden=iden):
+            if iden.startswith(prefix) and await allowed(perm, gateiden=iden):
                 if matchcron is not None:
                     mesg = 'Provided iden matches more than one cron job.'
                     raise s_exc.StormRuntimeError(mesg=mesg, iden=prefix)

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -599,7 +599,7 @@ class LibPkg(Lib):
         }
 
     async def _libPkgAdd(self, pkgdef, verify=False):
-        self.runt.confirm(('pkg', 'add'), None)
+        await self.runt.confirm(('pkg', 'add'), None)
         pkgdef = await toprim(pkgdef)
         verify = await tobool(verify)
         await self.runt.snap.core.addStormPkg(pkgdef, verify=verify)
@@ -620,7 +620,7 @@ class LibPkg(Lib):
         return True
 
     async def _libPkgDel(self, name):
-        self.runt.confirm(('pkg', 'del'), None)
+        await self.runt.confirm(('pkg', 'del'), None)
         await self.runt.snap.core.delStormPkg(name)
 
     async def _libPkgList(self):
@@ -718,7 +718,7 @@ class LibDmon(Lib):
             raise s_exc.NoSuchIden(mesg=mesg)
 
         if dmon.get('user') != self.runt.user.iden:
-            self.runt.confirm(('dmon', 'del', iden))
+            await self.runt.confirm(('dmon', 'del', iden))
 
         await self.runt.snap.core.delStormDmon(iden)
 
@@ -729,7 +729,7 @@ class LibDmon(Lib):
         return await self.runt.snap.core.getStormDmons()
 
     async def _libDmonLog(self, iden):
-        self.runt.confirm(('dmon', 'log'))
+        await self.runt.confirm(('dmon', 'log'))
         return await self.runt.snap.core.getStormDmonLog(iden)
 
     async def _libDmonAdd(self, text, name='noname', ddef=None):
@@ -748,7 +748,7 @@ class LibDmon(Lib):
         ddef = await toprim(ddef)
 
         viewiden = self.runt.snap.view.iden
-        self.runt.confirm(('dmon', 'add'), gateiden=viewiden)
+        await self.runt.confirm(('dmon', 'add'), gateiden=viewiden)
 
         opts = {'vars': varz, 'view': viewiden}
 
@@ -772,7 +772,7 @@ class LibDmon(Lib):
             return False
 
         viewiden = ddef['stormopts']['view']
-        self.runt.confirm(('dmon', 'add'), gateiden=viewiden)
+        await self.runt.confirm(('dmon', 'add'), gateiden=viewiden)
 
         await self.runt.snap.core.bumpStormDmon(iden)
         return True
@@ -785,7 +785,7 @@ class LibDmon(Lib):
             return False
 
         viewiden = ddef['stormopts']['view']
-        self.runt.confirm(('dmon', 'add'), gateiden=viewiden)
+        await self.runt.confirm(('dmon', 'add'), gateiden=viewiden)
 
         return await self.runt.snap.core.disableStormDmon(iden)
 
@@ -797,7 +797,7 @@ class LibDmon(Lib):
             return False
 
         viewiden = ddef['stormopts']['view']
-        self.runt.confirm(('dmon', 'add'), gateiden=viewiden)
+        await self.runt.confirm(('dmon', 'add'), gateiden=viewiden)
 
         return await self.runt.snap.core.enableStormDmon(iden)
 
@@ -879,10 +879,10 @@ class LibService(Lib):
         Helper to handle service.get.* permissions
         '''
         try:
-            self.runt.confirm(('service', 'get', ssvc.iden))
+            await self.runt.confirm(('service', 'get', ssvc.iden))
         except s_exc.AuthDeny as e:
             try:
-                self.runt.confirm(('service', 'get', ssvc.name))
+                await self.runt.confirm(('service', 'get', ssvc.name))
             except s_exc.AuthDeny:
                 raise e from None
             else:
@@ -890,7 +890,7 @@ class LibService(Lib):
                 await self.runt.warnonce(mesg, svcname=ssvc.name, svciden=ssvc.iden)
 
     async def _libSvcAdd(self, name, url):
-        self.runt.confirm(('service', 'add'))
+        await self.runt.confirm(('service', 'add'))
         sdef = {
             'name': name,
             'url': url,
@@ -898,7 +898,7 @@ class LibService(Lib):
         return await self.runt.snap.core.addStormSvc(sdef)
 
     async def _libSvcDel(self, iden):
-        self.runt.confirm(('service', 'del'))
+        await self.runt.confirm(('service', 'del'))
         return await self.runt.snap.core.delStormSvc(iden)
 
     async def _libSvcGet(self, name):
@@ -916,7 +916,7 @@ class LibService(Lib):
         return True
 
     async def _libSvcList(self):
-        self.runt.confirm(('service', 'list'))
+        await self.runt.confirm(('service', 'list'))
         retn = []
 
         for ssvc in self.runt.snap.core.getStormSvcs():
@@ -1375,7 +1375,7 @@ class LibBase(Lib):
         if rootperms is not None:
 
             for perm in rootperms:
-                if self.runt.allowed(perm):
+                if await self.runt.allowed(perm):
                     asroot = True
                     break
 
@@ -1386,7 +1386,7 @@ class LibBase(Lib):
 
         else:
             perm = ('storm', 'asroot', 'mod') + tuple(name.split('.'))
-            asroot = self.runt.allowed(perm)
+            asroot = await self.runt.allowed(perm)
 
             if mdef.get('asroot', False) and not asroot:
                 mesg = f'Module ({name}) elevates privileges.  You need perm: storm.asroot.mod.{name}'
@@ -1985,7 +1985,7 @@ class LibAxon(Lib):
         return item
 
     async def readlines(self, sha256):
-        self.runt.confirm(('storm', 'lib', 'axon', 'get'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'get'))
         await self.runt.snap.core.getAxon()
 
         sha256 = await tostr(sha256)
@@ -1993,7 +1993,7 @@ class LibAxon(Lib):
             yield line
 
     async def jsonlines(self, sha256):
-        self.runt.confirm(('storm', 'lib', 'axon', 'get'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'get'))
         await self.runt.snap.core.getAxon()
 
         sha256 = await tostr(sha256)
@@ -2002,7 +2002,7 @@ class LibAxon(Lib):
 
     async def dels(self, sha256s):
 
-        self.runt.confirm(('storm', 'lib', 'axon', 'del'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'del'))
 
         sha256s = await toprim(sha256s)
 
@@ -2018,7 +2018,7 @@ class LibAxon(Lib):
 
     async def del_(self, sha256):
 
-        self.runt.confirm(('storm', 'lib', 'axon', 'del'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'del'))
         sha256 = await tostr(sha256)
 
         sha256b = s_common.uhex(sha256)
@@ -2029,7 +2029,7 @@ class LibAxon(Lib):
 
     async def wget(self, url, headers=None, params=None, method='GET', json=None, body=None, ssl=True, timeout=None, proxy=None):
 
-        self.runt.confirm(('storm', 'lib', 'axon', 'wget'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'wget'))
 
         if proxy is not None and not self.runt.isAdmin():
             raise s_exc.AuthDeny(mesg=s_exc.proxy_admin_mesg, user=self.runt.user.iden, username=self.runt.user.name)
@@ -2063,7 +2063,7 @@ class LibAxon(Lib):
 
     async def wput(self, sha256, url, headers=None, params=None, method='PUT', ssl=True, timeout=None, proxy=None):
 
-        self.runt.confirm(('storm', 'lib', 'axon', 'wput'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'wput'))
 
         if proxy is not None and not self.runt.isAdmin():
             raise s_exc.AuthDeny(mesg=s_exc.proxy_admin_mesg, user=self.runt.user.iden, username=self.runt.user.name)
@@ -2154,7 +2154,7 @@ class LibAxon(Lib):
         wait = await tobool(wait)
         timeout = await toint(timeout, noneok=True)
 
-        self.runt.confirm(('storm', 'lib', 'axon', 'has'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'has'))
 
         await self.runt.snap.core.getAxon()
         axon = self.runt.snap.core.axon
@@ -2164,7 +2164,7 @@ class LibAxon(Lib):
 
     async def csvrows(self, sha256, dialect='excel', **fmtparams):
 
-        self.runt.confirm(('storm', 'lib', 'axon', 'get'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'get'))
         await self.runt.snap.core.getAxon()
 
         sha256 = await tostr(sha256)
@@ -2175,7 +2175,7 @@ class LibAxon(Lib):
             await asyncio.sleep(0)
 
     async def metrics(self):
-        self.runt.confirm(('storm', 'lib', 'axon', 'has'))
+        await self.runt.confirm(('storm', 'lib', 'axon', 'has'))
         return await self.runt.snap.core.axon.metrics()
 
 @registry.registerLib
@@ -3472,8 +3472,8 @@ class LibTelepath(Lib):
     async def _methTeleOpen(self, url):
         url = await tostr(url)
         scheme = url.split('://')[0]
-        if not self.runt.allowed(('lib', 'telepath', 'open', scheme)):
-            self.runt.confirm(('storm', 'lib', 'telepath', 'open', scheme))
+        if not await self.runt.allowed(('lib', 'telepath', 'open', scheme)):
+            await self.runt.confirm(('storm', 'lib', 'telepath', 'open', scheme))
         return Proxy(self.runt, await self.runt.getTeleProxy(url))
 
 @registry.registerType
@@ -6469,8 +6469,8 @@ class Layer(Prim):
             raise s_exc.AuthDeny(mesg=mesg, user=self.runt.user.iden, username=self.runt.user.name)
 
         scheme = url.split('://')[0]
-        if not self.runt.allowed(('lib', 'telepath', 'open', scheme)):
-            self.runt.confirm(('storm', 'lib', 'telepath', 'open', scheme))
+        if not await self.runt.allowed(('lib', 'telepath', 'open', scheme)):
+            await self.runt.confirm(('storm', 'lib', 'telepath', 'open', scheme))
 
         async with await s_telepath.openurl(url):
             pass
@@ -6510,8 +6510,8 @@ class Layer(Prim):
 
         scheme = url.split('://')[0]
 
-        if not self.runt.allowed(('lib', 'telepath', 'open', scheme)):
-            self.runt.confirm(('storm', 'lib', 'telepath', 'open', scheme))
+        if not await self.runt.allowed(('lib', 'telepath', 'open', scheme)):
+            await self.runt.confirm(('storm', 'lib', 'telepath', 'open', scheme))
 
         async with await s_telepath.openurl(url):
             pass
@@ -6929,13 +6929,13 @@ class View(Prim):
 
         # check that the user can read from the view
         # ( to emulate perms check for being able to run storm at all )
-        self.runt.confirm(('view', 'read'), gateiden=viewiden)
+        await self.runt.confirm(('view', 'read'), gateiden=viewiden)
 
-        self.runt.confirm(('node', 'add', form), gateiden=layriden)
+        await self.runt.confirm(('node', 'add', form), gateiden=layriden)
         if props is not None:
             for propname in props.keys():
                 fullname = f'{form}:{propname}'
-                self.runt.confirm(('node', 'prop', 'set', fullname), gateiden=layriden)
+                await self.runt.confirm(('node', 'prop', 'set', fullname), gateiden=layriden)
 
         if viewiden == self.runt.snap.view.iden:
             return await self.runt.snap.addNode(form, valu, props=props)
@@ -7018,7 +7018,7 @@ class View(Prim):
                     mesg = f'No layer with iden: {layriden}'
                     raise s_exc.NoSuchLayer(mesg=mesg)
 
-                self.runt.confirm(('layer', 'read'), gateiden=layr.iden)
+                await self.runt.confirm(('layer', 'read'), gateiden=layr.iden)
 
             if not self.runt.isAdmin(gateiden=view.iden):
                 mesg = 'User must be an admin of the view to set the layers.'
@@ -7276,7 +7276,7 @@ class LibTrigger(Lib):
         if trigger is None:
             return None
 
-        self.runt.confirm(('trigger', 'get'), gateiden=iden)
+        await self.runt.confirm(('trigger', 'get'), gateiden=iden)
 
         return Trigger(self.runt, trigger.pack())
 
@@ -7388,9 +7388,9 @@ class Trigger(Prim):
             raise s_exc.NoSuchView(mesg=viewiden)
 
         trigview = self.valu.get('view')
-        self.runt.confirm(('view', 'read'), gateiden=viewiden)
-        self.runt.confirm(('trigger', 'add'), gateiden=viewiden)
-        self.runt.confirm(('trigger', 'del'), gateiden=trigiden)
+        await self.runt.confirm(('view', 'read'), gateiden=viewiden)
+        await self.runt.confirm(('trigger', 'add'), gateiden=viewiden)
+        await self.runt.confirm(('trigger', 'del'), gateiden=trigiden)
 
         useriden = self.runt.user.iden
         tdef = dict(self.valu)
@@ -7556,8 +7556,8 @@ class LibUsers(Lib):
             return User(self.runt, udef['iden'])
 
     async def _methUsersAdd(self, name, passwd=None, email=None, iden=None):
-        if not self.runt.allowed(('auth', 'user', 'add')):
-            self.runt.confirm(('storm', 'lib', 'auth', 'users', 'add'))
+        if not await self.runt.allowed(('auth', 'user', 'add')):
+            await self.runt.confirm(('storm', 'lib', 'auth', 'users', 'add'))
         name = await tostr(name)
         iden = await tostr(iden, True)
         email = await tostr(email, True)
@@ -7566,8 +7566,8 @@ class LibUsers(Lib):
         return User(self.runt, udef['iden'])
 
     async def _methUsersDel(self, iden):
-        if not self.runt.allowed(('auth', 'user', 'del')):
-            self.runt.confirm(('storm', 'lib', 'auth', 'users', 'del'))
+        if not await self.runt.allowed(('auth', 'user', 'del')):
+            await self.runt.confirm(('storm', 'lib', 'auth', 'users', 'del'))
         await self.runt.snap.core.delUser(iden)
 
 @registry.registerLib
@@ -7640,14 +7640,14 @@ class LibRoles(Lib):
             return Role(self.runt, rdef['iden'])
 
     async def _methRolesAdd(self, name):
-        if not self.runt.allowed(('auth', 'role', 'add')):
-            self.runt.confirm(('storm', 'lib', 'auth', 'roles', 'add'))
+        if not await self.runt.allowed(('auth', 'role', 'add')):
+            await self.runt.confirm(('storm', 'lib', 'auth', 'roles', 'add'))
         rdef = await self.runt.snap.core.addRole(name)
         return Role(self.runt, rdef['iden'])
 
     async def _methRolesDel(self, iden):
-        if not self.runt.allowed(('auth', 'role', 'del')):
-            self.runt.confirm(('storm', 'lib', 'auth', 'roles', 'del'))
+        if not await self.runt.allowed(('auth', 'role', 'del')):
+            await self.runt.confirm(('storm', 'lib', 'auth', 'roles', 'del'))
         await self.runt.snap.core.delRole(iden)
 
 @registry.registerLib
@@ -7951,19 +7951,19 @@ class UserProfile(Prim):
 
     async def deref(self, name):
         name = await tostr(name)
-        self.runt.confirm(('auth', 'user', 'get', 'profile', name))
+        await self.runt.confirm(('auth', 'user', 'get', 'profile', name))
         return copy.deepcopy(await self.runt.snap.core.getUserProfInfo(self.valu, name))
 
     async def setitem(self, name, valu):
         name = await tostr(name)
 
         if valu is undef:
-            self.runt.confirm(('auth', 'user', 'pop', 'profile', name))
+            await self.runt.confirm(('auth', 'user', 'pop', 'profile', name))
             await self.runt.snap.core.popUserProfInfo(self.valu, name)
             return
 
         valu = await toprim(valu)
-        self.runt.confirm(('auth', 'user', 'set', 'profile', name))
+        await self.runt.confirm(('auth', 'user', 'set', 'profile', name))
         await self.runt.snap.core.setUserProfInfo(self.valu, name, valu)
 
     async def iter(self):
@@ -7972,7 +7972,7 @@ class UserProfile(Prim):
             yield item
 
     async def value(self):
-        self.runt.confirm(('auth', 'user', 'get', 'profile'))
+        await self.runt.confirm(('auth', 'user', 'get', 'profile'))
         return copy.deepcopy(await self.runt.snap.core.getUserProfile(self.valu))
 
 @registry.registerType
@@ -8035,7 +8035,7 @@ class UserJson(Prim):
 
         fullpath = ('users', self.valu, 'json') + path
         if self.runt.user.iden != self.valu:
-            self.runt.confirm(('user', 'json', 'get'))
+            await self.runt.confirm(('user', 'json', 'get'))
 
         return await self.runt.snap.core.hasJsonObj(fullpath)
 
@@ -8049,7 +8049,7 @@ class UserJson(Prim):
         fullpath = ('users', self.valu, 'json') + path
 
         if self.runt.user.iden != self.valu:
-            self.runt.confirm(('user', 'json', 'get'))
+            await self.runt.confirm(('user', 'json', 'get'))
 
         if prop is None:
             return await self.runt.snap.core.getJsonObj(fullpath)
@@ -8067,7 +8067,7 @@ class UserJson(Prim):
         fullpath = ('users', self.valu, 'json') + path
 
         if self.runt.user.iden != self.valu:
-            self.runt.confirm(('user', 'json', 'set'))
+            await self.runt.confirm(('user', 'json', 'set'))
 
         if prop is None:
             await self.runt.snap.core.setJsonObj(fullpath, valu)
@@ -8085,7 +8085,7 @@ class UserJson(Prim):
         fullpath = ('users', self.valu, 'json') + path
 
         if self.runt.user.iden != self.valu:
-            self.runt.confirm(('user', 'json', 'set'))
+            await self.runt.confirm(('user', 'json', 'set'))
 
         if prop is None:
             await self.runt.snap.core.delJsonObj(fullpath)
@@ -8098,7 +8098,7 @@ class UserJson(Prim):
         path = await toprim(path)
 
         if self.runt.user.iden != self.valu:
-            self.runt.confirm(('user', 'json', 'get'))
+            await self.runt.confirm(('user', 'json', 'get'))
 
         fullpath = ('users', self.valu, 'json')
         if path is not None:
@@ -8389,7 +8389,7 @@ class User(Prim):
         return await self.value()
 
     async def _methUserTell(self, text):
-        self.runt.confirm(('tell', self.valu), default=True)
+        await self.runt.confirm(('tell', self.valu), default=True)
         mesgdata = {
             'text': await tostr(text),
             'from': self.runt.user.iden,
@@ -8408,11 +8408,11 @@ class User(Prim):
 
         name = await tostr(name)
         if self.runt.user.iden == self.valu:
-            self.runt.confirm(('auth', 'self', 'set', 'name'), default=True)
+            await self.runt.confirm(('auth', 'self', 'set', 'name'), default=True)
             await self.runt.snap.core.setUserName(self.valu, name)
             return
 
-        self.runt.confirm(('auth', 'user', 'set', 'name'))
+        await self.runt.confirm(('auth', 'user', 'set', 'name'))
         await self.runt.snap.core.setUserName(self.valu, name)
 
     async def _derefGet(self, name):
@@ -8454,24 +8454,24 @@ class User(Prim):
         return user.getAllowedReason(perm, gateiden=gateiden, default=default)
 
     async def _methUserGrant(self, iden, indx=None):
-        self.runt.confirm(('auth', 'user', 'grant'))
+        await self.runt.confirm(('auth', 'user', 'grant'))
         indx = await toint(indx, noneok=True)
         await self.runt.snap.core.addUserRole(self.valu, iden, indx=indx)
 
     async def _methUserSetRoles(self, idens):
-        self.runt.confirm(('auth', 'user', 'grant'))
-        self.runt.confirm(('auth', 'user', 'revoke'))
+        await self.runt.confirm(('auth', 'user', 'grant'))
+        await self.runt.confirm(('auth', 'user', 'revoke'))
         idens = await toprim(idens)
         await self.runt.snap.core.setUserRoles(self.valu, idens)
 
     async def _methUserRevoke(self, iden):
-        self.runt.confirm(('auth', 'user', 'revoke'))
+        await self.runt.confirm(('auth', 'user', 'revoke'))
         await self.runt.snap.core.delUserRole(self.valu, iden)
 
     async def _methUserSetRules(self, rules, gateiden=None):
         rules = await toprim(rules)
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'user', 'set', 'rules'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'user', 'set', 'rules'), gateiden=gateiden)
         await self.runt.snap.core.setUserRules(self.valu, rules, gateiden=gateiden)
 
     async def getRules(self, gateiden=None):
@@ -8483,19 +8483,19 @@ class User(Prim):
         rule = await toprim(rule)
         indx = await toint(indx, noneok=True)
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'user', 'set', 'rules'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'user', 'set', 'rules'), gateiden=gateiden)
         await self.runt.snap.core.addUserRule(self.valu, rule, indx=indx, gateiden=gateiden)
 
     async def _methUserDelRule(self, rule, gateiden=None):
         rule = await toprim(rule)
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'user', 'set', 'rules'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'user', 'set', 'rules'), gateiden=gateiden)
         await self.runt.snap.core.delUserRule(self.valu, rule, gateiden=gateiden)
 
     async def _methUserPopRule(self, indx, gateiden=None):
 
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'user', 'set', 'rules'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'user', 'set', 'rules'), gateiden=gateiden)
 
         indx = await toint(indx)
         rules = list(await self.getRules(gateiden=gateiden))
@@ -8511,16 +8511,16 @@ class User(Prim):
     async def _methUserSetEmail(self, email):
         email = await tostr(email)
         if self.runt.user.iden == self.valu:
-            self.runt.confirm(('auth', 'self', 'set', 'email'), default=True)
+            await self.runt.confirm(('auth', 'self', 'set', 'email'), default=True)
             await self.runt.snap.core.setUserEmail(self.valu, email)
             return
 
-        self.runt.confirm(('auth', 'user', 'set', 'email'))
+        await self.runt.confirm(('auth', 'user', 'set', 'email'))
         await self.runt.snap.core.setUserEmail(self.valu, email)
 
     async def _methUserSetAdmin(self, admin, gateiden=None):
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'user', 'set', 'admin'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'user', 'set', 'admin'), gateiden=gateiden)
         admin = await tobool(admin)
 
         await self.runt.snap.core.setUserAdmin(self.valu, admin, gateiden=gateiden)
@@ -8528,14 +8528,14 @@ class User(Prim):
     async def _methUserSetPasswd(self, passwd):
         passwd = await tostr(passwd, noneok=True)
         if self.runt.user.iden == self.valu:
-            self.runt.confirm(('auth', 'self', 'set', 'passwd'), default=True)
+            await self.runt.confirm(('auth', 'self', 'set', 'passwd'), default=True)
             return await self.runt.snap.core.setUserPasswd(self.valu, passwd)
 
-        self.runt.confirm(('auth', 'user', 'set', 'passwd'))
+        await self.runt.confirm(('auth', 'user', 'set', 'passwd'))
         return await self.runt.snap.core.setUserPasswd(self.valu, passwd)
 
     async def _methUserSetLocked(self, locked):
-        self.runt.confirm(('auth', 'user', 'set', 'locked'))
+        await self.runt.confirm(('auth', 'user', 'set', 'locked'))
         await self.runt.snap.core.setUserLocked(self.valu, await tobool(locked))
 
     async def value(self):
@@ -8650,7 +8650,7 @@ class Role(Prim):
         return rdef.get(name, s_common.novalu)
 
     async def _setRoleName(self, name):
-        self.runt.confirm(('auth', 'role', 'set', 'name'))
+        await self.runt.confirm(('auth', 'role', 'set', 'name'))
         name = await tostr(name)
         await self.runt.snap.core.setRoleName(self.valu, name)
 
@@ -8677,26 +8677,26 @@ class Role(Prim):
     async def _methRoleSetRules(self, rules, gateiden=None):
         rules = await toprim(rules)
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'role', 'set', 'rules'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'role', 'set', 'rules'), gateiden=gateiden)
         await self.runt.snap.core.setRoleRules(self.valu, rules, gateiden=gateiden)
 
     async def _methRoleAddRule(self, rule, gateiden=None, indx=None):
         rule = await toprim(rule)
         indx = await toint(indx, noneok=True)
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'role', 'set', 'rules'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'role', 'set', 'rules'), gateiden=gateiden)
         await self.runt.snap.core.addRoleRule(self.valu, rule, indx=indx, gateiden=gateiden)
 
     async def _methRoleDelRule(self, rule, gateiden=None):
         rule = await toprim(rule)
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'role', 'set', 'rules'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'role', 'set', 'rules'), gateiden=gateiden)
         await self.runt.snap.core.delRoleRule(self.valu, rule, gateiden=gateiden)
 
     async def _methRolePopRule(self, indx, gateiden=None):
 
         gateiden = await tostr(gateiden, noneok=True)
-        self.runt.confirm(('auth', 'role', 'set', 'rules'), gateiden=gateiden)
+        await self.runt.confirm(('auth', 'role', 'set', 'rules'), gateiden=gateiden)
 
         indx = await toint(indx)
 
@@ -9178,7 +9178,7 @@ class LibCron(Lib):
         cron = await self._matchIdens(prefix, ('cron', 'set'))
         iden = cron['iden']
 
-        self.runt.confirm(('cron', 'set'), gateiden=iden)
+        await self.runt.confirm(('cron', 'set'), gateiden=iden)
         return await self.runt.snap.core.moveCronJob(self.runt.user.iden, iden, view)
 
     async def _methCronList(self):

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -4952,22 +4952,11 @@ class StormTypesTest(s_test.SynTest):
                      ),
                      'storm': 'function x() { [ ps:person=* ] return($node) }',
                     },
-                    {
-                     'name': 'authtest.defaultcheckmod',
-                     'asroot:perms': (
-                        ('wootwoot.wow',),
-                     ),
-                     'storm': 'function x() { [ ps:person=* ] return($node) }',
-                    },
                 ),
                 'commands': (
                     {'name': 'authtest.asuser',
                      'perms': (('wootwoot',), ),
                      'storm': '$lib.print(hithere)',
-                    },
-                    {'name': 'authtest.defaultcheckcmd',
-                     'perms': (('wootwoot.wow',), ),
-                     'storm': '$lib.print(worked)',
                     },
                 ),
             }
@@ -5020,11 +5009,7 @@ class StormTypesTest(s_test.SynTest):
             msgs = await core.stormlist('authtest.asuser', opts=asvisi)
             self.stormIsInPrint('hithere', msgs)
 
-            # msgs = await core.stormlist('authtest.defaultcheckcmd', opts=asvisi)
-            # self.stormIsInPrint('worked', msgs)
-
             self.len(1, await core.nodes('yield $lib.import(authtest.privsep).x()', opts=asvisi))
-            self.len(1, await core.nodes('yield $lib.import(authtest.defaultcheckmod).x()', opts=asvisi))
 
             udef = await core.callStorm('return($lib.auth.users.get($iden))', opts={'vars': {'iden': visi.iden}})
             self.nn(udef)

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -4952,11 +4952,22 @@ class StormTypesTest(s_test.SynTest):
                      ),
                      'storm': 'function x() { [ ps:person=* ] return($node) }',
                     },
+                    {
+                     'name': 'authtest.defaultcheckmod',
+                     'asroot:perms': (
+                        ('wootwoot.wow',),
+                     ),
+                     'storm': 'function x() { [ ps:person=* ] return($node) }',
+                    },
                 ),
                 'commands': (
                     {'name': 'authtest.asuser',
                      'perms': (('wootwoot',), ),
                      'storm': '$lib.print(hithere)',
+                    },
+                    {'name': 'authtest.defaultcheckcmd',
+                     'perms': (('wootwoot.wow',), ),
+                     'storm': '$lib.print(worked)',
                     },
                 ),
             }
@@ -5009,7 +5020,11 @@ class StormTypesTest(s_test.SynTest):
             msgs = await core.stormlist('authtest.asuser', opts=asvisi)
             self.stormIsInPrint('hithere', msgs)
 
+            # msgs = await core.stormlist('authtest.defaultcheckcmd', opts=asvisi)
+            # self.stormIsInPrint('worked', msgs)
+
             self.len(1, await core.nodes('yield $lib.import(authtest.privsep).x()', opts=asvisi))
+            self.len(1, await core.nodes('yield $lib.import(authtest.defaultcheckmod).x()', opts=asvisi))
 
             udef = await core.callStorm('return($lib.auth.users.get($iden))', opts={'vars': {'iden': visi.iden}})
             self.nn(udef)


### PR DESCRIPTION
- Updated `.allowed()` and `.confirm()` in the storm runtime to pull the permission definition and use it's default value instead of the kwarg.
- Added test