### PR TITLE
Updates for Python 3.12 compatibility (SYN-6184)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,6 +525,7 @@ workflows:
               only: /.*/
             branches:
                only: /.*/
+               ignore: feat_python312
 
       - python311:
           filters:
@@ -532,6 +533,7 @@ workflows:
               only: /.*/
             branches:
               only: /.*/
+              ignore: feat_python312
 
       - python311_replay:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,7 +525,6 @@ workflows:
               only: /.*/
             branches:
                only: /.*/
-               ignore: feat_python312
 
       - python311:
           filters:
@@ -533,7 +532,6 @@ workflows:
               only: /.*/
             branches:
               only: /.*/
-              ignore: feat_python312
 
       - python311_replay:
           filters:

--- a/synapse/cmds/cron.py
+++ b/synapse/cmds/cron.py
@@ -454,8 +454,7 @@ A subcommand is required.  Use 'cron -h' for more detailed help.  '''
 
     @staticmethod
     def _format_timestamp(ts):
-        # N.B. normally better to use fromtimestamp with UTC timezone, but we don't want timezone to print out
-        return datetime.datetime.utcfromtimestamp(ts).isoformat(timespec='minutes')
+        return datetime.datetime.fromtimestamp(ts, datetime.UTC).strftime('%Y-%m-%dT%H:%M')
 
     async def _handle_list(self, core, opts):
         cronlist = await core.listCronJobs()

--- a/synapse/lib/stormlib/stix.py
+++ b/synapse/lib/stormlib/stix.py
@@ -1144,8 +1144,9 @@ class LibStixExport(s_stormtypes.Lib):
         return StixBundle(self, self.runt, config)
 
     def timestamp(self, tick):
-        dt = datetime.datetime.utcfromtimestamp(tick / 1000.0)
-        return dt.isoformat(timespec='milliseconds') + 'Z'
+        dt = datetime.datetime.fromtimestamp(tick / 1000.0, datetime.UTC)
+        millis = int(dt.microsecond / 1000)
+        return f'{dt.strftime("%Y-%m-%dT%H:%M:%S")}.{millis:03d}Z'
 
 stix_sdos = {
     'attack-pattern',

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -9481,9 +9481,7 @@ class CronJob(Prim):
 
     @staticmethod
     def _formatTimestamp(ts):
-        # N.B. normally better to use fromtimestamp with UTC timezone,
-        # but we don't want timezone to print out
-        return datetime.datetime.utcfromtimestamp(ts).isoformat(timespec='minutes')
+        return datetime.datetime.fromtimestamp(ts, datetime.UTC).strftime('%Y-%m-%dT%H:%M')
 
     async def _methCronJobPprint(self):
         user = self.valu.get('username')

--- a/synapse/tests/test_common.py
+++ b/synapse/tests/test_common.py
@@ -183,11 +183,11 @@ class CommonTest(s_t_utils.SynTest):
             parts = [chunk for chunk in s_common.chunks({1, 2, 3}, 10000)]
 
         # dict is unslicable
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises((TypeError, KeyError)) as cm:
             parts = [chunk for chunk in s_common.chunks({1: 2}, 10000)]
 
         # empty dict is caught during the [0:0] slice
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises((TypeError, KeyError)) as cm:
             parts = [chunk for chunk in s_common.chunks({}, 10000)]
 
     def test_common_ehex_uhex(self):

--- a/synapse/tests/test_lib_multislabseqn.py
+++ b/synapse/tests/test_lib_multislabseqn.py
@@ -169,6 +169,12 @@ class MultiSlabSeqn(s_t_utils.SynTest):
                 # Give a chance for the non-iterated async generators to get cleaned up
                 await asyncio.sleep(0)
                 await asyncio.sleep(0)
+                # FIXME This test is timing dependent and failed on 3.12.0rc3 with
+                # only two sleeps.
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
 
                 # Make sure we're not holding onto more than 2 slabs
 

--- a/synapse/tests/test_lib_multislabseqn.py
+++ b/synapse/tests/test_lib_multislabseqn.py
@@ -13,7 +13,7 @@ from synapse.tests.utils import alist
 
 class MultiSlabSeqn(s_t_utils.SynTest):
 
-    async def test_multislabseqn(self):
+    async def test_multislabseqn_base(self):
 
         with self.getTestDir() as dirn:
 
@@ -166,16 +166,6 @@ class MultiSlabSeqn(s_t_utils.SynTest):
                 exp = [(11, 'foo11b'), (12, 'foo12'), (13, 'foo13b'), (14, 'foo14'), (15, 'done')]
                 self.eq(exp, retn)
 
-                # Give a chance for the non-iterated async generators to get cleaned up
-                await asyncio.sleep(0)
-                await asyncio.sleep(0)
-                # FIXME This test is timing dependent and failed on 3.12.0rc3 with
-                # only two sleeps.
-                await asyncio.sleep(0)
-                await asyncio.sleep(0)
-                await asyncio.sleep(0)
-                await asyncio.sleep(0)
-
                 # Make sure we're not holding onto more than 2 slabs
 
                 # rotate
@@ -186,6 +176,10 @@ class MultiSlabSeqn(s_t_utils.SynTest):
 
                 fns = sorted(s_common.listdir(dirn, glob='*.lmdb'))
                 self.len(3, fns)
+
+                # Slab @ 13 will get fini out
+                _slab = msqn._openslabs[13][0]
+                self.true(await _slab.waitfini(6))
 
                 self.len(2, msqn._openslabs)
 

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -2966,11 +2966,11 @@ class StormTest(s_t_utils.SynTest):
             mesgs = await core.stormlist('[ test:str=bar ]')
 
             tick = mesgs[0][1]['tick']
-            tickdt = datetime.datetime.utcfromtimestamp(tick / 1000.0)
+            tickdt = datetime.datetime.fromtimestamp(tick / 1000.0, datetime.UTC)
             tickstr = tickdt.strftime('%Y/%m/%d %H:%M:%S.%f')
 
             tock = mesgs[-1][1]['tock']
-            tockdt = datetime.datetime.utcfromtimestamp(tock / 1000.0)
+            tockdt = datetime.datetime.fromtimestamp(tock / 1000.0, datetime.UTC)
             tockstr = tockdt.strftime('%Y/%m/%d %H:%M:%S.%f')
 
             await asyncio.sleep(0.01)


### PR DESCRIPTION
- Replace utcfromtimestamp with fromtimestamp https://github.com/python/cpython/issues/103857
- `s_common.chunks` Can raise a KeyError when trying to chunk a dictionary https://github.com/python/cpython/issues/84783
- `link.fromspawn` cannot be called from the interpreter / ioloop that created the original link https://github.com/python/cpython/issues/88968