### PR TITLE
Support mTLS in HTTP requests (SYN-5896)

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -613,6 +613,14 @@ class AxonApi(s_cell.CellApi, s_share.Share):  # type: ignore
             The response body will be stored, regardless of the response code. The ``ok`` value in the reponse does not
             reflect that a status code, such as a 404, was encountered when retrieving the URL.
 
+            The ssl_opts dictionary may contain the following values::
+
+                {
+                    'verify': <bool> - Perform SSL/TLS verification. Is overridden by the ssl argument.
+                    'client_cert': <str> - PEM encoded full chain certificate for use in mTLS.
+                    'client_key': <str> - PEM encoded key for use in mTLS. Alternatively, can be included in client_cert.
+                }
+
             The dictionary returned by this may contain the following values::
 
                 {
@@ -1466,6 +1474,14 @@ class Axon(s_cell.Cell):
                     'content_transfer_encoding': <str> - Optional content-transfer-encoding header for the field.
                 }
 
+            The ssl_opts dictionary may contain the following values::
+
+                {
+                    'verify': <bool> - Perform SSL/TLS verification. Is overridden by the ssl argument.
+                    'client_cert': <str> - PEM encoded full chain certificate for use in mTLS.
+                    'client_key': <str> - PEM encoded key for use in mTLS. Alternatively, can be included in client_cert.
+                }
+
             The dictionary returned by this may contain the following values::
 
                 {
@@ -1648,6 +1664,14 @@ class Axon(s_cell.Cell):
         Notes:
             The response body will be stored, regardless of the response code. The ``ok`` value in the reponse does not
             reflect that a status code, such as a 404, was encountered when retrieving the URL.
+
+            The ssl_opts dictionary may contain the following values::
+
+                {
+                    'verify': <bool> - Perform SSL/TLS verification. Is overridden by the ssl argument.
+                    'client_cert': <str> - PEM encoded full chain certificate for use in mTLS.
+                    'client_key': <str> - PEM encoded key for use in mTLS. Alternatively, can be included in client_cert.
+                }
 
             The dictionary returned by this may contain the following values::
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -3879,6 +3879,10 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             if proxyurl is not None:
                 conf['http:proxy'] = proxyurl
 
+            cadir = self.conf.get('tls:ca:dir')
+            if cadir is not None:
+                conf['tls:ca:dir'] = cadir
+
             self.axon = await s_axon.Axon.anit(path, conf=conf, parent=self)
             self.axoninfo = await self.axon.getCellInfo()
             self.axon.onfini(self.axready.clear)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1,5 +1,6 @@
 import gc
 import os
+import ssl
 import copy
 import time
 import fcntl
@@ -12,6 +13,7 @@ import tarfile
 import argparse
 import datetime
 import platform
+import tempfile
 import functools
 import contextlib
 import multiprocessing
@@ -32,6 +34,7 @@ import synapse.lib.boss as s_boss
 import synapse.lib.coro as s_coro
 import synapse.lib.hive as s_hive
 import synapse.lib.link as s_link
+import synapse.lib.cache as s_cache
 import synapse.lib.const as s_const
 import synapse.lib.nexus as s_nexus
 import synapse.lib.queue as s_queue
@@ -58,6 +61,7 @@ import synapse.tools.backup as s_t_backup
 logger = logging.getLogger(__name__)
 
 SLAB_MAP_SIZE = 128 * s_const.mebibyte
+SSLCTX_CACHE_SIZE = 1000
 
 '''
 Base classes for the synapse "cell" microservice architecture.
@@ -1150,6 +1154,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         self.apikeydb = self.slab.initdb('user:apikeys')  # apikey -> useriden
         self.usermetadb = self.slab.initdb('user:meta')  # useriden + <valu> -> dict valu
         self.rolemetadb = self.slab.initdb('role:meta')  # roleiden + <valu> -> dict valu
+
+        self._sslctx_cache = s_cache.FixedCache(self._makeCachedSslCtx, size=SSLCTX_CACHE_SIZE)
 
         self.hive = await self._initCellHive()
 
@@ -4338,3 +4344,64 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 self.slab.delete(key_iden, db=self.apikeydb)
             self.slab.delete(lkey, db=self.usermetadb)
             await asyncio.sleep(0)
+
+    def _makeCachedSslCtx(self, opts):
+
+        opts = dict(opts)
+
+        cadir = self.conf.get('tls:ca:dir')
+
+        purpose = ssl.Purpose[opts['purpose']]
+
+        if cadir is not None:
+            sslctx = s_common.getSslCtx(cadir, purpose=purpose)
+        else:
+            sslctx = ssl.create_default_context(purpose=purpose)
+
+        if not opts['verify']:
+            sslctx.check_hostname = False
+            sslctx.verify_mode = ssl.CERT_NONE
+
+        if not opts['client_cert']:
+            return sslctx
+
+        client_cert = opts['client_cert'].encode()
+
+        if opts['client_key']:
+            client_key = opts['client_key'].encode()
+        else:
+            client_key = None
+            client_key_path = None
+
+        with self.getTempDir() as tmpdir:
+
+            with tempfile.NamedTemporaryFile(dir=tmpdir, mode='wb', delete=False) as fh:
+                fh.write(client_cert)
+                client_cert_path = fh.name
+
+            if client_key:
+                with tempfile.NamedTemporaryFile(dir=tmpdir, mode='wb', delete=False) as fh:
+                    fh.write(client_key)
+                    client_key_path = fh.name
+
+            try:
+                sslctx.load_cert_chain(client_cert_path, keyfile=client_key_path)
+            except ssl.SSLError as e:
+                raise s_exc.BadArg(mesg=f'Error loading client cert: {str(e)}') from None
+
+        return sslctx
+
+    def getCachedSslCtx(self, opts, verify=True):
+
+        if opts is None:
+            opts = {}
+
+        if verify is None:
+            # support aiohttp convention
+            verify = True
+
+        opts['verify'] = verify
+        opts = s_schemas.reqValidSslCtxOpts(opts)
+
+        key = tuple(sorted(opts.items()))
+        return self._sslctx_cache.get(key)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -4391,16 +4391,14 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         return sslctx
 
-    def getCachedSslCtx(self, opts, verify=True):
+    def getCachedSslCtx(self, opts=None, verify=None):
 
         if opts is None:
             opts = {}
 
-        if verify is None:
-            # support aiohttp convention
-            verify = True
+        if verify is not None:
+            opts['verify'] = verify
 
-        opts['verify'] = verify
         opts = s_schemas.reqValidSslCtxOpts(opts)
 
         key = tuple(sorted(opts.items()))

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -4355,12 +4355,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         cadir = self.conf.get('tls:ca:dir')
 
-        purpose = ssl.Purpose[opts['purpose']]
-
         if cadir is not None:
-            sslctx = s_common.getSslCtx(cadir, purpose=purpose)
+            sslctx = s_common.getSslCtx(cadir, purpose=ssl.Purpose.SERVER_AUTH)
         else:
-            sslctx = ssl.create_default_context(purpose=purpose)
+            sslctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
 
         if not opts['verify']:
             sslctx.check_hostname = False

--- a/synapse/lib/oauth.py
+++ b/synapse/lib/oauth.py
@@ -230,13 +230,7 @@ class OAuthMixin(s_nexus.Pusher):
 
         timeout = aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT)
 
-        cadir = self.conf.get('tls:ca:dir')
-        if ssl_verify is False:
-            ssl = False
-        elif cadir:
-            ssl = s_common.getSslCtx(cadir)
-        else:
-            ssl = None
+        ssl = self.getCachedSslCtx(verify=ssl_verify)
 
         async with aiohttp.ClientSession(timeout=timeout) as sess:
 

--- a/synapse/lib/schemas.py
+++ b/synapse/lib/schemas.py
@@ -263,3 +263,18 @@ _cellUserApiKeySchema = {
     ],
 }
 reqValidUserApiKeyDef = s_config.getJsValidator(_cellUserApiKeySchema)
+
+reqValidSslCtxOpts = s_config.getJsValidator({
+    'type': 'object',
+    'properties': {
+        'purpose': {
+            'type': 'string',
+            'default': 'SERVER_AUTH',
+            'enum': ['SERVER_AUTH'],
+        },
+        'verify': {'type': 'boolean', 'default': True},
+        'client_cert': {'type': ['string', 'null'], 'default': None},
+        'client_key': {'type': ['string', 'null'], 'default': None},
+    },
+    'additionalProperties': False,
+})

--- a/synapse/lib/schemas.py
+++ b/synapse/lib/schemas.py
@@ -267,11 +267,6 @@ reqValidUserApiKeyDef = s_config.getJsValidator(_cellUserApiKeySchema)
 reqValidSslCtxOpts = s_config.getJsValidator({
     'type': 'object',
     'properties': {
-        'purpose': {
-            'type': 'string',
-            'default': 'SERVER_AUTH',
-            'enum': ['SERVER_AUTH'],
-        },
         'verify': {'type': 'boolean', 'default': True},
         'client_cert': {'type': ['string', 'null'], 'default': None},
         'client_key': {'type': ['string', 'null'], 'default': None},

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -88,6 +88,14 @@ class WebSocket(s_base.Base, s_stormtypes.StormType):
 class LibHttp(s_stormtypes.Lib):
     '''
     A Storm Library exposing an HTTP client API.
+
+    For APIs that accept an ssl_opts argument, the dictionary may contain the following values::
+
+        {
+            'verify': <bool> - Perform SSL/TLS verification. Is overridden by the ssl_verify argument.
+            'client_cert': <str> - PEM encoded full chain certificate for use in mTLS.
+            'client_key': <str> - PEM encoded key for use in mTLS. Alternatively, can be included in client_cert.
+        }
     '''
     _storm_locals = (
         {'name': 'get', 'desc': 'Get the contents of a given URL.',
@@ -98,8 +106,6 @@ class LibHttp(s_stormtypes.Lib):
                        'default': None},
                       {'name': 'ssl_verify', 'type': 'boolean', 'desc': 'Perform SSL/TLS verification.',
                        'default': True},
-                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
-                       'default': None},
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None},
                       {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request in seconds.',
@@ -108,6 +114,9 @@ class LibHttp(s_stormtypes.Lib):
                        'default': True},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
+                      {'name': 'ssl_opts', 'type': 'dict',
+                       'desc': 'Optional SSL/TLS options. See $lib.inet.http help for additional details.',
+                       'default': None},
                   ),
                   'returns': {'type': 'inet:http:resp', 'desc': 'The response object.'}}},
         {'name': 'post', 'desc': 'Post data to a given URL.',
@@ -122,8 +131,6 @@ class LibHttp(s_stormtypes.Lib):
                        'default': None},
                       {'name': 'ssl_verify', 'type': 'boolean', 'desc': 'Perform SSL/TLS verification.',
                        'default': True},
-                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
-                       'default': None},
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None},
                       {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request in seconds.',
@@ -139,6 +146,9 @@ class LibHttp(s_stormtypes.Lib):
                        'default': None},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
+                      {'name': 'ssl_opts', 'type': 'dict',
+                       'desc': 'Optional SSL/TLS options. See $lib.inet.http help for additional details.',
+                       'default': None},
                   ),
                   'returns': {'type': 'inet:http:resp', 'desc': 'The response object.'}}},
         {'name': 'head', 'desc': 'Get the HEAD response for a URL.',
@@ -149,8 +159,6 @@ class LibHttp(s_stormtypes.Lib):
                        'default': None},
                       {'name': 'ssl_verify', 'type': 'boolean', 'desc': 'Perform SSL/TLS verification.',
                        'default': True},
-                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
-                       'default': None},
                       {'name': 'params', 'type': 'dict',
                        'desc': 'Optional parameters which may be passed to the request.',
                        'default': None},
@@ -160,6 +168,9 @@ class LibHttp(s_stormtypes.Lib):
                        'default': False},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
+                      {'name': 'ssl_opts', 'type': 'dict',
+                       'desc': 'Optional SSL/TLS options. See $lib.inet.http help for additional details.',
+                       'default': None},
                   ),
                   'returns': {'type': 'inet:http:resp', 'desc': 'The response object.'}}},
         {'name': 'request', 'desc': 'Make an HTTP request using the given HTTP method to the url.',
@@ -175,8 +186,6 @@ class LibHttp(s_stormtypes.Lib):
                        'default': None},
                       {'name': 'ssl_verify', 'type': 'boolean', 'desc': 'Perform SSL/TLS verification.',
                        'default': True},
-                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
-                       'default': None},
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the request.',
                        'default': None},
                       {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request in seconds.',
@@ -192,6 +201,9 @@ class LibHttp(s_stormtypes.Lib):
                        'default': None},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
+                      {'name': 'ssl_opts', 'type': 'dict',
+                       'desc': 'Optional SSL/TLS options. See $lib.inet.http help for additional details.',
+                       'default': None},
                    ),
                   'returns': {'type': 'inet:http:resp', 'desc': 'The response object.'}
                   }
@@ -204,14 +216,15 @@ class LibHttp(s_stormtypes.Lib):
                        'default': None},
                       {'name': 'ssl_verify', 'type': 'boolean', 'desc': 'Perform SSL/TLS verification.',
                        'default': True},
-                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
-                       'default': None},
                       {'name': 'timeout', 'type': 'int', 'desc': 'Total timeout for the request in seconds.',
                        'default': 300},
                       {'name': 'params', 'type': 'dict', 'desc': 'Optional parameters which may be passed to the connection request.',
                        'default': None},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
+                      {'name': 'ssl_opts', 'type': 'dict',
+                       'desc': 'Optional SSL/TLS options. See $lib.inet.http help for additional details.',
+                       'default': None},
                   ),
                   'returns': {'type': 'inet:http:socket', 'desc': 'A websocket object.'}}},
         {'name': 'urlencode', 'desc': '''
@@ -300,24 +313,24 @@ class LibHttp(s_stormtypes.Lib):
         code = await s_stormtypes.toint(code)
         return s_common.httpcodereason(code)
 
-    async def _httpEasyHead(self, url, headers=None, ssl_verify=True, ssl_opts=None, params=None, timeout=300,
-                            allow_redirects=False, proxy=None):
-        return await self._httpRequest('HEAD', url, headers=headers, ssl_verify=ssl_verify, ssl_opts=ssl_opts,
-                                       params=params, timeout=timeout, allow_redirects=allow_redirects, proxy=proxy)
+    async def _httpEasyHead(self, url, headers=None, ssl_verify=True, params=None, timeout=300,
+                            allow_redirects=False, proxy=None, ssl_opts=None):
+        return await self._httpRequest('HEAD', url, headers=headers, ssl_verify=ssl_verify, params=params,
+                                       timeout=timeout, allow_redirects=allow_redirects, proxy=proxy, ssl_opts=ssl_opts)
 
-    async def _httpEasyGet(self, url, headers=None, ssl_verify=True, ssl_opts=None, params=None, timeout=300,
-                           allow_redirects=True, proxy=None):
-        return await self._httpRequest('GET', url, headers=headers, ssl_verify=ssl_verify, ssl_opts=ssl_opts,
-                                       params=params, timeout=timeout, allow_redirects=allow_redirects, proxy=proxy)
+    async def _httpEasyGet(self, url, headers=None, ssl_verify=True, params=None, timeout=300,
+                           allow_redirects=True, proxy=None, ssl_opts=None):
+        return await self._httpRequest('GET', url, headers=headers, ssl_verify=ssl_verify, params=params,
+                                       timeout=timeout, allow_redirects=allow_redirects, proxy=proxy, ssl_opts=ssl_opts)
 
-    async def _httpPost(self, url, headers=None, json=None, body=None, ssl_verify=True, ssl_opts=None,
-                        params=None, timeout=300, allow_redirects=True, fields=None, proxy=None):
+    async def _httpPost(self, url, headers=None, json=None, body=None, ssl_verify=True,
+                        params=None, timeout=300, allow_redirects=True, fields=None, proxy=None, ssl_opts=None):
         return await self._httpRequest('POST', url, headers=headers, json=json, body=body,
-                                       ssl_verify=ssl_verify, ssl_opts=ssl_opts, params=params, timeout=timeout,
-                                       allow_redirects=allow_redirects, fields=fields, proxy=proxy)
+                                       ssl_verify=ssl_verify, params=params, timeout=timeout,
+                                       allow_redirects=allow_redirects, fields=fields, proxy=proxy, ssl_opts=ssl_opts)
 
-    async def inetHttpConnect(self, url, headers=None, ssl_verify=True, ssl_opts=None, timeout=300,
-                              params=None, proxy=None):
+    async def inetHttpConnect(self, url, headers=None, ssl_verify=True, timeout=300,
+                              params=None, proxy=None, ssl_opts=None):
 
         url = await s_stormtypes.tostr(url)
         headers = await s_stormtypes.toprim(headers)
@@ -379,8 +392,8 @@ class LibHttp(s_stormtypes.Lib):
         return data
 
     async def _httpRequest(self, meth, url, headers=None, json=None, body=None,
-                           ssl_verify=True, ssl_opts=None, params=None, timeout=300, allow_redirects=True,
-                           fields=None, proxy=None):
+                           ssl_verify=True, params=None, timeout=300, allow_redirects=True,
+                           fields=None, proxy=None, ssl_opts=None):
         meth = await s_stormtypes.tostr(meth)
         url = await s_stormtypes.tostr(url)
         json = await s_stormtypes.toprim(json)
@@ -390,9 +403,9 @@ class LibHttp(s_stormtypes.Lib):
         params = await s_stormtypes.toprim(params)
         timeout = await s_stormtypes.toint(timeout, noneok=True)
         ssl_verify = await s_stormtypes.tobool(ssl_verify, noneok=True)
-        ssl_opts = await s_stormtypes.toprim(ssl_opts)
         allow_redirects = await s_stormtypes.tobool(allow_redirects)
         proxy = await s_stormtypes.toprim(proxy)
+        ssl_opts = await s_stormtypes.toprim(ssl_opts)
 
         kwargs = {'allow_redirects': allow_redirects}
         if params:
@@ -408,7 +421,7 @@ class LibHttp(s_stormtypes.Lib):
                 self.runt.confirm(('storm', 'lib', 'axon', 'wput'))
                 axon = self.runt.snap.core.axon
                 info = await axon.postfiles(fields, url, headers=headers, params=params, method=meth,
-                                            ssl=ssl_verify, ssl_opts=ssl_opts, timeout=timeout, proxy=proxy)
+                                            ssl=ssl_verify, timeout=timeout, proxy=proxy, ssl_opts=ssl_opts)
                 return HttpResp(info)
 
         kwargs['ssl'] = self.runt.snap.core.getCachedSslCtx(opts=ssl_opts, verify=ssl_verify)

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -407,9 +407,8 @@ class LibHttp(s_stormtypes.Lib):
             if any(['sha256' in field for field in fields]):
                 self.runt.confirm(('storm', 'lib', 'axon', 'wput'))
                 axon = self.runt.snap.core.axon
-                # todo: pass through ssl_opts
-                info = await axon.postfiles(fields, url, headers=headers, params=params,
-                                            method=meth, ssl=ssl_verify, timeout=timeout, proxy=proxy)
+                info = await axon.postfiles(fields, url, headers=headers, params=params, method=meth,
+                                            ssl=ssl_verify, ssl_opts=ssl_opts, timeout=timeout, proxy=proxy)
                 return HttpResp(info)
 
         kwargs['ssl'] = self.runt.snap.core.getCachedSslCtx(opts=ssl_opts, verify=ssl_verify)

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -346,7 +346,7 @@ class LibHttp(s_stormtypes.Lib):
         if params:
             kwargs['params'] = params
 
-        kwargs['ssl'] = self.runt.snap.core.getCachedSslCtx(ssl_opts, verify=ssl_verify)
+        kwargs['ssl'] = self.runt.snap.core.getCachedSslCtx(opts=ssl_opts, verify=ssl_verify)
 
         try:
             sess = await sock.enter_context(aiohttp.ClientSession(connector=connector, timeout=timeout))
@@ -412,7 +412,7 @@ class LibHttp(s_stormtypes.Lib):
                                             method=meth, ssl=ssl_verify, timeout=timeout, proxy=proxy)
                 return HttpResp(info)
 
-        kwargs['ssl'] = self.runt.snap.core.getCachedSslCtx(ssl_opts, verify=ssl_verify)
+        kwargs['ssl'] = self.runt.snap.core.getCachedSslCtx(opts=ssl_opts, verify=ssl_verify)
 
         if proxy is None:
             proxy = await self.runt.snap.core.getConfOpt('http:proxy')

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 import logging
+import ssl
 import urllib.parse
 
 logger = logging.getLogger(__name__)
@@ -416,7 +417,10 @@ class LibHttp(s_stormtypes.Lib):
         if ssl_verify is False:
             kwargs['ssl'] = False
         elif cadir:
-            kwargs['ssl'] = s_common.getSslCtx(cadir)
+            # kwargs['ssl'] = s_common.getSslCtx(cadir)
+            sslctx = s_common.getSslCtx(cadir)
+            sslctx.load_cert_chain(f'{cadir}/clients/someuser.crt', f'{cadir}/clients/someuser.key')
+            kwargs['ssl'] = sslctx
         else:
             # default aiohttp behavior
             kwargs['ssl'] = None

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -1951,6 +1951,8 @@ class LibAxon(Lib):
                        'default': None},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
+                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
+                       'default': None},
                   ),
                   'returns': {'type': 'dict', 'desc': 'A status dictionary of metadata.'}}},
         {'name': 'wput', 'desc': """
@@ -1971,6 +1973,8 @@ class LibAxon(Lib):
                        'default': None},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
+                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
+                       'default': None},
                   ),
                   'returns': {'type': 'dict', 'desc': 'A status dictionary of metadata.'}}},
         {'name': 'urlfile', 'desc': '''
@@ -2207,7 +2211,8 @@ class LibAxon(Lib):
         axon = self.runt.snap.core.axon
         return await axon.del_(sha256b)
 
-    async def wget(self, url, headers=None, params=None, method='GET', json=None, body=None, ssl=True, timeout=None, proxy=None):
+    async def wget(self, url, headers=None, params=None, method='GET', json=None, body=None,
+                   ssl=True, timeout=None, proxy=None, ssl_opts=None):
 
         if not self.runt.allowed(('axon', 'wget')):
             self.runt.confirm(('storm', 'lib', 'axon', 'wget'))
@@ -2222,6 +2227,7 @@ class LibAxon(Lib):
         headers = await toprim(headers)
         timeout = await toprim(timeout)
         proxy = await toprim(proxy)
+        ssl_opts = await toprim(ssl_opts)
 
         if proxy is not None:
             self.runt.confirm(('storm', 'lib', 'inet', 'http', 'proxy'))
@@ -2238,11 +2244,12 @@ class LibAxon(Lib):
 
         axon = self.runt.snap.core.axon
         resp = await axon.wget(url, headers=headers, params=params, method=method, ssl=ssl, body=body, json=json,
-                               timeout=timeout, **kwargs)
+                               timeout=timeout, ssl_opts=ssl_opts, **kwargs)
         resp['original_url'] = url
         return resp
 
-    async def wput(self, sha256, url, headers=None, params=None, method='PUT', ssl=True, timeout=None, proxy=None):
+    async def wput(self, sha256, url, headers=None, params=None, method='PUT',
+                   ssl=True, timeout=None, proxy=None, ssl_opts=None):
 
         if not self.runt.allowed(('axon', 'wput')):
             self.runt.confirm(('storm', 'lib', 'axon', 'wput'))
@@ -2256,6 +2263,7 @@ class LibAxon(Lib):
         params = await toprim(params)
         headers = await toprim(headers)
         timeout = await toprim(timeout)
+        ssl_opts = await toprim(ssl_opts)
 
         params = self.strify(params)
         headers = self.strify(headers)
@@ -2271,7 +2279,8 @@ class LibAxon(Lib):
         if axonvers >= (2, 97, 0):
             kwargs['proxy'] = proxy
 
-        return await axon.wput(sha256byts, url, headers=headers, params=params, method=method, ssl=ssl, timeout=timeout, **kwargs)
+        return await axon.wput(sha256byts, url, headers=headers, params=params, method=method,
+                               ssl=ssl, timeout=timeout, ssl_opts=ssl_opts, **kwargs)
 
     async def urlfile(self, *args, **kwargs):
         gateiden = self.runt.snap.wlyr.iden

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -1916,6 +1916,14 @@ class LibStr(Lib):
 class LibAxon(Lib):
     '''
     A Storm library for interacting with the Cortex's Axon.
+
+    For APIs that accept an ssl_opts argument, the dictionary may contain the following values::
+
+        {
+            'verify': <bool> - Perform SSL/TLS verification. Is overridden by the ssl argument.
+            'client_cert': <str> - PEM encoded full chain certificate for use in mTLS.
+            'client_key': <str> - PEM encoded key for use in mTLS. Alternatively, can be included in client_cert.
+        }
     '''
     _storm_locals = (
         {'name': 'wget', 'desc': """
@@ -1951,7 +1959,8 @@ class LibAxon(Lib):
                        'default': None},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
-                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
+                      {'name': 'ssl_opts', 'type': 'dict',
+                       'desc': 'Optional SSL/TLS options. See $lib.axon help for additional details.',
                        'default': None},
                   ),
                   'returns': {'type': 'dict', 'desc': 'A status dictionary of metadata.'}}},
@@ -1973,7 +1982,8 @@ class LibAxon(Lib):
                        'default': None},
                       {'name': 'proxy', 'type': ['bool', 'null', 'str'],
                        'desc': 'Set to a proxy URL string or $lib.false to disable proxy use.', 'default': None},
-                      {'name': 'ssl_opts', 'type': 'dict', 'desc': 'Optional SSL/TLS options.',
+                      {'name': 'ssl_opts', 'type': 'dict',
+                       'desc': 'Optional SSL/TLS options. See $lib.axon help for additional details.',
                        'default': None},
                   ),
                   'returns': {'type': 'dict', 'desc': 'A status dictionary of metadata.'}}},

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -34,10 +34,14 @@ import synapse.lib.scope as s_scope
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.trigger as s_trigger
 import synapse.lib.urlhelp as s_urlhelp
+import synapse.lib.version as s_version
 import synapse.lib.stormctrl as s_stormctrl
 import synapse.lib.provenance as s_provenance
 
 logger = logging.getLogger(__name__)
+
+AXON_MINVERS_PROXY = (2, 97, 0)
+AXON_MINVERS_SSLOPTS = '>=2.162.0'
 
 class Undef:
     _storm_typename = 'undef'
@@ -2249,12 +2253,18 @@ class LibAxon(Lib):
 
         kwargs = {}
         axonvers = self.runt.snap.core.axoninfo['synapse']['version']
-        if axonvers >= (2, 97, 0):
+        if axonvers >= AXON_MINVERS_PROXY:
             kwargs['proxy'] = proxy
+
+        if ssl_opts is not None:
+            mesg = f'The ssl_opts argument requires an Axon Synapse version {AXON_MINVERS_SSLOPTS}, ' \
+                   f'but the Axon is running {axonvers}'
+            s_version.reqVersion(axonvers, AXON_MINVERS_SSLOPTS, mesg=mesg)
+            kwargs['ssl_opts'] = ssl_opts
 
         axon = self.runt.snap.core.axon
         resp = await axon.wget(url, headers=headers, params=params, method=method, ssl=ssl, body=body, json=json,
-                               timeout=timeout, ssl_opts=ssl_opts, **kwargs)
+                               timeout=timeout, **kwargs)
         resp['original_url'] = url
         return resp
 
@@ -2286,11 +2296,17 @@ class LibAxon(Lib):
 
         kwargs = {}
         axonvers = self.runt.snap.core.axoninfo['synapse']['version']
-        if axonvers >= (2, 97, 0):
+        if axonvers >= AXON_MINVERS_PROXY:
             kwargs['proxy'] = proxy
 
+        if ssl_opts is not None:
+            mesg = f'The ssl_opts argument requires an Axon Synapse version {AXON_MINVERS_SSLOPTS}, ' \
+                   f'but the Axon is running {axonvers}'
+            s_version.reqVersion(axonvers, AXON_MINVERS_SSLOPTS, mesg=mesg)
+            kwargs['ssl_opts'] = ssl_opts
+
         return await axon.wput(sha256byts, url, headers=headers, params=params, method=method,
-                               ssl=ssl, timeout=timeout, ssl_opts=ssl_opts, **kwargs)
+                               ssl=ssl, timeout=timeout, **kwargs)
 
     async def urlfile(self, *args, **kwargs):
         gateiden = self.runt.snap.wlyr.iden

--- a/synapse/tests/test_lib_stormhttp.py
+++ b/synapse/tests/test_lib_stormhttp.py
@@ -766,6 +766,17 @@ class StormHttpTest(s_test.SynTest):
                 self.true(ret[0])
                 self.eq('woot', ret[1]['hi'])
 
+                ## postfile
+                resp = await core.callStorm('''
+                    ($size, $sha256) = $lib.bytes.put($lib.base64.decode(Zm9v))
+                    $fields = ([
+                        {"name": "file", "sha256": $sha256},
+                    ])
+                    return($lib.inet.http.post($url, fields=$fields, ssl_opts=$sslopts))
+                ''', opts=opts)
+                self.eq(200, resp['code'])
+                self.eq(['foo'], json.loads(resp['body'])['result']['params']['file'])
+
                 # verify arg precedence
 
                 core.conf.pop('tls:ca:dir')


### PR DESCRIPTION
* Introduces SSL Context caching
* Also fixes a bug where tls:ca:dir was not passed through to embedded Axon
* Also fixes a bug where http:proxy was not honored in Axon.wput