### PR TITLE
Clamp certdir cname and aha provisioning name values (SYN-6634)

### DIFF
--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -386,6 +386,9 @@ class EnrollApi:
             mesg = f'Invalid user CSR CN={name}.'
             raise s_exc.BadArg(mesg=mesg)
 
+        logger.info(f'Signing user CSR for [{username}], signas={ahanetw}',
+                   extra=await self.aha.getLogExtra(name=username, signas=ahanetw))
+
         pkey, cert = self.aha.certdir.signUserCsr(xcsr, ahanetw, save=False)
         return self.aha.certdir._certToByts(cert)
 
@@ -415,6 +418,9 @@ class ProvApi:
             mesg = f'Invalid host CSR CN={name}.'
             raise s_exc.BadArg(mesg=mesg)
 
+        logger.info(f'Signing host CSR for [{hostname}], signas={ahanetw}',
+                    extra=await self.aha.getLogExtra(name=hostname, signas=ahanetw))
+
         pkey, cert = self.aha.certdir.signHostCsr(xcsr, ahanetw, save=False)
         return self.aha.certdir._certToByts(cert)
 
@@ -430,6 +436,9 @@ class ProvApi:
         if name != username:
             mesg = f'Invalid user CSR CN={name}.'
             raise s_exc.BadArg(mesg=mesg)
+
+        logger.info(f'Signing user CSR for [{username}], signas={ahanetw}',
+                    extra=await self.aha.getLogExtra(name=username, signas=ahanetw))
 
         pkey, cert = self.aha.certdir.signUserCsr(xcsr, ahanetw, save=False)
         return self.aha.certdir._certToByts(cert)
@@ -1010,6 +1019,9 @@ class AhaCell(s_cell.Cell):
             mesg = 'The AHA server does not have a provision:listen URL!'
             raise s_exc.NeedConfValu(mesg=mesg)
 
+        if not name:
+            raise s_exc.BadArg(mesg='Empty name values are not allowed for provisioning.')
+
         if provinfo is None:
             provinfo = {}
 
@@ -1038,6 +1050,10 @@ class AhaCell(s_cell.Cell):
             raise s_exc.BadConfValu(mesg=mesg, name='aha:network', expected=mynetw, got=netw)
 
         hostname = f'{name}.{netw}'
+
+        if len(hostname) > 64:
+            mesg = f'Computed hostname value must not exceed 64 characters in length. {hostname=}, len={len(hostname)}'
+            raise s_exc.BadArg(mesg=mesg)
 
         conf.setdefault('aha:name', name)
         dmon_port = provinfo.get('dmon:port', 0)
@@ -1140,7 +1156,14 @@ class AhaCell(s_cell.Cell):
             mesg = 'AHA server requires aha:network configuration.'
             raise s_exc.NeedConfValu(mesg=mesg)
 
+        if not name:
+            raise s_exc.BadArg(mesg='Empty name values are not allowed for provisioning.')
+
         username = f'{name}@{ahanetw}'
+
+        if len(username) > 64:
+            mesg = f'Computed username value must not exceed 64 characters in length. username={username}, len={len(username)}'
+            raise s_exc.BadArg(mesg=mesg)
 
         user = await self.auth.getUserByName(username)
 

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -1052,7 +1052,7 @@ class AhaCell(s_cell.Cell):
         hostname = f'{name}.{netw}'
 
         if len(hostname) > 64:
-            mesg = f'Computed hostname value must not exceed 64 characters in length. {hostname=}, len={len(hostname)}'
+            mesg = f'Hostname value must not exceed 64 characters in length. {hostname=}, len={len(hostname)}'
             raise s_exc.BadArg(mesg=mesg)
 
         conf.setdefault('aha:name', name)
@@ -1162,7 +1162,7 @@ class AhaCell(s_cell.Cell):
         username = f'{name}@{ahanetw}'
 
         if len(username) > 64:
-            mesg = f'Computed username value must not exceed 64 characters in length. username={username}, len={len(username)}'
+            mesg = f'Username value must not exceed 64 characters in length. username={username}, len={len(username)}'
             raise s_exc.BadArg(mesg=mesg)
 
         user = await self.auth.getUserByName(username)

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -1501,6 +1501,11 @@ class CertDir:
         return c_rsa.generate_private_key(65537, self.crypto_numbits)
 
     def _genCertBuilder(self, name: str, pubkey: c_types.PublicKeyTypes) -> c_x509.CertificateBuilder:
+
+        if not 1 <= len(name) <= 64:
+            mesg = f'certificate name values must be between 1-64 characters. got name={name}, len={len(name)}'
+            raise s_exc.CryptoErr(mesg=mesg)
+
         builder = c_x509.CertificateBuilder()
         builder = builder.subject_name(c_x509.Name([
             c_x509.NameAttribute(c_x509.NameOID.COMMON_NAME, name),
@@ -1514,6 +1519,10 @@ class CertDir:
         return builder
 
     def _genPkeyCsr(self, name: str, mode: str, outp: OutPutOrNone = None) -> bytes:
+
+        if not 1 <= len(name) <= 64:
+            mesg = f'csr name values must be between 1-64 characters. got name={name}, len={len(name)}'
+            raise s_exc.CryptoErr(mesg=mesg)
 
         pkey = self._genPrivKey()
 

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -1503,7 +1503,7 @@ class CertDir:
     def _genCertBuilder(self, name: str, pubkey: c_types.PublicKeyTypes) -> c_x509.CertificateBuilder:
 
         if not 1 <= len(name) <= 64:
-            mesg = f'certificate name values must be between 1-64 characters. got name={name}, len={len(name)}'
+            mesg = f'Certificate name values must be between 1-64 characters. got name={name}, len={len(name)}'
             raise s_exc.CryptoErr(mesg=mesg)
 
         builder = c_x509.CertificateBuilder()
@@ -1521,7 +1521,7 @@ class CertDir:
     def _genPkeyCsr(self, name: str, mode: str, outp: OutPutOrNone = None) -> bytes:
 
         if not 1 <= len(name) <= 64:
-            mesg = f'csr name values must be between 1-64 characters. got name={name}, len={len(name)}'
+            mesg = f'CSR name values must be between 1-64 characters. got name={name}, len={len(name)}'
             raise s_exc.CryptoErr(mesg=mesg)
 
         pkey = self._genPrivKey()

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -1329,7 +1329,6 @@ class AhaTest(s_test.SynTest):
             with self.getTestDir() as dirn:
                 aha00dirn = s_common.gendir(dirn, 'aha00')
                 svc0dirn = s_common.gendir(dirn, 'svc00')
-                svc1dirn = s_common.gendir(dirn, 'svc01')
                 async with await s_base.Base.anit() as cm:
                     # Add enough space to allow aha CA bootstraping.
                     basenet = 'loop.vertex.link'
@@ -1392,3 +1391,19 @@ class AhaTest(s_test.SynTest):
                     with self.raises(s_exc.BadArg) as errcm:
                         await aha.addAhaUserEnroll('')
                     self.isin('Empty name values are not allowed for provisioning.', errcm.exception.get('mesg'))
+
+            # add an aha bootstrapping test failure
+            with self.getTestDir() as dirn:
+                aha00dirn = s_common.gendir(dirn, 'aha00')
+                async with await s_base.Base.anit() as cm:
+                    # Make the network too long that we cannot bootstrap the CA
+                    basenet = 'loop.vertex.link'
+                    networkname = f'{"x" * (64 - len(basenet))}.{basenet}'
+                    aconf = {
+                        'aha:name': 'aha',
+                        'aha:network': networkname,
+                        'provision:listen': f'ssl://aha.{networkname}:0'
+                    }
+                    with self.raises(s_exc.CryptoErr) as errcm:
+                        await s_aha.AhaCell.anit(aha00dirn, conf=aconf)
+                    self.isin('certificate name values must be between 1-64 characters', errcm.exception.get('mesg'))

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -1355,7 +1355,7 @@ class AhaTest(s_test.SynTest):
 
                     with self.raises(s_exc.BadArg) as errcm:
                         await aha.addAhaSvcProv('00.svc', provinfo=None)
-                    self.isin('Computed hostname value must not exceed 64 characters in length.',
+                    self.isin('Hostname value must not exceed 64 characters in length.',
                               errcm.exception.get('mesg'))
                     self.isin('len=65', errcm.exception.get('mesg'))
 
@@ -1369,7 +1369,7 @@ class AhaTest(s_test.SynTest):
                     # Cannot generate a user cert that would be a problem for signing
                     with self.raises(s_exc.BadArg) as errcm:
                         await aha.addAhaUserEnroll('ruhroh')
-                    self.isin('Computed username value must not exceed 64 characters in length.',
+                    self.isin('Username value must not exceed 64 characters in length.',
                               errcm.exception.get('mesg'))
                     self.isin('len=65', errcm.exception.get('mesg'))
 
@@ -1406,4 +1406,4 @@ class AhaTest(s_test.SynTest):
                     }
                     with self.raises(s_exc.CryptoErr) as errcm:
                         await s_aha.AhaCell.anit(aha00dirn, conf=aconf)
-                    self.isin('certificate name values must be between 1-64 characters', errcm.exception.get('mesg'))
+                    self.isin('Certificate name values must be between 1-64 characters', errcm.exception.get('mesg'))

--- a/synapse/tests/test_lib_certdir.py
+++ b/synapse/tests/test_lib_certdir.py
@@ -340,6 +340,22 @@ class CertDirTest(s_t_utils.SynTest):
             inter_cakey = cdir.getCaKey(inter_name)
             self.basic_assertions(cdir, inter_cacert, inter_cakey, cacert=cacert)
 
+            # Per RFC5280 common-name has a length of 1 to 64 characters
+            # https://datatracker.ietf.org/doc/html/rfc5280#appendix-A.1
+            c64 = 'V' * 64
+            cakey64, cacert64 = cdir.genCaCert(c64)
+            self.basic_assertions(cdir, cacert64, cakey64)
+
+            c1 = 'V' * 1
+            cakey1, cacert1 = cdir.genCaCert(c1)
+            self.basic_assertions(cdir, cacert1, cakey1)
+
+            with self.raises(s_exc.CryptoErr) as cm:
+                cdir.genCaCert('V' * 65)
+
+            with self.raises(s_exc.CryptoErr) as cm:
+                cdir.genCaCert('')
+
     def test_certdir_hosts(self):
         with self.getCertDir() as cdir:
             caname = 'syntest'
@@ -557,6 +573,14 @@ class CertDirTest(s_t_utils.SynTest):
             key = cdir.getHostKey(hostname)
             self.basic_assertions(cdir, cert, key, cacert=cacert)
 
+            # Per RFC5280 common-name has a length of 1 to 64 characters
+            # Do not generate CSRs which exceed that name range.
+            with self.raises(s_exc.CryptoErr) as cm:
+                cdir.genHostCsr('V' * 65)
+
+            with self.raises(s_exc.CryptoErr) as cm:
+                cdir.genHostCsr('')
+
     def test_certdir_users_csr(self):
         with self.getCertDir() as cdir:
             caname = 'syntest'
@@ -579,6 +603,14 @@ class CertDirTest(s_t_utils.SynTest):
             cert = cdir.getUserCert(username)
             key = cdir.getUserKey(username)
             self.basic_assertions(cdir, cert, key, cacert=cacert)
+
+            # Per RFC5280 common-name has a length of 1 to 64 characters
+            # Do not generate CSRs which exceed that name range.
+            with self.raises(s_exc.CryptoErr) as cm:
+                cdir.genUserCsr('V' * 65)
+
+            with self.raises(s_exc.CryptoErr) as cm:
+                cdir.genUserCsr('')
 
     def test_certdir_importfile(self):
         with self.getCertDir() as cdir:


### PR DESCRIPTION
- Ensure that we do not generate CSRs or make certificates with potentially invalid X509 Common Name length strings.
- Update AHA to prevent creating invalid provisioning requests.