### PR TITLE
SYN-6078: view worldreadable flag when making views in storm

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -4400,11 +4400,11 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         self._calcViewsByLayer()
 
-    async def addView(self, vdef, nexs=True):
+    async def addView(self, vdef, nexs=True, worldreadable=False):
 
         vdef['iden'] = s_common.guid()
         vdef.setdefault('parent', None)
-        vdef.setdefault('worldreadable', False)
+        vdef.setdefault('worldreadable', worldreadable)
         vdef.setdefault('creator', self.auth.rootuser.iden)
 
         s_view.reqValidVdef(vdef)

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -4400,11 +4400,11 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         self._calcViewsByLayer()
 
-    async def addView(self, vdef, nexs=True, worldreadable=False):
+    async def addView(self, vdef, nexs=True):
 
         vdef['iden'] = s_common.guid()
         vdef.setdefault('parent', None)
-        vdef.setdefault('worldreadable', worldreadable)
+        vdef.setdefault('worldreadable', False)
         vdef.setdefault('creator', self.auth.rootuser.iden)
 
         s_view.reqValidVdef(vdef)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -896,10 +896,11 @@ stormcmds = (
         'descr': 'Add a view to the cortex.',
         'cmdargs': (
             ('--name', {'default': None, 'help': 'The name of the new view.'}),
+            ('--worldreadable', {'type': 'bool', 'default': False, 'help': 'Grant read access to the `all` role.'}),
             ('--layers', {'default': [], 'nargs': '*', 'help': 'Layers for the view.'}),
         ),
         'storm': '''
-            $view = $lib.view.add($cmdopts.layers, name=$cmdopts.name)
+            $view = $lib.view.add($cmdopts.layers, name=$cmdopts.name, worldreadable=$cmdopts.worldreadable)
             $lib.print($view.repr())
             $lib.print("View added.")
         ''',

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -6714,7 +6714,8 @@ class LibView(Lib):
          'type': {'type': 'function', '_funcname': '_methViewAdd',
                   'args': (
                       {'name': 'layers', 'type': 'list', 'desc': 'A list of layer idens which make up the view.', },
-                      {'name': 'name', 'type': 'str', 'desc': 'The name of the view.', 'default': None, }
+                      {'name': 'name', 'type': 'str', 'desc': 'The name of the view.', 'default': None, },
+                      {'name': 'worldreadable', 'type': 'boolean', 'desc': 'Grant read access to the `all` role.', 'default': False, },
                   ),
                   'returns': {'type': 'view', 'desc': 'A ``view`` object representing the new View.', }}},
         {'name': 'del', 'desc': 'Delete a View from the Cortex.',
@@ -6747,13 +6748,15 @@ class LibView(Lib):
             'list': self._methViewList,
         }
 
-    async def _methViewAdd(self, layers, name=None):
+    async def _methViewAdd(self, layers, name=None, worldreadable=False):
         name = await tostr(name, noneok=True)
         layers = await toprim(layers)
+        worldreadable = await tobool(worldreadable)
 
         vdef = {
             'creator': self.runt.user.iden,
-            'layers': layers
+            'layers': layers,
+            'worldreadable': worldreadable,
         }
 
         if name is not None:

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -6064,12 +6064,19 @@ class CortexBasicTest(s_t_utils.SynTest):
 
     async def test_addview(self):
         async with self.getTestCore() as core:
+            allrole = core.auth.allrole
+
             (await core.addLayer()).get('iden')
             deflayr = (await core.getLayerDef()).get('iden')
 
             vdef = {'layers': (deflayr,)}
             view = (await core.addView(vdef)).get('iden')
             self.nn(core.getView(view))
+            self.false(allrole.allowed(('view', 'read'), gateiden=view))
+
+            view = (await core.addView(vdef, worldreadable=True)).get('iden')
+            self.nn(core.getView(view))
+            self.true(allrole.allowed(('view', 'read'), gateiden=view))
 
             # Missing layers
             vdef = {'name': 'mylayer'}

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -6064,7 +6064,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
     async def test_addview(self):
         async with self.getTestCore() as core:
-            allrole = core.auth.allrole
+            visi = await core.auth.addUser('visi')
 
             (await core.addLayer()).get('iden')
             deflayr = (await core.getLayerDef()).get('iden')
@@ -6072,11 +6072,12 @@ class CortexBasicTest(s_t_utils.SynTest):
             vdef = {'layers': (deflayr,)}
             view = (await core.addView(vdef)).get('iden')
             self.nn(core.getView(view))
-            self.false(allrole.allowed(('view', 'read'), gateiden=view))
+            self.false(visi.allowed(('view', 'read'), gateiden=view))
 
-            view = (await core.addView(vdef, worldreadable=True)).get('iden')
+            vdef['worldreadable'] = True
+            view = (await core.addView(vdef)).get('iden')
             self.nn(core.getView(view))
-            self.true(allrole.allowed(('view', 'read'), gateiden=view))
+            self.true(visi.allowed(('view', 'read'), gateiden=view))
 
             # Missing layers
             vdef = {'name': 'mylayer'}

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -3945,7 +3945,7 @@ class StormTypesTest(s_test.SynTest):
 
         async with self.getTestCore() as core:
 
-            allrole = core.auth.allrole
+            visi = await core.auth.addUser('visi')
 
             # Add a layer
             ldef = await core.addLayer()
@@ -3954,12 +3954,12 @@ class StormTypesTest(s_test.SynTest):
             # Add a view via stormlib, worldreadable=False (default)
             iden = await core.callStorm(f'return($lib.view.add(({layer.iden},)).iden)')
             self.nn(iden)
-            self.false(allrole.allowed(('view', 'read'), gateiden=iden))
+            self.false(visi.allowed(('view', 'read'), gateiden=iden))
 
             # Add a view via stormlib, worldreadable=True (default)
             iden = await core.callStorm(f'return($lib.view.add(({layer.iden},), worldreadable=$lib.true).iden)')
             self.nn(newiden)
-            self.true(allrole.allowed(('view', 'read'), gateiden=iden))
+            self.true(visi.allowed(('view', 'read'), gateiden=iden))
 
             # Add a view via storm cmd, worldreadable=False (default)
             msgs = await core.stormlist(f'view.add --name view1 --layers {layer.iden}')
@@ -3970,7 +3970,7 @@ class StormTypesTest(s_test.SynTest):
 
             iden = views.get('view1')
             self.nn(iden)
-            self.false(allrole.allowed(('view', 'read'), gateiden=iden))
+            self.false(visi.allowed(('view', 'read'), gateiden=iden))
 
             # Add a view via storm cmd, worldreadable=True
             msgs = await core.stormlist(f'view.add --name view1 --worldreadable $lib.true --layers {layer.iden}')
@@ -3981,7 +3981,7 @@ class StormTypesTest(s_test.SynTest):
 
             iden = views.get('view1')
             self.nn(iden)
-            self.true(allrole.allowed(('view', 'read'), gateiden=iden))
+            self.true(visi.allowed(('view', 'read'), gateiden=iden))
 
     async def test_storm_view_deporder(self):
 


### PR DESCRIPTION
- Added `worldreadable` arg/flag to cortex, `$lib.view.add`, and `view.add`.
- Added tests

Resolves SYN-6078