### PR TITLE
Update Storm command reference

### DIFF
--- a/docs/synapse/userguides/storm_ref_cmd.rstorm
+++ b/docs/synapse/userguides/storm_ref_cmd.rstorm
@@ -2729,20 +2729,17 @@ specified value or combination of values.
   
   inet:flow | uniq (:src:ipv4, :dst:ipv4)
 
-- Alerts (``risk:alert``) nodes can be categorized in various ways. This includes ``:priority`` and ``:severity``
-  properties, both of which use a set of fixed text values (e.g., "low" vs. "highest") that correspond to integers
-  (e.g., 20 vs. 50). These integer values could be summed to provide a relative "urgency" metric based on the combined
-  priority and severity values. You want to lift a set of alerts (``risk:alert`` nodes) representing the unique set of
-  total values as a sampling of this data:
+- Nodes can be uniqued based on variables. Alert (``risk:alert``) nodes can be categorized in various ways. This
+  includes ``:priority`` and ``:severity`` properties, both of which use a set of fixed text values (e.g., "low" vs.
+  "highest") that  correspond to integers (e.g., 20 vs. 50). These integer values could be joined together in a
+  variable to provide a sample of alerts which have unique combinations of those values:
 
-.. storm-pre:: [ (risk:alert=* :name='Cat sitting in front of monitor' :priority=20 :severity=20) (risk:alert=* :name='Out of coffee' :priority=10 :severity=50) (risk:alert=* :name='Laptop BIOS update bricked system' :priority=50 :severity=50) (risk:alert=* :name='New version of favorite Power-Up released' :priority=30 :severity=30) ]
-.. storm-pre:: risk:alert:priority +:severity $pri=:priority $sev=:severity $urgency=($pri + $sev) | uniq $urgency
+.. storm-pre:: [ (risk:alert=* :name='Cat sitting in front of monitor' :priority=20 :severity=20) (risk:alert=* :name='Out of coffee' :priority=10 :severity=50) (risk:alert=* :name='Laptop BIOS update bricked system' :priority=50 :severity=50) (risk:alert=* :name='New version of favorite Power-Up released' :priority=50 :severity=50) ]
+.. storm-pre:: risk:alert:priority +:severity $pri=:priority $sev=:severity $value=($pri, $sev) | uniq $value
 ::
   
-  risk:alert:priority +:severity $pri=:priority $sev=:severity $urgency=($pri + $sev) | uniq $urgency
+  risk:alert:priority +:severity $pri=:priority $sev=:severity $value=($pri, $sev) | uniq $value
 
-
-.. storm
 
 .. _storm-uptime:
 

--- a/docs/synapse/userguides/storm_ref_cmd.rstorm
+++ b/docs/synapse/userguides/storm_ref_cmd.rstorm
@@ -2729,6 +2729,18 @@ specified value or combination of values.
   
   inet:flow | uniq (:src:ipv4, :dst:ipv4)
 
+- Alerts (``risk:alert``) nodes can be categorized in various ways. This includes ``:priority`` and ``:severity``
+  properties, both of which use a set of fixed text values (e.g., "low" vs. "highest") that correspond to integers
+  (e.g., 20 vs. 50). These integer values could be summed to provide a relative "urgency" metric based on the combined
+  priority and severity values. You want to lift a set of alerts (``risk:alert`` nodes) representing the unique set of
+  total values as a sampling of this data:
+
+.. storm-pre:: [ (risk:alert=* :name='Cat sitting in front of monitor' :priority=20 :severity=20) (risk:alert=* :name='Out of coffee' :priority=10 :severity=50) (risk:alert=* :name='Laptop BIOS update bricked system' :priority=50 :severity=50) (risk:alert=* :name='New version of favorite Power-Up released' :priority=30 :severity=30) ]
+.. storm-pre:: risk:alert:priority +:severity $pri=:priority $sev=:severity $urgency=($pri + $sev) | uniq $urgency
+::
+  
+  risk:alert:priority +:severity $pri=:priority $sev=:severity $urgency=($pri + $sev) | uniq $urgency
+
 
 .. storm
 

--- a/docs/synapse/userguides/storm_ref_cmd.rstorm
+++ b/docs/synapse/userguides/storm_ref_cmd.rstorm
@@ -174,8 +174,10 @@ service pools.
 - `aha.pool.list`_
 - `aha.pool.svc.add`_
 - `aha.pool.svc.del`_
+- `aha.svc.list`_
+- `aha.svc.stat`_
 
-Help for individual ``auth.*`` commands can be displayed using:
+Help for individual ``aha.*`` commands can be displayed using:
 
   ``<command> --help``
 
@@ -184,7 +186,7 @@ Help for individual ``auth.*`` commands can be displayed using:
 aha.pool.add
 ++++++++++++
 
-The ``storm.aha.pool.add`` command creates a new AHA service pool.
+The ``aha.pool.add`` command creates a new AHA service pool.
 
 **Syntax:**
 
@@ -196,7 +198,7 @@ The ``storm.aha.pool.add`` command creates a new AHA service pool.
 aha.pool.del
 ++++++++++++
 
-The ``storm.aha.pool.del`` command deletes an AHA service pool configuration.
+The ``aha.pool.del`` command deletes an AHA service pool configuration.
 
 **Syntax:**
 
@@ -208,7 +210,7 @@ The ``storm.aha.pool.del`` command deletes an AHA service pool configuration.
 aha.pool.list
 +++++++++++++
 
-The ``storm.aha.pool.list`` command lists AHA service pools and their associated services.
+The ``aha.pool.list`` command lists AHA service pools and their associated services.
 
 **Syntax:**
 
@@ -220,7 +222,7 @@ The ``storm.aha.pool.list`` command lists AHA service pools and their associated
 aha.pool.svc.add
 ++++++++++++++++
 
-The ``storm.aha.pool.svc.add`` command adds a service to an existing AHA service pool.
+The ``aha.pool.svc.add`` command adds a service to an existing AHA service pool.
 
 **Syntax:**
 
@@ -232,11 +234,35 @@ The ``storm.aha.pool.svc.add`` command adds a service to an existing AHA service
 aha.pool.svc.del
 ++++++++++++++++
 
-The ``storm.aha.pool.svc.del`` command removes a service from an existing AHA service pool.
+The ``aha.pool.svc.del`` command removes a service from an existing AHA service pool.
 
 **Syntax:**
 
 .. storm-cli:: aha.pool.svc.del --help
+
+
+.. _storm-aha-svc-list:
+
+aha.svc.list
+++++++++++++
+
+The ``aha.svc.list`` command lists AHA services.
+
+**Syntax:**
+
+.. storm-cli:: aha.svc.list --help
+
+
+.. _storm-aha-svc-stat:
+
+aha.svc.stat
+++++++++++++
+
+The ``aha.svc.stat`` command displays all information for an AHA service.
+
+**Syntax:**
+
+.. storm-cli:: aha.svc.stat --help
 
 
 .. _storm-auth:
@@ -609,6 +635,62 @@ The ``cortex.httpapi.stat`` command is used to show the detailed information for
 **Syntax:**
 
 .. storm-cli:: cortex.httpapi.stat --help
+
+
+.. _storm-cortex-storm-pool:
+
+cortex.storm.pool
+-----------------
+
+.. NOTE::
+
+   See the :ref:`deploymentguide` section on :ref:`deployment-guide-storm-pool` for additional background on Storm query pools.
+
+Storm includes ``cortex.storm.pool.*`` commands that allow a user to work with Storm query mirror pools.
+
+- `cortex.storm.pool.del`_
+- `cortex.storm.pool.get`_
+- `cortex.storm.pool.set`_
+
+Help for individual ``cortex.storm.pool.*`` commands can be displayed using:
+
+  ``<command> --help``
+
+
+..  _storm-cortex-storm-pool-del:
+
+cortex.storm.pool.del
++++++++++++++++++++++
+
+The ``cortex.storm.pool.del`` command deletes a Storm query offload mirror pool configuration.
+
+**Syntax:**
+
+.. storm-cli:: cortex.storm.pool.del --help
+
+..  _storm-cortex-storm-pool-get:
+
+
+cortex.storm.pool.get
++++++++++++++++++++++
+
+The ``cortex.storm.pool.get`` command displays the Storm query offload mirror pool configuration.
+
+**Syntax:**
+
+.. storm-cli:: cortex.storm.pool.get --help
+
+
+..  _storm-cortex-storm-pool-set:
+
+cortex.storm.pool.set
++++++++++++++++++++++
+
+The ``cortex.storm.pool.set`` command sets the Storm query offload mirror pool configuration.
+
+**Syntax:**
+
+.. storm-cli:: cortex.storm.pool.set --help
 
 
 .. _storm-count:
@@ -1011,6 +1093,8 @@ Nodes created using generate commands will have a limited subset of properties s
 an organization node deconflicted and created based on a name will only have its ``ou:org:name``
 property set). Users can set additional property values as they see fit.
 
+- `gen.geo.place`_
+- `gen.it.av.scan.result`_
 - `gen.it.prod.soft`_
 - `gen.lang.language`_
 - `gen.ou.campaign`_
@@ -1036,6 +1120,42 @@ Help for individual ``gen.*`` commands can be displayed using:
   New ``gen.*`` commands are added to Synapse on an ongoing basis as we identify new cases
   where such commands are helpful. Use the ``help`` command for the current list of ``gen.*``
   commands available in your instance of Synapse.
+
+.. _storm-gen-geo-place:
+
+gen.geo.place
++++++++++++++
+
+The ``gen.geo.place`` command locates (lifts) or creates a ``geo:place`` node based on the place
+name (``geo:place:name`` and / or ``geo:place:names`` properties).
+
+**Syntax:**
+
+.. storm-cli:: gen.geo.place --help
+
+
+.. _storm-gen-it-av-scan-result:
+
+gen.it.av.scan.result
++++++++++++++++++++++
+
+The ``gen.it.av.scan.result`` command locates (lifts) or creates an ``it:av:scan:result`` node based
+on the form and value of the object scanned and the signature name used for the scan.
+
+You can optionally include the name of the scanner / scan engine and/or the time the scan was performed
+for additional deconfliction.
+
+.. NOTE::
+  
+  The command can be used to generate ``it:av:scan:result`` nodes from existing ``it:av:filehit`` nodes.
+  The ``it:av:filehit`` form has been marked as deprecated and will be removed in a future version of Synapse.
+  Some :ref:`synapse_powerups` that previously created ``it:av:filehit`` nodes may include dedicated commands
+  to assist with migration; if a migration tool exists, it will be documented in the Admin Guide section of
+  the Power-Up's Help.
+
+**Syntax:**
+
+.. storm-cli:: gen.it.av.scan.result --help
 
 
 .. _storm-gen-it-prod-soft:
@@ -1222,7 +1342,7 @@ gen.risk.vuln
 
 The ``gen.risk.vuln`` command locates (lifts) or creates a ``risk:tool:vuln`` node using the
 Common Vulnerabilities and Exposures (CVE) number associated with the vulnerability
-(``risk:vuln:cve``).
+(``risk:vuln:cve``) and the name of the entity reporting on the vulnerability (``risk:vuln:reporter:name``).
 
 **Syntax:**
 
@@ -2568,8 +2688,13 @@ be uniquely identified), which can be obtained using ``trigger.list`` or by lift
 uniq
 ----
 
-The ``uniq`` command removes duplicate results from a Storm query. Results are uniqued based on each
-node's node identifier (node ID / iden) so that only the first node with a given node ID is returned.
+The ``uniq`` command removes duplicate results from a Storm query. By default, results are uniqued based on
+each node's node identifier (node ID / iden) so that only the first node with a given node ID is returned.
+(You can think of this as effectively deconflicting on a node's primary property.)
+
+You can optionally specify a property, set of properties, or a variable as a parameter to unique the results
+based on that value / set of values instead of the node ID. Synapse will return the first node with the
+specified value or combination of values.
 
 **Syntax:**
 
@@ -2582,8 +2707,30 @@ node's node identifier (node ID / iden) so that only the first node with a given
   resolved to:
 
 .. storm-pre:: [inet:dns:a=(gdforum.info, 111.90.148.124) inet:dns:a=(live-settings.com, 209.99.40.222) inet:dns:a=(drive-google.ga, 141.8.224.221) ] -> inet:fqdn [+#rep.threatconnect.fancybear ]
-.. storm-cli:: inet:fqdn#rep.threatconnect.fancybear -> inet:dns:a -> inet:ipv4 | uniq
+.. storm-pre:: inet:fqdn#rep.threatconnect.fancybear -> inet:dns:a -> inet:ipv4 | uniq
+::
+  
+  inet:fqdn#rep.threatconnect.fancybear -> inet:dns:a -> inet:ipv4 | uniq
 
+
+- Lift a set of network flow (``inet:flow``) nodes and unique (de-duplicate) them based on the source IPv4 address:
+
+.. storm-pre:: [ ( inet:flow=* :src:ipv4=1.1.1.1 :dst:ipv4=2.2.2.2 ) ( inet:flow=* :src:ipv4=11.11.11.11 :dst:ipv4=3.3.3.3 ) ( inet:flow=* :src:ipv4=1.1.1.1 :dst:ipv4=4.4.4.4 ) ( inet:flow=* :src:ipv4=1.1.1.1 :dst:ipv4=4.4.4.4 ) ( inet:flow=* :src:ipv4=121.121.121.121 :dst:ipv4=2.2.2.2 ) ]
+.. storm-pre:: inet:flow | uniq :src:ipv4
+::
+  
+  inet:flow | uniq :src:ipv4
+
+
+- Lift a set of network flow (``inet:flow``) nodes and de-duplicate them based on each unique combination of source and destination IPv4 addresses:
+
+.. storm-pre:: inet:flow | uniq (:src:ipv4, :dst:ipv4)
+::
+  
+  inet:flow | uniq (:src:ipv4, :dst:ipv4)
+
+
+.. storm
 
 .. _storm-uptime:
 


### PR DESCRIPTION
- Clarify uniq command can take parameters and add examples.
- Include recently added commands.
- Clarify gen.risk.vuln now also takes a reporter name.
- Fix bad copypasta for aha.* commands.