### PR TITLE
Remove unnecessary done check in schedCoro (SYN-7789)

### DIFF
--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -498,10 +498,7 @@ class Base:
         def taskDone(task):
             self._active_tasks.remove(task)
             try:
-                if not task.done():
-                    task.result()
-            except asyncio.CancelledError:  # pragma: no cover  TODO:  remove once >= py 3.8 only
-                pass
+                task.result()
             except Exception:
                 logger.exception('Task %s scheduled through Base.schedCoro raised exception', task)
 


### PR DESCRIPTION
My guess is that this was intended to somehow handle a `concurrent.Future` making it here in this invalid state as `result()` will actually make that wait rather than throwing an InvalidStateError. This should be an asyncio task though, and I still don't see any way that the done callback could fire and not be in the done state here.