### PR TITLE
Introduces is* functions for strings

### DIFF
--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -4045,6 +4045,132 @@ class Str(Prim):
                        'desc': 'Keyword values which are substituted into the string.', },
                   ),
                   'returns': {'type': 'str', 'desc': 'The new string.', }}},
+         {'name': 'isalnum', 'desc': '''
+            Returns true if all chars in the string are alphanumeric, false otherwise.
+
+            Examples:
+                Test if string `aca123` is alphanumeric::
+
+                    $foo="aca123" return ( $foo.isalnum() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsAlnum',
+                  'returns': {'type': 'bool', 'desc': 'Whether string is alphanumeric', }}},
+         {'name': 'isalpha', 'desc': '''
+            Returns true if all chars in the string are in the alphabet, false otherwise.
+
+            Examples:
+                Test if string `aca` contains only letters in the alphabet::
+
+                    $foo="aca" return ( $foo.isalpha() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsAlpha',
+                  'returns': {'type': 'bool', 'desc': 'Whether string only contains chars from alphabet', }}},
+         {'name': 'isascii', 'desc': '''
+            Returns true if all chars in the string are ASCII chars, false otherwise.
+
+            Examples:
+                Test if string `aca` contains only letters in the alphabet::
+
+                    $foo="aca" return ( $foo.isascii() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsASCII',
+                  'returns': {'type': 'bool', 'desc': 'Whether all the chars are ASCII', }}},
+         {'name': 'isdecimal', 'desc': '''
+            Returns true if all the chars are decimals (including unicode), false otherwise.
+
+            Examples:
+                Test if string `123` contains only decimals::
+
+                    $foo="123" return ( $foo.isdecimal() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsDecimal',
+                  'returns': {'type': 'bool', 'desc': 'Whether all the chars are decimals', }}},
+         {'name': 'isdigit', 'desc': '''
+            Returns true if all the chars are decimals, false otherwise.
+            Exponents are considered as digits.
+
+            Examples:
+                Test if string `123` contains only digits::
+
+                    $foo="123" return ( $foo.isdigit() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsDigit',
+                  'returns': {'type': 'bool', 'desc': 'Whether all the chars are digits', }}},
+         {'name': 'isidentifier', 'desc': '''
+            Returns true if the string is a valid identifier, false otherwise.
+            A valid identifier only contains alphanumeric letters (a-z) and (0-9), or underscores (_).
+            and cannot start with a number, or contain any spaces.
+
+            Examples:
+                Test if string `aca_123` is a valid identifier::
+
+                    $foo="aca_123" return ( $foo.isidentifier() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsIdentifier',
+                  'returns': {'type': 'bool', 'desc': 'Whether the string is a valid identifier', }}},
+         {'name': 'islower', 'desc': '''
+            Returns true if all the chars are in lower case, false otherwise.
+            Numbers, symbols and spaces are not checked, only alphabet characters.
+
+            Examples:
+                Test if string `aca` only contains lower case chars::
+
+                    $foo="aca" return ( $foo.islower() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsLower',
+                  'returns': {'type': 'bool', 'desc': 'Whether all chars are in lower case', }}},
+         {'name': 'isnumeric', 'desc': '''
+            Returns true if all the chars are numeric, false otherwise.
+            Unicode fractions are considered as numeric, but not decimals like `1.5`.
+
+            Examples:
+                Test if string `123` only contains numeric chars::
+
+                    $foo="123" return ( $foo.isnumeric() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsNumeric',
+                  'returns': {'type': 'bool', 'desc': 'Whether all chars are numeric', }}},
+         {'name': 'isprintable', 'desc': '''
+            Returns true if all the chars are printable, false otherwise.
+
+            Examples:
+                Test if string `aca 123` only contains printable chars::
+
+                    $foo="aca 123" return ( $foo.isprintable() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsPrintable',
+                  'returns': {'type': 'bool', 'desc': 'Whether all chars are printable', }}},
+         {'name': 'isspace', 'desc': '''
+            Returns true if all the chars are whitespaces, false otherwise.
+
+            Examples:
+                Test if string `   ` only contains whitespaces::
+
+                    $foo="   " return ( $foo.isspace() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsSpace',
+                  'returns': {'type': 'bool', 'desc': 'Whether all chars are whitespaces', }}},
+         {'name': 'istitle', 'desc': '''
+            Returns true if all words in a text start with a upper case letter and others are lower case, false otherwise.
+
+            Examples:
+                Test if string `Aca Test` has words start with a upper case letter and others are lower case::
+
+                    $foo="Aca Test" return ( $foo.istitle() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsTitle',
+                  'returns': {'type': 'bool', 'desc': 'Whether all words starts with an upper case', }}},
+         {'name': 'isupper', 'desc': '''
+            Returns true if all the characters are in upper case, false otherwise.
+            Numbers, symbols and spaces are not checked, only alphabet characters.
+
+            Examples:
+                Test if string `ACA` only contains upper case chars::
+
+                    $foo="ACA" return ( $foo.isupper() ) // true
+            ''',
+         'type': {'type': 'function', '_funcname': '_methStrIsUpper',
+                  'returns': {'type': 'bool', 'desc': 'Whether all chars are upper case', }}},
     )
     _storm_typename = 'str'
     _ismutable = False
@@ -4074,6 +4200,18 @@ class Str(Prim):
             'slice': self._methStrSlice,
             'reverse': self._methStrReverse,
             'format': self._methStrFormat,
+            'isalnum': self._methStrIsAlNum,
+            'isalpha': self._methStrIsAlpha,
+            'isascii': self._methStrIsASCII,
+            'isdecimal': self._methStrIsDecimal,
+            'isdigit': self._methStrIsDigit,
+            'isidentifier': self._methStrIsIdentifier,
+            'islower': self._methStrIsLower,
+            'isnumeric': self._methStrIsNumeric,
+            'isprintable': self._methStrIsPrintable,
+            'isspace': self._methStrIsSpace,
+            'istitle': self._methStrIsTitle,
+            'isupper': self._methStrIsUpper,
         }
 
     def __int__(self):
@@ -4188,6 +4326,54 @@ class Str(Prim):
     @stormfunc(readonly=True)
     async def _methStrReverse(self):
         return self.valu[::-1]
+
+    @stormfunc(readonly=True)
+    async def _methStrIsAlNum(self):
+        return self.valu.isalnum()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsAlpha(self):
+        return self.valu.isalpha()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsASCII(self):
+        return self.valu.isascii()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsDecimal(self):
+        return self.valu.isdecimal()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsDigit(self):
+        return self.valu.isdigit()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsIdentifier(self):
+        return self.valu.isidentifier()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsLower(self):
+        return self.valu.islower()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsNumeric(self):
+        return self.valu.isnumeric()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsPrintable(self):
+        return self.valu.isprintable()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsSpace(self):
+        return self.valu.isspace()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsTitle(self):
+        return self.valu.istitle()
+
+    @stormfunc(readonly=True)
+    async def _methStrIsUpper(self):
+        return self.valu.isupper()
 
 @registry.registerType
 class Bytes(Prim):

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -1349,6 +1349,42 @@ class StormTypesTest(s_test.SynTest):
             q = '$foo="hehe {haha} {newp}" return ( $foo.format(haha=yup, baz=faz) )'
             self.eq('hehe yup {newp}', await core.callStorm(q))
 
+            q = '$foo="aca123" return ( $foo.isalnum() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="aca" return ( $foo.isalpha() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="aca123!" return ( $foo.isascii() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="123" return ( $foo.isdecimal() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="123" return ( $foo.isdigit() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="aca_123" return ( $foo.isidentifier() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="aca" return ( $foo.islower() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="123" return ( $foo.isnumeric() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="aca" return ( $foo.isprintable() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="      " return ( $foo.isspace() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="Hello" return ( $foo.istitle() )'
+            self.eq(True, await core.callStorm(q))
+
+            q = '$foo="ACA" return ( $foo.isupper() )'
+            self.eq(True, await core.callStorm(q))
+
             # tuck the regx tests in with str
             self.true(await core.callStorm(r'''return($lib.regex.matches('^foo', foobar))'''))
             self.true(await core.callStorm(r'''return($lib.regex.matches('foo', FOOBAR, $lib.regex.flags.i))'''))


### PR DESCRIPTION
Introduces additional functions for testing strings. These are generally faster and more readable than their regular expression equivalent. I found those useful when writing rapid power-ups and integrations with 3rd party services.

Methods are a direct mapping from their Python equivalent
- `isalnum()`
- `isalpha()`
- `isascii()`
- `isdecimal()`
- `isdigit()`
- `isidentifier()`
- `islower()`
- `isnumeric()`
- `isprintable()`
- `isspace()`
- `istitle()`
- `isupper()`
