### PR TITLE
Ensure Base / Cell signal handler tasks are tracked to avoid GC (SYN-4952)

### DIFF
--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -143,6 +143,7 @@ class Base:
         self._fini_atexit = False
         self._active_tasks = None       # the set of free running tasks associated with me
         self._context_managers = None   # the set of context managers i must fini
+        self._syn_signal_tasks = None   # intialized as a Set when addSignalHandlers is called.
 
     async def postAnit(self):
         '''
@@ -559,14 +560,20 @@ class Base:
         '''
         Register SIGTERM/SIGINT signal handlers with the ioloop to fini this object.
         '''
+        if self._syn_signal_tasks is None:
+            self._syn_signal_tasks = set()
 
         def sigterm():
-            print('Caught SIGTERM, shutting down.')
-            asyncio.create_task(self.fini())
+            logger.warning('Caught SIGTERM, shutting down.')
+            task = asyncio.create_task(self.fini())
+            self._syn_signal_tasks.add(task)
+            task.add_done_callback(self._syn_signal_tasks.discard)
 
         def sigint():
-            print('Caught SIGINT, shutting down.')
-            asyncio.create_task(self.fini())
+            logger.warning('Caught SIGINT, shutting down.')
+            task = asyncio.create_task(self.fini())
+            self._syn_signal_tasks.add(task)
+            task.add_done_callback(self._syn_signal_tasks.discard)
 
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(signal.SIGINT, sigint)

--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -143,7 +143,7 @@ class Base:
         self._fini_atexit = False
         self._active_tasks = None       # the set of free running tasks associated with me
         self._context_managers = None   # the set of context managers i must fini
-        self._syn_signal_tasks = None   # intialized as a Set when addSignalHandlers is called.
+        self._syn_signal_tasks = None   # initialized as a Set when addSignalHandlers is called.
 
     async def postAnit(self):
         '''

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -4085,7 +4085,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         await s_base.Base.addSignalHandlers(self)
 
         def sighup():
-            asyncio.create_task(self.reload())
+            logger.info('Caught SIGHUP, running reloadable subsystems.')
+            task = asyncio.create_task(self.reload())
+            self._syn_signal_tasks.add(task)
+            task.add_done_callback(self._syn_signal_tasks.discard)
 
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(signal.SIGHUP, sighup)


### PR DESCRIPTION
- Ensure asyncio tasks caused by signal handlers are held onto to with a strong reference to avoid GC
- Use logger.warning instead of print when noting a service has received SIGINT / SIGKILL 