### PR TITLE
Replacing keccak from pycryptodome with eth-utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ stix2-validator>=3.0.0,<4.0.0
 vcrpy>=4.3.1,<5.2.0
 base58>=2.1.0,<2.2.0
 python-bitcoinlib>=0.11.0,<0.13.0
-pycryptodome>=3.11.0,<3.21.0
 typing-extensions>=3.7.4,<5.0.0  # synapse.vendor.xrpl req
 scalecodec>=1.0.2,<1.3.0  # synapse.vendor.substrateinterface req
 cbor2>=5.4.1,<5.7.0
@@ -33,3 +32,4 @@ beautifulsoup4[html5lib]>=4.11.1,<5.0.0
 # have a minimum version bumped in the event of a OpenSSL vulnerability that
 # needs to be patched.
 cryptography>=39.0.1,<42.0.0
+eth-utils>=3.0.0

--- a/synapse/lib/crypto/coin.py
+++ b/synapse/lib/crypto/coin.py
@@ -5,7 +5,7 @@ import cbor2  # cardano
 import regex
 import bech32  # cardano
 import base58  # btc and cardano
-import Crypto.Hash.keccak as c_keccak
+import eth_utils
 import bitcoin  # btc
 import bitcoin.bech32 as bitcoin_b32  # btc
 import synapse.vendor.cashaddress.convert as cashaddr_convert  # BCH support
@@ -54,7 +54,7 @@ def ether_eip55(body: str):
     # From EIP-55 reference implementation
     hex_addr = body.lower()
     checksummed_buffer = ""
-    hashed_address = c_keccak.new(data=hex_addr.encode(), digest_bits=256).hexdigest()
+    hashed_address = eth_utils.keccak(text=hex_addr).hex()
 
     for nibble_index, character in enumerate(hex_addr):
         if character in "0123456789":


### PR DESCRIPTION
The pycryptodome package is a fork of [PyCyrpto](https://www.pycrypto.org/) which is unmaintained, obsolete, and contains security vulnerabilities. To remedy this, this change removes the dependency on pycryptodome and instead uses the eth-utils package to perform the keccak hash.