### PR TITLE
SYN-6401: Diff can yield None into the Storm pipeline

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -960,6 +960,10 @@ class Url(s_types.Str):
                 raise s_exc.BadTypeValu(valu=orig, name=self.name,
                                         mesg='Missing address/url') from None
 
+        if not hostparts and not pathpart:
+            raise s_exc.BadTypeValu(valu=orig, name=self.name,
+                                    mesg='Missing address/url') from None
+
         base = f'{proto}://{hostparts}{pathpart}'
         subs['base'] = base
         norm = f'{base}{parampart}'

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -1344,6 +1344,10 @@ class InetModelTest(s_t_utils.SynTest):
             t = core.model.type(formname)
             self.raises(s_exc.BadTypeValu, t.norm, 'http:///wat')
             self.raises(s_exc.BadTypeValu, t.norm, 'wat')  # No Protocol
+            self.raises(s_exc.BadTypeValu, t.norm, "file://''")  # Missing address/url
+            self.raises(s_exc.BadTypeValu, t.norm, "file://#")  # Missing address/url
+            self.raises(s_exc.BadTypeValu, t.norm, "file://$")  # Missing address/url
+            self.raises(s_exc.BadTypeValu, t.norm, "file://%")  # Missing address/url
 
             self.raises(s_exc.BadTypeValu, t.norm, 'www.google\udcfesites.com/hehe.asp')
             valu = t.norm('http://www.googlesites.com/hehe\udcfestuff.asp')


### PR DESCRIPTION
bugfix: Fix bug in `inet:url` normalization function to disallow URLs that don't have a valid host or path