### PR TITLE
Enh: Some `inet:service` gen functions, resolves SYN-7880

### DIFF
--- a/synapse/lib/stormlib/gen.py
+++ b/synapse/lib/stormlib/gen.py
@@ -164,7 +164,7 @@ class LibGen(s_stormtypes.Lib):
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
                   'returns': {'type': 'node', 'desc': 'An inet:tls:servercert node with the given server and SHA256.'}}},
-        {'name': 'platformByName',
+        {'name': 'inetServicePlatformByName',
          'desc': 'Returns an inet:service:platform by name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
@@ -173,7 +173,7 @@ class LibGen(s_stormtypes.Lib):
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
                   'returns': {'type': 'node', 'desc': 'An inet:service:platform node with the given name.'}}},
-        {'name': 'accountByPlatformAndName',
+        {'name': 'inetServiceAccountByNameAndPlatform',
          'desc': 'Returns an inet:service:account node by account name and platform name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
@@ -183,11 +183,22 @@ class LibGen(s_stormtypes.Lib):
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
                   'returns': {'type': 'node', 'desc': 'An inet:service:account node with the given name and platform.'}}},
-        {'name': 'groupByPlatformAndName',
+        {'name': 'inetServiceGroupByNameAndPlatform',
          'desc': 'Returns an inet:service:group by account name and platform name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
                       {'name': 'name', 'type': ['str', 'inet:group'], 'desc': 'The name of the group.'},
+                      {'name': 'plat', 'type': ['str', 'inet:service:platform:name'], 'desc': 'The name of the platform.'},
+                      {'name': 'try', 'type': 'boolean', 'default': False,
+                       'desc': 'Type normalization will fail silently instead of raising an exception.'},
+                  ),
+
+                  'returns': {'type': 'node', 'desc': 'An inet:service:group with the given name and platform.'}}},
+        {'name': 'inetServiceInstanceByNameAndPlatform',
+         'desc': 'Returns an inet:service:instance by instance name and platform name, adding the node if it does not exist.',
+         'type': {'type': 'function', '_funcname': '_storm_query',
+                  'args': (
+                      {'name': 'name', 'type': 'str', 'desc': 'The name of the instance.'},
                       {'name': 'plat', 'type': ['str', 'inet:service:platform:name'], 'desc': 'The name of the platform.'},
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
@@ -536,7 +547,7 @@ class LibGen(s_stormtypes.Lib):
             return($node)
         }
 
-        function platformByName(name, try=$lib.false) {
+        function inetServicePlatformByName(name, try=$lib.false) {
             ($ok, $name) = $__maybeCast($try, inet:service:platform:name, $name)
             if (not $ok) { return() }
 
@@ -547,11 +558,11 @@ class LibGen(s_stormtypes.Lib):
             return($node)
         }
 
-        function accountByPlatformAndName(name, plat, try=$lib.false) {
+        function inetServiceAccountByNameAndPlatform(name, plat, try=$lib.false) {
             ($ok, $name) = $__maybeCast($try, inet:user, $name)
             if (not $ok) { return() }
 
-            $platform = $platformByName($plat, try=$try)
+            $platform = $inetServicePlatformByName($plat, try=$try)
             if (not $platform) { return() }
 
             $guid = $lib.guid(gen, account, $platform, $name)
@@ -560,15 +571,14 @@ class LibGen(s_stormtypes.Lib):
             [ inet:service:account=(gen, account, $platform, $name)
                   :user=$name
                   :platform=$platform ]
-
             return($node)
         }
 
-        function groupByPlatformAndName(name, plat, try=$lib.false) {
+        function inetServiceGroupByNameAndPlatform(name, plat, try=$lib.false) {
             ($ok, $name) = $__maybeCast($try, inet:group, $name)
             if (not $ok) { return() }
 
-            $platform = $platformByName($plat, try=$try)
+            $platform = $inetServicePlatformByName($plat, try=$try)
             if (not $platform) { return() }
 
             $guid = $lib.guid(gen, group, $platform, $name)
@@ -578,7 +588,23 @@ class LibGen(s_stormtypes.Lib):
             [ inet:service:group=$guid
                   :name=$name
                   :platform=$platform ]
+            return($node)
+        }
 
+        function inetServiceInstanceByNameAndPlatform(name, plat, try=$lib.false) {
+            ($ok, $name) = $__maybeCast($try, str, $name)
+            if (not $ok) { return() }
+
+            $platform = $inetServicePlatformByName($plat, try=$try)
+            if (not $platform) { return() }
+
+            $guid = $lib.guid(gen, instance, $platform, $name)
+            inet:service:group=$guid
+            return($node)
+
+            [ inet:service:instance=$guid
+                  :name=$name
+                  :platform=$platform ]
             return($node)
         }
     '''

--- a/synapse/lib/stormlib/gen.py
+++ b/synapse/lib/stormlib/gen.py
@@ -164,35 +164,36 @@ class LibGen(s_stormtypes.Lib):
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
                   'returns': {'type': 'node', 'desc': 'An inet:tls:servercert node with the given server and SHA256.'}}},
-        {'name': 'servicePlatformByName',
-         'desc': '',
+        {'name': 'platformByName',
+         'desc': 'Returns an inet:service:platform by name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
-                      {'name': 'name', 'type': ['str', 'inet:service:platform:name'], 'desc': ''},
+                      {'name': 'name', 'type': ['str', 'inet:service:platform:name'], 'desc': 'The name of the platform.'},
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'node', 'desc': ''}}},
+                  'returns': {'type': 'node', 'desc': 'An inet:service:platform node with the given name.'}}},
         {'name': 'accountByPlatformAndName',
-         'desc': '',
+         'desc': 'Returns an inet:service:account node by account name and platform name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
-                      {'name': 'name', 'type': ['str', 'inet:user'], 'desc': ''},
-                      {'name': 'plat', 'type': ['str', 'inet:service:platform:name'], 'desc': ''},
+                      {'name': 'name', 'type': ['str', 'inet:user'], 'desc': 'The name of the account.'},
+                      {'name': 'plat', 'type': ['str', 'inet:service:platform:name'], 'desc': 'The name of the platform.'},
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'node', 'desc': ''}}},
+                  'returns': {'type': 'node', 'desc': 'An inet:service:account node with the given name and platform.'}}},
         {'name': 'groupByPlatformAndName',
-         'desc': '',
+         'desc': 'Returns an inet:service:group by account name and platform name, adding the node if it does not exist.',
          'type': {'type': 'function', '_funcname': '_storm_query',
                   'args': (
-                      {'name': 'name', 'type': ['str', 'inet:group'], 'desc': ''},
-                      {'name': 'plat', 'type': ['str', 'inet:service:platform:name'], 'desc': ''},
+                      {'name': 'name', 'type': ['str', 'inet:group'], 'desc': 'The name of the group.'},
+                      {'name': 'plat', 'type': ['str', 'inet:service:platform:name'], 'desc': 'The name of the platform.'},
                       {'name': 'try', 'type': 'boolean', 'default': False,
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
-                  'returns': {'type': 'node', 'desc': ''}}},
+
+                  'returns': {'type': 'node', 'desc': 'An inet:service:group with the given name and platform.'}}},
     )
     _storm_lib_path = ('gen',)
 
@@ -535,7 +536,7 @@ class LibGen(s_stormtypes.Lib):
             return($node)
         }
 
-        function servicePlatformByName(name, try=$lib.false) {
+        function platformByName(name, try=$lib.false) {
             ($ok, $name) = $__maybeCast($try, inet:service:platform:name, $name)
             if (not $ok) { return() }
 
@@ -550,13 +551,13 @@ class LibGen(s_stormtypes.Lib):
             ($ok, $name) = $__maybeCast($try, inet:user, $name)
             if (not $ok) { return() }
 
-            $platform = $servicePlatformByName($plat, try=$try)
+            $platform = $platformByName($plat, try=$try)
             if (not $platform) { return() }
 
             $guid = $lib.guid(gen, account, $platform, $name)
             return($node)
 
-            [ inet:service:account=(gen, account, $plat, $name)
+            [ inet:service:account=(gen, account, $platform, $name)
                   :user=$name
                   :platform=$platform ]
 
@@ -567,7 +568,7 @@ class LibGen(s_stormtypes.Lib):
             ($ok, $name) = $__maybeCast($try, inet:group, $name)
             if (not $ok) { return() }
 
-            $platform = $servicePlatformByName($plat, try=$try)
+            $platform = $platformByName($plat, try=$try)
             if (not $platform) { return() }
 
             $guid = $lib.guid(gen, group, $platform, $name)

--- a/synapse/lib/stormlib/gen.py
+++ b/synapse/lib/stormlib/gen.py
@@ -542,7 +542,7 @@ class LibGen(s_stormtypes.Lib):
             inet:service:platform:name=$name
             return($node)
 
-            [ inet:service:plaform=(gen, platform, $name) :name=$name ]
+            [ inet:service:platform=(gen, platform, $name) :name=$name ]
             return($node)
         }
 
@@ -550,12 +550,15 @@ class LibGen(s_stormtypes.Lib):
             ($ok, $name) = $__maybeCast($try, inet:user, $name)
             if (not $ok) { return() }
 
-            //$platform = $servicePlatformByName($plat, try=$try)
-            //if (not $platform) { return() }
+            $platform = $servicePlatformByName($plat, try=$try)
+            if (not $platform) { return() }
+
+            $guid = $lib.guid(gen, account, $platform, $name)
+            return($node)
 
             [ inet:service:account=(gen, account, $plat, $name)
-                  :name=$name
-                  :platform=$plat ]
+                  :user=$name
+                  :platform=$platform ]
 
             return($node)
         }
@@ -564,12 +567,16 @@ class LibGen(s_stormtypes.Lib):
             ($ok, $name) = $__maybeCast($try, inet:group, $name)
             if (not $ok) { return() }
 
-            //$platform = $servicePlatformByName($plat, try=$try)
-            //if (not $platform) { return() }
+            $platform = $servicePlatformByName($plat, try=$try)
+            if (not $platform) { return() }
 
-            [ inet:service:group=(gen, account, $platform, $name)
+            $guid = $lib.guid(gen, group, $platform, $name)
+            inet:service:group=$guid
+            return($node)
+
+            [ inet:service:group=$guid
                   :name=$name
-                  :platform=$plat ]
+                  :platform=$platform ]
 
             return($node)
         }

--- a/synapse/lib/stormlib/gen.py
+++ b/synapse/lib/stormlib/gen.py
@@ -164,6 +164,35 @@ class LibGen(s_stormtypes.Lib):
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
                   'returns': {'type': 'node', 'desc': 'An inet:tls:servercert node with the given server and SHA256.'}}},
+        {'name': 'servicePlatformByName',
+         'desc': '',
+         'type': {'type': 'function', '_funcname': '_storm_query',
+                  'args': (
+                      {'name': 'name', 'type': ['str', 'inet:service:platform:name'], 'desc': ''},
+                      {'name': 'try', 'type': 'boolean', 'default': False,
+                       'desc': 'Type normalization will fail silently instead of raising an exception.'},
+                  ),
+                  'returns': {'type': 'node', 'desc': ''}}},
+        {'name': 'accountByPlatformAndName',
+         'desc': '',
+         'type': {'type': 'function', '_funcname': '_storm_query',
+                  'args': (
+                      {'name': 'name', 'type': ['str', 'inet:user'], 'desc': ''},
+                      {'name': 'plat', 'type': ['str', 'inet:service:platform:name'], 'desc': ''},
+                      {'name': 'try', 'type': 'boolean', 'default': False,
+                       'desc': 'Type normalization will fail silently instead of raising an exception.'},
+                  ),
+                  'returns': {'type': 'node', 'desc': ''}}},
+        {'name': 'groupByPlatformAndName',
+         'desc': '',
+         'type': {'type': 'function', '_funcname': '_storm_query',
+                  'args': (
+                      {'name': 'name', 'type': ['str', 'inet:group'], 'desc': ''},
+                      {'name': 'plat', 'type': ['str', 'inet:service:platform:name'], 'desc': ''},
+                      {'name': 'try', 'type': 'boolean', 'default': False,
+                       'desc': 'Type normalization will fail silently instead of raising an exception.'},
+                  ),
+                  'returns': {'type': 'node', 'desc': ''}}},
     )
     _storm_lib_path = ('gen',)
 
@@ -503,6 +532,45 @@ class LibGen(s_stormtypes.Lib):
             if (not $crypto) { return() }
 
             [ inet:tls:servercert=($server, $crypto) ]
+            return($node)
+        }
+
+        function servicePlatformByName(name, try=$lib.false) {
+            ($ok, $name) = $__maybeCast($try, inet:service:platform:name, $name)
+            if (not $ok) { return() }
+
+            inet:service:platform:name=$name
+            return($node)
+
+            [ inet:service:plaform=(gen, platform, $name) :name=$name ]
+            return($node)
+        }
+
+        function accountByPlatformAndName(name, plat, try=$lib.false) {
+            ($ok, $name) = $__maybeCast($try, inet:user, $name)
+            if (not $ok) { return() }
+
+            //$platform = $servicePlatformByName($plat, try=$try)
+            //if (not $platform) { return() }
+
+            [ inet:service:account=(gen, account, $plat, $name)
+                  :name=$name
+                  :platform=$plat ]
+
+            return($node)
+        }
+
+        function groupByPlatformAndName(name, plat, try=$lib.false) {
+            ($ok, $name) = $__maybeCast($try, inet:group, $name)
+            if (not $ok) { return() }
+
+            //$platform = $servicePlatformByName($plat, try=$try)
+            //if (not $platform) { return() }
+
+            [ inet:service:group=(gen, account, $platform, $name)
+                  :name=$name
+                  :platform=$plat ]
+
             return($node)
         }
     '''

--- a/synapse/lib/stormlib/gen.py
+++ b/synapse/lib/stormlib/gen.py
@@ -204,7 +204,7 @@ class LibGen(s_stormtypes.Lib):
                        'desc': 'Type normalization will fail silently instead of raising an exception.'},
                   ),
 
-                  'returns': {'type': 'node', 'desc': 'An inet:service:group with the given name and platform.'}}},
+                  'returns': {'type': 'node', 'desc': 'An inet:service:instance with the given name and platform.'}}},
     )
     _storm_lib_path = ('gen',)
 

--- a/synapse/tests/test_lib_stormlib_gen.py
+++ b/synapse/tests/test_lib_stormlib_gen.py
@@ -355,5 +355,18 @@ class StormLibGenTest(s_test.SynTest):
                     'plat': 'github',
                 }
             }
-            nodes = await core.nodes('yield $lib.gen.accountByPlatformAndName($name, $plat)', opts=opts)
-            breakpoint()
+
+            plat = await core.nodes('yield $lib.gen.servicePlatformByName(github)')
+            self.len(1, plat)
+            plat = plat[0]
+            self.eq(plat.get('name'), 'github')
+
+            nodes = await core.nodes('yield $lib.gen.accountByPlatformAndName(visi, github)', opts=opts)
+            self.len(1, nodes)
+            self.eq(nodes[0].get('user'), 'visi')
+            self.eq(nodes[0].get('platform'), plat.ndef[1])
+
+            nodes = await core.nodes('yield $lib.gen.groupByPlatformAndName(vertexproject, github)')
+            self.len(1, nodes)
+            self.eq(nodes[0].get('name'), 'vertexproject')
+            self.eq(nodes[0].get('platform'), plat.ndef[1])

--- a/synapse/tests/test_lib_stormlib_gen.py
+++ b/synapse/tests/test_lib_stormlib_gen.py
@@ -344,3 +344,16 @@ class StormLibGenTest(s_test.SynTest):
             nodes = await core.nodes('yield $lib.gen.cryptoX509CertBySha256($sha256)', opts=opts)
             self.len(1, nodes)
             self.eq(nodes[0].repr(), crypto)
+
+    async def test_stormlib_gen_service(self):
+
+        async with self.getTestCore() as core:
+
+            opts = {
+                'vars': {
+                    'name': 'rakuy0',
+                    'plat': 'github',
+                }
+            }
+            nodes = await core.nodes('yield $lib.gen.accountByPlatformAndName($name, $plat)', opts=opts)
+            breakpoint()

--- a/synapse/tests/test_lib_stormlib_gen.py
+++ b/synapse/tests/test_lib_stormlib_gen.py
@@ -349,24 +349,26 @@ class StormLibGenTest(s_test.SynTest):
 
         async with self.getTestCore() as core:
 
-            opts = {
-                'vars': {
-                    'name': 'rakuy0',
-                    'plat': 'github',
-                }
-            }
-
-            plat = await core.nodes('yield $lib.gen.servicePlatformByName(github)')
+            plat = await core.nodes('yield $lib.gen.inetServicePlatformByName(github)')
             self.len(1, plat)
             plat = plat[0]
             self.eq(plat.get('name'), 'github')
 
-            nodes = await core.nodes('yield $lib.gen.accountByPlatformAndName(visi, github)', opts=opts)
+            nodes = await core.nodes('yield $lib.gen.inetServiceAccountByNameAndPlatform(visi, github)')
             self.len(1, nodes)
             self.eq(nodes[0].get('user'), 'visi')
             self.eq(nodes[0].get('platform'), plat.ndef[1])
 
-            nodes = await core.nodes('yield $lib.gen.groupByPlatformAndName(vertexproject, github)')
+            nodes = await core.nodes('yield $lib.gen.inetServiceGroupByNameAndPlatform(vertexproject, github)')
             self.len(1, nodes)
             self.eq(nodes[0].get('name'), 'vertexproject')
+            self.eq(nodes[0].get('platform'), plat.ndef[1])
+
+            nodes = await core.nodes('yield $lib.gen.inetServiceInstanceByNameAndPlatform(vertexdiscord, discord)')
+            self.len(1, nodes)
+            self.eq(nodes[0].get('name'), 'vertexdiscord')
+
+            plat = await core.nodes('inet:service:platform:name=discord')
+            self.len(1, plat)
+            plat = plat[0]
             self.eq(nodes[0].get('platform'), plat.ndef[1])


### PR DESCRIPTION
Names are a bit of a mouthful, but are generally in line with the other gen functions. Don't know if we want to tighten those up at all.