### PR TITLE
SYN-7185: archive rapid7 repos

### DIFF
--- a/docs/synapse/power_ups.rst
+++ b/docs/synapse/power_ups.rst
@@ -64,8 +64,6 @@ Documentation for specific Advanced Power-Ups can be found here:
 - `Synapse Nettools <https://synapse.docs.vertex.link/projects/nettools/en/latest/>`_
 - `Synapse NSRL <https://synapse.docs.vertex.link/projects/nsrl/en/latest/>`_
 - `Synapse Playwright <https://synapse.docs.vertex.link/projects/playwright/en/latest/>`_
-- `Synapse Rapid7 <https://synapse.docs.vertex.link/projects/rapid7/en/latest/>`_
-- `Synapse Rapid7 SonarRDNS <https://synapse.docs.vertex.link/projects/rapid7-sonarrdns/en/latest/>`_
 - `Synapse S3 <https://synapse.docs.vertex.link/projects/s3/en/latest/>`_
 - `Synapse Search <https://synapse.docs.vertex.link/projects/search/en/latest/>`_
 - `Synapse Sidepocket <https://synapse.docs.vertex.link/projects/sidepocket/en/latest/>`_


### PR DESCRIPTION
docs: Removed references to rapid7 powerups.