### PR TITLE
Check CI runner has work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
             # Activate our venv and generate a xml report
             . venv/bin/activate
             python -m coverage xml
-            if [ $? -eq 0 -a -e coverage.xml ]; then
+            if [ $? -eq 0 -a -f coverage.xml ]; then
               # Download and verify the codecov binary
               curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
               curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,13 @@ commands:
             . venv/bin/activate
             python -m coverage xml
             # Execute the binary...
-              ./codecov \
-                -t "${CODECOV_TOKEN}" \
-                -n "${CODECOV_PREFIX}${PYVERS}node${CIRCLE_NODE_INDEX}" \
-                -F "${CODECOV_FLAG}" \
-                -f ./coverage.xml \
-                -v \
-                -Z || echo 'Codecov upload failed'
+            ./codecov \
+              -t "${CODECOV_TOKEN}" \
+              -n "${CODECOV_PREFIX}${PYVERS}node${CIRCLE_NODE_INDEX}" \
+              -F "${CODECOV_FLAG}" \
+              -f ./coverage.xml \
+              -v \
+              -Z || echo 'Codecov upload failed'
 
   do_venv_setup:
     description: "Setup venv for testing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ commands:
                   -f ./coverage.xml \
                   -v \
                   -Z || echo 'Codecov upload failed'
+            else
+              echo "No coverage results found to upload."
             fi
 
   do_venv_setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,25 +14,27 @@ commands:
       - run:
           name: Upload Coverage Results
           command: |
-            # Download and verify the codecov binary
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM
-            chmod +x codecov
             # Activate our venv and generate a xml report
             . venv/bin/activate
             python -m coverage xml
-            # Execute the binary...
-            ./codecov \
-              -t "${CODECOV_TOKEN}" \
-              -n "${CODECOV_PREFIX}${PYVERS}node${CIRCLE_NODE_INDEX}" \
-              -F "${CODECOV_FLAG}" \
-              -f ./coverage.xml \
-              -v \
-              -Z || echo 'Codecov upload failed'
+            if [ $? -eq 0 -a -e coverage.xml ]; then
+              # Download and verify the codecov binary
+              curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
+              curl -Os https://uploader.codecov.io/latest/linux/codecov
+              curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+              curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+              gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+              shasum -a 256 -c codecov.SHA256SUM
+              chmod +x codecov
+              # Execute the binary...
+                ./codecov \
+                  -t "${CODECOV_TOKEN}" \
+                  -n "${CODECOV_PREFIX}${PYVERS}node${CIRCLE_NODE_INDEX}" \
+                  -F "${CODECOV_FLAG}" \
+                  -f ./coverage.xml \
+                  -v \
+                  -Z || echo 'Codecov upload failed'
+            fi
 
   do_venv_setup:
     description: "Setup venv for testing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,29 +14,25 @@ commands:
       - run:
           name: Upload Coverage Results
           command: |
+            # Download and verify the codecov binary
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
             # Activate our venv and generate a xml report
             . venv/bin/activate
             python -m coverage xml
-            if [ $? -eq 0 -a -f coverage.xml ]; then
-              # Download and verify the codecov binary
-              curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
-              curl -Os https://uploader.codecov.io/latest/linux/codecov
-              curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-              curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-              gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
-              shasum -a 256 -c codecov.SHA256SUM
-              chmod +x codecov
-              # Execute the binary...
-                ./codecov \
-                  -t "${CODECOV_TOKEN}" \
-                  -n "${CODECOV_PREFIX}${PYVERS}node${CIRCLE_NODE_INDEX}" \
-                  -F "${CODECOV_FLAG}" \
-                  -f ./coverage.xml \
-                  -v \
-                  -Z || echo 'Codecov upload failed'
-            else
-              echo "No coverage results found to upload."
-            fi
+            # Execute the binary...
+              ./codecov \
+                -t "${CODECOV_TOKEN}" \
+                -n "${CODECOV_PREFIX}${PYVERS}node${CIRCLE_NODE_INDEX}" \
+                -F "${CODECOV_FLAG}" \
+                -f ./coverage.xml \
+                -v \
+                -Z || echo 'Codecov upload failed'
 
   do_venv_setup:
     description: "Setup venv for testing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,13 @@ commands:
   check_runner_has_work:
     description: Check that this runner has work to do
     steps:
-      - run: |
-        mkdir -p ./tmp && \
-        >./tmp/tests.txt && \
-        circleci tests glob synapse/tests/test_*.py synapse/vendor/*/tests/test_*.py | circleci tests run --split-by=timings --command ">./tmp/tests.txt xargs echo"
-        [ -s tmp/tests.txt ] || circleci-agent step halt #if there are no tests, terminate execution after this step
+      - run:
+          name: Check workload
+          command: |
+            mkdir -p ./tmp && \
+            >./tmp/tests.txt && \
+            circleci tests glob synapse/tests/test_*.py synapse/vendor/*/tests/test_*.py | circleci tests run --split-by=timings --command ">./tmp/tests.txt xargs echo"
+            [ -s tmp/tests.txt ] || circleci-agent step halt #if there are no tests, terminate execution after this step
 
   test_steps_doc:
     description: "Documentation test steps"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,15 @@ commands:
             mkdir test-reports
             circleci tests glob synapse/tests/test_*.py synapse/vendor/*/tests/test_*.py | circleci tests run --split-by=timings --command "xargs python3 -m pytest -v -s -rs --durations 6 --maxfail 6 -p no:logging --junitxml=test-reports/junit.xml -o junit_family=xunit1 ${COVERAGE_ARGS}"
 
+  check_runner_has_work:
+    description: Check that this runner has work to do
+    steps:
+      - run: |
+        mkdir -p ./tmp && \
+        >./tmp/tests.txt && \
+        circleci tests glob synapse/tests/test_*.py synapse/vendor/*/tests/test_*.py | circleci tests run --split-by=timings --command ">./tmp/tests.txt xargs echo"
+        [ -s tmp/tests.txt ] || circleci-agent step halt #if there are no tests, terminate execution after this step
+
   test_steps_doc:
     description: "Documentation test steps"
     steps:
@@ -108,6 +117,8 @@ commands:
     description: "Python test steps"
     steps:
       - checkout
+
+      - check_runner_has_work
 
       - run:
           name: checkout regression repo


### PR DESCRIPTION
When "rerun failed tests" is selected in CircleCI, the parallelism might be wider than the number of tests. This means that some runners might not have any tests to execute. This change checks if the runner has work and bails early if not.