### PR TITLE
Mark the cryotank iden keyword argument as deprecated.

### DIFF
--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -89,9 +89,11 @@ class CryoTank(s_base.Base):
         return iden
 
     def getOffset(self, iden):
+        s_common.deprecated('cryotank.getOffset(...) API, ', curv='2.148.0', eolv='2.150.0')
         return self.offs.get(iden)
 
     def setOffset(self, iden, offs):
+        s_common.deprecated('cryotank.setOffset(...) API, ', curv='2.148.0', eolv='2.150.0')
         return self.offs.set(iden, offs)
 
     def last(self):
@@ -106,7 +108,7 @@ class CryoTank(s_base.Base):
 
         Args:
             items (list):  A list of objects to store in the CryoTank.
-            seqn (iden, offs): An iden / offset pair to record.
+            seqn (iden, offs): An iden / offset pair to record. This argument is deprecated. Callers should track offsets.
 
         Returns:
             int: The ending offset of the items or seqn.
@@ -121,6 +123,7 @@ class CryoTank(s_base.Base):
             await asyncio.sleep(0)
 
         if seqn is not None:
+            s_common.deprecated('cryotank.puts(seqn=...) argument, ', curv='2.148.0', eolv='2.150.0')
             iden, offs = seqn
             self.setOffset(iden, offs + size)
 
@@ -159,7 +162,7 @@ class CryoTank(s_base.Base):
             ((index, object)): Index and item values.
         '''
         if iden is not None:
-            s_common.deprecated('cryotank(iden=...) argument, ', curv='2.148.0', eolv='2.150.0')
+            s_common.deprecated('cryotank.slice(iden=...) argument, ', curv='2.148.0', eolv='2.150.0')
             self.setOffset(iden, offs)
 
         i = 0
@@ -180,12 +183,13 @@ class CryoTank(s_base.Base):
         Args:
             offs (int): The index of the desired datum (starts at 0)
             size (int): The max number of items to yield.
-            iden (str): The iden for offset tracking.
+            iden (str): The iden for offset tracking. This argument is deprecated. Callers should track offsets.
 
         Yields:
             ((indx, bytes)): Index and msgpacked bytes.
         '''
         if iden is not None:
+            s_common.deprecated('cryotank.rows(iden=...) argument, ', curv='2.148.0', eolv='2.150.0')
             self.setOffset(iden, offs)
 
         for i, (indx, byts) in enumerate(self._items.rows(offs)):
@@ -216,6 +220,8 @@ class CryoApi(s_cell.CellApi):
         return True
 
     async def slice(self, name, offs, size=None, iden=None, wait=False, timeout=None):
+        if iden:
+            s_common.deprecated('cryocell.slice(iden=...) argument.', curv='2.148.0', eolv='2.150.0')
         tank = await self.cell.init(name)
         async for item in tank.slice(offs, size=size, iden=iden, wait=wait, timeout=timeout):
             yield item
@@ -228,14 +234,19 @@ class CryoApi(s_cell.CellApi):
         return tank.last()
 
     async def puts(self, name, items, seqn=None):
+        if seqn:
+            s_common.deprecated('cryocell.puts(seqn=...) argument.', curv='2.148.0', eolv='2.150.0')
         tank = await self.cell.init(name)
         return await tank.puts(items, seqn=seqn)
 
     async def offset(self, name, iden):
+        s_common.deprecated('cryocell.offset() API.', curv='2.148.0', eolv='2.150.0')
         tank = await self.cell.init(name)
         return tank.getOffset(iden)
 
     async def rows(self, name, offs, size, iden=None):
+        if iden:
+            s_common.deprecated('cryocell.rows(iden=...) Argument.', curv='2.148.0', eolv='2.150.0')
         tank = await self.cell.init(name)
         async for item in tank.rows(offs, size, iden=iden):
             yield item

--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -151,7 +151,7 @@ class CryoTank(s_base.Base):
         Args:
             offs (int): The index of the desired datum (starts at 0)
             size (int): The max number of items to yield.
-            iden (str): The iden for offset tracking.
+            iden (str): The iden for offset tracking. This argument is deprecated. Callers should track offsets.
             wait (bool): Once caught up, yield new results in realtime
             timeout (int): Max time to wait for a new item.
 

--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -159,6 +159,7 @@ class CryoTank(s_base.Base):
             ((index, object)): Index and item values.
         '''
         if iden is not None:
+            s_common.deprecated('cryotank(iden=...) argument, ', curv='2.148.0', eolv='2.150.0')
             self.setOffset(iden, offs)
 
         i = 0


### PR DESCRIPTION
The `iden=` argument on the CryoCell and CryoTank is marked as deprecated. It will be removed in v2.150.0.

Callers should track offsets locally.