### PR TITLE
SYN-6209: $lib.regex.escape

### DIFF
--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3192,6 +3192,22 @@ class LibRegx(Lib):
                        'default': 0, },
                   ),
                   'returns': {'type': 'str', 'desc': 'The new string with matches replaced.', }}},
+        {'name': 'escape', 'desc': '''
+            Escape a string for use as a literal in a regular expression pattern.
+
+            Example:
+
+                Escape node values for use in a regex pattern::
+                    it:dev:mutex#rep.foo.bar
+                    for $match in $lib.regex.findall($lib.regex.escape($node.repr()), $mydocument) {
+                        // do something with $match
+                    }
+                    ''',
+         'type': {'type': 'function', '_funcname': 'escape',
+                  'args': (
+                      {'name': 'text', 'type': 'str', 'desc': 'The text to escape.', },
+                  ),
+                  'returns': {'type': 'str', 'desc': 'Input string with special characters escaped.', }}},
         {'name': 'flags.i', 'desc': 'Regex flag to indicate that case insensitive matches are allowed.',
          'type': 'int', },
         {'name': 'flags.m', 'desc': 'Regex flag to indicate that multiline matches are allowed.', 'type': 'int', },
@@ -3208,6 +3224,7 @@ class LibRegx(Lib):
             'matches': self.matches,
             'findall': self.findall,
             'replace': self.replace,
+            'escape': self.escape,
             'flags': {'i': regex.IGNORECASE,
                       'm': regex.MULTILINE,
                       },
@@ -3257,6 +3274,11 @@ class LibRegx(Lib):
         pattern = await tostr(pattern)
         regx = await self._getRegx(pattern, flags)
         return regx.findall(text)
+
+    @stormfunc(readonly=True)
+    async def escape(self, text):
+        text = await tostr(text)
+        return regex.escape(text)
 
 @registry.registerLib
 class LibCsv(Lib):

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3198,11 +3198,13 @@ class LibRegx(Lib):
             Example:
 
                 Escape node values for use in a regex pattern::
+
                     for $match in $lib.regex.findall($lib.regex.escape($node.repr()), $mydocument) {
                         // do something with $match
                     }
 
                 Escape node values for use in regular expression filters::
+
                     it:dev:str~=$lib.regex.escape($node.repr())
                     ''',
          'type': {'type': 'function', '_funcname': 'escape',

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3193,15 +3193,17 @@ class LibRegx(Lib):
                   ),
                   'returns': {'type': 'str', 'desc': 'The new string with matches replaced.', }}},
         {'name': 'escape', 'desc': '''
-            Escape a string for use in a regular expression pattern.
+            Escape arbitrary strings for use in a regular expression pattern.
 
             Example:
 
                 Escape node values for use in a regex pattern::
-                    it:dev:mutex#rep.foo.bar
                     for $match in $lib.regex.findall($lib.regex.escape($node.repr()), $mydocument) {
                         // do something with $match
                     }
+
+                Escape node values for use in regular expression filters::
+                    it:dev:str~=$lib.regex.escape($node.repr())
                     ''',
          'type': {'type': 'function', '_funcname': 'escape',
                   'args': (

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -3193,7 +3193,7 @@ class LibRegx(Lib):
                   ),
                   'returns': {'type': 'str', 'desc': 'The new string with matches replaced.', }}},
         {'name': 'escape', 'desc': '''
-            Escape a string for use as a literal in a regular expression pattern.
+            Escape a string for use in a regular expression pattern.
 
             Example:
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -1323,6 +1323,8 @@ class StormTypesTest(s_test.SynTest):
 
             self.eq('foo bar baz faz', await core.callStorm('return($lib.regex.replace("[ ]{2,}", " ", "foo  bar   baz faz"))'))
 
+            self.eq('foo\.bar\.baz', await core.callStorm('return($lib.regex.escape("foo.bar.baz"))'))
+
             self.eq(((1, 2, 3)), await core.callStorm('return(("[1, 2, 3]").json())'))
 
             with self.raises(s_exc.BadJsonText):

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -1324,6 +1324,7 @@ class StormTypesTest(s_test.SynTest):
             self.eq('foo bar baz faz', await core.callStorm('return($lib.regex.replace("[ ]{2,}", " ", "foo  bar   baz faz"))'))
 
             self.eq(r'foo\.bar\.baz', await core.callStorm('return($lib.regex.escape("foo.bar.baz"))'))
+            self.eq(r'foo\ bar\ baz', await core.callStorm('return($lib.regex.escape("foo bar baz"))'))
 
             self.eq(((1, 2, 3)), await core.callStorm('return(("[1, 2, 3]").json())'))
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -1323,7 +1323,7 @@ class StormTypesTest(s_test.SynTest):
 
             self.eq('foo bar baz faz', await core.callStorm('return($lib.regex.replace("[ ]{2,}", " ", "foo  bar   baz faz"))'))
 
-            self.eq('foo\.bar\.baz', await core.callStorm('return($lib.regex.escape("foo.bar.baz"))'))
+            self.eq(r'foo\.bar\.baz', await core.callStorm('return($lib.regex.escape("foo.bar.baz"))'))
 
             self.eq(((1, 2, 3)), await core.callStorm('return(("[1, 2, 3]").json())'))
 


### PR DESCRIPTION
feat: Added ``$lib.regex.escape()`` function to escape arbitrary strings for use as a regular expression pattern.