### PR TITLE
Cell reload / SIGHUP handler (SYN-5886)

### DIFF
--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2622,7 +2622,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             sslctx (ssl.SSLContext): An externally managed SSL Context.
 
         Note:
-            IF the SSL context is not provided, the Cell will assume it
+            If the SSL context is not provided, the Cell will assume it
             manages the SSL context it creates for a given listener and will
             add a reload handler for reloading the SSL certificates from disk.
         '''

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2624,7 +2624,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         Note:
             If the SSL context is not provided, the Cell will assume it
             manages the SSL context it creates for a given listener and will
-            add a reload handler for reloading the SSL certificates from disk.
+            add a reload handler named https:certs to enabled reloading the
+            SSL certificates from disk.
         '''
 
         addr = socket.gethostbyname(host)
@@ -2663,7 +2664,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 sslctx.load_cert_chain(certpath, pkeypath)
                 return True
 
-            self.addReloadableSystem(f'HTTPS_SSL_Reload_Cert_port={lport}', reload)
+            self.addReloadableSystem('https:certs', reload)
 
         return (lhost, lport)
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -815,8 +815,8 @@ class CellApi(s_base.Base):
         return self.cell.getReloadSystems()
 
     @adminapi(log=True)
-    async def reload(self, name=None):
-        return await self.cell.reload(name)
+    async def reload(self, subsystem=None):
+        return await self.cell.reload(subsystem=subsystem)
 
 class Cell(s_nexus.Pusher, s_telepath.Aware):
     '''
@@ -3967,14 +3967,14 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
     def getReloadSystems(self):
         return tuple(self._reloadfuncs.keys())
 
-    async def reload(self, name=None):
+    async def reload(self, subsystem=None):
         ret = {}
-        if name:
-            func = self._reloadfuncs.get(name)
+        if subsystem:
+            func = self._reloadfuncs.get(subsystem)
             if func is None:
-                raise s_exc.NoSuchName(mesg=f'No reload system named {name}',
-                                       name=name)
-            ret[name] = await self._runReloadFunc(name, func)
+                raise s_exc.NoSuchName(mesg=f'No reload system named {subsystem}',
+                                       name=subsystem)
+            ret[subsystem] = await self._runReloadFunc(subsystem, func)
         else:
             # Run all funcs
             for (rname, func) in self._reloadfuncs.items():

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -810,7 +810,7 @@ class CellApi(s_base.Base):
             'threshold': gc.get_threshold(),
         }
 
-    @adminapi(log=True)
+    @adminapi()
     async def getReloadNames(self):
         return self.cell.getReloadNames()
 
@@ -3976,4 +3976,5 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         except Exception:
             logger.exception(f'Error running reload function {name}')
             return False
+        logger.debug(f'Completed cell reload function {name}')
         return True

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -3947,12 +3947,12 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(signal.SIGHUP, sighup)
 
-    def addReloadSystem(self, name: str, func):
+    def addReloadableSystem(self, name: str, func: callable):
         '''
-        Add a reload system. This may be dynamically called at at time.
+        Add a reloadable system. This may be dynamically called at at time.
 
         Args:
-            name (str): Name of the function.
+            name (str): Name of the system.
             func: The callable for reloading a given system.
 
         Note:
@@ -3964,7 +3964,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         '''
         self._reloadfuncs[name] = func
 
-    def getReloadSystems(self):
+    def getReloadableSystems(self):
         return tuple(self._reloadfuncs.keys())
 
     async def reload(self, subsystem=None):

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -815,8 +815,8 @@ class CellApi(s_base.Base):
         return self.cell.getReloadNames()
 
     @adminapi(log=True)
-    async def reloadCell(self, name=None):
-        return await self.cell.reloadCell(name)
+    async def reload(self, name=None):
+        return await self.cell.reload(name)
 
 class Cell(s_nexus.Pusher, s_telepath.Aware):
     '''
@@ -3941,7 +3941,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         await s_base.Base.addSignalHandlers(self)
 
         def sighup():
-            asyncio.create_task(self.reloadCell())
+            asyncio.create_task(self.reload())
 
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(signal.SIGHUP, sighup)
@@ -3952,7 +3952,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
     def getReloadNames(self):
         return tuple(self._reloadfuncs.keys())
 
-    async def reloadCell(self, name=None):
+    async def reload(self, name=None):
         ret = {}
         if name:
             func = self._reloadfuncs.get(name)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -811,8 +811,8 @@ class CellApi(s_base.Base):
         }
 
     @adminapi()
-    async def getReloadSystems(self):
-        return self.cell.getReloadSystems()
+    async def getReloadableSystems(self):
+        return self.cell.getReloadableSystems()
 
     @adminapi(log=True)
     async def reload(self, subsystem=None):
@@ -2663,7 +2663,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 sslctx.load_cert_chain(certpath, pkeypath)
                 return True
 
-            self.addReloadSystem(f'HTTPS_SSL_Reload_Cert_port={lport}', reload)
+            self.addReloadableSystem(f'HTTPS_SSL_Reload_Cert_port={lport}', reload)
 
         return (lhost, lport)
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -4,6 +4,7 @@ import copy
 import time
 import fcntl
 import shutil
+import signal
 import socket
 import asyncio
 import logging
@@ -3934,6 +3935,15 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
     async def getSpooledSet(self):
         async with await s_spooled.Set.anit(dirn=self.dirn, cell=self) as sset:
             yield sset
+
+    async def addSignalHandlers(self):
+        await s_base.Base.addSignalHandlers(self)
+
+        def sighup():
+            asyncio.create_task(self.reloadCell())
+
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGHUP, sighup)
 
     def addReloadFunc(self, name: str, func):
         self._reloadfuncs[name] = func

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -2662,7 +2662,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             def reload():
                 sslctx.load_cert_chain(certpath, pkeypath)
 
-            self.addReloadFunc(f'HTTPS_SSL_Reload_port={lport}', reload)
+            self.addReloadFunc(f'HTTPS_SSL_Reload_Cert_port={lport}', reload)
 
         return (lhost, lport)
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2193,14 +2193,14 @@ class CellTest(s_t_utils.SynTest):
             async with cell.getLocalProxy() as prox:
 
                 # No registered reload functions yet
-                names = await prox.getReloadSystems()
+                names = await prox.getReloadableSystems()
                 self.len(0, names)
                 # No functions to run yet
                 self.eq({}, await prox.reload())
 
                 # Add reload func and get its name
                 await cell.addTestReload()
-                names = await prox.getReloadSystems()
+                names = await prox.getReloadableSystems()
                 self.len(1, names)
                 name = names[0]
 
@@ -2263,7 +2263,7 @@ class CellTest(s_t_utils.SynTest):
                 await cell.auth.rootuser.setPasswd('root')
                 hhost, hport = await cell.addHttpsPort(0, host='127.0.0.1')
 
-                names = await prox.getReloadSystems()
+                names = await prox.getReloadableSystems()
                 self.ge(len(names), 1)
 
                 bitems = []

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2266,7 +2266,7 @@ class CellTest(s_t_utils.SynTest):
                 bstrt = asyncio.Event()
                 bdone = asyncio.Event()
 
-               def get_pem_cert():
+                def get_pem_cert():
                     # Only run this in a executor thread
                     ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
                     ctx.check_hostname = False

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2325,8 +2325,8 @@ class CellTest(s_t_utils.SynTest):
                         # reload listeners
                         await cell.reloadCell()
 
-                        original_cert = await s_coro.executor(get_pem_cert)
-                        rcert = crypto.load_certificate(crypto.FILETYPE_PEM, original_cert)
+                        reloaded_cert = await s_coro.executor(get_pem_cert)
+                        rcert = crypto.load_certificate(crypto.FILETYPE_PEM, reloaded_cert)
                         self.eq(rcert.get_subject().CN, 'SomeTestCertificate')
 
                         async with self.getHttpSess(auth=('root', 'root'), port=hport) as sess:

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2224,7 +2224,7 @@ class CellTest(s_t_utils.SynTest):
 
                 # Attempting to call a value by name that doesn't exist fails
                 with self.raises(s_exc.NoSuchName) as cm:
-                    await cell.reload(name='newp')
+                    await cell.reload(subsystem='newp')
                 self.eq('newp', cm.exception.get('name'))
                 self.isin('newp', cm.exception.get('mesg'))
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2193,14 +2193,14 @@ class CellTest(s_t_utils.SynTest):
             async with cell.getLocalProxy() as prox:
 
                 # No registered reload functions yet
-                names = await prox.getReloadNames()
+                names = await prox.getReloadSystems()
                 self.len(0, names)
                 # No functions to run yet
                 self.eq({}, await prox.reload())
 
                 # Add reload func and get its name
                 await cell.addTestReload()
-                names = await prox.getReloadNames()
+                names = await prox.getReloadSystems()
                 self.len(1, names)
                 name = names[0]
 
@@ -2263,7 +2263,7 @@ class CellTest(s_t_utils.SynTest):
                 await cell.auth.rootuser.setPasswd('root')
                 hhost, hport = await cell.addHttpsPort(0, host='127.0.0.1')
 
-                names = await prox.getReloadNames()
+                names = await prox.getReloadSystems()
                 self.ge(len(names), 1)
 
                 bitems = []

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -98,16 +98,6 @@ class EchoAuth(s_cell.Cell):
         if doraise:
             raise s_exc.BadTime(mesg='call again later')
 
-class ReloadCell(s_cell.Cell):
-    async def postAnit(self):
-        self._testdata = {}
-
-    async def _addTestReload(self):
-        async def func():
-            self._testdata = {}
-
-        self.addReloadFunc('testreload', func)
-
 async def altAuthCtor(cell):
     authconf = cell.conf.get('auth:conf')
     assert authconf['foo'] == 'bar'
@@ -2173,7 +2163,7 @@ class CellTest(s_t_utils.SynTest):
                 self.nn(info['threshold'])
 
     async def test_cell_reload(self):
-        async with self.getTestCell(ReloadCell) as cell:  # type: ReloadCell
+        async with self.getTestCell(s_t_utils.ReloadCell) as cell:  # type: s_t_utils.ReloadCell
             async with cell.getLocalProxy() as prox:
 
                 # No registered reload functions yet
@@ -2254,7 +2244,7 @@ class CellTest(s_t_utils.SynTest):
                 # Add reload func and reload everything
                 cell._testdata['foo'] = 'bar'
                 self.eq(cell._testdata, {'foo': 'bar'})
-                await cell._addTestReload()
+                await cell.addTestReload()
                 # Reload all registered functions
                 await cell.reloadCell()
                 self.eq(cell._testdata, {})

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2206,7 +2206,7 @@ class CellTest(s_t_utils.SynTest):
 
                 # Reload by name
                 self.false(cell._reloaded)
-                self.eq({name: True}, await cell.reload(name))
+                self.eq({name: (True, True)}, await cell.reload(name))
                 self.true(cell._reloaded)
 
                 # Add a second function
@@ -2214,8 +2214,12 @@ class CellTest(s_t_utils.SynTest):
 
                 # Reload all registered functions
                 cell._reloaded = False
-                self.eq({'testreload': True, 'badreload': False},
-                        await cell.reload())
+                ret = await cell.reload()
+                self.eq(ret.get('testreload'), (True, True))
+                fail = ret.get('badreload')
+                self.false(fail[0])
+                self.eq('ZeroDivisionError', fail[1][0])
+                self.eq('division by zero', fail[1][1].get('mesg'))
                 self.true(cell._reloaded)
 
                 # Attempting to call a value by name that doesn't exist fails

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2196,7 +2196,7 @@ class CellTest(s_t_utils.SynTest):
                 names = await prox.getReloadNames()
                 self.len(0, names)
                 # No functions to run yet
-                self.eq({}, await prox.reloadCell())
+                self.eq({}, await prox.reload())
 
                 # Add reload func and get its name
                 await cell.addTestReload()
@@ -2206,7 +2206,7 @@ class CellTest(s_t_utils.SynTest):
 
                 # Reload by name
                 self.false(cell._reloaded)
-                self.eq({name: True}, await cell.reloadCell(name))
+                self.eq({name: True}, await cell.reload(name))
                 self.true(cell._reloaded)
 
                 # Add a second function
@@ -2215,12 +2215,12 @@ class CellTest(s_t_utils.SynTest):
                 # Reload all registered functions
                 cell._reloaded = False
                 self.eq({'testreload': True, 'badreload': False},
-                        await cell.reloadCell())
+                        await cell.reload())
                 self.true(cell._reloaded)
 
                 # Attempting to call a value by name that doesn't exist fails
                 with self.raises(s_exc.NoSuchName) as cm:
-                    await cell.reloadCell(name='newp')
+                    await cell.reload(name='newp')
                 self.eq('newp', cm.exception.get('name'))
                 self.isin('newp', cm.exception.get('mesg'))
 
@@ -2323,7 +2323,7 @@ class CellTest(s_t_utils.SynTest):
                             cdir.saveCertPem(cert, certpath)
 
                         # reload listeners
-                        await cell.reloadCell()
+                        await cell.reload()
 
                         reloaded_cert = await s_coro.executor(get_pem_cert)
                         rcert = crypto.load_certificate(crypto.FILETYPE_PEM, reloaded_cert)

--- a/synapse/tests/test_tools_reload.py
+++ b/synapse/tests/test_tools_reload.py
@@ -1,0 +1,54 @@
+import synapse.tools.reload as s_t_reload
+
+import synapse.tests.utils as s_test
+
+class ReloadToolTest(s_test.SynTest):
+
+    async def test_tool_reload(self):
+        outp = self.getTestOutp()
+
+        async with self.getTestCell(s_test.ReloadCell) as cell:  # type: s_test.ReloadCell
+            url = cell.getLocalUrl()
+            argb = ('--svcurl', url)
+
+            argv = argb + ('list',)
+            ret = await s_t_reload.main(argv, outp)
+            self.eq(0, ret)
+            outp.expect('no registered reload functions')
+
+            outp.clear()
+            argv = argb + ('reload',)
+            ret = await s_t_reload.main(argv, outp)
+            self.eq(0, ret)
+            outp.expect('No functions executed.')
+
+            await cell.addTestReload()
+            await cell.addTestBadReload()
+
+            outp.clear()
+            argv = argb + ('list',)
+            ret = await s_t_reload.main(argv, outp)
+            self.eq(0, ret)
+            outp.expect('testreload')
+            outp.expect('badreload')
+
+            outp.clear()
+            argv = argb + ('reload', '-n', 'testreload')
+            ret = await s_t_reload.main(argv, outp)
+            self.eq(0, ret)
+            outp.expect('testreload                              Success')
+
+            outp.clear()
+            argv = argb + ('reload',)
+            ret = await s_t_reload.main(argv, outp)
+            self.eq(0, ret)
+            outp.expect('testreload                              Success')
+            outp.expect('badreload                               Failed')
+
+            # Sad name test
+            outp.clear()
+            argv = argb + ('reload', '-n', 'haha')
+            ret = await s_t_reload.main(argv, outp)
+            self.eq(1, ret)
+            outp.expect('Error reloading cell')
+            outp.expect('NoSuchName')

--- a/synapse/tests/test_tools_reload.py
+++ b/synapse/tests/test_tools_reload.py
@@ -14,13 +14,13 @@ class ReloadToolTest(s_test.SynTest):
             argv = argb + ('list',)
             ret = await s_t_reload.main(argv, outp)
             self.eq(0, ret)
-            outp.expect('no registered reload functions')
+            outp.expect('no registered reload subsystems')
 
             outp.clear()
             argv = argb + ('reload',)
             ret = await s_t_reload.main(argv, outp)
             self.eq(0, ret)
-            outp.expect('No functions executed.')
+            outp.expect('No subsystems executed.')
 
             await cell.addTestReload()
             await cell.addTestBadReload()

--- a/synapse/tests/test_tools_reload.py
+++ b/synapse/tests/test_tools_reload.py
@@ -20,7 +20,7 @@ class ReloadToolTest(s_test.SynTest):
             argv = argb + ('reload',)
             ret = await s_t_reload.main(argv, outp)
             self.eq(0, ret)
-            outp.expect('No subsystems executed.')
+            outp.expect('No subsystems reloaded.')
 
             await cell.addTestReload()
             await cell.addTestBadReload()

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -833,24 +833,21 @@ test_schema = {
 
 class ReloadCell(s_cell.Cell):
     async def postAnit(self):
-        self._testdata = {}
         self._reloaded = False
+        self._reloadevt = None
+
     async def getCellInfo(self):
         info = await s_cell.Cell.getCellInfo(self)
-        info['cell']['reloaded'] = self.reloaded
+        info['cell']['reloaded'] = self._reloaded
         return info
 
     async def addTestReload(self):
         async def func():
-            self._testdata = {}
+            self._reloaded = True
+            if self._reloadevt:
+                self._reloadevt.set()
 
         self.addReloadFunc('testreload', func)
-
-    async def addTrackedReload():
-        async def func():
-            self._reloaded = True
-
-        self.addReloadFunc('trackedreload', func)
 
     async def addTestBadReload(self):
         async def func():

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -846,6 +846,7 @@ class ReloadCell(s_cell.Cell):
             self._reloaded = True
             if self._reloadevt:
                 self._reloadevt.set()
+            return True
 
         self.addReloadFunc('testreload', func)
 

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -52,6 +52,7 @@ import synapse.cryotank as s_cryotank
 import synapse.telepath as s_telepath
 
 import synapse.lib.aha as s_aha
+import synapse.lib.cell as s_cell
 import synapse.lib.coro as s_coro
 import synapse.lib.cmdr as s_cmdr
 import synapse.lib.hive as s_hive
@@ -829,6 +830,33 @@ test_schema = {
         },
         'type': 'object',
     }
+
+class ReloadCell(s_cell.Cell):
+    async def postAnit(self):
+        self._testdata = {}
+        self._reloaded = False
+    async def getCellInfo(self):
+        info = await s_cell.Cell.getCellInfo(self)
+        info['cell']['reloaded'] = self.reloaded
+        return info
+
+    async def addTestReload(self):
+        async def func():
+            self._testdata = {}
+
+        self.addReloadFunc('testreload', func)
+
+    async def addTrackedReload():
+        async def func():
+            self._reloaded = True
+
+        self.addReloadFunc('trackedreload', func)
+
+    async def addTestBadReload(self):
+        async def func():
+            return 1 / 0
+
+        self.addReloadFunc('badreload', func)
 
 class SynTest(unittest.TestCase):
     '''

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -848,13 +848,13 @@ class ReloadCell(s_cell.Cell):
                 self._reloadevt.set()
             return True
 
-        self.addReloadFunc('testreload', func)
+        self.addReloadSystem('testreload', func)
 
     async def addTestBadReload(self):
         async def func():
             return 1 / 0
 
-        self.addReloadFunc('badreload', func)
+        self.addReloadSystem('badreload', func)
 
 class SynTest(unittest.TestCase):
     '''

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -848,13 +848,13 @@ class ReloadCell(s_cell.Cell):
                 self._reloadevt.set()
             return True
 
-        self.addReloadSystem('testreload', func)
+        self.addReloadableSystem('testreload', func)
 
     async def addTestBadReload(self):
         async def func():
             return 1 / 0
 
-        self.addReloadSystem('badreload', func)
+        self.addReloadableSystem('badreload', func)
 
 class SynTest(unittest.TestCase):
     '''

--- a/synapse/tools/reload.py
+++ b/synapse/tools/reload.py
@@ -35,7 +35,7 @@ async def main(argv, outp=s_output.stdout):
             if opts.cmd == 'reload':
                 outp.printf(f'Reloading cell at {s_urlhelp.sanitizeUrl(opts.svcurl)}')
                 try:
-                    ret = await cell.reloadCell(name=opts.name)
+                    ret = await cell.reload(name=opts.name)
                 except Exception as e:
                     outp.printf(f'Error reloading cell: {e}')
                     return 1

--- a/synapse/tools/reload.py
+++ b/synapse/tools/reload.py
@@ -11,7 +11,7 @@ import synapse.lib.output as s_output
 import synapse.lib.urlhelp as s_urlhelp
 
 descr = '''
-List or execute reload functions on a Synapse service.
+List or execute reload subsystems on a Synapse service.
 '''
 
 async def main(argv, outp=s_output.stdout):
@@ -24,13 +24,13 @@ async def main(argv, outp=s_output.stdout):
         async with await s_telepath.openurl(opts.svcurl) as cell:
 
             if opts.cmd == 'list':
-                names = await cell.getReloadNames()
+                names = await cell.getReloadSystems()
                 if names:
-                    outp.printf(f'Cell at {s_urlhelp.sanitizeUrl(opts.svcurl)} has the following reload functions:')
+                    outp.printf(f'Cell at {s_urlhelp.sanitizeUrl(opts.svcurl)} has the following reload subsystems:')
                     for name in names:
                         outp.printf(name)
                 else:
-                    outp.printf(f'Cell at {s_urlhelp.sanitizeUrl(opts.svcurl)} has no registered reload functions.')
+                    outp.printf(f'Cell at {s_urlhelp.sanitizeUrl(opts.svcurl)} has no registered reload subsystems.')
 
             if opts.cmd == 'reload':
                 outp.printf(f'Reloading cell at {s_urlhelp.sanitizeUrl(opts.svcurl)}')
@@ -41,7 +41,7 @@ async def main(argv, outp=s_output.stdout):
                     return 1
 
                 if not ret:
-                    outp.printf('No functions executed.')
+                    outp.printf('No subsystems executed.')
                 else:
                     outp.printf(f'{"Name:".ljust(40)}{"Result:".ljust(10)}Value:')
                     for name, (isok, valu) in ret.items():
@@ -64,9 +64,9 @@ def getArgParser():
     subpars = pars.add_subparsers(required=True,
                                   title='subcommands',
                                   dest='cmd',)
-    pars_list = subpars.add_parser('list', help='List reload functions.')
-    reld_list = subpars.add_parser('reload', help='Reload registered functions.')
-    reld_list.add_argument('-n', '--name', type=str, help='Name of a function to reload.')
+    pars_list = subpars.add_parser('list', help='List subsystems which can be reloaded.')
+    reld_list = subpars.add_parser('reload', help='Reload registered subsystems.')
+    reld_list.add_argument('-n', '--name', type=str, help='Name of a subsystem to reload.')
 
     return pars
 

--- a/synapse/tools/reload.py
+++ b/synapse/tools/reload.py
@@ -24,7 +24,7 @@ async def main(argv, outp=s_output.stdout):
         async with await s_telepath.openurl(opts.svcurl) as cell:
 
             if opts.cmd == 'list':
-                names = await cell.getReloadSystems()
+                names = await cell.getReloadableSystems()
                 if names:
                     outp.printf(f'Cell at {s_urlhelp.sanitizeUrl(opts.svcurl)} has the following reload subsystems:')
                     for name in names:

--- a/synapse/tools/reload.py
+++ b/synapse/tools/reload.py
@@ -1,0 +1,69 @@
+import sys
+import yaml
+import asyncio
+import argparse
+
+import synapse.common as s_common
+import synapse.telepath as s_telepath
+
+
+import synapse.lib.output as s_output
+import synapse.lib.urlhelp as s_urlhelp
+
+descr = '''
+List or execute reload functions on a Synapse service.
+'''
+
+async def main(argv, outp=s_output.stdout):
+
+    pars = getArgParser()
+    opts = pars.parse_args(argv)
+
+    async with s_telepath.withTeleEnv():
+
+        async with await s_telepath.openurl(opts.svcurl) as cell:
+
+            if opts.cmd == 'list':
+                names = await cell.getReloadNames()
+                if names:
+                    outp.printf(f'Cell at {s_urlhelp.sanitizeUrl(opts.svcurl)} has the following reload functions:')
+                    for name in names:
+                        outp.printf(name)
+                else:
+                    outp.printf(f'Cell at {s_urlhelp.sanitizeUrl(opts.svcurl)} has no registered reload functions.')
+
+            if opts.cmd == 'reload':
+                outp.printf(f'Reloading cell at {s_urlhelp.sanitizeUrl(opts.svcurl)}')
+                try:
+                    ret = await cell.reloadCell(name=opts.name)
+                except Exception as e:
+                    outp.printf(f'Error reloading cell: {e}')
+                    return 1
+
+                if not ret:
+                    outp.printf('No functions executed.')
+                else:
+                    outp.printf(f'{"Name:".ljust(40)}Result:')
+                    for name, valu in ret.items():
+                        if valu:
+                            result = 'Success'
+                        else:
+                            result = 'Failed'
+                        outp.printf(f'{name.ljust(40)}{result}')
+    return 0
+
+def getArgParser():
+    pars = argparse.ArgumentParser(prog='reload', description=descr)
+    pars.add_argument('--svcurl', default='cell:///vertex/storage', help='The telepath URL of the Synapse service.')
+
+    subpars = pars.add_subparsers(required=True,
+                                  title='subcommands',
+                                  dest='cmd',)
+    pars_list = subpars.add_parser('list', help='List reload functions.')
+    reld_list = subpars.add_parser('reload', help='Reload registered functions.')
+    reld_list.add_argument('-n', '--name', type=str, help='Name of a function to reload.')
+
+    return pars
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(asyncio.run(main(sys.argv[1:])))

--- a/synapse/tools/reload.py
+++ b/synapse/tools/reload.py
@@ -43,13 +43,18 @@ async def main(argv, outp=s_output.stdout):
                 if not ret:
                     outp.printf('No functions executed.')
                 else:
-                    outp.printf(f'{"Name:".ljust(40)}Result:')
-                    for name, valu in ret.items():
-                        if valu:
+                    outp.printf(f'{"Name:".ljust(40)}{"Result:".ljust(10)}Value:')
+                    for name, (isok, valu) in ret.items():
+                        if isok:
+                            mesg = str(valu)
                             result = 'Success'
                         else:
+                            mesg = valu[1].get('mesg')
+                            if mesg is None:
+                                mesg = valu[0]
                             result = 'Failed'
-                        outp.printf(f'{name.ljust(40)}{result}')
+
+                        outp.printf(f'{name.ljust(40)}{result.ljust(10)}{mesg}')
     return 0
 
 def getArgParser():

--- a/synapse/tools/reload.py
+++ b/synapse/tools/reload.py
@@ -41,7 +41,7 @@ async def main(argv, outp=s_output.stdout):
                     return 1
 
                 if not ret:
-                    outp.printf('No subsystems executed.')
+                    outp.printf('No subsystems reloaded.')
                 else:
                     outp.printf(f'{"Name:".ljust(40)}{"Result:".ljust(10)}Value:')
                     for name, (isok, valu) in ret.items():

--- a/synapse/tools/reload.py
+++ b/synapse/tools/reload.py
@@ -35,7 +35,7 @@ async def main(argv, outp=s_output.stdout):
             if opts.cmd == 'reload':
                 outp.printf(f'Reloading cell at {s_urlhelp.sanitizeUrl(opts.svcurl)}')
                 try:
-                    ret = await cell.reload(name=opts.name)
+                    ret = await cell.reload(subsystem=opts.name)
                 except Exception as e:
                     outp.printf(f'Error reloading cell: {e}')
                     return 1


### PR DESCRIPTION
- Add Cell + CellAPI apis for listing and running reload functions
- ``Cell.addHttpsPort`` now adds a reload function to reload the SSL certificates when the SSL context is not provided
- ``Cell.addSignalHandlers`` now adds a SIGHUP handler to call all registered reload functions
- Add ``synapse.tools.reload`` to interact with a services reload functions