### PR TITLE
Update TLS support for $lib.inet.imap, $lib.inet.smtp, update aioimpaplib  (SYN-7592, SYN-7800, SYN-7801)

### DIFF
--- a/changes/66247462dea46da6522b61eaaddec744.yaml
+++ b/changes/66247462dea46da6522b61eaaddec744.yaml
@@ -1,0 +1,5 @@
+---
+desc: Update the ``aioimaplib`` library constraints to ``>=1.1.0,<1.2.0``.
+prs: []
+type: feat
+...

--- a/changes/bb2fcc477ab4c2984f6ef0f395435784.yaml
+++ b/changes/bb2fcc477ab4c2984f6ef0f395435784.yaml
@@ -1,0 +1,7 @@
+---
+desc: Update ``$lib.inet.imap`` and ``$lib.inet.stmp`` APIs to use certificates present
+  in the Cortex ``tls:ca:dir`` directory. Add ``ssl_verify`` options to the ``$lib.inet.imap.connect()``
+  and ``inet:smtp:message.send()`` APIs to disable TLS verification.
+prs: []
+type: feat
+...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     'PyYAML>=5.4,<6.1.0',
     'aiohttp>=3.10.0,<4.0',
     'aiohttp-socks>=0.9.0,<0.10.0',
-    'aioimaplib>=1.0.1,<1.1.0',
+    'aioimaplib>=1.1.0,<1.2.0',
     'aiosmtplib>=3.0.0,<3.1.0',
     'prompt-toolkit>=3.0.4,<3.1.0',
     'lark==1.1.9',

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ regex>=2022.9.11
 PyYAML>=5.4,<6.1.0
 aiohttp>=3.10.0,<4.0
 aiohttp-socks>=0.9.0,<0.10.0
-aioimaplib>=1.0.1,<1.1.0
+aioimaplib>=1.1.0,<1.2.0
 aiosmtplib>=3.0.0,<3.1.0
 prompt-toolkit>=3.0.4,<3.1.0
 lark==1.1.9

--- a/synapse/lib/stormlib/imap.py
+++ b/synapse/lib/stormlib/imap.py
@@ -50,6 +50,8 @@ class ImapLib(s_stormtypes.Lib):
                      'desc': 'The time to wait for all commands on the server to execute.'},
                     {'type': 'bool', 'name': 'ssl', 'default': True,
                      'desc': 'Use SSL to connect to the IMAP server.'},
+                    {'type': 'bool', 'name': 'ssl_verify', 'default': True,
+                     'desc': 'Perform SSL/TLS verification.'},
                 ),
                 'returns': {
                     'type': 'inet:imap:server',
@@ -69,17 +71,19 @@ class ImapLib(s_stormtypes.Lib):
             'connect': self.connect,
         }
 
-    async def connect(self, host, port=993, timeout=30, ssl=True):
+    async def connect(self, host, port=993, timeout=30, ssl=True, ssl_verify=True):
 
         self.runt.confirm(('storm', 'inet', 'imap', 'connect'))
 
         ssl = await s_stormtypes.tobool(ssl)
         host = await s_stormtypes.tostr(host)
         port = await s_stormtypes.toint(port)
+        ssl_verify = await s_stormtypes.tobool(ssl_verify)
         timeout = await s_stormtypes.toint(timeout, noneok=True)
 
         if ssl:
-            imap_cli = aioimaplib.IMAP4_SSL(host=host, port=port, timeout=timeout)
+            ctx = self.runt.snap.core.getCachedSslCtx(opts=None, verify=ssl_verify)
+            imap_cli = aioimaplib.IMAP4_SSL(host=host, port=port, timeout=timeout, ssl_context=ctx)
         else:
             imap_cli = aioimaplib.IMAP4(host=host, port=port, timeout=timeout)
 

--- a/synapse/lib/stormlib/smtp.py
+++ b/synapse/lib/stormlib/smtp.py
@@ -96,6 +96,8 @@ class SmtpMessage(s_stormtypes.StormType):
                         'desc': 'Use the STARTTLS directive with the SMTP server.'},
                     {'name': 'timeout', 'type': 'int', 'default': 60,
                         'desc': 'The timeout (in seconds) to wait for message delivery.'},
+                    {'type': 'bool', 'name': 'ssl_verify', 'default': True,
+                     'desc': 'Perform SSL/TLS verification.'},
                   ),
                   'returns': {'type': 'list', 'desc': 'An ($ok, $valu) tuple.'}}},
 
@@ -148,7 +150,8 @@ class SmtpMessage(s_stormtypes.StormType):
     async def _getEmailHtml(self):
         return self.bodyhtml
 
-    async def send(self, host, port=25, user=None, passwd=None, usetls=False, starttls=False, timeout=60):
+    async def send(self, host, port=25, user=None, passwd=None, usetls=False, starttls=False, timeout=60,
+                   ssl_verify=True):
 
         self.runt.confirm(('storm', 'inet', 'smtp', 'send'))
 
@@ -161,6 +164,7 @@ class SmtpMessage(s_stormtypes.StormType):
             port = await s_stormtypes.toint(port)
             usetls = await s_stormtypes.tobool(usetls)
             starttls = await s_stormtypes.tobool(starttls)
+            ssl_verify = await s_stormtypes.tobool(ssl_verify)
 
             if usetls and starttls:
                 raise s_exc.BadArg(mesg='usetls and starttls are mutually exclusive arguments.')
@@ -183,6 +187,10 @@ class SmtpMessage(s_stormtypes.StormType):
 
             recipients = [await s_stormtypes.tostr(e) for e in self.recipients]
 
+            ctx = None
+            if usetls or starttls:
+                ctx = self.runt.snap.core.getCachedSslCtx(opts=None, verify=ssl_verify)
+
             futu = aiosmtplib.send(message,
                                    port=port,
                                    hostname=host,
@@ -191,7 +199,9 @@ class SmtpMessage(s_stormtypes.StormType):
                                    use_tls=usetls,
                                    start_tls=starttls,
                                    username=user,
-                                   password=passwd)
+                                   password=passwd,
+                                   tls_context=ctx,
+                                   )
 
             await s_common.wait_for(futu, timeout=timeout)
 

--- a/synapse/tests/test_lib_stormlib_imap.py
+++ b/synapse/tests/test_lib_stormlib_imap.py
@@ -196,7 +196,7 @@ class ImapTest(s_test.SynTest):
                 '''
                 retn = await core.callStorm(scmd)
                 self.eq((True, None), retn)
-                self.none(client_args[-1][0][5])  # type: ssl.SSLContext
+                self.none(client_args[-1][0][5])
 
                 # delete
                 scmd = '''

--- a/synapse/tests/test_lib_stormlib_imap.py
+++ b/synapse/tests/test_lib_stormlib_imap.py
@@ -196,7 +196,6 @@ class ImapTest(s_test.SynTest):
                 '''
                 retn = await core.callStorm(scmd)
                 self.eq((True, None), retn)
-                pprint(client_args[-1])
                 self.none(client_args[-1][0][5])  # type: ssl.SSLContext
 
                 # delete

--- a/synapse/tests/test_lib_stormlib_smtp.py
+++ b/synapse/tests/test_lib_stormlib_smtp.py
@@ -1,3 +1,6 @@
+import ssl
+import email.mime.multipart as e_muiltipart
+
 from unittest import mock
 import synapse.tests.utils as s_test
 
@@ -5,7 +8,9 @@ class SmtpTest(s_test.SynTest):
 
     async def test_storm_smtp(self):
 
+        called_args = []
         async def send(*args, **kwargs):
+            called_args.append((args, kwargs))
             return
 
         with mock.patch('aiosmtplib.send', send):
@@ -14,6 +19,9 @@ class SmtpTest(s_test.SynTest):
 
                 retn = await core.callStorm('return($lib.inet.smtp.message().send(127.0.0.1))')
                 self.false(retn[0])
+                self.eq(retn[1].get('err'), 'StormRuntimeError')
+                self.isin('The inet:smtp:message has no HTML or text body.', retn[1].get('errmsg'))
+                self.len(0, called_args)
 
                 retn = await core.callStorm('''
                     $message = $lib.inet.smtp.message()
@@ -31,6 +39,49 @@ class SmtpTest(s_test.SynTest):
                     return($message.send('smtp.gmail.com', port=465, usetls=true))
                 ''')
                 self.eq(retn, (True, {}))
+                mesg = called_args[-1][0][0]  # type: e_muiltipart.MIMEMultipart
+                self.eq(mesg.get_all('subject'), ['woot'])
+                payload = mesg.get_payload()
+                self.len(2, payload)
+                self.eq([pl.get_content_type() for pl in payload],
+                        ['text/plain', 'text/html'])
+                ctx = self.nn(called_args[-1][1].get('tls_context'))  # type: ssl.SSLContext
+                self.eq(ctx.verify_mode, ssl.CERT_REQUIRED)
+                self.eq(called_args[-1][1].get('port'), 465)
+                self.true(called_args[-1][1].get('use_tls'))
+                self.false(called_args[-1][1].get('start_tls'))
+
+                retn = await core.callStorm('''
+                    $message = $lib.inet.smtp.message()
+                    $message.text = "HELLO WORLD"
+                    $message.sender = visi@vertex.link
+                    $message.headers.Subject = woot
+                    $message.recipients.append(visi@vertex.link)
+                    return($message.send('smtp.gmail.com', port=465, starttls=true, ssl_verify=(false)))
+                ''')
+                self.eq(retn, (True, {}))
+                mesg = called_args[-1][0][0]  # type: e_muiltipart.MIMEMultipart
+                payload = mesg.get_payload()
+                self.len(1, payload)
+                self.eq([pl.get_content_type() for pl in payload], ['text/plain'])
+                ctx = self.nn(called_args[-1][1].get('tls_context'))  # type: ssl.SSLContext
+                self.eq(ctx.verify_mode, ssl.CERT_NONE)
+                self.false(called_args[-1][1].get('use_tls'))
+                self.true(called_args[-1][1].get('start_tls'))
+
+                retn = await core.callStorm('''
+                    $message = $lib.inet.smtp.message()
+                    $message.text = "HELLO WORLD"
+                    $message.sender = visi@vertex.link
+                    $message.headers.Subject = woot
+                    $message.recipients.append(visi@vertex.link)
+                    return($message.send('smtp.gmail.com', port=25))
+                ''')
+                self.eq(retn, (True, {}))
+                self.none(called_args[-1][1].get('tls_context'))  # type: ssl.SSLContext
+                self.eq(called_args[-1][1].get('port'), 25)
+                self.false(called_args[-1][1].get('use_tls'))
+                self.false(called_args[-1][1].get('start_tls'))
 
                 isok, info = await core.callStorm('''
                     $message = $lib.inet.smtp.message()


### PR DESCRIPTION
Add tls:ca:dir support and ssl_verify options to Storm IMAP and SMTP libraries (SYN-7800, SYN-7801)
Update aioimaplib version (SYN-7592)

Related https://github.com/vertexproject/vtx-base-image/pull/665