### PR TITLE
SYN-7204: aiohttp 3.9.4 breaks axon wput test

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -8,6 +8,7 @@ import contextlib
 
 import aiohttp
 import aiohttp_socks
+import aiohttp.client_exceptions
 
 import synapse.exc as s_exc
 import synapse.common as s_common
@@ -1551,6 +1552,10 @@ class Axon(s_cell.Cell):
                 raise
 
             except Exception as e:
+                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
+                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
+                    e = e.__cause__
+
                 logger.exception(f'Error POSTing files to [{s_urlhelp.sanitizeUrl(url)}]')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')
@@ -1605,6 +1610,10 @@ class Axon(s_cell.Cell):
                 raise
 
             except Exception as e:
+                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
+                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
+                    e = e.__cause__
+
                 logger.exception(f'Error streaming [{sha256}] to [{s_urlhelp.sanitizeUrl(url)}]')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1548,9 +1548,6 @@ class Axon(s_cell.Cell):
                     }
                     return info
 
-            except asyncio.CancelledError:  # pragma: no cover
-                raise
-
             except Exception as e:
                 logger.exception(f'Error POSTing files to [{s_urlhelp.sanitizeUrl(url)}]')
                 err = s_common.err(e)
@@ -1600,9 +1597,6 @@ class Axon(s_cell.Cell):
                         'headers': dict(resp.headers),
                     }
                     return info
-
-            except asyncio.CancelledError:  # pragma: no cover
-                raise
 
             except Exception as e:
                 logger.exception(f'Error streaming [{sha256}] to [{s_urlhelp.sanitizeUrl(url)}]')

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -8,7 +8,6 @@ import contextlib
 
 import aiohttp
 import aiohttp_socks
-import aiohttp.client_exceptions
 
 import synapse.exc as s_exc
 import synapse.common as s_common
@@ -1552,10 +1551,6 @@ class Axon(s_cell.Cell):
                 raise
 
             except Exception as e:
-                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
-                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
-                    e = e.__cause__
-
                 logger.exception(f'Error POSTing files to [{s_urlhelp.sanitizeUrl(url)}]')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')
@@ -1610,10 +1605,6 @@ class Axon(s_cell.Cell):
                 raise
 
             except Exception as e:
-                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
-                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
-                    e = e.__cause__
-
                 logger.exception(f'Error streaming [{sha256}] to [{s_urlhelp.sanitizeUrl(url)}]')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1747,6 +1747,10 @@ class Axon(s_cell.Cell):
                 raise
 
             except Exception as e:
+                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
+                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
+                    e = e.__cause__
+
                 logger.exception(f'Failed to wget {s_urlhelp.sanitizeUrl(url)}')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1551,6 +1551,10 @@ class Axon(s_cell.Cell):
                 raise
 
             except Exception as e:
+                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
+                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
+                    e = e.__cause__
+
                 logger.exception(f'Error POSTing files to [{s_urlhelp.sanitizeUrl(url)}]')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')
@@ -1605,6 +1609,10 @@ class Axon(s_cell.Cell):
                 raise
 
             except Exception as e:
+                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
+                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
+                    e = e.__cause__
+
                 logger.exception(f'Error streaming [{sha256}] to [{s_urlhelp.sanitizeUrl(url)}]')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1508,35 +1508,34 @@ class Axon(s_cell.Cell):
 
         atimeout = aiohttp.ClientTimeout(total=timeout)
 
+        async with aiohttp.ClientSession(connector=connector, timeout=atimeout) as sess:
+            try:
+                data = aiohttp.FormData()
+                data._is_multipart = True
 
-        try:
-            data = aiohttp.FormData()
-            data._is_multipart = True
+                for field in fields:
 
-            for field in fields:
+                    name = field.get('name')
+                    if not isinstance(name, str):
+                        mesg = f'Each field requires a "name" key with a string value: {name}'
+                        raise s_exc.BadArg(mesg=mesg, name=name)
 
-                name = field.get('name')
-                if not isinstance(name, str):
-                    mesg = f'Each field requires a "name" key with a string value: {name}'
-                    raise s_exc.BadArg(mesg=mesg, name=name)
+                    sha256 = field.get('sha256')
+                    if sha256:
+                        sha256b = s_common.uhex(sha256)
+                        await self._reqHas(sha256b)
+                        valu = self.get(sha256b)
+                    else:
+                        valu = field.get('value')
+                        if not isinstance(valu, (bytes, str)):
+                            valu = json.dumps(valu)
 
-                sha256 = field.get('sha256')
-                if sha256:
-                    sha256b = s_common.uhex(sha256)
-                    await self._reqHas(sha256b)
-                    valu = self.get(sha256b)
-                else:
-                    valu = field.get('value')
-                    if not isinstance(valu, (bytes, str)):
-                        valu = json.dumps(valu)
+                    data.add_field(name,
+                                   valu,
+                                   content_type=field.get('content_type'),
+                                   filename=field.get('filename'),
+                                   content_transfer_encoding=field.get('content_transfer_encoding'))
 
-                data.add_field(name,
-                               valu,
-                               content_type=field.get('content_type'),
-                               filename=field.get('filename'),
-                               content_transfer_encoding=field.get('content_transfer_encoding'))
-
-            async with aiohttp.ClientSession(connector=connector, timeout=atimeout) as sess:
                 async with sess.request(method, url, headers=headers, params=params,
                                         data=data, ssl=ssl) as resp:
                     info = {
@@ -1549,31 +1548,27 @@ class Axon(s_cell.Cell):
                     }
                     return info
 
-        except asyncio.CancelledError:  # pramga: no cover
-            raise
+            except asyncio.CancelledError:  # pramga: no cover
+                raise
 
-        except Exception as e:
-            # ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
-            # if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
-            #     e = e.__cause__
+            except Exception as e:
+                logger.exception(f'Error POSTing files to [{s_urlhelp.sanitizeUrl(url)}]')
+                err = s_common.err(e)
+                errmsg = err[1].get('mesg')
+                if errmsg:
+                    reason = f'Exception occurred during request: {err[0]}: {errmsg}'
+                else:
+                    reason = f'Exception occurred during request: {err[0]}'
 
-            logger.exception(f'Error POSTing files to [{s_urlhelp.sanitizeUrl(url)}]')
-            err = s_common.err(e)
-            errmsg = err[1].get('mesg')
-            if errmsg:
-                reason = f'Exception occurred during request: {err[0]}: {errmsg}'
-            else:
-                reason = f'Exception occurred during request: {err[0]}'
-
-            return {
-                'ok': False,
-                'err': err,
-                'url': url,
-                'body': b'',
-                'code': -1,
-                'reason': reason,
-                'headers': dict(),
-            }
+                return {
+                    'ok': False,
+                    'err': err,
+                    'url': url,
+                    'body': b'',
+                    'code': -1,
+                    'reason': reason,
+                    'headers': dict(),
+                }
 
     async def wput(self, sha256, url, params=None, headers=None, method='PUT', ssl=True, timeout=None,
                    filename=None, filemime=None, proxy=None, ssl_opts=None):
@@ -1591,10 +1586,9 @@ class Axon(s_cell.Cell):
 
         atimeout = aiohttp.ClientTimeout(total=timeout)
 
-        try:
-            await self._reqHas(sha256)
-
-            async with aiohttp.ClientSession(connector=connector, timeout=atimeout) as sess:
+        async with aiohttp.ClientSession(connector=connector, timeout=atimeout) as sess:
+            try:
+                await self._reqHas(sha256)
                 async with sess.request(method, url, headers=headers, params=params,
                                         data=self.get(sha256), ssl=ssl) as resp:
 
@@ -1607,27 +1601,27 @@ class Axon(s_cell.Cell):
                     }
                     return info
 
-        except asyncio.CancelledError:  # pragma: no cover
-            raise
+            except asyncio.CancelledError:  # pragma: no cover
+                raise
 
-        except Exception as e:
-            logger.exception(f'Error streaming [{sha256}] to [{s_urlhelp.sanitizeUrl(url)}]')
-            err = s_common.err(e)
-            errmsg = err[1].get('mesg')
-            if errmsg:
-                mesg = f"{err[0]}: {errmsg}"
-                reason = f'Exception occurred during request: {err[0]}: {errmsg}'
-            else:
-                mesg = err[0]
-                reason = f'Exception occurred during request: {err[0]}'
+            except Exception as e:
+                logger.exception(f'Error streaming [{sha256}] to [{s_urlhelp.sanitizeUrl(url)}]')
+                err = s_common.err(e)
+                errmsg = err[1].get('mesg')
+                if errmsg:
+                    mesg = f"{err[0]}: {errmsg}"
+                    reason = f'Exception occurred during request: {err[0]}: {errmsg}'
+                else:
+                    mesg = err[0]
+                    reason = f'Exception occurred during request: {err[0]}'
 
-            return {
-                'ok': False,
-                'mesg': mesg,
-                'code': -1,
-                'reason': reason,
-                'err': err,
-            }
+                return {
+                    'ok': False,
+                    'mesg': mesg,
+                    'code': -1,
+                    'reason': reason,
+                    'err': err,
+                }
 
     def _flatten_clientresponse(self,
                                 resp: aiohttp.ClientResponse,

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1746,10 +1746,6 @@ class Axon(s_cell.Cell):
                 raise
 
             except Exception as e:
-                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
-                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
-                    e = e.__cause__
-
                 logger.exception(f'Failed to wget {s_urlhelp.sanitizeUrl(url)}')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -1548,7 +1548,7 @@ class Axon(s_cell.Cell):
                     }
                     return info
 
-            except asyncio.CancelledError:  # pramga: no cover
+            except asyncio.CancelledError:  # pragma: no cover
                 raise
 
             except Exception as e:

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 import aiohttp
 import aiohttp_socks
+import aiohttp.client_exceptions
 
 import synapse.exc as s_exc
 import synapse.common as s_common
@@ -475,6 +476,10 @@ class LibHttp(s_stormtypes.Lib):
             except asyncio.CancelledError:  # pragma: no cover
                 raise
             except Exception as e:
+                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
+                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
+                    e = e.__cause__
+
                 logger.exception(f'Error during http {meth} @ {url}')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -476,10 +476,6 @@ class LibHttp(s_stormtypes.Lib):
             except asyncio.CancelledError:  # pragma: no cover
                 raise
             except Exception as e:
-                ClientConnectionError = getattr(aiohttp.client_exceptions, 'ClientConnectionError', None)
-                if ClientConnectionError is not None and isinstance(e, ClientConnectionError):
-                    e = e.__cause__
-
                 logger.exception(f'Error during http {meth} @ {url}')
                 err = s_common.err(e)
                 errmsg = err[1].get('mesg')

--- a/synapse/lib/stormhttp.py
+++ b/synapse/lib/stormhttp.py
@@ -7,7 +7,6 @@ logger = logging.getLogger(__name__)
 
 import aiohttp
 import aiohttp_socks
-import aiohttp.client_exceptions
 
 import synapse.exc as s_exc
 import synapse.common as s_common

--- a/synapse/tools/autodoc.py
+++ b/synapse/tools/autodoc.py
@@ -717,7 +717,7 @@ async def docModel(outp,
                 raise s_exc.SynErr(mesg='Invalid example', form=form, example=example, info=mnfo)
             if mtyp == 'node':
                 node = True
-        if not node:  # pramga: no cover
+        if not node:  # pragma: no cover
             raise s_exc.SynErr(mesg='Unable to make a node from example.', form=form, example=example)
 
     rst = s_autodoc.RstHelp()


### PR DESCRIPTION
bugfix: Catch aiohttp ClientConnectionError and use the underlying exception to generate the return info