### PR TITLE
SYN-5967: Convert yaml.safe_load to yaml.load(..., yaml.CSafeLoader)

### DIFF
--- a/docs/synapse/adminguide.rstorm
+++ b/docs/synapse/adminguide.rstorm
@@ -1179,7 +1179,7 @@ roles. In the example below, all users would have the general ``users`` role and
 +---------------------+------------------------------+-------------------------------------------------+
 | **senior analyst**  | ``node.tag.add.cno.threat``  | Senior analysts can apply tags in the           |
 |                     |                              |                                                 |
-|                     |                              | ``cno.threat`` and ``cno.mal`` trees            |
+|                     | ``node.tag.add.cno.mal``     | ``cno.threat`` and ``cno.mal`` trees            |
 |                     |                              |                                                 |
 |                     |                              | (assessments related to threat clusters and     |
 |                     |                              |                                                 |

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -34,6 +34,13 @@ import synapse.lib.const as s_const
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.structlog as s_structlog
 
+try:
+    from yaml import CSafeLoader as Loader
+    from yaml import CSafeDumper as Dumper
+except ImportError:
+    from yaml import SafeLoader as Loader
+    from yaml import SafeDumper as Dumper
+
 class NoValu:
     pass
 
@@ -510,16 +517,14 @@ def yamlload(*paths):
         return None
 
     with io.open(path, 'rb') as fd:
-        byts = fd.read()
-        if not byts:
-            return None
-        return yaml.safe_load(byts.decode('utf8'))
+        return yaml.load(fd, Loader)
 
 def yamlsave(obj, *paths):
     path = genpath(*paths)
     with genfile(path) as fd:
-        s = yaml.safe_dump(obj, allow_unicode=False, default_flow_style=False,
-                           default_style='', explicit_start=True, explicit_end=True, sort_keys=True)
+        s = yaml.dump(obj, allow_unicode=False, default_flow_style=False,
+                  default_style='', explicit_start=True, explicit_end=True,
+                  sort_keys=True, Dumper=Dumper)
         fd.truncate(0)
         fd.write(s.encode('utf8'))
 

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -58,6 +58,9 @@ novalu = NoValu()
 
 logger = logging.getLogger(__name__)
 
+if Loader != yaml.CSafeLoader:  # pragma: no cover
+    logger.warning('PyYAML is using the pure python fallback implementation. This will impact performance negatively.')
+
 def now():
     '''
     Get the current epoch time in milliseconds.

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -37,7 +37,7 @@ import synapse.lib.structlog as s_structlog
 try:
     from yaml import CSafeLoader as Loader
     from yaml import CSafeDumper as Dumper
-except ImportError:
+except ImportError:  # pragma: no cover
     from yaml import SafeLoader as Loader
     from yaml import SafeDumper as Dumper
 

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -510,6 +510,9 @@ def jssave(js, *paths):
     with io.open(path, 'wb') as fd:
         fd.write(json.dumps(js, sort_keys=True, indent=2).encode('utf8'))
 
+def yamlloads(data):
+    return yaml.load(data, Loader)
+
 def yamlload(*paths):
 
     path = genpath(*paths)
@@ -517,16 +520,15 @@ def yamlload(*paths):
         return None
 
     with io.open(path, 'rb') as fd:
-        return yaml.load(fd, Loader)
+        return yamlloads(fd)
 
 def yamlsave(obj, *paths):
     path = genpath(*paths)
     with genfile(path) as fd:
-        s = yaml.dump(obj, allow_unicode=False, default_flow_style=False,
-                  default_style='', explicit_start=True, explicit_end=True,
-                  sort_keys=True, Dumper=Dumper)
         fd.truncate(0)
-        fd.write(s.encode('utf8'))
+        yaml.dump(obj, allow_unicode=True, default_flow_style=False,
+                  default_style='', explicit_start=True, explicit_end=True,
+                  encoding='utf8', stream=fd, Dumper=Dumper)
 
 def yamlmod(obj, *paths):
     '''

--- a/synapse/lib/config.py
+++ b/synapse/lib/config.py
@@ -205,7 +205,7 @@ class Config(c_abc.MutableMapping):
                     logger.debug(f'Boolean type is missing default information. Will not form argparse for [{name}]')
                     continue
                 default = bool(default)
-                akwargs['type'] = yaml.safe_load
+                akwargs['type'] = s_common.yamlloads
                 akwargs['choices'] = [True, False]
                 akwargs['help'] = akwargs['help'] + f' This option defaults to {default}.'
 
@@ -304,7 +304,7 @@ class Config(c_abc.MutableMapping):
             for name, envar in name2envar.items():
                 envv = os.getenv(envar)
                 if envv is not None:
-                    envv = yaml.safe_load(envv)
+                    envv = s_common.yamlloads(envv)
 
                     curv = self.get(name, s_common.novalu)
                     if curv is not s_common.novalu:

--- a/synapse/lib/stormlib/yaml.py
+++ b/synapse/lib/stormlib/yaml.py
@@ -1,4 +1,5 @@
 import synapse.exc as s_exc
+import synapse.common as s_common
 
 import synapse.lib.stormtypes as s_stormtypes
 
@@ -41,6 +42,6 @@ class LibYaml(s_stormtypes.Lib):
     async def load(self, valu):
         valu = await s_stormtypes.tostr(valu)
         try:
-            return yaml.safe_load(valu)
+            return s_common.yamlloads(valu)
         except yaml.error.YAMLError as e:
             raise s_exc.BadArg(mesg=f'Invalid YAML text: {str(e)}')

--- a/synapse/lib/stormlib/yaml.py
+++ b/synapse/lib/stormlib/yaml.py
@@ -37,7 +37,7 @@ class LibYaml(s_stormtypes.Lib):
     async def save(self, valu, sort_keys=True):
         valu = await s_stormtypes.toprim(valu)
         sort_keys = await s_stormtypes.tobool(sort_keys)
-        return yaml.safe_dump(valu, sort_keys=sort_keys)
+        return yaml.safe_dump(valu, sort_keys=sort_keys, Dumper=s_common.Dumper)
 
     async def load(self, valu):
         valu = await s_stormtypes.tostr(valu)

--- a/synapse/lib/stormlib/yaml.py
+++ b/synapse/lib/stormlib/yaml.py
@@ -37,7 +37,7 @@ class LibYaml(s_stormtypes.Lib):
     async def save(self, valu, sort_keys=True):
         valu = await s_stormtypes.toprim(valu)
         sort_keys = await s_stormtypes.tobool(sort_keys)
-        return yaml.safe_dump(valu, sort_keys=sort_keys, Dumper=s_common.Dumper)
+        return yaml.dump(valu, sort_keys=sort_keys, Dumper=s_common.Dumper)
 
     async def load(self, valu):
         valu = await s_stormtypes.tostr(valu)

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -162,7 +162,7 @@ async def getAhaProxy(urlinfo):
 
             if cellinfo['synapse']['version'] >= (2, 95, 0):
                 filters = {
-                    'mirror': bool(yaml.safe_load(urlinfo.get('mirror', 'false')))
+                    'mirror': bool(s_common.yamlloads(urlinfo.get('mirror', 'false')))
                 }
                 ahasvc = await asyncio.wait_for(proxy.getAhaSvc(host, filters=filters), timeout=5)
             else:

--- a/synapse/tests/test_common.py
+++ b/synapse/tests/test_common.py
@@ -289,6 +289,16 @@ class CommonTest(s_t_utils.SynTest):
                 fd.write(s.encode())
             self.raises(yaml.YAMLError, s_common.yamlload, dirn, 'explode.yaml')
 
+            data = '{"foo":"bar", "unicode": "✊"}'
+            obj = s_common.yamlloads(data)
+            self.eq(obj, {'foo': 'bar', 'unicode': '✊'})
+
+            obj = s_common.yamlloads(data.encode('utf8'))
+            self.eq(obj, {'foo': 'bar', 'unicode': '✊'})
+
+            obj = s_common.yamlloads('{"foo": "bar", "unicode": "\u270A"}')
+            self.eq(obj, {'foo': 'bar', 'unicode': '✊'})
+
     def test_switchext(self):
         retn = s_common.switchext('foo.txt', ext='.rdf')
         self.eq(retn, s_common.genpath('foo.rdf'))

--- a/synapse/tests/test_common.py
+++ b/synapse/tests/test_common.py
@@ -289,6 +289,10 @@ class CommonTest(s_t_utils.SynTest):
                 fd.write(s.encode())
             self.raises(yaml.YAMLError, s_common.yamlload, dirn, 'explode.yaml')
 
+            # Make sure we're testing the CSafeLoader and not the python native
+            # implementation
+            self.eq(s_common.Loader, yaml.CSafeLoader)
+
             data = '{"foo":"bar", "unicode": "✊"}'
             obj = s_common.yamlloads(data)
             self.eq(obj, {'foo': 'bar', 'unicode': '✊'})

--- a/synapse/tools/moduser.py
+++ b/synapse/tools/moduser.py
@@ -79,12 +79,12 @@ async def main(argv, outp=s_output.stdout):
                 return 0
 
             if opts.admin is not None:
-                admin = yaml.safe_load(opts.admin)
+                admin = s_common.yamlloads(opts.admin)
                 outp.printf(f'...setting admin: {opts.admin}')
                 await cell.setUserAdmin(useriden, admin)
 
             if opts.locked is not None:
-                locked = yaml.safe_load(opts.locked)
+                locked = s_common.yamlloads(opts.locked)
                 outp.printf(f'...setting locked: {opts.locked}')
                 await cell.setUserLocked(useriden, locked)
 


### PR DESCRIPTION
- Switch to opportunistically using yaml CSafeLoader instead of the pure-python SafeLoader (via safe_load)
- Add `synapse.common.yamlloads` to deserialize yaml data from a string
- Update tests
