### PR TITLE
Bug: Node property set / deletion permissions precedence order issue (SYN-7038, SYN-7077)

### DIFF
--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -116,6 +116,9 @@ class Prop:
             self.setperms.append(('node', 'prop', 'set', form.name, self.name))
             self.delperms.append(('node', 'prop', 'del', form.name, self.name))
 
+        self.setperms.reverse()  # Make them in precedence order
+        self.delperms.reverse()  # Make them in precedence order
+
         self.form = form
         self.type = None
         self.typedef = typedef

--- a/synapse/lib/hiveauth.py
+++ b/synapse/lib/hiveauth.py
@@ -44,8 +44,6 @@ def formatAllowedReason(resp):
 
     if meta.get('islocked'):
         return 'The user is locked.'
-    if meta.get('default'):
-        return 'No matching rule found.'
 
     isgate = meta.get('isgate')
     isadmin = meta.get('isadmin')

--- a/synapse/lib/hiveauth.py
+++ b/synapse/lib/hiveauth.py
@@ -38,6 +38,42 @@ def textFromRule(rule):
         text = '!' + text
     return text
 
+def formatAllowedReason(resp):
+    '''Format a string response for the HiveUser.getAllowedReason API response.'''
+    (allow, meta) = resp
+
+    if meta.get('islocked'):
+        return 'The user is locked.'
+    if meta.get('default'):
+        return 'No matching rule found.'
+
+    isgate = meta.get('isgate')
+    isadmin = meta.get('isadmin')
+    isrole = meta.get('isrole')
+    rname = meta.get('rolename')
+    gateiden = meta.get('gateiden')
+    rule = meta.get('rule')
+
+    if isadmin:
+        if isgate:
+            return f'The user is an admin of auth gate {gateiden}.'
+        return 'The user is a global admin.'
+
+    if rule:
+        if isgate:
+            if isrole:
+                m = f'Matched role rule ({textFromRule((allow, rule))}) for role {rname} on gate {gateiden}.'
+            else:
+                m = f'Matched user rule ({textFromRule((allow, rule))}) on gate {gateiden}.'
+        else:
+            if isrole:
+                m = f'Matched role rule ({textFromRule((allow, rule))}) for role {rname}.'
+            else:
+                m = f'Matched user rule ({textFromRule((allow, rule))}).'
+        return m
+
+    return 'No matching rule found.'
+
 class Auth(s_nexus.Pusher):
     '''
     Auth is a user authentication and authorization stored in a Hive.  Users
@@ -858,6 +894,7 @@ class HiveUser(HiveRuler):
         self.vars = await varz.dict(nexs=True)
 
         self.permcache = s_cache.FixedCache(self._allowed)
+        self.allowedcache = s_cache.FixedCache(self._getAllowedReason)
 
     def pack(self, packroles=False):
 
@@ -903,6 +940,9 @@ class HiveUser(HiveRuler):
         return self.permcache.get((perm, default, gateiden))
 
     def _allowed(self, pkey):
+        '''
+        NOTE: This must remain in sync with any changes to _getAllowedReason()!
+        '''
 
         perm, default, gateiden = pkey
 
@@ -951,18 +991,23 @@ class HiveUser(HiveRuler):
 
         return default
 
-    def getAllowedReason(self, perm, gateiden=None, default=False):
+    def getAllowedReason(self, perm, default=None, gateiden=None):
         '''
-        A non-optimized diagnostic routine which will return a tuple
-        of (allowed, reason). This is implemented separately for perf.
+        A routine which will return a tuple of (allowed, info).
+        '''
+        perm = tuple(perm)
+        return self.allowedcache.get((perm, default, gateiden))
 
+    def _getAllowedReason(self, pkey):
+        '''
         NOTE: This must remain in sync with any changes to _allowed()!
         '''
+        perm, default, gateiden = pkey
         if self.info.get('locked'):
-            return (False, 'The user is locked.')
+            return (False, {'islocked': True})
 
         if self.info.get('admin'):
-            return (True, 'The user is a global admin.')
+            return (True, {'isadmin': True})
 
         # 1. check authgate user rules
         if gateiden is not None:
@@ -971,16 +1016,16 @@ class HiveUser(HiveRuler):
             if info is not None:
 
                 if info.get('admin'):
-                    return (True, f'The user is an admin of auth gate {gateiden}.')
+                    return (True, {'isadmin': True, 'isgate': True, 'gateiden': gateiden})
 
                 for allow, path in info.get('rules', ()):
                     if perm[:len(path)] == path:
-                        return (allow, f'Matched user rule ({textFromRule((allow, path))}) on gate {gateiden}.')
+                        return (allow, {'rule': path, 'isgate': True, 'gateiden': gateiden})
 
         # 2. check user rules
         for allow, path in self.info.get('rules', ()):
             if perm[:len(path)] == path:
-                return (allow, f'Matched user rule ({textFromRule((allow, path))}).')
+                return (allow, {'rule': path})
 
         # 3. check authgate role rules
         if gateiden is not None:
@@ -993,18 +1038,20 @@ class HiveUser(HiveRuler):
 
                 for allow, path in info.get('rules', ()):
                     if perm[:len(path)] == path:
-                        return (allow, f'Matched role rule ({textFromRule((allow, path))}) for role {role.name} on gate {gateiden}.')
+                        return (allow, {'rule': path, 'isgate': True, 'isrole': True, 'rolename': role.name,
+                                        'gateiden': gateiden})
 
         # 4. check role rules
         for role in self.getRoles():
             for allow, path in role.info.get('rules', ()):
                 if perm[:len(path)] == path:
-                    return (allow, f'Matched role rule ({textFromRule((allow, path))}) for role {role.name}.')
+                    return (allow, {'rule': path, 'isrole': True, 'rolename': role.name})
 
-        return (default, 'No matching rule found.')
+        return (default, {'default': True})
 
     def clearAuthCache(self):
         self.permcache.clear()
+        self.allowedcache.clear()
 
     async def genGateInfo(self, gateiden):
         info = self.authgates.get(gateiden)

--- a/synapse/lib/hiveauth.py
+++ b/synapse/lib/hiveauth.py
@@ -45,26 +45,25 @@ def formatAllowedReason(resp):
     if meta.get('islocked'):
         return 'The user is locked.'
 
-    isgate = meta.get('isgate')
     isadmin = meta.get('isadmin')
-    isrole = meta.get('isrole')
+    roleiden = meta.get('roleiden')
     rname = meta.get('rolename')
     gateiden = meta.get('gateiden')
     rule = meta.get('rule')
 
     if isadmin:
-        if isgate:
+        if gateiden:
             return f'The user is an admin of auth gate {gateiden}.'
         return 'The user is a global admin.'
 
     if rule:
-        if isgate:
-            if isrole:
+        if gateiden:
+            if roleiden:
                 m = f'Matched role rule ({textFromRule((allow, rule))}) for role {rname} on gate {gateiden}.'
             else:
                 m = f'Matched user rule ({textFromRule((allow, rule))}) on gate {gateiden}.'
         else:
-            if isrole:
+            if roleiden:
                 m = f'Matched role rule ({textFromRule((allow, rule))}) for role {rname}.'
             else:
                 m = f'Matched user rule ({textFromRule((allow, rule))}).'
@@ -1014,11 +1013,11 @@ class HiveUser(HiveRuler):
             if info is not None:
 
                 if info.get('admin'):
-                    return (True, {'isadmin': True, 'isgate': True, 'gateiden': gateiden})
+                    return (True, {'isadmin': True, 'gateiden': gateiden})
 
                 for allow, path in info.get('rules', ()):
                     if perm[:len(path)] == path:
-                        return (allow, {'rule': path, 'isgate': True, 'gateiden': gateiden})
+                        return (allow, {'rule': path, 'gateiden': gateiden})
 
         # 2. check user rules
         for allow, path in self.info.get('rules', ()):
@@ -1036,14 +1035,14 @@ class HiveUser(HiveRuler):
 
                 for allow, path in info.get('rules', ()):
                     if perm[:len(path)] == path:
-                        return (allow, {'rule': path, 'isgate': True, 'isrole': True, 'rolename': role.name,
+                        return (allow, {'rule': path, 'roleiden': role.iden, 'rolename': role.name,
                                         'gateiden': gateiden})
 
         # 4. check role rules
         for role in self.getRoles():
             for allow, path in role.info.get('rules', ()):
                 if perm[:len(path)] == path:
-                    return (allow, {'rule': path, 'isrole': True, 'rolename': role.name})
+                    return (allow, {'rule': path, 'roleiden': role.iden, 'rolename': role.name})
 
         return (default, {'default': True})
 

--- a/synapse/lib/hiveauth.py
+++ b/synapse/lib/hiveauth.py
@@ -827,7 +827,7 @@ class HiveRole(HiveRuler):
                         return allow
             return default
 
-        # 2. check user rules
+        # 2. check role rules
         for allow, path in self.info.get('rules', ()):
             if perm[:len(path)] == path:
                 return allow

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2213,12 +2213,12 @@ class Runtime(s_base.Base):
         # XXX FIXME Make this a strong assertion in the datamodel unit tests for <3.0.0
         assert len(prop.setperms) == 2, f'Invalid number of property perms for {prop.full}'
 
-        allowed0, meta0 = self.allowedReason(prop.setperms[0], gateiden=self.snap.wlyr.iden)
+        allowed0, meta0 = self.allowedReason(prop.setperms[0], gateiden=layriden)
 
         if meta0.get('isadmin'):
             return
 
-        allowed1, meta1 = self.allowedReason(prop.setperms[1], gateiden=self.snap.wlyr.iden)
+        allowed1, meta1 = self.allowedReason(prop.setperms[1], gateiden=layriden)
 
         if allowed0 and allowed1:
             return
@@ -2246,12 +2246,15 @@ class Runtime(s_base.Base):
         # XXX FIXME Make this a strong assertion in the datamodel unit tests for <3.0.0
         assert len(prop.setperms) == 2, f'Invalid number of property perms for {prop.full}'
 
-        allowed0, meta0 = self.allowedReason(prop.delperms[0], gateiden=self.snap.wlyr.iden)
+        if layriden is None:
+            layriden = self.snap.wlyr.iden
+
+        allowed0, meta0 = self.allowedReason(prop.delperms[0], gateiden=layriden)
 
         if meta0.get('isadmin'):
             return
 
-        allowed1, meta1 = self.allowedReason(prop.delperms[1], gateiden=self.snap.wlyr.iden)
+        allowed1, meta1 = self.allowedReason(prop.delperms[1], gateiden=layriden)
 
         if allowed0 and allowed1:
             return

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2187,6 +2187,22 @@ class Runtime(s_base.Base):
 
         return self.user.allowed(perms, gateiden=gateiden, default=default)
 
+    def allowedRaw(self, perms, gateiden=None, default=None):
+        '''
+        Similar to allowed, but always prefer the default value specified by the caller.
+        Default values are still pulled from permdefs if there is a match there; but still prefer caller default.
+        This results in a ternary response that can be used to know if a rule had a positive/negative or no match.
+        '''
+        if self.asroot:
+            return True
+
+        if default is None:
+            permdef = self.snap.core.getPermDef(perms)
+            if permdef:
+                default = permdef.get('default', default)
+
+        return self.user.allowed(perms, gateiden=gateiden, default=default)
+
     def allowedReason(self, perms, gateiden=None, default=None):
         '''
         Get the allowed value and the reason a permission is allowed or not.
@@ -2223,19 +2239,12 @@ class Runtime(s_base.Base):
         # XXX FIXME Make this a strong assertion in the datamodel unit tests for <3.0.0
         assert len(prop.setperms) == 2, f'Invalid number of property perms for {prop.full}'
 
-        allowed0, reason0 = self.allowedReason(prop.setperms[0], gateiden=self.snap.wlyr.iden)
-
-        # Admin / locked - succeed or fail
-        if reason0.get('isadmin'):
+        allowed0 = self.allowedRaw(prop.setperms[0], gateiden=self.snap.wlyr.iden)
+        if allowed0:
             return
 
-        if reason0.get('islocked'):
-            raise s_exc.AuthDeny(mesg=f'User ({self.user.name}) is locked.', user=self.user.iden,
-                                 username=self.user.name)
-
-        allowed1, reason1 = self.allowedReason(prop.setperms[1], gateiden=self.snap.wlyr.iden)
-
-        if allowed0 or (allowed0, allowed1) == (None, True):
+        allowed1 = self.allowedRaw(prop.setperms[1], gateiden=self.snap.wlyr.iden)
+        if (allowed0, allowed1) == (None, True):
             return
 
         self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2226,7 +2226,7 @@ class Runtime(s_base.Base):
                 self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
             return
 
-        if (allowed0, allowed1) == (None, True):
+        if allowed0 is None and allowed1 is True:
             return
 
         self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
@@ -2253,7 +2253,7 @@ class Runtime(s_base.Base):
                 self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
             return
 
-        if (allowed0, allowed1) == (None, True):
+        if allowed0 is None and allowed1 is True:
             return
 
         self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2220,14 +2220,20 @@ class Runtime(s_base.Base):
             if allowed1:
                 return
             elif allowed1 is False:
+                # This is a allow-with-precedence case.
                 # Inspect meta to determine if the rule a0 is more specific than rule a1
                 if len(meta0.get('rule')) >= len(meta1.get('rule')):
                     return
                 self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
             return
 
-        if allowed0 is None and allowed1 is True:
-            return
+        if allowed1:
+            if allowed0 is None:
+                return
+            # allowed0 here is False. This is a deny-with-precedence case.
+            # Inspect meta to determine if the rule a1 is more specific than rule a0
+            if len(meta1.get('rule')) > len(meta0.get('rule')):
+                return
 
         self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
 
@@ -2247,14 +2253,20 @@ class Runtime(s_base.Base):
             if allowed1:
                 return
             elif allowed1 is False:
+                # This is a allow-with-precedence case.
                 # Inspect meta to determine if the rule a0 is more specific than rule a1
                 if len(meta0.get('rule')) >= len(meta1.get('rule')):
                     return
                 self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
             return
 
-        if allowed0 is None and allowed1 is True:
-            return
+        if allowed1:
+            if allowed0 is None:
+                return
+            # allowed1 here is False. This is a deny-with-precedence case.
+            # Inspect meta to determine if the rule a1 is more specific than rule a0
+            if len(meta1.get('rule')) > len(meta0.get('rule')):
+                return
 
         self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2209,10 +2209,6 @@ class Runtime(s_base.Base):
         if layriden is None:
             layriden = self.snap.wlyr.iden
 
-        # TODO - This entire construct simplifies in 3.0.0+ when we remove the old style prop set permission.
-        # XXX FIXME Make this a strong assertion in the datamodel unit tests for <3.0.0
-        assert len(prop.setperms) == 2, f'Invalid number of property perms for {prop.full}'
-
         allowed0, meta0 = self.allowedReason(prop.setperms[0], gateiden=layriden)
 
         if meta0.get('isadmin'):
@@ -2220,31 +2216,22 @@ class Runtime(s_base.Base):
 
         allowed1, meta1 = self.allowedReason(prop.setperms[1], gateiden=layriden)
 
-        if allowed0 and allowed1:
+        if allowed0:
+            if allowed1:
+                return
+            elif allowed1 is False:
+                # Inspect meta to determine if the rule a0 is more specific than rule a1
+                if len(meta0.get('rule')) >= len(meta1.get('rule')):
+                    return
+                self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
             return
-
-        if not allowed0 and not allowed1:
-            self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
 
         if (allowed0, allowed1) == (None, True):
-            return
-
-        if (allowed0, allowed1) == (True, False):
-            # Inspect meta to determine if the rule a0 is more specific than rule a1
-            if len(meta0.get('rule')) >= len(meta1.get('rule')):
-                return
-            self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
-
-        if allowed0:
             return
 
         self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
 
     def confirmPropDel(self, prop, layriden=None):
-
-        # TODO - This entire construct simplifies in 3.0.0+ when we remove the old style prop set permission.
-        # XXX FIXME Make this a strong assertion in the datamodel unit tests for <3.0.0
-        assert len(prop.setperms) == 2, f'Invalid number of property perms for {prop.full}'
 
         if layriden is None:
             layriden = self.snap.wlyr.iden
@@ -2256,22 +2243,17 @@ class Runtime(s_base.Base):
 
         allowed1, meta1 = self.allowedReason(prop.delperms[1], gateiden=layriden)
 
-        if allowed0 and allowed1:
+        if allowed0:
+            if allowed1:
+                return
+            elif allowed1 is False:
+                # Inspect meta to determine if the rule a0 is more specific than rule a1
+                if len(meta0.get('rule')) >= len(meta1.get('rule')):
+                    return
+                self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
             return
-
-        if not allowed0 and not allowed1:
-            self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
 
         if (allowed0, allowed1) == (None, True):
-            return
-
-        if (allowed0, allowed1) == (True, False):
-            # Inspect meta to determine if the rule a0 is more specific than rule a1
-            if len(meta0.get('rule')) >= len(meta1.get('rule')):
-                return
-            self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
-
-        if allowed0:
             return
 
         self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2179,8 +2179,6 @@ class Runtime(s_base.Base):
             return True
 
         if default is None:
-            default = False
-
             permdef = self.snap.core.getPermDef(perms)
             if permdef:
                 default = permdef.get('default', False)
@@ -2192,20 +2190,28 @@ class Runtime(s_base.Base):
         if layriden is None:
             layriden = self.snap.wlyr.iden
 
-        if any(self.allowed(perm, gateiden=self.snap.wlyr.iden) for perm in prop.setperms):
+        allowed0 = self.allowed(prop.setperms[0], gateiden=self.snap.wlyr.iden)
+        if allowed0:
+            for perm in prop.setperms[1:]:
+                if self.allowed(perm, gateiden=self.snap.wlyr.iden) is False:  # Something has denied this rule.
+                    self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
             return
 
-        self.user.raisePermDeny(prop.setperms[-1], gateiden=layriden)
+        self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
 
     def confirmPropDel(self, prop, layriden=None):
 
         if layriden is None:
             layriden = self.snap.wlyr.iden
 
-        if any(self.allowed(perm, gateiden=self.snap.wlyr.iden) for perm in prop.delperms):
+        allowed0 = self.allowed(prop.delperms[0], gateiden=self.snap.wlyr.iden)
+        if allowed0:
+            for perm in prop.delperms[1:]:
+                if self.allowed(perm, gateiden=self.snap.wlyr.iden) is False:
+                    self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
             return
 
-        self.user.raisePermDeny(prop.delperms[-1], gateiden=layriden)
+        self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
 
     def confirmEasyPerm(self, item, perm, mesg=None):
         if not self.asroot:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2179,39 +2179,46 @@ class Runtime(s_base.Base):
             return True
 
         if default is None:
+            default = False
+
             permdef = self.snap.core.getPermDef(perms)
             if permdef:
                 default = permdef.get('default', False)
 
         return self.user.allowed(perms, gateiden=gateiden, default=default)
 
+    def allowedReason(self, perms, gateiden=None, default=None):
+        if self.asroot:
+            return True, {'isadmin': True}
+
+        if default is None:
+            default = False
+
+            permdef = self.snap.core.getPermDef(perms)
+            if permdef:
+                default = permdef.get('default', False)
+
+        return self.user.getAllowedReason(perms, gateiden=gateiden, default=default)
+
     def confirmPropSet(self, prop, layriden=None):
 
         if layriden is None:
             layriden = self.snap.wlyr.iden
 
-        allowed0 = self.allowed(prop.setperms[0], gateiden=self.snap.wlyr.iden)
-        if allowed0:
-            for perm in prop.setperms[1:]:
-                if self.allowed(perm, gateiden=self.snap.wlyr.iden) is False:  # Something has denied this rule.
-                    self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
+        if any(self.allowed(perm, gateiden=self.snap.wlyr.iden) for perm in prop.setperms):
             return
 
-        self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
+        self.user.raisePermDeny(prop.setperms[-1], gateiden=layriden)
 
     def confirmPropDel(self, prop, layriden=None):
 
         if layriden is None:
             layriden = self.snap.wlyr.iden
 
-        allowed0 = self.allowed(prop.delperms[0], gateiden=self.snap.wlyr.iden)
-        if allowed0:
-            for perm in prop.delperms[1:]:
-                if self.allowed(perm, gateiden=self.snap.wlyr.iden) is False:
-                    self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
+        if any(self.allowed(perm, gateiden=self.snap.wlyr.iden) for perm in prop.delperms):
             return
 
-        self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
+        self.user.raisePermDeny(prop.delperms[-1], gateiden=layriden)
 
     def confirmEasyPerm(self, item, perm, mesg=None):
         if not self.asroot:

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2230,11 +2230,10 @@ class Runtime(s_base.Base):
             return
 
         if (allowed0, allowed1) == (True, False):
-            # Inspect meta to determine if the rule a1 is more specific than rule a0
-            if len(meta1.get('rule')) > len(meta0.get('rule')):
-                # R1 deny was more specific than R0 allow
-                self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
-            return
+            # Inspect meta to determine if the rule a0 is more specific than rule a1
+            if len(meta0.get('rule')) >= len(meta1.get('rule')):
+                return
+            self.user.raisePermDeny(prop.setperms[0], gateiden=layriden)
 
         if allowed0:
             return
@@ -2264,11 +2263,10 @@ class Runtime(s_base.Base):
             return
 
         if (allowed0, allowed1) == (True, False):
-            # Inspect meta to determine if the rule a1 is more specific than rule a0
-            if len(meta1.get('rule')) > len(meta0.get('rule')):
-                # R1 deny was more specific than R0 allow
-                self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
-            return
+            # Inspect meta to determine if the rule a0 is more specific than rule a1
+            if len(meta0.get('rule')) >= len(meta1.get('rule')):
+                return
+            self.user.raisePermDeny(prop.delperms[0], gateiden=layriden)
 
         if allowed0:
             return

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2187,22 +2187,6 @@ class Runtime(s_base.Base):
 
         return self.user.allowed(perms, gateiden=gateiden, default=default)
 
-    def allowedRaw(self, perms, gateiden=None, default=None):
-        '''
-        Similar to allowed, but always prefer the default value specified by the caller.
-        Default values are still pulled from permdefs if there is a match there; but still prefer caller default.
-        This results in a ternary response that can be used to know if a rule had a positive/negative or no match.
-        '''
-        if self.asroot:
-            return True
-
-        if default is None:
-            permdef = self.snap.core.getPermDef(perms)
-            if permdef:
-                default = permdef.get('default', default)
-
-        return self.user.allowed(perms, gateiden=gateiden, default=default)
-
     def allowedReason(self, perms, gateiden=None, default=None):
         '''
         Similar to allowed, but always prefer the default value specified by the caller.

--- a/synapse/lib/stormlib/auth.py
+++ b/synapse/lib/stormlib/auth.py
@@ -4,7 +4,6 @@ import asyncio
 import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.lib.stormtypes as s_stormtypes
-import synapse.lib.hiveauth as s_hiveauth
 
 stormcmds = (
     {
@@ -1194,8 +1193,7 @@ class User(s_stormtypes.Prim):
         perm = tuple(permname.split('.'))
         user = await self.runt.snap.core.auth.reqUser(self.valu)
         reason = user.getAllowedReason(perm, gateiden=gateiden, default=default)
-        mesg = s_hiveauth.formatAllowedReason(reason)
-        return reason[0], mesg
+        return reason.value, reason.mesg
 
     async def _methUserGrant(self, iden, indx=None):
         self.runt.confirm(('auth', 'user', 'grant'))

--- a/synapse/lib/stormlib/auth.py
+++ b/synapse/lib/stormlib/auth.py
@@ -4,7 +4,6 @@ import asyncio
 import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.lib.stormtypes as s_stormtypes
-import synapse.lib.hiveauth as s_hiveauth
 
 stormcmds = (
     {
@@ -1193,9 +1192,7 @@ class User(s_stormtypes.Prim):
 
         perm = tuple(permname.split('.'))
         user = await self.runt.snap.core.auth.reqUser(self.valu)
-        reason = user.getAllowedReason(perm, gateiden=gateiden, default=default)
-        mesg = s_hiveauth.formatAllowedReason(reason)
-        return reason[0], mesg
+        return user.getAllowedReason(perm, gateiden=gateiden, default=default)
 
     async def _methUserGrant(self, iden, indx=None):
         self.runt.confirm(('auth', 'user', 'grant'))

--- a/synapse/lib/stormlib/auth.py
+++ b/synapse/lib/stormlib/auth.py
@@ -4,6 +4,7 @@ import asyncio
 import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.lib.stormtypes as s_stormtypes
+import synapse.lib.hiveauth as s_hiveauth
 
 stormcmds = (
     {
@@ -1192,7 +1193,9 @@ class User(s_stormtypes.Prim):
 
         perm = tuple(permname.split('.'))
         user = await self.runt.snap.core.auth.reqUser(self.valu)
-        return user.getAllowedReason(perm, gateiden=gateiden, default=default)
+        reason = user.getAllowedReason(perm, gateiden=gateiden, default=default)
+        mesg = s_hiveauth.formatAllowedReason(reason)
+        return reason[0], mesg
 
     async def _methUserGrant(self, iden, indx=None):
         self.runt.confirm(('auth', 'user', 'grant'))

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3605,7 +3605,7 @@ class AstTest(s_test.SynTest):
         # True  True    Allow
         # True  False   Allow with precedence
         # False None    Deny
-        # False True    Deny with precdence
+        # False True    Deny with precedence
         # False False   Deny
 
         async with self.getTestCore() as core:  # type: s_cortex.Cortex

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3579,3 +3579,52 @@ class AstTest(s_test.SynTest):
             self.stormHasNoWarnErr(msgs)
 
             self.len(1, await core.nodes('inet:ipv4=1.2.3.4 [ -:asn ]', opts={'user': visi}))
+
+        # Negative permission tests
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news.published"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser node')
+            aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) .seen=2020 :published=2020]'
+            msgs = await core.stormlist(q, opts=aslow)
+            for m in msgs:
+                print(m)
+            self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
+
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news.published"')
+            await core.callStorm('auth.user.addrule lowuser node')
+            aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) .seen=2021 :published=2021]'
+            msgs = await core.stormlist(q, opts=aslow)
+            for m in msgs:
+                print(m)
+            self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
+
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news.published"')
+            await core.callStorm('auth.user.addrule lowuser node')
+            aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) .seen=2022 :published=2022]'
+            msgs = await core.stormlist(q, opts=aslow)
+            for m in msgs:
+                print(m)
+            self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
+
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+
+            await core.callStorm('auth.user.addrule lowuser node')
+            aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) .seen=2023 :published=2023]'
+            msgs = await core.stormlist(q, opts=aslow)
+            for m in msgs:
+                print(m)
+            self.stormHasNoErr(msgs)

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3608,6 +3608,9 @@ class AstTest(s_test.SynTest):
         # False True    Deny with precedence
         # False False   Deny
 
+        # These tests assume that only positive permissions are present to grant node.add / node.prop.set
+        # and then denies on node.prop.set.
+
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             q = '[media:news=* :published=2020]'
 
@@ -3620,8 +3623,6 @@ class AstTest(s_test.SynTest):
             aslow = {'user': unfo.get('iden')}
 
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
             # test 1
@@ -3633,8 +3634,6 @@ class AstTest(s_test.SynTest):
             await core.callStorm('auth.user.addrule $name node.add', opts=opts)
             aslow = {'user': unfo.get('iden')}
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormHasNoErr(msgs)
 
             # test 2
@@ -3646,8 +3645,6 @@ class AstTest(s_test.SynTest):
             await core.callStorm('auth.user.addrule $name node.add', opts=opts)
             aslow = {'user': unfo.get('iden')}
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
             # test 3
@@ -3659,8 +3656,6 @@ class AstTest(s_test.SynTest):
             await core.callStorm('auth.user.addrule $name node.add', opts=opts)
             aslow = {'user': unfo.get('iden')}
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormHasNoWarnErr(msgs)
 
             # test 4
@@ -3673,8 +3668,6 @@ class AstTest(s_test.SynTest):
             await core.callStorm('auth.user.addrule $name node.add', opts=opts)
             aslow = {'user': unfo.get('iden')}
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormHasNoWarnErr(msgs)
 
             # test 5
@@ -3687,8 +3680,6 @@ class AstTest(s_test.SynTest):
             await core.callStorm('auth.user.addrule $name node.add', opts=opts)
             aslow = {'user': unfo.get('iden')}
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormHasNoWarnErr(msgs)
 
             # test 6
@@ -3700,8 +3691,6 @@ class AstTest(s_test.SynTest):
             await core.callStorm('auth.user.addrule $name node.add', opts=opts)
             aslow = {'user': unfo.get('iden')}
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
             # test 7
@@ -3714,8 +3703,6 @@ class AstTest(s_test.SynTest):
             await core.callStorm('auth.user.addrule $name node.add', opts=opts)
             aslow = {'user': unfo.get('iden')}
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
             # test 8
@@ -3724,15 +3711,16 @@ class AstTest(s_test.SynTest):
             unfo = await core.addUser(name)
             opts = {'vars': {'name': name}}
             await core.callStorm('auth.user.addrule $name "!node.prop.set.media:news.published"', opts=opts)
-            await core.callStorm('auth.user.addrule $name "node.prop.set.media:news:published"', opts=opts)
+            await core.callStorm('auth.user.addrule $name "!node.prop.set.media:news:published"', opts=opts)
             await core.callStorm('auth.user.addrule $name node.add', opts=opts)
             aslow = {'user': unfo.get('iden')}
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
         # Negative permission tests
+        # These tests confirm the behavior when a deny rule is used to deny the permission
+        # but may still have a underlying allow rule present.
+
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
 
@@ -3761,7 +3749,7 @@ class AstTest(s_test.SynTest):
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
 
-            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news.published"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
             await core.callStorm('auth.user.addrule lowuser node')
             aslow = {'user': unfo.get('iden')}
             q = '[media:news=(m0,) .seen=2022 :published=2022]'

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3749,7 +3749,7 @@ class AstTest(s_test.SynTest):
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
 
-            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news.published"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
             await core.callStorm('auth.user.addrule lowuser node')
             aslow = {'user': unfo.get('iden')}
             q = '[media:news=(m0,) .seen=2022 :published=2022]'

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3661,7 +3661,7 @@ class AstTest(s_test.SynTest):
 
             unfo = await core.addUser('lowuser')
 
-            await core.callStorm('auth.user.addrule lowuser "!!node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
             await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news.published"')
 
             await core.callStorm('auth.user.addrule lowuser node')

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3730,8 +3730,6 @@ class AstTest(s_test.SynTest):
             aslow = {'user': unfo.get('iden')}
             q = '[media:news=(m0,) .seen=2020 :published=2020]'
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
@@ -3742,8 +3740,6 @@ class AstTest(s_test.SynTest):
             aslow = {'user': unfo.get('iden')}
             q = '[media:news=(m0,) .seen=2021 :published=2021]'
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
@@ -3754,9 +3750,40 @@ class AstTest(s_test.SynTest):
             aslow = {'user': unfo.get('iden')}
             q = '[media:news=(m0,) .seen=2022 :published=2022]'
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
+
+        # This is a horribly legal mix :(
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser node.prop.set')
+            await core.callStorm('auth.user.addrule lowuser node.add')
+            aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) .seen=2022 :published=2022]'
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
+
+        # "Don't do this in production" example. Since the r1 DENY permission is not more precise
+        # than the R0 allow permission, we allow the action.
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+            await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser node')
+            aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) .seen=2022 :published=2022]'
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormHasNoWarnErr(msgs)
+
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+            await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news.published"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser node')
+            aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) .seen=2022 :published=2022]'
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormHasNoWarnErr(msgs)
 
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
@@ -3765,8 +3792,6 @@ class AstTest(s_test.SynTest):
             aslow = {'user': unfo.get('iden')}
             q = '[media:news=(m0,) .seen=2023 :published=2023]'
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormHasNoErr(msgs)
 
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
@@ -3778,8 +3803,6 @@ class AstTest(s_test.SynTest):
 
             q = '[media:news=(m1,) :published=2020]'
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormHasNoErr(msgs)
 
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
@@ -3793,8 +3816,6 @@ class AstTest(s_test.SynTest):
             aslow = {'user': unfo.get('iden')}
 
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
@@ -3808,6 +3829,4 @@ class AstTest(s_test.SynTest):
             aslow = {'user': unfo.get('iden')}
 
             msgs = await core.stormlist(q, opts=aslow)
-            for m in msgs:
-                print(m)
             self.stormHasNoErr(msgs)

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3749,7 +3749,7 @@ class AstTest(s_test.SynTest):
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
 
-            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news.published"')
             await core.callStorm('auth.user.addrule lowuser node')
             aslow = {'user': unfo.get('iden')}
             q = '[media:news=(m0,) .seen=2022 :published=2022]'

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import synapse.exc as s_exc
 import synapse.common as s_common
+import synapse.datamodel as s_datamodel
 
 import synapse.lib.ast as s_ast
 import synapse.lib.snap as s_snap
@@ -3557,7 +3558,17 @@ class AstTest(s_test.SynTest):
 
     async def test_ast_prop_perms(self):
 
-        async with self.getTestCore() as core:
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+
+            # TODO: This goes away in 3.0.0 when we remove old style permissions.
+            for key, prop in core.model.props.items():
+                if not isinstance(prop, s_datamodel.Prop):
+                    continue
+                if prop.isuniv:
+                    continue
+                self.len(2, prop.delperms)
+                self.len(2, prop.setperms)
+
             visi = (await core.addUser('visi'))['iden']
 
             self.len(1, await core.nodes('[ inet:ipv4=1.2.3.4 :asn=10 ]'))

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3628,3 +3628,46 @@ class AstTest(s_test.SynTest):
             for m in msgs:
                 print(m)
             self.stormHasNoErr(msgs)
+
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+
+            await core.callStorm('auth.user.addrule lowuser node.add')
+            await core.callStorm('auth.user.addrule lowuser node.prop.set.media:news:published')
+            aslow = {'user': unfo.get('iden')}
+
+            q = '[media:news=(m1,) :published=2020]'
+            msgs = await core.stormlist(q, opts=aslow)
+            for m in msgs:
+                print(m)
+            self.stormHasNoErr(msgs)
+
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+
+            unfo = await core.addUser('lowuser')
+
+            await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news.published"')
+
+            await core.callStorm('auth.user.addrule lowuser node')
+            aslow = {'user': unfo.get('iden')}
+
+            msgs = await core.stormlist(q, opts=aslow)
+            for m in msgs:
+                print(m)
+            self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
+
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+
+            unfo = await core.addUser('lowuser')
+
+            await core.callStorm('auth.user.addrule lowuser "!!node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news.published"')
+
+            await core.callStorm('auth.user.addrule lowuser node')
+            aslow = {'user': unfo.get('iden')}
+
+            msgs = await core.stormlist(q, opts=aslow)
+            for m in msgs:
+                print(m)
+            self.stormHasNoErr(msgs)

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -3728,9 +3728,125 @@ class AstTest(s_test.SynTest):
             msgs = await core.stormlist(q, opts=aslow)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
+        # Exhaustive test for node.prop.del behaviors
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            q = 'inet:asn=$valu [ -:name ]'
+
+            # test 0
+            # None  None    Deny
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            varz = {'valu': 0}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormIsInErr('must have permission node.prop.del.inet:asn.name', msgs)
+
+            # test 1
+            # None  True    Allow
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            opts = {'vars': {'name': name}}
+            await core.callStorm('auth.user.addrule $name node.prop.del.inet:asn:name', opts=opts)
+
+            varz = {'valu': 1}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormHasNoErr(msgs)
+
+            # test 2
+            # None  False   Deny
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            opts = {'vars': {'name': name}}
+            await core.callStorm('auth.user.addrule $name "!node.prop.del:inet:asn:name"', opts=opts)
+            varz = {'valu': 2}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormIsInErr('must have permission node.prop.del.inet:asn.name', msgs)
+
+            # test 3
+            # True  None    Allow
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            opts = {'vars': {'name': name}}
+            await core.callStorm('auth.user.addrule $name "node.prop.del.inet:asn.name"', opts=opts)
+
+            varz = {'valu': 3}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormHasNoWarnErr(msgs)
+
+            # test 4
+            # True  True    Allow
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            opts = {'vars': {'name': name}}
+            await core.callStorm('auth.user.addrule $name "node.prop.del.inet:asn.name"', opts=opts)
+            await core.callStorm('auth.user.addrule $name "node.prop.del.inet:asn:name"', opts=opts)
+            varz = {'valu': 4}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormHasNoWarnErr(msgs)
+
+            # test 5
+            # True  False   Allow with precedence
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            opts = {'vars': {'name': name}}
+            await core.callStorm('auth.user.addrule $name "node.prop.del.inet:asn.name"', opts=opts)
+            await core.callStorm('auth.user.addrule $name "!node.prop.del.inet:asn:name"', opts=opts)
+            varz = {'valu': 5}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormHasNoWarnErr(msgs)
+
+            # test 6
+            # False None    Deny
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            opts = {'vars': {'name': name}}
+            await core.callStorm('auth.user.addrule $name "!node.prop.del.inet:asn.name"', opts=opts)
+            varz = {'valu': 6}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormIsInErr('must have permission node.prop.del.inet:asn.name', msgs)
+
+            # test 7
+            # False True    Deny with precedence
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            opts = {'vars': {'name': name}}
+            await core.callStorm('auth.user.addrule $name "!node.prop.del.inet:asn.name"', opts=opts)
+            await core.callStorm('auth.user.addrule $name "node.prop.del.inet:asn:name"', opts=opts)
+            varz = {'valu': 7}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormIsInErr('must have permission node.prop.del.inet:asn.name', msgs)
+
+            # test 8
+            # False False   Deny
+            name = s_common.guid()
+            unfo = await core.addUser(name)
+            opts = {'vars': {'name': name}}
+            await core.callStorm('auth.user.addrule $name "!node.prop.del.inet:asn.name"', opts=opts)
+            await core.callStorm('auth.user.addrule $name "!node.prop.del.inet:asn:name"', opts=opts)
+            varz = {'valu': 8}
+            aslow = {'user': unfo.get('iden'), 'vars': varz}
+            self.len(1, await core.nodes('[inet:asn=$valu :name=name]', opts={'vars': varz}))
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormIsInErr('must have permission node.prop.del.inet:asn.name', msgs)
+
         # Negative permission tests
         # These tests confirm the behavior when a deny rule is used to deny the permission
-        # but may still have a underlying allow rule present.
+        # but may still have an underlying allow rule present.
 
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
@@ -3743,6 +3859,7 @@ class AstTest(s_test.SynTest):
             msgs = await core.stormlist(q, opts=aslow)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
+        # New style permission being deny, blanket node allowed
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
 
@@ -3753,6 +3870,7 @@ class AstTest(s_test.SynTest):
             msgs = await core.stormlist(q, opts=aslow)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
+        # Old style permission being deny, blanket node allowed
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
 
@@ -3763,7 +3881,7 @@ class AstTest(s_test.SynTest):
             msgs = await core.stormlist(q, opts=aslow)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
 
-        # This is a horribly legal mix :(
+        # This is a legal mix which has a logical equivalence to test case #7
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
             await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
@@ -3786,58 +3904,37 @@ class AstTest(s_test.SynTest):
             msgs = await core.stormlist(q, opts=aslow)
             self.stormHasNoWarnErr(msgs)
 
+        # A valid construction - the user is granted one a new style prop set perm but denied others.
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
             await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news.published"')
-            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
-            await core.callStorm('auth.user.addrule lowuser node')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set"')
+            await core.callStorm('auth.user.addrule lowuser node.add')
             aslow = {'user': unfo.get('iden')}
-            q = '[media:news=(m0,) .seen=2022 :published=2022]'
+            q = '[media:news=(m0,) :published=2022]'
             msgs = await core.stormlist(q, opts=aslow)
             self.stormHasNoWarnErr(msgs)
 
+        # A valid construction - the user is granted one a old style prop set perm but denied others.
+        # This is a deny with precedence.
         async with self.getTestCore() as core:  # type: s_cortex.Cortex
             unfo = await core.addUser('lowuser')
-
-            await core.callStorm('auth.user.addrule lowuser node')
-            aslow = {'user': unfo.get('iden')}
-            q = '[media:news=(m0,) .seen=2023 :published=2023]'
-            msgs = await core.stormlist(q, opts=aslow)
-            self.stormHasNoErr(msgs)
-
-        async with self.getTestCore() as core:  # type: s_cortex.Cortex
-            unfo = await core.addUser('lowuser')
-
-            await core.callStorm('auth.user.addrule lowuser node.add')
-            await core.callStorm('auth.user.addrule lowuser node.prop.set.media:news:published')
-            aslow = {'user': unfo.get('iden')}
-
-            q = '[media:news=(m1,) :published=2020]'
-            msgs = await core.stormlist(q, opts=aslow)
-            self.stormHasNoErr(msgs)
-
-        async with self.getTestCore() as core:  # type: s_cortex.Cortex
-
-            unfo = await core.addUser('lowuser')
-
             await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news:published"')
-            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news.published"')
-
-            await core.callStorm('auth.user.addrule lowuser node')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set"')
+            await core.callStorm('auth.user.addrule lowuser node.add')
             aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) :published=2022]'
+            msgs = await core.stormlist(q, opts=aslow)
+            self.stormHasNoWarnErr(msgs)
 
+        # "Don't do this in production" example. Since the r1 ALLOW permission is not more precise
+        # than the R0 allow permission, we allow the action.
+        async with self.getTestCore() as core:  # type: s_cortex.Cortex
+            unfo = await core.addUser('lowuser')
+            await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news:published"')
+            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news"')
+            await core.callStorm('auth.user.addrule lowuser node.add')
+            aslow = {'user': unfo.get('iden')}
+            q = '[media:news=(m0,) :published=2022]'
             msgs = await core.stormlist(q, opts=aslow)
             self.stormIsInErr('must have permission node.prop.set.media:news.published', msgs)
-
-        async with self.getTestCore() as core:  # type: s_cortex.Cortex
-
-            unfo = await core.addUser('lowuser')
-
-            await core.callStorm('auth.user.addrule lowuser "!node.prop.set.media:news:published"')
-            await core.callStorm('auth.user.addrule lowuser "node.prop.set.media:news.published"')
-
-            await core.callStorm('auth.user.addrule lowuser node')
-            aslow = {'user': unfo.get('iden')}
-
-            msgs = await core.stormlist(q, opts=aslow)
-            self.stormHasNoErr(msgs)


### PR DESCRIPTION
- When checking node.prop.set and node.prop.del permissions, give precedence to the new style permissions ( using node.prop.set.form.prop ) over the old style permissions ( node.prop.set.full ) 
- Ensure that conflicts between these two permission styles are resolved in a consistent fashion, and that only one of these forms of permissions is required when setting a deny permission.
- Fix a bug where the layeriden passed into the Runtime confirm APIs was not being used to check permissions in the merge command.
- Change hiveuser.getAllowedReason to return a result + metadata dictionary instead of a result + string. This API is now cached for performance.

This does not appear to have a negative impact on the performance of permission checking on property setting. The following is a test suite + test execution used to generate metrics. These metrics were run multiple times and generated consistent behavior:

```
import timeit

import synapse.cortex as s_cortex
import synapse.lib.storm as s_storm

import synapse.tests.utils as s_test

class PermTimeTest(s_test.SynTest):

    async def test_cortex_perm_time(self):
        async with self.getTestCore() as core:  # type: s_cortex.Cortex

            udef = await core.addUser('lowuser')
            lowuser = udef.get('iden')

            opts = core._initStormOpts({})

            form = core.model.form('media:news')
            prop = form.props.get('published')

            view = core._viewFromOpts(opts)
            user = core._userFromOpts(opts)
            text = '$lib.print(hello)'
            async with await view.snap(user=user) as snap:
                query = await core.getStormQuery(text, mode='storm')
                async with snap.getStormRuntime(query, opts=opts, user=user) as runt:  # type: s_storm.Runtime
                    # Populate the perm cache
                    runt.confirmPropSet(prop)
                    # Get the average cost of just running the prop check
                    n = 1_000_000

                    r = timeit.timeit('runt.confirmPropSet(prop)', globals=locals(), number=n)
                    avg = r/n
                    avg = avg * 1000 * 1000  # uS
                    print(f'ROOT USER {n=} {r=} {avg=} uS')

            # Try low-user with a old style perm check
            oldperm = (True, ('node', 'prop', 'set', 'media:news:published'))
            await core.addUserRule(lowuser, oldperm)

            opts = core._initStormOpts({'user': lowuser})

            view = core._viewFromOpts(opts)
            user = core._userFromOpts(opts)
            async with await view.snap(user=user) as snap:
                query = await core.getStormQuery(text, mode='storm')
                async with snap.getStormRuntime(query, opts=opts, user=user) as runt:  # type: s_storm.Runtime
                    # Populate the perm cache
                    runt.confirmPropSet(prop)
                    # Get the average cost of just running the prop check
                    n = 1_000_000

                    r = timeit.timeit('runt.confirmPropSet(prop)', globals=locals(), number=n)
                    avg = r / n
                    avg = avg * 1000 * 1000  # uS
                    print(f'LOWUSER OLD {n=} {r=} {avg=} uS')

            await core.delUserRule(lowuser, oldperm)

            newperm = (True, ('node', 'prop', 'set', 'media:news', 'published'))
            await core.addUserRule(lowuser, newperm)

            async with await view.snap(user=user) as snap:
                query = await core.getStormQuery(text, mode='storm')
                async with snap.getStormRuntime(query, opts=opts, user=user) as runt:  # type: s_storm.Runtime
                    # Populate the perm cache
                    runt.confirmPropSet(prop)
                    # Get the average cost of just running the prop check
                    n = 1_000_000

                    r = timeit.timeit('runt.confirmPropSet(prop)', globals=locals(), number=n)
                    avg = r / n
                    avg = avg * 1000 * 1000  # uS
                    print(f'LOWUSER NEW {n=} {r=} {avg=} uS')

            # A new rule to check for precdecenc performance
            genericdeny = (False, ('node', 'prop', 'set'))
            await core.addUserRule(lowuser, genericdeny)

            async with await view.snap(user=user) as snap:
                query = await core.getStormQuery(text, mode='storm')
                async with snap.getStormRuntime(query, opts=opts, user=user) as runt:  # type: s_storm.Runtime
                    # Dope the perm cache
                    runt.confirmPropSet(prop)
                    # Get the average cost of just running the prop check
                    n = 1_000_000

                    r = timeit.timeit('runt.confirmPropSet(prop)', globals=locals(), number=n)
                    avg = r / n
                    avg = avg * 1000 * 1000  # uS
                    print(f'LOWUSER MIX {n=} {r=} {avg=} uS')
```
example results
```

$ git checkout bug_node_perm_check
Switched to branch 'bug_node_perm_check'
Your branch is up to date with 'origin/bug_node_perm_check'.
$ git rev-parse HEAD
1a65e37170022d70727cb94bec0599742c0b85bb

$ python -m pytest test_permcheck_times.py 
= test session starts =
platform linux -- Python 3.11.4, pytest-7.4.3, pluggy-1.0.0 -- /home/epiphyte/.pyenv/versions/3.11.4/envs/syn3114/bin/python
cachedir: .pytest_cache
rootdir: /home/epiphyte/PycharmProjects/synapse
configfile: pytest.ini
plugins: anyio-3.7.0, xdist-3.5.0, cov-4.1.0
collected 1 item                                                                                                                                                                                      

test_permcheck_times.py::PermTimeTest::test_cortex_perm_time 
- live log call -
2024-03-20 21:26:07 [DEBUG] Using selector: EpollSelector [selector_events.py:__init__:MainThread:MainProcess]
2024-03-20 21:26:08 [WARNING] Detected 151 deprecated properties unlocked and not in use, recommend locking (https://v.vtx.lk/deprlock). [cortex.py:_warnDeprLocks:SynLoop:MainProcess]
2024-03-20 21:26:08 [INFO] Added user=lowuser [cell.py:addUser:SynLoop:MainProcess]
ROOT USER n=1000000 r=0.8242104339951766 avg=0.8242104339951766 uS
2024-03-20 21:26:11 [INFO] Added rule=(True, ('node', 'prop', 'set', 'media:news:published')) on user lowuser for gateiden=None [cell.py:addUserRule:SynLoop:MainProcess]
LOWUSER OLD n=1000000 r=1.4315228120030952 avg=1.4315228120030952 uS
2024-03-20 21:26:12 [INFO] Removing rule=(True, ('node', 'prop', 'set', 'media:news:published')) on user lowuser for gateiden=None [cell.py:delUserRule:SynLoop:MainProcess]
2024-03-20 21:26:12 [INFO] Added rule=(True, ('node', 'prop', 'set', 'media:news', 'published')) on user lowuser for gateiden=None [cell.py:addUserRule:SynLoop:MainProcess]
LOWUSER NEW n=1000000 r=1.4532976520058583 avg=1.4532976520058583 uS
2024-03-20 21:26:14 [INFO] Added rule=(False, ('node', 'prop', 'set')) on user lowuser for gateiden=None [cell.py:addUserRule:SynLoop:MainProcess]
LOWUSER MIX n=1000000 r=1.4623153249995084 avg=1.4623153249995084 uS
PASSED

= 1 passed in 10.56s =

$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ git rev-parse HEAD
bb0cb6ccf5639b5d9e6b6e649a84cf57486bab9c
$ python -m pytest test_permcheck_times.py 
= test session starts =
platform linux -- Python 3.11.4, pytest-7.4.3, pluggy-1.0.0 -- /home/epiphyte/.pyenv/versions/3.11.4/envs/syn3114/bin/python
cachedir: .pytest_cache
rootdir: /home/epiphyte/PycharmProjects/synapse
configfile: pytest.ini
plugins: anyio-3.7.0, xdist-3.5.0, cov-4.1.0
collected 1 item                                                                                                                                                                                      

test_permcheck_times.py::PermTimeTest::test_cortex_perm_time 
- live log call -
2024-03-20 21:26:32 [DEBUG] Using selector: EpollSelector [selector_events.py:__init__:MainThread:MainProcess]
2024-03-20 21:26:33 [WARNING] Detected 151 deprecated properties unlocked and not in use, recommend locking (https://v.vtx.lk/deprlock). [cortex.py:_warnDeprLocks:SynLoop:MainProcess]
2024-03-20 21:26:33 [INFO] Added user=lowuser [cell.py:addUser:SynLoop:MainProcess]
ROOT USER n=1000000 r=1.2284996360031073 avg=1.2284996360031073 uS
2024-03-20 21:26:35 [INFO] Added rule=(True, ('node', 'prop', 'set', 'media:news:published')) on user lowuser for gateiden=None [cell.py:addUserRule:SynLoop:MainProcess]
LOWUSER OLD n=1000000 r=1.217240384001343 avg=1.2172403840013433 uS
2024-03-20 21:26:37 [INFO] Removing rule=(True, ('node', 'prop', 'set', 'media:news:published')) on user lowuser for gateiden=None [cell.py:delUserRule:SynLoop:MainProcess]
2024-03-20 21:26:37 [INFO] Added rule=(True, ('node', 'prop', 'set', 'media:news', 'published')) on user lowuser for gateiden=None [cell.py:addUserRule:SynLoop:MainProcess]
LOWUSER NEW n=1000000 r=1.7815314149993355 avg=1.7815314149993355 uS
2024-03-20 21:26:38 [INFO] Added rule=(False, ('node', 'prop', 'set')) on user lowuser for gateiden=None [cell.py:addUserRule:SynLoop:MainProcess]
LOWUSER MIX n=1000000 r=1.782856523997907 avg=1.782856523997907 uS
PASSED

= 1 passed in 10.91s =
```