### PR TITLE
Replace synaspe.common.aclosing with contextlib.aclosing

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -1142,8 +1142,7 @@ def getSslCtx(cadir, purpose=ssl.Purpose.SERVER_AUTH):
             logger.exception(f'Error loading {certpath}')
     return sslctx
 
-# TODO:  Remove when this is added to contextlib in py 3.10
-class aclosing(contextlib.AbstractAsyncContextManager):
+class aclosing(contextlib.AbstractAsyncContextManager):  # pragma: no cover
     """Async context manager for safely finalizing an asynchronously cleaned-up
     resource such as an async generator, calling its ``aclose()`` method.
 

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -1162,6 +1162,7 @@ class aclosing(contextlib.AbstractAsyncContextManager):
 
     """
     def __init__(self, thing):
+        deprecated('synapse.common.aclosing()', curv='2.145.0', eolv='v2.150.0')
         self.thing = thing
     async def __aenter__(self):
         return self.thing

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -198,7 +198,7 @@ class Query(AstNode):
 
         async with contextlib.AsyncExitStack() as stack:
             for oper in self.kids:
-                genr = await stack.enter_async_context(s_common.aclosing(oper.run(runt, genr)))
+                genr = await stack.enter_async_context(contextlib.aclosing(oper.run(runt, genr)))
 
             async for node, path in genr:
                 runt.tick()
@@ -776,7 +776,7 @@ class ForLoop(Oper):
             if valu is None:
                 valu = ()
 
-            async with s_common.aclosing(s_coro.agen(valu)) as agen:
+            async with contextlib.aclosing(s_coro.agen(valu)) as agen:
                 async for item in agen:
 
                     if isinstance(name, (list, tuple)):
@@ -842,7 +842,7 @@ class ForLoop(Oper):
             if valu is None:
                 valu = ()
 
-            async with s_common.aclosing(s_coro.agen(valu)) as agen:
+            async with contextlib.aclosing(s_coro.agen(valu)) as agen:
                 async for item in agen:
 
                     if isinstance(name, (list, tuple)):
@@ -1235,14 +1235,14 @@ class YieldValu(Oper):
 
         async for node, path in genr:
             valu = await self.kids[0].compute(runt, path)
-            async with s_common.aclosing(self.yieldFromValu(runt, valu)) as agen:
+            async with contextlib.aclosing(self.yieldFromValu(runt, valu)) as agen:
                 async for subn in agen:
                     yield subn, runt.initPath(subn)
             yield node, path
 
         if node is None and self.kids[0].isRuntSafe(runt):
             valu = await self.kids[0].compute(runt, None)
-            async with s_common.aclosing(self.yieldFromValu(runt, valu)) as agen:
+            async with contextlib.aclosing(self.yieldFromValu(runt, valu)) as agen:
                 async for subn in agen:
                     yield subn, runt.initPath(subn)
 
@@ -1324,7 +1324,7 @@ class YieldValu(Oper):
             return
 
         if isinstance(valu, s_stormtypes.Prim):
-            async with s_common.aclosing(valu.nodes()) as genr:
+            async with contextlib.aclosing(valu.nodes()) as genr:
                 async for node in genr:
                     if node.snap.view.iden != viewiden:
                         mesg = f'Node is not from the current view. Node {node.iden()} is from {node.snap.view.iden} expected {viewiden}'

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -16,6 +16,7 @@ import binascii
 import datetime
 import calendar
 import functools
+import contextlib
 import collections
 from typing import Any
 
@@ -5216,7 +5217,7 @@ class Query(Prim):
                 yield item
 
     async def nodes(self):
-        async with s_common.aclosing(self._getRuntGenr()) as genr:
+        async with contextlib.aclosing(self._getRuntGenr()) as genr:
             async for node, path in genr:
                 yield node
 


### PR DESCRIPTION
- Remove use of synapse.common.aclosing in favor of contextlib.aclosing
- Mark our aclosing class as deprecated.