### PR TITLE
SYN-6334: Zeropad before checking hex value

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -687,11 +687,14 @@ class Hex(Type):
         )
 
     def _normPyStr(self, valu):
-        valu = s_chop.hexstr(valu)
+        if valu.startswith(('0x', '0X')):
+            valu = valu[2:]
 
         if self._zeropad and len(valu) < self._zeropad:
             padlen = self._zeropad - len(valu)
             valu = ('0' * padlen) + valu
+
+        valu = s_chop.hexstr(valu)
 
         if self._size and len(valu) != self._size:
             raise s_exc.BadTypeValu(valu=valu, reqwidth=self._size, name=self.name,

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -687,14 +687,26 @@ class Hex(Type):
         )
 
     def _normPyStr(self, valu):
-        if valu.startswith(('0x', '0X')):
+        valu = valu.strip().lower()
+        if valu.startswith('0x'):
             valu = valu[2:]
+
+        valu = valu.replace(' ', '').replace(':', '')
+
+        if not valu:
+            raise s_exc.BadTypeValu(valu=valu, name='hex',
+                                    mesg='No string left after stripping')
 
         if self._zeropad and len(valu) < self._zeropad:
             padlen = self._zeropad - len(valu)
             valu = ('0' * padlen) + valu
 
-        valu = s_chop.hexstr(valu)
+        try:
+            # checks for valid hex width and does character
+            # checking in C without using regex
+            s_common.uhex(valu)
+        except (binascii.Error, ValueError) as e:
+            raise s_exc.BadTypeValu(valu=valu, name='hex', mesg=str(e)) from None
 
         if self._size and len(valu) != self._size:
             raise s_exc.BadTypeValu(valu=valu, reqwidth=self._size, name=self.name,

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -321,6 +321,7 @@ class TypesTest(s_t_utils.SynTest):
             # size = 8, zeropad = True
             testvectors = [
                 ('0x12', '00000012'),
+                ('0x123', '00000123'),
                 ('0x1234', '00001234'),
                 ('0x123456', '00123456'),
                 ('0x12345678', '12345678'),
@@ -344,6 +345,7 @@ class TypesTest(s_t_utils.SynTest):
             # zeropad = 20
             testvectors = [
                 ('0x12', '00000000000000000012'),
+                ('0x123', '00000000000000000123'),
                 ('0x1234', '00000000000000001234'),
                 ('0x123456', '00000000000000123456'),
                 ('0x12345678', '00000000000012345678'),
@@ -433,8 +435,9 @@ class TypesTest(s_t_utils.SynTest):
             self.len(1, await core.nodes('test:hexa^=0xf00fb33b'))
 
             # Check creating and lifting zeropadded hex types
-            self.len(2, await core.nodes('[test:zeropad=11 test:zeropad=0x22]'))
+            self.len(3, await core.nodes('[test:zeropad=11 test:zeropad=0x22 test:zeropad=111]'))
             self.len(1, await core.nodes('test:zeropad=0x11'))
+            self.len(1, await core.nodes('test:zeropad=0x111'))
             self.len(1, await core.nodes('test:zeropad=000000000011'))
             self.len(1, await core.nodes('test:zeropad=00000000000000000011'))  # len=20
             self.len(0, await core.nodes('test:zeropad=0000000000000000000011'))  # len=22

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -320,12 +320,16 @@ class TypesTest(s_t_utils.SynTest):
 
             # size = 8, zeropad = True
             testvectors = [
-                ('0x12', '00000012'),
+                ('0X12', '00000012'),
                 ('0x123', '00000123'),
-                ('0x1234', '00001234'),
+                ('0X1234', '00001234'),
                 ('0x123456', '00123456'),
-                ('0x12345678', '12345678'),
+                ('0X12345678', '12345678'),
+                ('::', s_exc.BadTypeValu),
+                ('0x::', s_exc.BadTypeValu),
+                ('0x1234qwer', s_exc.BadTypeValu),
                 ('0x123456789a', s_exc.BadTypeValu),
+                ('::', s_exc.BadTypeValu),
                 (b'\x12', '00000012'),
                 (b'\x12\x34', '00001234'),
                 (b'\x12\x34\x56', '00123456'),

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -325,6 +325,8 @@ class TypesTest(s_t_utils.SynTest):
                 ('0X1234', '00001234'),
                 ('0x123456', '00123456'),
                 ('0X12345678', '12345678'),
+                ('56:78', '00005678'),
+                ('12:34:56:78', '12345678'),
                 ('::', s_exc.BadTypeValu),
                 ('0x::', s_exc.BadTypeValu),
                 ('0x1234qwer', s_exc.BadTypeValu),

--- a/synapse/tests/test_model_crypto.py
+++ b/synapse/tests/test_model_crypto.py
@@ -555,3 +555,18 @@ class CryptoModelTest(s_t_utils.SynTest):
             self.eq(nodes[0].ndef, ('crypto:x509:revoked', (crl, cert)))
             self.eq(nodes[0].get('crl'), crl)
             self.nn(nodes[0].get('cert'), cert)
+
+            # odd-length serials
+            serials = [
+                '1' * 7,
+                '2' * 9,
+                '3' * 15,
+                '4' * 17,
+                '5' * 31,
+                '6' * 33,
+                '7' * 39,
+            ]
+
+            for serial in serials:
+                msgs = await core.stormlist(f'[crypto:x509:cert=* :serial={serial}]')
+                self.stormHasNoErr(msgs)


### PR DESCRIPTION
bugfix: Zeropad hex strings before checking their validity.
test: Update hex type tests to check for odd-length hex strings.
test: Update crypto:x509 tests to check for odd-length hex serials.