### PR TITLE
SYN-6421: Synapse not modeling private inet:ipv4 with type=private

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -28,6 +28,8 @@ udots = regex.compile(r'[\u3002\uff0e\uff61]')
 cidrmasks = [((0xffffffff - (2 ** (32 - i) - 1)), (2 ** (32 - i))) for i in range(33)]
 ipv4max = 2 ** 32 - 1
 
+rfc6598 = ipaddress.IPv4Network('100.64.0.0/10')
+
 def getAddrType(ip):
 
     if ip.is_multicast:
@@ -44,6 +46,9 @@ def getAddrType(ip):
 
     if ip.is_reserved:
         return 'reserved'
+
+    if ip in rfc6598:
+        return 'shared'
 
     return 'unicast'
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -875,6 +875,18 @@ class InetModelTest(s_t_utils.SynTest):
             self.eq(2851995905, norm)
             self.eq(info.get('subs').get('type'), 'linklocal')
 
+            norm, info = t.norm('100.63.255.255')
+            self.eq(info.get('subs').get('type'), 'unicast')
+
+            norm, info = t.norm('100.64.0.0')
+            self.eq(info.get('subs').get('type'), 'shared')
+
+            norm, info = t.norm('100.127.255.255')
+            self.eq(info.get('subs').get('type'), 'shared')
+
+            norm, info = t.norm('100.128.0.0')
+            self.eq(info.get('subs').get('type'), 'unicast')
+
             # Don't allow invalid values
             with self.raises(s_exc.BadTypeValu):
                 t.norm(0x00000000 - 1)


### PR DESCRIPTION
bugfix: Updated RFC6598 addresses to have a type of `shared`.