### PR TITLE
Fix issue with automatic aha provisioning URL & bind precedence (SYN-7869)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -603,6 +603,7 @@ workflows:
             branches:
               only:
                 - master
+                - feat_aha_prov_url
 
       - build_docker_tag:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -603,7 +603,6 @@ workflows:
             branches:
               only:
                 - master
-                - feat_aha_prov_url
 
       - build_docker_tag:
           requires:

--- a/changes/3c27b826b9de26edad031a2593704ef7.yaml
+++ b/changes/3c27b826b9de26edad031a2593704ef7.yaml
@@ -1,0 +1,6 @@
+---
+desc: When generating the AHA provisioning URL, the AHA service now binds to 0.0.0.0
+  instead of the ``dns:name`` configuration value.
+prs: []
+type: bug
+...

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -732,9 +732,8 @@ class AhaCell(s_cell.Cell):
         # backward compatibilty with aha name.network configs
         # that do not intend to listen for provisioning.
         hostname = self.conf.get('dns:name')
-        network = self.conf.req('aha:network')
         if hostname is not None:
-            return f'ssl://0.0.0.0::27272?hostname={hostname}'
+            return f'ssl://0.0.0.0:27272?hostname={hostname}'
 
     def _getDmonListen(self):
 

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -732,8 +732,9 @@ class AhaCell(s_cell.Cell):
         # backward compatibilty with aha name.network configs
         # that do not intend to listen for provisioning.
         hostname = self.conf.get('dns:name')
+        network = self.conf.req('aha:network')
         if hostname is not None:
-            return f'ssl://{hostname}:27272'
+            return f'ssl://0.0.0.0::27272?hostname={hostname}&ca={network}'
 
     def _getDmonListen(self):
 

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -734,7 +734,7 @@ class AhaCell(s_cell.Cell):
         hostname = self.conf.get('dns:name')
         network = self.conf.req('aha:network')
         if hostname is not None:
-            return f'ssl://0.0.0.0::27272?hostname={hostname}&ca={network}'
+            return f'ssl://0.0.0.0::27272?hostname={hostname}'
 
     def _getDmonListen(self):
 


### PR DESCRIPTION
If the dns label is not available during service startup listening fails.