### PR TITLE
Add CryoTank permissions (SYN-3773)

### DIFF
--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -16,19 +16,16 @@ logger = logging.getLogger(__name__)
 
 class TankApi(s_cell.CellApi):
 
-    async def slice(self, offs, size=None, iden=None, wait=False, timeout=None):
-        async for item in self.cell.slice(offs, size=size, iden=iden, wait=wait, timeout=timeout):
+    async def slice(self, offs, size=None, wait=False, timeout=None):
+        async for item in self.cell.slice(offs, size=size, wait=wait, timeout=timeout):
             yield item
 
-    async def puts(self, items, seqn=None):
-        return await self.cell.puts(items, seqn=seqn)
+    async def puts(self, items):
+        return await self.cell.puts(items)
 
     async def metrics(self, offs, size=None):
         async for item in self.cell.metrics(offs, size=size):
             yield item
-
-    async def offset(self, iden):
-        return self.cell.getOffset(iden)
 
     async def iden(self):
         return await self.cell.iden()
@@ -53,7 +50,6 @@ class CryoTank(s_base.Base):
 
         self.slab = await s_lmdbslab.Slab.anit(path, map_async=True, **conf)
 
-        self.offs = s_slaboffs.SlabOffs(self.slab, 'offsets')
         self._items = s_slabseqn.SlabSeqn(self.slab, 'items')
         self._metrics = s_slabseqn.SlabSeqn(self.slab, 'metrics')
 
@@ -88,27 +84,18 @@ class CryoTank(s_base.Base):
 
         return iden
 
-    def getOffset(self, iden):
-        s_common.deprecated('cryotank.getOffset(...) API, ', curv='2.148.0', eolv='2.150.0')
-        return self.offs.get(iden)
-
-    def setOffset(self, iden, offs):
-        s_common.deprecated('cryotank.setOffset(...) API, ', curv='2.148.0', eolv='2.150.0')
-        return self.offs.set(iden, offs)
-
     def last(self):
         '''
         Return an (offset, item) tuple for the last element in the tank ( or None ).
         '''
         return self._items.last()
 
-    async def puts(self, items, seqn=None):
+    async def puts(self, items):
         '''
         Add the structured data from items to the CryoTank.
 
         Args:
             items (list):  A list of objects to store in the CryoTank.
-            seqn (iden, offs): An iden / offset pair to record. This argument is deprecated. Callers should track offsets.
 
         Returns:
             int: The ending offset of the items or seqn.
@@ -121,11 +108,6 @@ class CryoTank(s_base.Base):
             await self.fire('cryotank:puts', numrecords=len(chunk))
             size += len(chunk)
             await asyncio.sleep(0)
-
-        if seqn is not None:
-            s_common.deprecated('cryotank.puts(seqn=...) argument, ', curv='2.148.0', eolv='2.150.0')
-            iden, offs = seqn
-            self.setOffset(iden, offs + size)
 
         return size
 
@@ -147,23 +129,19 @@ class CryoTank(s_base.Base):
 
             yield indx, item
 
-    async def slice(self, offs, size=None, iden=None, wait=False, timeout=None):
+    async def slice(self, offs, size=None, wait=False, timeout=None):
         '''
         Yield a number of items from the CryoTank starting at a given offset.
 
         Args:
             offs (int): The index of the desired datum (starts at 0)
             size (int): The max number of items to yield.
-            iden (str): The iden for offset tracking. This argument is deprecated. Callers should track offsets.
             wait (bool): Once caught up, yield new results in realtime
             timeout (int): Max time to wait for a new item.
 
         Yields:
             ((index, object)): Index and item values.
         '''
-        if iden is not None:
-            s_common.deprecated('cryotank.slice(iden=...) argument, ', curv='2.148.0', eolv='2.150.0')
-            self.setOffset(iden, offs)
 
         i = 0
         async for indx, item in self._items.aiter(offs, wait=wait, timeout=timeout):
@@ -176,22 +154,17 @@ class CryoTank(s_base.Base):
             i += 1
             await asyncio.sleep(0)
 
-    async def rows(self, offs, size=None, iden=None):
+    async def rows(self, offs, size=None):
         '''
         Yield a number of raw items from the CryoTank starting at a given offset.
 
         Args:
             offs (int): The index of the desired datum (starts at 0)
             size (int): The max number of items to yield.
-            iden (str): The iden for offset tracking. This argument is deprecated. Callers should track offsets.
 
         Yields:
             ((indx, bytes)): Index and msgpacked bytes.
         '''
-        if iden is not None:
-            s_common.deprecated('cryotank.rows(iden=...) argument, ', curv='2.148.0', eolv='2.150.0')
-            self.setOffset(iden, offs)
-
         for i, (indx, byts) in enumerate(self._items.rows(offs)):
 
             if size is not None and i >= size:
@@ -228,12 +201,10 @@ class CryoApi(s_cell.CellApi):
         await self._reqInit(name, conf=conf)
         return self.cell.getTankIdenByName(name)
 
-    async def slice(self, name, offs, size=None, iden=None, wait=False, timeout=None):
-        if iden:
-            s_common.deprecated('cryocell.slice(iden=...) argument.', curv='2.148.0', eolv='2.150.0')
+    async def slice(self, name, offs, size=None, wait=False, timeout=None):
         tank = await self._reqInit(name)
         self.user.confirm(('cryo', 'tank', 'read'), gateiden=self.cell.getTankIdenByName(name))
-        async for item in tank.slice(offs, size=size, iden=iden, wait=wait, timeout=timeout):
+        async for item in tank.slice(offs, size=size, wait=wait, timeout=timeout):
             yield item
 
     async def list(self):
@@ -244,25 +215,15 @@ class CryoApi(s_cell.CellApi):
         self.user.confirm(('cryo', 'tank', 'read'), gateiden=self.cell.getTankIdenByName(name))
         return tank.last()
 
-    async def puts(self, name, items, seqn=None):
-        if seqn:
-            s_common.deprecated('cryocell.puts(seqn=...) argument.', curv='2.148.0', eolv='2.150.0')
+    async def puts(self, name, items):
         tank = await self._reqInit(name)
         self.user.confirm(('cryo', 'tank', 'put'), gateiden=self.cell.getTankIdenByName(name))
-        return await tank.puts(items, seqn=seqn)
+        return await tank.puts(items)
 
-    async def offset(self, name, iden):
-        s_common.deprecated('cryocell.offset() API.', curv='2.148.0', eolv='2.150.0')
+    async def rows(self, name, offs, size):
         tank = await self._reqInit(name)
         self.user.confirm(('cryo', 'tank', 'read'), gateiden=self.cell.getTankIdenByName(name))
-        return tank.getOffset(iden)
-
-    async def rows(self, name, offs, size, iden=None):
-        if iden:
-            s_common.deprecated('cryocell.rows(iden=...) Argument.', curv='2.148.0', eolv='2.150.0')
-        tank = await self._reqInit(name)
-        self.user.confirm(('cryo', 'tank', 'read'), gateiden=self.cell.getTankIdenByName(name))
-        async for item in tank.rows(offs, size, iden=iden):
+        async for item in tank.rows(offs, size):
             yield item
 
     async def metrics(self, name, offs, size=None):

--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -262,7 +262,7 @@ class CryoCell(s_cell.Cell):
 
             # remove old guid file
             guidpath = s_common.genpath(path, 'guid')
-            if os.path.isfile(path):
+            if os.path.isfile(guidpath):
                 os.unlink(guidpath)
 
             # if its a legacy cell remove that too
@@ -297,9 +297,6 @@ class CryoCell(s_cell.Cell):
             return await self.tankapi.anit(tank, link, user)
 
         raise s_exc.NoSuchPath(path=path)
-
-    async def exists(self, name):
-        return self.tanks.get(name) is not None
 
     async def init(self, name, conf=None, user=None):
         '''

--- a/synapse/cryotank.py
+++ b/synapse/cryotank.py
@@ -219,6 +219,8 @@ class CryoCell(s_cell.Cell):
 
         await s_cell.Cell.__anit__(self, dirn, conf)
 
+        await self.auth.addAuthGate('cryo', 'cryo')
+
         self._cryo_permdefs = []
         self._initCryoPerms()
 
@@ -337,7 +339,7 @@ class CryoCell(s_cell.Cell):
             return tank
 
         if user is not None:
-            user.confirm(('cryo', 'tank', 'add'))
+            user.confirm(('cryo', 'tank', 'add'), gateiden='cryo')
 
         iden = s_common.guid()
 

--- a/synapse/tests/test_cryotank.py
+++ b/synapse/tests/test_cryotank.py
@@ -253,12 +253,14 @@ class CryoTest(s_t_utils.SynTest):
 
                     tank00 = await cryo.init('tank00')
                     self.true(tank00iden == cryo.names.get('tank00').valu[0] == tank00.iden())
+                    self.false(os.path.exists(os.path.join(tank00.dirn, 'guid')))
                     self.false(os.path.exists(os.path.join(tank00.dirn, 'cell.guid')))
                     self.false(os.path.exists(os.path.join(tank00.dirn, 'slabs', 'cell.lmdb')))
                     self.eq(0, s_slaboffs.SlabOffs(tank00.slab, 'offsets').get(seqniden))
 
                     tank01 = await cryo.init('tank01')
                     self.true(tank01iden == cryo.names.get('tank01').valu[0] == tank01.iden())
+                    self.false(os.path.exists(os.path.join(tank01.dirn, 'guid')))
                     self.false(os.path.exists(os.path.join(tank01.dirn, 'cell.guid')))
                     self.false(os.path.exists(os.path.join(tank01.dirn, 'slabs', 'cell.lmdb')))
                     self.eq(0, s_slaboffs.SlabOffs(tank01.slab, 'offsets').get(seqniden))

--- a/synapse/tests/test_cryotank.py
+++ b/synapse/tests/test_cryotank.py
@@ -139,7 +139,7 @@ class CryoTest(s_t_utils.SynTest):
             ulower = (await cryo.addUser('lower'))['iden']
 
             utank0 = (await cryo.addUser('tank0'))['iden']
-            await cryo.addUserRule(utank0, (True, ('cryo', 'tank', 'add')))
+            await cryo.addUserRule(utank0, (True, ('cryo', 'tank', 'add')), gateiden='cryo')
 
             await cryo.init('tank1')
 

--- a/synapse/tests/test_cryotank.py
+++ b/synapse/tests/test_cryotank.py
@@ -145,6 +145,18 @@ class CryoTest(s_t_utils.SynTest):
 
             async with cryo.getLocalProxy(user='tank0') as prox:
 
+                # check perm defs
+
+                perms = await prox.getPermDefs()
+                self.eq([
+                    ('cryo', 'tank', 'add'),
+                    ('cryo', 'tank', 'put'),
+                    ('cryo', 'tank', 'read'),
+                ], [p['perm'] for p in perms])
+
+                perm = await prox.getPermDef(('cryo', 'tank', 'add'))
+                self.eq(('cryo', 'tank', 'add'), perm['perm'])
+
                 # creator is admin
 
                 tankiden0 = await prox.init('tank0')

--- a/synapse/tests/test_cryotank.py
+++ b/synapse/tests/test_cryotank.py
@@ -53,17 +53,6 @@ class CryoTest(s_t_utils.SynTest):
                 self.eq(3, (await prox.last('foo'))[0])
                 self.eq('baz', (await prox.last('foo'))[1][0])
 
-                iden = s_common.guid()
-                self.eq(0, await prox.offset('foo', iden))
-
-                items = await alist(prox.slice('foo', 0, size=1000, iden=iden))
-                self.eq(0, await prox.offset('foo', iden))
-                self.len(4, items)
-
-                items = await alist(prox.slice('foo', 4, size=1000, iden=iden))
-                self.eq(4, await prox.offset('foo', iden))
-                self.len(0, items)
-
                 # waiters
 
                 self.true(await prox.init('dowait'))
@@ -71,7 +60,7 @@ class CryoTest(s_t_utils.SynTest):
                 self.true(await prox.puts('dowait', cryodata))
                 await self.agenlen(2, prox.slice('dowait', 0, size=1000))
 
-                genr = prox.slice('dowait', 1, size=1000, wait=True, iden=iden).__aiter__()
+                genr = prox.slice('dowait', 1, size=1000, wait=True).__aiter__()
 
                 res = await asyncio.wait_for(genr.__anext__(), timeout=2)
                 self.eq(1, res[0])
@@ -82,7 +71,7 @@ class CryoTest(s_t_utils.SynTest):
 
                 await self.asyncraises(TimeoutError, asyncio.wait_for(genr.__anext__(), timeout=1))
 
-                genr = prox.slice('dowait', 4, size=1000, wait=True, timeout=1, iden=iden)
+                genr = prox.slice('dowait', 4, size=1000, wait=True, timeout=1)
                 res = await asyncio.wait_for(alist(genr), timeout=2)
                 self.eq([], res)
 
@@ -100,12 +89,6 @@ class CryoTest(s_t_utils.SynTest):
                     await lprox.puts(cryodata)
 
                     self.len(6, await alist(lprox.slice(0, 9999)))
-
-                    # test offset storage and updating
-                    iden = s_common.guid()
-                    self.eq(0, await lprox.offset(iden))
-                    self.eq(2, await lprox.puts(cryodata, seqn=(iden, 0)))
-                    self.eq(2, await lprox.offset(iden))
 
                 # test the new open share
                 async with cryo.getLocalProxy(share='cryotank/lulz') as lprox:


### PR DESCRIPTION
* Also removed deprecated offset tracking (cannot be released until >=2.150.0)
* Includes migration to remove old tank-cell data and match guids between the cryo names and the tanks