### PR TITLE
SYN-6814: Add note about Synapse not a data lake

### DIFF
--- a/docs/synapse/intro.rst
+++ b/docs/synapse/intro.rst
@@ -20,7 +20,7 @@ even over large and complex data sets.
 .. note::
 
     A :ref:`gloss-cortex` may easily grow to billions of nodes, but is not designed to consume and create billions of
-    nodes **per day**. In other words, Synapse is not meant to replace your big-data/data-lake storage; Synapse is
+    nodes per day. In other words, Synapse is not meant to replace your big-data/data-lake storage; Synapse is
     designed to connect to your data sources on demand in order to ingest data relevant for your analysis into the
     Synapse intelligence platform.
 

--- a/docs/synapse/intro.rst
+++ b/docs/synapse/intro.rst
@@ -17,6 +17,12 @@ structured and extensible :ref:`userguide_datamodel` and the powerful and intuit
 query language, Synapse gives analysts unparalleled power and flexibility to ask and answer any question,
 even over large and complex data sets.
 
+.. note::
+
+    A :ref:`gloss-cortex` may easily grow to billions of nodes, but is not designed for use cases involving billions of
+    records per-day. In a typical big-data/data-lake architecture, a :ref:`gloss-cortex` is optimally used to analyze
+    data resulting from queries to existing platforms and fuse data relevant to an analyst's investigation.
+
 .. _intro-features:
 
 Key Features

--- a/docs/synapse/intro.rst
+++ b/docs/synapse/intro.rst
@@ -19,9 +19,10 @@ even over large and complex data sets.
 
 .. note::
 
-    A :ref:`gloss-cortex` may easily grow to billions of nodes, but is not designed for use cases involving billions of
-    records per-day. In a typical big-data/data-lake architecture, a :ref:`gloss-cortex` is optimally used to analyze
-    data resulting from queries to existing platforms and fuse data relevant to an analyst's investigation.
+    A :ref:`gloss-cortex` may easily grow to billions of nodes, but is not designed to consume and create billions of
+    nodes **per day**. In other words, Synapse is not meant to replace your big-data/data-lake storage; Synapse is
+    designed to connect to your data sources on demand in order to ingest data **relevant for your analysis** into the
+    Synapse intelligence platform.
 
 .. _intro-features:
 

--- a/docs/synapse/intro.rst
+++ b/docs/synapse/intro.rst
@@ -21,7 +21,7 @@ even over large and complex data sets.
 
     A :ref:`gloss-cortex` may easily grow to billions of nodes, but is not designed to consume and create billions of
     nodes **per day**. In other words, Synapse is not meant to replace your big-data/data-lake storage; Synapse is
-    designed to connect to your data sources on demand in order to ingest data **relevant for your analysis** into the
+    designed to connect to your data sources on demand in order to ingest data relevant for your analysis into the
     Synapse intelligence platform.
 
 .. _intro-features:


### PR DESCRIPTION
Updated the introduction page with a note about Synapse not being a data lake. 

Preview:
![image](https://github.com/vertexproject/synapse/assets/11776738/23cc93f2-668e-496b-979b-695dfd8ae7b5)
