### PR TITLE
SYN-6612: lark doesn't parse correctly with python 3.11.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,7 +413,7 @@ jobs:
   python311:
     parallelism: 8
     docker:
-      - image: cimg/python:3.11.6
+      - image: cimg/python:3.11
         environment:
           PYVERS: 3.11
           RUN_SYNTAX: 1
@@ -430,7 +430,7 @@ jobs:
   python311_replay:
     parallelism: 6
     docker:
-      - image: cimg/python:3.11.6
+      - image: cimg/python:3.11
         environment:
           PYVERS: 3.11
           RUN_SYNTAX: 1
@@ -447,7 +447,7 @@ jobs:
   doctests:
     parallelism: 1
     docker:
-      - image: cimg/python:3.11.6
+      - image: cimg/python:3.11
         environment:
           PYVERS: 3.11
 
@@ -458,7 +458,7 @@ jobs:
 
   python_package_smoketest:
     docker:
-      - image: cimg/python:3.11.6
+      - image: cimg/python:3.11
         environment:
           PYPI_SMOKE_CODE: import synapse; print(synapse.version)
           PYTHON_TAG: py311
@@ -470,7 +470,7 @@ jobs:
 
   deploy_pypi:
     docker:
-      - image: cimg/python:3.11.6
+      - image: cimg/python:3.11
         environment:
           PYPI_SMOKE_CODE: import synapse; print(synapse.version)
           PYTHON_TAG: py311

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     'aioimaplib>=1.0.1,<1.1.0',
     'aiosmtplib>=3.0.0,<3.1.0',
     'prompt-toolkit>=3.0.4,<3.1.0',
-    'lark==1.1.8',
+    'lark==1.1.9',
     'Pygments>=2.7.4,<2.18.0',
     'packaging>=20.0,<24.0',
     'fastjsonschema>=2.18.0,<2.20.0',

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ aiohttp-socks>=0.8.0,<0.9.0
 aioimaplib>=1.0.1,<1.1.0
 aiosmtplib>=3.0.0,<3.1.0
 prompt-toolkit>=3.0.4,<3.1.0
-lark==1.1.8
+lark==1.1.9
 Pygments>=2.7.4,<2.18.0
 fastjsonschema>=2.18.0,<2.20.0
 packaging>=20.0,<24.0


### PR DESCRIPTION
- Update lark to 1.1.9 which has python 3.11.7 fix
- Unpin CI images from 3.11.6 back to 3.11