### PR TITLE
SYN-6169: Manually setting parent does not include nested layers in reparented view

### DIFF
--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -289,12 +289,16 @@ class View(s_nexus.Pusher):  # type: ignore
     async def _calcForkLayers(self):
         # recompute the proper set of layers for a forked view
         # (this may only be called from within a nexus handler)
-        layers = [self.layers[0]]
+        layers = []
 
-        view = self.parent
-        while view is not None:
+        # Add one layer from each of the views that aren't the bottom view
+        view = self
+        while view.parent is not None:
             layers.append(view.layers[0])
             view = view.parent
+
+        # Add all of the bottom view's layers
+        layers.extend(view.layers)
 
         self.layers = layers
         await self.info.set('layers', [layr.iden for layr in layers])

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -289,15 +289,74 @@ class View(s_nexus.Pusher):  # type: ignore
     async def _calcForkLayers(self):
         # recompute the proper set of layers for a forked view
         # (this may only be called from within a nexus handler)
+
+        '''
+        We spent a lot of time thinking/talking about this so some hefty
+        comments are in order:
+
+        For a given stack of views (example below), only the bottom view of
+        the stack may have more than one original layer. When adding a new view to the
+        top of the stack (via `<viewE>.setViewInfo('parent', <viewD>)`), we
+        grab the top layer of each of the views from View D to View B and then
+        all of the layers from View A. We know this is the right behavior
+        because all views above the bottom view only have one original layer
+        (but will include all of the layers of it's parents) which is enforced
+        by `setViewInfo()`.
+
+        View D
+        - Layer 6 (original to View D)
+        - Layer 5 (copied from View C)
+        - Layer 4 (copied from View B)
+        - Layer 3 (copied from View A)
+        - Layer 2 (copied from View A)
+        - Layer 1 (copied from View A)
+
+        View C (parent of D)
+        - Layer 5 (original to View C)
+        - Layer 4 (copied from View B)
+        - Layer 3 (copied from View A)
+        - Layer 2 (copied from View A)
+        - Layer 1 (copied from View A)
+
+        View B (parent of C)
+        - Layer 4 (original to View B)
+        - Layer 3 (copied from View A)
+        - Layer 2 (copied from View A)
+        - Layer 1 (copied from View A)
+
+        View A (parent of B)
+        - Layer 3
+        - Layer 2
+        - Layer 1
+
+        Continuing the exercise: when adding View E, it has it's own layer
+        (Layer 7). We then copy Layer 6 from View D, Layer 5 from View C, Layer
+        4 from View B, and Layers 3-1 from View A (the bottom view). This gives
+        us the new view which looks like this:
+
+        View E:
+        - Layer 7 (original to View E)
+        - Layer 6 (copied from View D)
+        - Layer 5 (copied from View C)
+        - Layer 4 (copied from View B)
+        - Layer 3 (copied from View A)
+        - Layer 2 (copied from View A)
+        - Layer 1 (copied from View A)
+
+        View D (now parent of View E)
+        ... (everything from View D and below is the same as above)
+        '''
+
         layers = []
 
-        # Add one layer from each of the views that aren't the bottom view
+        # Add the top layer from each of the views that aren't the bottom view.
+        # This is the view's original layer.
         view = self
         while view.parent is not None:
             layers.append(view.layers[0])
             view = view.parent
 
-        # Add all of the bottom view's layers
+        # Add all of the bottom view's layers.
         layers.extend(view.layers)
 
         self.layers = layers

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -6058,6 +6058,36 @@ class CortexBasicTest(s_t_utils.SynTest):
             self.len(1, await core.nodes('[ test:str=newlayr ]', opts=opts))
             self.len(0, await core.nodes('test:str=newlayr'))
 
+    async def test_view_set_parent(self):
+        async with self.getTestCore() as core:
+
+            layer1 = (await core.addLayer()).get('iden')
+            layer2 = (await core.addLayer()).get('iden')
+            layer3 = (await core.addLayer()).get('iden')
+
+            videna = (await core.addView(
+                {'layers': (layer1,)}
+            )).get('iden')
+
+            videnb = (await core.addView(
+                {'layers': (layer2, layer3)}
+            )).get('iden')
+
+            viewa = core.getView(videna)
+            viewb = core.getView(videnb)
+
+            self.len(1, viewa.layers)
+            self.len(2, viewb.layers)
+
+            await viewa.setViewInfo('parent', videnb)
+
+            self.len(3, viewa.layers)
+            self.eq(layer1, viewa.layers[0].iden)
+            self.eq(layer2, viewa.layers[1].iden)
+            self.eq(layer3, viewa.layers[2].iden)
+
+            self.len(2, viewb.layers)
+
     async def test_cortex_lockmemory(self):
         '''
         Verify that dedicated configuration setting impacts the layer

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -6064,6 +6064,7 @@ class CortexBasicTest(s_t_utils.SynTest):
             layer1 = (await core.addLayer()).get('iden')
             layer2 = (await core.addLayer()).get('iden')
             layer3 = (await core.addLayer()).get('iden')
+            layer4 = (await core.addLayer()).get('iden')
 
             videna = (await core.addView(
                 {'layers': (layer1,)}
@@ -6071,6 +6072,10 @@ class CortexBasicTest(s_t_utils.SynTest):
 
             videnb = (await core.addView(
                 {'layers': (layer2, layer3)}
+            )).get('iden')
+
+            videnc = (await core.addView(
+                {'layers': (layer4,)}
             )).get('iden')
 
             viewa = core.getView(videna)
@@ -6081,12 +6086,19 @@ class CortexBasicTest(s_t_utils.SynTest):
 
             await viewa.setViewInfo('parent', videnb)
 
+            # Make sure View A has all the layers we expect it to have - one
+            # from itself and two from View B. Also make sure they're in the
+            # order we expect.
             self.len(3, viewa.layers)
             self.eq(layer1, viewa.layers[0].iden)
             self.eq(layer2, viewa.layers[1].iden)
             self.eq(layer3, viewa.layers[2].iden)
 
             self.len(2, viewb.layers)
+
+            # This fails because viewb has more than one layer
+            with self.raises(s_exc.BadArg):
+                await viewb.setViewInfo('parent', videnc)
 
     async def test_cortex_lockmemory(self):
         '''


### PR DESCRIPTION
bugfix: fixed bug when parenting a view to another view or stack of views where the bottom view  has more than one layer.