### PR TITLE
SYN-5920: $trig.set() allows any keys which allows nonsensical triggers

### DIFF
--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -7358,7 +7358,6 @@ class Trigger(Prim):
 
     async def set(self, name, valu):
         trigiden = self.valu.get('iden')
-        useriden = self.runt.user.iden
         viewiden = self.runt.snap.view.iden
 
         name = await tostr(name)

--- a/synapse/lib/trigger.py
+++ b/synapse/lib/trigger.py
@@ -315,7 +315,8 @@ class Trigger:
         '''
         Set one of the dynamic elements of the trigger definition.
         '''
-        assert name in ('enabled', 'user', 'storm', 'doc', 'name', 'async')
+        if name not in ('enabled', 'user', 'storm', 'doc', 'name', 'async'):
+            raise s_exc.BadArg(mesg=f'Invalid key name provided: {name}')
 
         if valu == self.tdef.get(name):
             return

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -4152,6 +4152,10 @@ class StormTypesTest(s_test.SynTest):
             tdef = await core.callStorm(q, opts={'vars': {'trig': trig}})
             self.eq(tdef.get('doc'), 'awesome trigger')
 
+            with self.raises(s_exc.BadArg):
+                q = '$t = $lib.trigger.get($trig) $t.set("foo", "bar")'
+                await core.callStorm(q, opts={'vars': {'trig': trig}})
+
             nodes = await core.nodes('[ test:str=test1 ]')
             self.nn(nodes[0].tags.get('tagged'))
 


### PR DESCRIPTION
- Change assert in trigger.set() to a check which raises `s_exc.BadArg`
- Update test