### PR TITLE
SYN-6423: Modifying a data prop on a node and attempting to re-set it doesn't perform any edits

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -3066,10 +3066,10 @@ class PropValue(Value):
                                                     name=name, form=path.node.form.name))
 
             valu = path.node.get(name)
-            if isinstance(valu, dict):
-                # dicts get special cased because changing the dict affects the node
+            if isinstance(valu, (dict, list, tuple)):
+                # these get special cased because changing them affects the node
                 # while it's in the pipeline but the modification doesn't get stored
-                valu = s_msgpack.deepcopy(valu, use_list=True)
+                valu = s_msgpack.deepcopy(valu)
             return prop, valu
 
         # handle implicit pivot properties
@@ -3091,10 +3091,10 @@ class PropValue(Value):
                                                 name=name, form=node.form.name))
 
             if i >= imax:
-                if isinstance(valu, dict):
-                    # dicts get special cased because changing the dict affects the node
+                if isinstance(valu, (dict, list, tuple)):
+                    # these get special cased because changing them affects the node
                     # while it's in the pipeline but the modification doesn't get stored
-                    valu = s_msgpack.deepcopy(valu, use_list=True)
+                    valu = s_msgpack.deepcopy(valu)
                 return prop, valu
 
             form = runt.model.forms.get(prop.type.name)

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -1267,8 +1267,9 @@ class SetItemOper(Oper):
             count += 1
 
             item = s_stormtypes.fromprim(await self.kids[0].compute(runt, path), basetypes=False)
-            if item is None:
-                mesg = '$lib.null does not support assignment.'
+            if not hasattr(item, 'setitem'):
+                ityp = await s_stormtypes.totype(item)
+                mesg = f'{ityp} does not support assignment.'
                 raise self.kids[0].addExcInfo(s_exc.StormRuntimeError(mesg=mesg))
 
             if runt.readonly and not getattr(item.setitem, '_storm_readonly', False):
@@ -1287,8 +1288,9 @@ class SetItemOper(Oper):
         if count == 0 and self.isRuntSafe(runt):
 
             item = s_stormtypes.fromprim(await self.kids[0].compute(runt, None), basetypes=False)
-            if item is None:
-                mesg = '$lib.null does not support assignment.'
+            if not hasattr(item, 'setitem'):
+                ityp = await s_stormtypes.totype(item)
+                mesg = f'{ityp} does not support assignment.'
                 raise self.kids[0].addExcInfo(s_exc.StormRuntimeError(mesg=mesg))
 
             name = await self.kids[1].compute(runt, None)

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -1267,10 +1267,6 @@ class SetItemOper(Oper):
             count += 1
 
             item = s_stormtypes.fromprim(await self.kids[0].compute(runt, path), basetypes=False)
-            if not hasattr(item, 'setitem'):
-                ityp = await s_stormtypes.totype(item)
-                mesg = f'{ityp} does not support assignment.'
-                raise self.kids[0].addExcInfo(s_exc.StormRuntimeError(mesg=mesg))
 
             if runt.readonly and not getattr(item.setitem, '_storm_readonly', False):
                 mesg = 'Storm runtime is in readonly mode, cannot create or edit nodes and other graph data.'
@@ -1288,10 +1284,6 @@ class SetItemOper(Oper):
         if count == 0 and self.isRuntSafe(runt):
 
             item = s_stormtypes.fromprim(await self.kids[0].compute(runt, None), basetypes=False)
-            if not hasattr(item, 'setitem'):
-                ityp = await s_stormtypes.totype(item)
-                mesg = f'{ityp} does not support assignment.'
-                raise self.kids[0].addExcInfo(s_exc.StormRuntimeError(mesg=mesg))
 
             name = await self.kids[1].compute(runt, None)
             valu = await self.kids[2].compute(runt, None)

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3109,16 +3109,31 @@ class AstTest(s_test.SynTest):
         async with self.getTestCore() as core:
 
             # Create node with data prop, assign data prop to var, update var
-            q = '[ it:exec:query=(test,) :opts=({"foo": "bar"}) ] $opts=:opts $opts.bar = "baz"'
+            q = '[ it:exec:query=(test1,) :opts=({"foo": "bar"}) ] $opts=:opts $opts.bar = "baz"'
             nodes = await core.nodes(q)
             self.len(1, nodes)
             self.eq(nodes[0].props.get('opts'), {'foo': 'bar'})
 
+            q = '[ it:exec:query=(test1,) :opts=({"foo": "bar"}) ] $opts=:opts $opts.bar = "baz" [ :opts=$opts ]'
+            nodes = await core.nodes(q)
+            self.len(1, nodes)
+            self.eq(nodes[0].props.get('opts'), {'foo': 'bar', 'bar': 'baz'})
+
+            q = '''
+            '''
+            msgs = await core.stormlist('[ it:exec:query=(test2,) :opts=({"foo": "bar"}) ]')
+            self.stormHasNoWarnErr(msgs)
+
             # Lift node with data prop, assign data prop to var, update var
-            q = 'it:exec:query=(test,) $opts=:opts $opts.bar = "baz"'
+            q = 'it:exec:query=(test2,) $opts=:opts $opts.bar = "baz"'
             nodes = await core.nodes(q)
             self.len(1, nodes)
             self.eq(nodes[0].props.get('opts'), {'foo': 'bar'})
+
+            q = 'it:exec:query=(test2,) $opts=:opts $opts.bar = "baz" [ :opts=$opts ]'
+            nodes = await core.nodes(q)
+            self.len(1, nodes)
+            self.eq(nodes[0].props.get('opts'), {'foo': 'bar', 'bar': 'baz'})
 
             # Create node for the lift below
             q = '''
@@ -3134,3 +3149,8 @@ class AstTest(s_test.SynTest):
             nodes = await core.nodes(q)
             self.len(1, nodes)
             self.eq(nodes[0].props.get('raw'), {'foo': 'bar'})
+
+            q = f'it:app:snort:hit $raw = :flow::raw $raw.baz="box" | spin | inet:flow [ :raw=$raw ]'
+            nodes = await core.nodes(q)
+            self.len(1, nodes)
+            self.eq(nodes[0].props.get('raw'), {'foo': 'bar', 'baz': 'box'})

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -1622,33 +1622,6 @@ class AstTest(s_test.SynTest):
             self.eq(erfo[1][0], 'StormRuntimeError')
             self.eq(erfo[1][1].get('mesg'), 'Set does not support assignment.')
 
-            q = '$foo = $lib.null $foo.bar = baz'
-            msgs = await core.stormlist(q)
-            erfo = [m for m in msgs if m[0] == 'err'][0]
-            self.eq(erfo[1][0], 'StormRuntimeError')
-            self.eq(erfo[1][1].get('mesg'), 'null does not support assignment.')
-
-            q = '''
-            [inet:fqdn=foo]
-            $foo=$lib.null
-            inet:fqdn
-            $foo.bar = baz
-            '''
-            msgs = await core.stormlist(q)
-            erfo = [m for m in msgs if m[0] == 'err'][0]
-            self.eq(erfo[1][0], 'StormRuntimeError')
-            self.eq(erfo[1][1].get('mesg'), 'null does not support assignment.')
-
-            msgs = await core.stormlist('$foo=bar $foo.bar = baz')
-            erfo = [m for m in msgs if m[0] == 'err'][0]
-            self.eq(erfo[1][0], 'StormRuntimeError')
-            self.eq(erfo[1][1].get('mesg'), 'str does not support assignment.')
-
-            msgs = await core.stormlist('$foo=(1) $foo.bar = baz')
-            erfo = [m for m in msgs if m[0] == 'err'][0]
-            self.eq(erfo[1][0], 'StormRuntimeError')
-            self.eq(erfo[1][1].get('mesg'), 'int does not support assignment.')
-
     async def test_ast_initfini(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -1626,7 +1626,7 @@ class AstTest(s_test.SynTest):
             msgs = await core.stormlist(q)
             erfo = [m for m in msgs if m[0] == 'err'][0]
             self.eq(erfo[1][0], 'StormRuntimeError')
-            self.eq(erfo[1][1].get('mesg'), '$lib.null does not support assignment.')
+            self.eq(erfo[1][1].get('mesg'), 'null does not support assignment.')
 
             q = '''
             [inet:fqdn=foo]
@@ -1637,7 +1637,17 @@ class AstTest(s_test.SynTest):
             msgs = await core.stormlist(q)
             erfo = [m for m in msgs if m[0] == 'err'][0]
             self.eq(erfo[1][0], 'StormRuntimeError')
-            self.eq(erfo[1][1].get('mesg'), '$lib.null does not support assignment.')
+            self.eq(erfo[1][1].get('mesg'), 'null does not support assignment.')
+
+            msgs = await core.stormlist('$foo=bar $foo.bar = baz')
+            erfo = [m for m in msgs if m[0] == 'err'][0]
+            self.eq(erfo[1][0], 'StormRuntimeError')
+            self.eq(erfo[1][1].get('mesg'), 'str does not support assignment.')
+
+            msgs = await core.stormlist('$foo=(1) $foo.bar = baz')
+            erfo = [m for m in msgs if m[0] == 'err'][0]
+            self.eq(erfo[1][0], 'StormRuntimeError')
+            self.eq(erfo[1][1].get('mesg'), 'int does not support assignment.')
 
     async def test_ast_initfini(self):
 

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -1628,6 +1628,17 @@ class AstTest(s_test.SynTest):
             self.eq(erfo[1][0], 'StormRuntimeError')
             self.eq(erfo[1][1].get('mesg'), '$lib.null does not support assignment.')
 
+            q = '''
+            [inet:fqdn=foo]
+            $foo=$lib.null
+            inet:fqdn
+            $foo.bar = baz
+            '''
+            msgs = await core.stormlist(q)
+            erfo = [m for m in msgs if m[0] == 'err'][0]
+            self.eq(erfo[1][0], 'StormRuntimeError')
+            self.eq(erfo[1][1].get('mesg'), '$lib.null does not support assignment.')
+
     async def test_ast_initfini(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
bugfix: Perform a deepcopy of data prop values so modifications don't affect the node while it's in the pipeline.