### PR TITLE
SYN-7154: modelrev.runstorm to disable pool

### DIFF
--- a/synapse/lib/modelrev.py
+++ b/synapse/lib/modelrev.py
@@ -768,6 +768,12 @@ class ModelRev:
         Returns:
             None
         '''
+        if opts is None:
+            opts = {}
+
+        # Migrations only run on leaders
+        opts['mirror'] = False
+
         async def _runStorm():
             async for mesgtype, mesginfo in self.core.storm(text, opts=opts):
                 if mesgtype == 'print':


### PR DESCRIPTION
feat: Configure model migrations to only run on cortex leaders.