### PR TITLE
Loosen the inet:web:hashtag regex a bit, resolves SYN-7452

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -1415,7 +1415,7 @@ class InetModule(s_module.CoreModule):
                         'doc': 'A channel within a web service or instance such as slack or discord.'
                     }),
 
-                    ('inet:web:hashtag', ('str', {'lower': True, 'regex': r'^#[\w]+$'}), {
+                    ('inet:web:hashtag', ('str', {'lower': True, 'regex': r'^#\w[\w·]*(?<!·)$'}), {
                         'doc': 'A hashtag used in a web post.',
                     }),
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 
 import synapse.exc as s_exc
@@ -12,10 +11,16 @@ class InetModelTest(s_t_utils.SynTest):
     async def test_model_inet_basics(self):
         async with self.getTestCore() as core:
             self.len(1, await core.nodes('[ inet:web:hashtag="#hehe" ]'))
+            self.len(1, await core.nodes('[ inet:web:hashtag="#foo·bar"]'))  # note the interpunct
+            self.len(1, await core.nodes('[ inet:web:hashtag="#fo·o·······b·ar"]'))
             with self.raises(s_exc.BadTypeValu):
                 await core.nodes('[ inet:web:hashtag="foo" ]')
             with self.raises(s_exc.BadTypeValu):
                 await core.nodes('[ inet:web:hashtag="#foo bar" ]')
+            with self.raises(s_exc.BadTypeValu):
+                self.len(1, await core.nodes('[ inet:web:hashtag="#·bar"]'))
+            with self.raises(s_exc.BadTypeValu):
+                self.len(1, await core.nodes('[ inet:web:hashtag="#foo·"]'))
 
             nodes = await core.nodes('''
                 [ inet:web:instance=(foo,)


### PR DESCRIPTION
https://www.unicode.org/reports/tr31/#Specific_Character_Adjustments

The middle dot is the only exception I could find for a special character as part of a hashtag. The other "MidLetter" characters here (https://unicode.org/reports/tr29/#MidLetter) don't seem to be applicable?