### PR TITLE
SYN-6925: null error when granting admin perms to a role on a vault

### DIFF
--- a/synapse/lib/stormlib/vault.py
+++ b/synapse/lib/stormlib/vault.py
@@ -279,7 +279,7 @@ stormcmds = (
             }
 
             if $cmdopts.role {
-                $iden = $lib.auth.roles.byname($cmdopts.user).iden
+                $iden = $lib.auth.roles.byname($cmdopts.role).iden
                 $type = "Role"
             } else {
                 $iden = $lib.auth.users.byname($cmdopts.user).iden

--- a/synapse/tests/test_lib_stormlib_vault.py
+++ b/synapse/tests/test_lib_stormlib_vault.py
@@ -397,21 +397,30 @@ class StormlibVaultTest(s_test.SynTest):
             self.true(core._hasEasyPerm(vault, visi1, s_cell.PERM_READ))
 
             rvault_out = split(f'''
-            Vault: rvault
+            Vault: {riden}
+              Name: rvault
               Type: {vtype}
               Scope: role
-              Iden: {riden}
               Permissions:
                 Users:
                   visi1: read
                 Roles:
                   contributor: read
+              Configs:
+                server: rvault
             ''')[1:]
 
             opts = {'vars': {'vtype': vtype}, 'user': visi1.iden}
             msgs = await core.stormlist('vault.list --type $vtype', opts=opts)
-            for line in uvault_out:
+            for line in rvault_out:
                 self.stormIsInPrint(line, msgs)
+
+            msgs = await core.stormlist('vault.set.perm rvault --level admin --role contributor')
+            self.stormHasNoWarnErr(msgs)
+            self.stormIsInPrint('Successfully set permissions on vault rvault.', msgs)
+
+            msgs = await core.stormlist('vault.list --type $vtype', opts=opts)
+            self.stormIsInPrint('contributor: admin', msgs)
 
             # vault.del
             msgs = await core.stormlist('vault.del uvault')


### PR DESCRIPTION
bugfix: Fixed an error in ``vault.set.perm`` where attempting to set role permissions on a vault would cause an error.