### PR TITLE
SYN-6144: stormtypes stor functions are not checked for readonly status

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -1097,6 +1097,10 @@ class SetItemOper(Oper):
     '''
     async def run(self, runt, genr):
 
+        if runt.readonly:
+            mesg = 'Storm runtime is in readonly mode, cannot create or edit nodes and other graph data.'
+            raise self.addExcInfo(s_exc.IsReadOnly(mesg=mesg))
+
         count = 0
         async for node, path in genr:
 

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -1097,10 +1097,6 @@ class SetItemOper(Oper):
     '''
     async def run(self, runt, genr):
 
-        if runt.readonly:
-            mesg = 'Storm runtime is in readonly mode, cannot create or edit nodes and other graph data.'
-            raise self.addExcInfo(s_exc.IsReadOnly(mesg=mesg))
-
         count = 0
         async for node, path in genr:
 

--- a/synapse/lib/stormlib/smtp.py
+++ b/synapse/lib/stormlib/smtp.py
@@ -130,6 +130,7 @@ class SmtpMessage(s_stormtypes.StormType):
             'sender': self._setSenderEmail,
         })
 
+    @s_stormtypes.stormfunc(readonly=True)
     async def _setSenderEmail(self, valu):
         # TODO handle inet:email and ps:contact Nodes
         self.sender = await s_stormtypes.tostr(valu)
@@ -137,9 +138,11 @@ class SmtpMessage(s_stormtypes.StormType):
     async def _getSenderEmail(self):
         return self.sender
 
+    @s_stormtypes.stormfunc(readonly=True)
     async def _setEmailText(self, text):
         self.bodytext = await s_stormtypes.tostr(text)
 
+    @s_stormtypes.stormfunc(readonly=True)
     async def _setEmailHtml(self, html):
         self.bodyhtml = await s_stormtypes.tostr(html)
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -450,6 +450,10 @@ class StormType:
             mesg = f'Setting {name} is not supported on {self._storm_typename}.'
             raise s_exc.NoSuchName(name=name, mesg=mesg)
 
+        if s_scope.get('runt').readonly and not getattr(stor, '_storm_readonly', False):
+            mesg = f'Function ({stor.__name__}) is not marked readonly safe.'
+            raise s_exc.IsReadOnly(mesg=mesg, name=name, valu=valu)
+
         await s_coro.ornot(stor, valu)
 
     async def deref(self, name):
@@ -1337,6 +1341,7 @@ class LibBase(Lib):
     async def _getRuntDebug(self):
         return self.runt.debug
 
+    @stormfunc(readonly=True)
     async def _setRuntDebug(self, debug):
         self.runt.debug = await tobool(debug)
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -439,10 +439,6 @@ class StormType:
 
     async def setitem(self, name, valu):
 
-        if hasattr(self, 'runt') and self.runt.readonly:
-            mesg = 'Cannot assign values in a readonly runtime.'
-            raise s_exc.IsReadOnly(mesg=mesg, type=self._storm_typename, name=name, valu=valu)
-
         if not self.stors:
             mesg = f'{self.__class__.__name__} does not support assignment.'
             raise s_exc.StormRuntimeError(mesg=mesg)

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -8134,6 +8134,10 @@ class UserProfile(Prim):
     async def setitem(self, name, valu):
         name = await tostr(name)
 
+        if s_scope.get('runt').readonly:
+            mesg = 'Storm runtime is in readonly mode, cannot create or edit nodes and other graph data.'
+            raise s_exc.IsReadOnly(mesg=mesg, name=name, valu=valu)
+
         if valu is undef:
             self.runt.confirm(('auth', 'user', 'pop', 'profile', name))
             await self.runt.snap.core.popUserProfInfo(self.valu, name)
@@ -8304,6 +8308,10 @@ class UserVars(Prim):
 
     async def setitem(self, name, valu):
         name = await tostr(name)
+
+        if s_scope.get('runt').readonly:
+            mesg = 'Storm runtime is in readonly mode, cannot create or edit nodes and other graph data.'
+            raise s_exc.IsReadOnly(mesg=mesg, name=name, valu=valu)
 
         if valu is undef:
             await self.runt.snap.core.popUserVarValu(self.valu, name)

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -439,6 +439,10 @@ class StormType:
 
     async def setitem(self, name, valu):
 
+        if hasattr(self, 'runt') and self.runt.readonly:
+            mesg = 'Cannot assign values in a readonly runtime.'
+            raise s_exc.IsReadOnly(mesg=mesg, type=self._storm_typename, name=name, valu=valu)
+
         if not self.stors:
             mesg = f'{self.__class__.__name__} does not support assignment.'
             raise s_exc.StormRuntimeError(mesg=mesg)

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -6480,10 +6480,18 @@ words\tword\twrd'''
                                                      'newname': 'oops'
                                                  }})
 
-            self.stormIsInErr('Storm runtime is in readonly mode, cannot create or edit nodes and other graph data.', msgs)
+            self.stormIsInErr('Function (_storUserName) is not marked readonly safe.', msgs)
 
             q = '$user=$lib.auth.users.get($iden) return ( $user.name )'
             name = await core.callStorm(q, opts={'vars': {
                                                      'iden': user,
                                                  }})
             self.eq(name, udef.get('name'))
+
+            q = '$lib.debug=$lib.true return($lib.debug)'
+            debug = await core.callStorm(q, opts={'readonly': True,
+                                                  'vars': {
+                                                      'iden': user,
+                                                      'newname': 'oops'
+                                                 }})
+            self.true(debug)

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -6482,16 +6482,21 @@ words\tword\twrd'''
 
             self.stormIsInErr('Function (_storUserName) is not marked readonly safe.', msgs)
 
-            q = '$user=$lib.auth.users.get($iden) return ( $user.name )'
-            name = await core.callStorm(q, opts={'vars': {
-                                                     'iden': user,
-                                                 }})
-            self.eq(name, udef.get('name'))
+            mesg = 'Storm runtime is in readonly mode, cannot create or edit nodes and other graph data.'
+
+            q = '$user=$lib.auth.users.get($iden) $user.profile.foo = bar'
+            msgs = await core.stormlist(q, opts={'readonly': True,
+                                                 'vars': {'iden': user}})
+
+            self.stormIsInErr(mesg, msgs)
+
+            q = '$user=$lib.auth.users.get($iden) $user.vars.foo = bar'
+            msgs = await core.stormlist(q, opts={'readonly': True,
+                                                 'vars': {'iden': user}})
+
+            self.stormIsInErr(mesg, msgs)
 
             q = '$lib.debug=$lib.true return($lib.debug)'
             debug = await core.callStorm(q, opts={'readonly': True,
-                                                  'vars': {
-                                                      'iden': user,
-                                                      'newname': 'oops'
-                                                 }})
+                                                  'vars': {'iden': user}})
             self.true(debug)

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -6480,7 +6480,7 @@ words\tword\twrd'''
                                                      'newname': 'oops'
                                                  }})
 
-            self.stormIsInErr('Cannot assign values in a readonly runtime.', msgs)
+            self.stormIsInErr('Storm runtime is in readonly mode, cannot create or edit nodes and other graph data.', msgs)
 
             q = '$user=$lib.auth.users.get($iden) return ( $user.name )'
             name = await core.callStorm(q, opts={'vars': {


### PR DESCRIPTION
feat: Check storm runtime for readonly status when setting properties on storm types.