### PR TITLE
SYN-6325: make yaml dep have loud fallback to pure py

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -61,8 +61,11 @@ novalu = NoValu()
 
 logger = logging.getLogger(__name__)
 
-if Loader != yaml.CSafeLoader:  # pragma: no cover
-    logger.warning('PyYAML is using the pure python fallback implementation. This will impact performance negatively.')
+if Loader == yaml.SafeLoader:  # pragma: no cover
+    logger.warning('*****************************************************************************************************')
+    logger.warning('* PyYAML is using the pure python fallback implementation. This will impact performance negatively. *')
+    logger.warning('* See PyYAML docs (https://pyyaml.org/wiki/PyYAMLDocumentation) for tips on resolving this issue.   *')
+    logger.warning('*****************************************************************************************************')
 
 def now():
     '''

--- a/synapse/lib/msgpack.py
+++ b/synapse/lib/msgpack.py
@@ -10,7 +10,10 @@ logger = logging.getLogger(__name__)
 # Single Packer object which is reused for performance
 pakr = msgpack.Packer(use_bin_type=True, unicode_errors='surrogatepass')
 if isinstance(pakr, m_fallback.Packer):  # pragma: no cover
-    logger.warning('msgpack is using the pure python fallback implementation. This will impact performance negatively.')
+    logger.warning('******************************************************************************************************')
+    logger.warning('* msgpack is using the pure python fallback implementation. This will impact performance negatively. *')
+    logger.warning('* Check https://github.com/msgpack/msgpack-python for troubleshooting msgpack on your platform.      *')
+    logger.warning('******************************************************************************************************')
     pakr = None
 
 # synapse.lib.msgpack.un uses a hardcoded subset of these arguments for speed


### PR DESCRIPTION
bugfix: Fix pyyaml fallback detection so it doesn't raise an exception.
feat: Update pyyaml fallback warning to be louder (banner style).
feat: Update msgpack fallback warning to be louder (banner style).