### PR TITLE
Mark the realfunc used to implement storm functions as readonly safe (SYN-6129)

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -4282,6 +4282,7 @@ class Function(AstNode):
         async def once():
             argdefs = await argskid.compute(runt, None)
 
+            @s_stormtypes.stormfunc(readonly=True)
             async def realfunc(*args, **kwargs):
                 return await self.callfunc(runt, argdefs, args, kwargs)
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -7575,9 +7575,11 @@ class LibAuth(Lib):
         }
 
     @staticmethod
+    @stormfunc(readonly=True)
     def ruleFromText(text):
         return ruleFromText(text)
 
+    @stormfunc(readonly=True)
     async def textFromRule(self, rule):
         rule = await toprim(rule)
         text = '.'.join(rule[1])
@@ -7585,9 +7587,11 @@ class LibAuth(Lib):
             text = '!' + text
         return text
 
+    @stormfunc(readonly=True)
     async def getPermDefs(self):
         return self.runt.snap.core.getPermDefs()
 
+    @stormfunc(readonly=True)
     async def getPermDef(self, perm):
         perm = await toprim(perm)
         return self.runt.snap.core.getPermDef(perm)

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -2060,6 +2060,18 @@ class AstTest(s_test.SynTest):
             with self.raises(s_exc.IsReadOnly):
                 await core.nodes('inet:ipv4 | limit 1 | tee { [+#foo] }', opts={'readonly': True})
 
+            q = 'function func(arg) { $lib.print(`hello {$arg}`) return () } $func(world)'
+            msgs = await core.stormlist(q, opts={'readonly': True})
+            self.stormIsInPrint('hello world', msgs)
+
+            q = 'function func(arg) { [test:str=$arg] return ($node) } $func(world)'
+            with self.raises(s_exc.IsReadOnly) as cm:
+                await core.nodes(q, opts={'readonly': True})
+
+            q = 'function func(arg) { auth.user.addrule root $arg | return () } $func(hehe.haha)'
+            msgs = await core.stormlist(q, opts={'readonly': True})
+            self.stormIsInErr('Function (_methUserAddRule) is not marked readonly safe.', msgs)
+
     async def test_ast_yield(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
- Mark ``realfunc`` as readonly safe. This allows user defined functions to be executed in a readonly runtime. The storm in the ``realfunc`` is still checked for readonly safe actions.
- Mark the ``$lib.auth`` functions as readonly safe.