### PR TITLE
Remove glob.synchelp (SYN-5985)

### DIFF
--- a/synapse/glob.py
+++ b/synapse/glob.py
@@ -85,38 +85,3 @@ def sync(coro, timeout=None):
     '''
     loop = initloop()
     return asyncio.run_coroutine_threadsafe(coro, loop).result(timeout)
-
-def synchelp(f):
-    '''
-    The synchelp decorator allows the transparent execution of
-    a coroutine using the global loop from a thread other than
-    the event loop.  In both use cases, the actual work is done
-    by the global event loop.
-
-    Examples:
-
-        Use as a decorator::
-
-            @s_glob.synchelp
-            async def stuff(x, y):
-                await dostuff()
-
-        Calling the stuff function as regular async code using the standard await syntax::
-
-            valu = await stuff(x, y)
-
-        Calling the stuff function as regular sync code outside of the event loop thread::
-
-            valu = stuff(x, y)
-
-    '''
-    def wrap(*args, **kwargs):
-
-        coro = f(*args, **kwargs)
-
-        if not iAmLoop():
-            return sync(coro)
-
-        return coro
-
-    return wrap

--- a/synapse/telepath.py
+++ b/synapse/telepath.py
@@ -460,7 +460,6 @@ class Method:
         self.__name__ = name
         self.__self__ = proxy
 
-    @s_glob.synchelp
     async def __call__(self, *args, **kwargs):
         todo = (self.name, args, kwargs)
         return await self.proxy.task(todo, name=self.share)
@@ -1342,7 +1341,6 @@ def alias(name):
 
     return url
 
-@s_glob.synchelp
 async def openurl(url, **opts):
     '''
     Open a URL to a remote telepath object.

--- a/synapse/tests/test_telepath.py
+++ b/synapse/tests/test_telepath.py
@@ -265,20 +265,6 @@ class TeleTest(s_t_utils.SynTest):
         self.true(prox.isfini)
         await self.asyncraises(s_exc.IsFini, prox.bar((10, 20)))
 
-    async def test_telepath_sync_genr(self):
-
-        foo = Foo()
-
-        def sync():
-            return [x for x in prox.genr()]
-
-        async with self.getTestDmon() as dmon:
-
-            dmon.share('foo', foo)
-
-            async with await s_telepath.openurl('tcp://127.0.0.1/foo', port=dmon.addr[1]) as prox:
-                self.eq((10, 20, 30), await s_coro.executor(sync))
-
     def test_telepath_sync_genr_break(self):
 
         try:

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -44,7 +44,6 @@ from prompt_toolkit.formatted_text import FormattedText
 
 import synapse.exc as s_exc
 import synapse.axon as s_axon
-import synapse.glob as s_glob
 import synapse.common as s_common
 import synapse.cortex as s_cortex
 import synapse.daemon as s_daemon
@@ -892,6 +891,9 @@ class SynTest(unittest.IsolatedAsyncioTestCase):
         unittest.IsolatedAsyncioTestCase.__init__(self, *args, **kwargs)
         self._NextBuid = 0
         self._NextGuid = 0
+
+    async def asyncSetUp(self):
+        asyncio.get_running_loop().set_debug(False)
 
     def checkNode(self, node, expected):
         ex_ndef, ex_props = expected

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -887,23 +887,11 @@ class ReloadCell(s_cell.Cell):
 
         self.addReloadableSystem('badreload', func)
 
-class SynTest(unittest.TestCase):
-    '''
-    Mark all async test methods as s_glob.synchelp decorated.
-
-    Note:
-        This precludes running a single unit test via path using the unittest module.
-    '''
+class SynTest(unittest.IsolatedAsyncioTestCase):
     def __init__(self, *args, **kwargs):
-        unittest.TestCase.__init__(self, *args, **kwargs)
+        unittest.IsolatedAsyncioTestCase.__init__(self, *args, **kwargs)
         self._NextBuid = 0
         self._NextGuid = 0
-
-        for s in dir(self):
-            attr = getattr(self, s, None)
-            # If s is an instance method and starts with 'test_', synchelp wrap it
-            if inspect.iscoroutinefunction(attr) and s.startswith('test_') and inspect.ismethod(attr):
-                setattr(self, s, s_glob.synchelp(attr))
 
     def checkNode(self, node, expected):
         ex_ndef, ex_props = expected


### PR DESCRIPTION
Marked as WIP because SynTest adds synchelp to all test functions so now we need to do something else to make them run.