### PR TITLE
aha pool updates (SYN-7109, SYN-7110, SYN-7169)

### DIFF
--- a/synapse/lib/stormlib/aha.py
+++ b/synapse/lib/stormlib/aha.py
@@ -35,6 +35,7 @@ class AhaPoolLib(s_stormtypes.Lib):
         if poolinfo is not None:
             return AhaPool(self.runt, poolinfo)
 
+    @s_stormtypes.stormfunc(readonly=True)
     async def list(self):
 
         self.runt.reqAdmin()
@@ -59,6 +60,9 @@ class AhaPool(s_stormtypes.StormType):
             'add': self.add,
             'del': self._del,
         })
+
+    async def stormrepr(self):
+        return f'{self._storm_typename}: {self.poolinfo.get("name")}'
 
     async def _derefGet(self, name):
         return self.poolinfo.get(name)
@@ -97,7 +101,6 @@ stormcmds = (
         for $pool in $lib.aha.pool.list() {
             $count = ($count + 1)
             $lib.print(`Pool: {$pool.name}`)
-            $lib.print($pool)
             for ($svcname, $svcinfo) in $pool.services {
                 $lib.print(`    {$svcname}`)
             }

--- a/synapse/lib/stormlib/cortex.py
+++ b/synapse/lib/stormlib/cortex.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 import synapse.exc as s_exc
+import synapse.telepath as s_telepath
 
 import synapse.lib.storm as s_storm
 import synapse.lib.stormtypes as s_stormtypes
@@ -1194,6 +1195,11 @@ class StormPoolSetCmd(s_storm.Cmd):
 
         async for node, path in genr: # pragma: no cover
             yield node, path
+
+        try:
+            s_telepath.chopurl(self.opts.url)
+        except s_exc.BadUrl as e:
+            raise s_exc.BadArg(mesg=f'Unable to set Storm pool URL from url={self.opts.url} : {e.get("mesg")}') from None
 
         opts = {
             'timeout:sync': self.opts.sync_timeout,

--- a/synapse/lib/stormlib/cortex.py
+++ b/synapse/lib/stormlib/cortex.py
@@ -1212,6 +1212,10 @@ class StormPoolSetCmd(s_storm.Cmd):
 class StormPoolDelCmd(s_storm.Cmd):
     '''
     Remove a Storm query offload mirror pool configuration.
+
+    Notes:
+        This will result in tearing down any Storm queries currently being serviced by the Storm pool.
+        This may result in this command raising an exception if it was offloaded to a pool member. That would be an expected behavior.
     '''
     name = 'cortex.storm.pool.del'
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -7808,6 +7808,9 @@ class CortexBasicTest(s_t_utils.SynTest):
                     self.stormHasNoWarnErr(msgs)
                     self.stormIsInPrint('AHA service (01.core...) added to service pool (pool00.loop.vertex.link)', msgs)
 
+                    msgs = await core00.stormlist('cortex.storm.pool.set newp')
+                    self.stormIsInErr(':// not found in [newp]', msgs)
+
                     msgs = await core00.stormlist('cortex.storm.pool.set --connection-timeout 1 --sync-timeout 1 aha://pool00...')
                     self.stormHasNoWarnErr(msgs)
                     self.stormIsInPrint('Storm pool configuration set.', msgs)

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -1184,6 +1184,9 @@ class AhaTest(s_test.SynTest):
                     self.stormIsInPrint('    00.loop.vertex.link', msgs)
                     self.stormIsInPrint('1 pools', msgs)
 
+                    msgs = await core00.stormlist('$lib.print($lib.aha.pool.get(pool00.loop.vertex.link))')
+                    self.stormIsInPrint('aha:pool: pool00.loop.vertex.link', msgs)
+
                     async with await s_telepath.open('aha://pool00...') as pool:
 
                         replay = s_common.envbool('SYNDEV_NEXUS_REPLAY')


### PR DESCRIPTION
- Add a stormrepr to aha:pool, remove stray print
- Ensure that we can chop the URL provided for the cortex.storm.pool.set argument
- Add a note to cortex.storm.pool.del about the expected behavior of cancelling queries, potentially include the command itself.