### PR TITLE
Set AHA svcinfo/ready to false conditionally (SYN-7217)

### DIFF
--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -807,8 +807,7 @@ class AhaCell(s_cell.Cell):
     async def _setAhaSvcDown(self, name, linkiden, network=None):
         svcname, svcnetw, svcfull = self._nameAndNetwork(name, network)
         path = ('aha', 'services', svcnetw, svcname)
-        delv = await self.jsonstor.cmpDelPathObjProp(path, 'svcinfo/online', linkiden)
-        if delv:
+        if await self.jsonstor.cmpDelPathObjProp(path, 'svcinfo/online', linkiden):
             await self.jsonstor.setPathObjProp(path, 'svcinfo/ready', False)
 
         # Check if we have any links which may need to be removed

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -807,7 +807,9 @@ class AhaCell(s_cell.Cell):
     async def _setAhaSvcDown(self, name, linkiden, network=None):
         svcname, svcnetw, svcfull = self._nameAndNetwork(name, network)
         path = ('aha', 'services', svcnetw, svcname)
-        await self.jsonstor.cmpDelPathObjProp(path, 'svcinfo/online', linkiden)
+        delv = await self.jsonstor.cmpDelPathObjProp(path, 'svcinfo/online', linkiden)
+        if delv:
+            await self.jsonstor.setPathObjProp(path, 'svcinfo/ready', False)
 
         # Check if we have any links which may need to be removed
         current_sessions = {s_common.guid(iden): sess for iden, sess in self.dmon.sessions.items()}

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -1126,7 +1126,7 @@ class AhaTest(s_test.SynTest):
                     ready = svcinfo.get('ready')
                     online = svcinfo.get('online')
                     self.none(online)
-                    self.false(ready)  # Ready is  cleared upon restart / setting service down.
+                    self.false(ready)  # Ready is cleared upon restart / setting service down.
 
                     n = 3
                     if len(stack._exit_callbacks) > 0:

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -1126,7 +1126,7 @@ class AhaTest(s_test.SynTest):
                     ready = svcinfo.get('ready')
                     online = svcinfo.get('online')
                     self.none(online)
-                    self.true(ready)  # Ready is not cleared upon restart
+                    self.false(ready)  # Ready is  cleared upon restart / setting service down.
 
                     n = 3
                     if len(stack._exit_callbacks) > 0:

--- a/synapse/tests/test_lib_stormlib_aha.py
+++ b/synapse/tests/test_lib_stormlib_aha.py
@@ -139,7 +139,7 @@ Member:     00.cell.loop.vertex.link'''
                 self.len(nevents, await waiter.wait(timeout=12))
 
                 msgs = await core00.stormlist('aha.svc.list')
-                self.stormIsInPrint('01.cell.loop.vertex.link                      false  false  true', msgs)
+                self.stormIsInPrint('01.cell.loop.vertex.link                      false  false  false', msgs)
 
                 # Fake a record
                 await aha.addAhaSvc('00.newp', info={'urlinfo': {'scheme': 'tcp', 'host': '0.0.0.0', 'port': '3030'}},


### PR DESCRIPTION
When tearing down a service, we can no longer know if it is ready. Conditionally clear the ready value.