### PR TITLE
Add new assets to package data, protect against directory traversal and non-existent requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ include-package-data = true
 
 [tool.setuptools.package-data]
 'synapse' = [
+    'assets/**',
     'data/*.mpk',
     'data/certs/**',
     'data/attack-flow/**',

--- a/synapse/assets/__init__.py
+++ b/synapse/assets/__init__.py
@@ -1,7 +1,9 @@
 import os
+import logging
 
 import synapse.common as s_common
 
+logger = logging.getLogger(__name__)
 dirname = os.path.dirname(__file__)
 
 def getStorm(*names):
@@ -17,6 +19,18 @@ def getStorm(*names):
         text = storm.get('migrations', 'model-0.2.28.storm')
         await core.callStorm(text)
     '''
-    with s_common.genfile(dirname, 'storm', *names) as fp:
-        text = fp.read()
+    fp = getAssetPath('storm', *names)
+    with s_common.genfile(fp) as fd:
+        text = fd.read()
     return text.decode('utf8')
+
+def getAssetPath(*names):
+    fp = s_common.genpath(dirname, *names)
+    absfp = os.path.abspath(fp)
+    if not absfp.startswith(dirname):
+        logger.error(f'{absfp} is not in {dirname}')
+        raise ValueError(f'Path escaping detected for {names}')
+    if not os.path.isfile(absfp):
+        logger.error('{} does not exist'.format(absfp))
+        raise ValueError(f'Asset does not exist for {names}')
+    return absfp

--- a/synapse/tests/test_assets.py
+++ b/synapse/tests/test_assets.py
@@ -1,0 +1,25 @@
+import os
+import synapse.assets as s_assets
+
+import synapse.tests.utils as s_t_utils
+
+class TestAssets(s_t_utils.SynTest):
+
+    def test_assets_path(self):
+
+        fp = s_assets.getAssetPath('storm', 'migrations', 'model-0.2.28.storm')
+        self.true(os.path.isfile(fp))
+
+        with self.raises(ValueError) as cm:
+            s_assets.getAssetPath('../../../../../../../etc/passwd')
+        self.isin('Path escaping', str(cm.exception))
+
+        with self.raises(ValueError) as cm:
+            s_assets.getAssetPath('newp', 'does', 'not', 'exit')
+        self.isin('Asset does not exist', str(cm.exception))
+
+    def test_assets_storm(self):
+
+        text = s_assets.getStorm('migrations', 'model-0.2.28.storm')
+        self.isinstance(text, str)
+        self.gt(len(text), 0)


### PR DESCRIPTION
master images are currently broken

```
$ docker run --rm -it --entrypoint /bin/bash vertexproject/synapse-cortex:master
root@0dc70febf25d:/# ls -lthR /usr/local/lib/python3.11/dist-packages/synapse/assets
/usr/local/lib/python3.11/dist-packages/synapse/assets:
total 8.0K
-rw-r--r-- 1 root root  496 Sep  4 21:11 __init__.py
drwxr-xr-x 2 root root 4.0K Sep  4 21:11 __pycache__

/usr/local/lib/python3.11/dist-packages/synapse/assets/__pycache__:
total 4.0K
-rw-r--r-- 1 root root 1.2K Sep  4 21:11 __init__.cpython-311.pyc
```

vs

```
$ docker run --rm -it --entrypoint /bin/bash vertexproject/synapse-cortex:dev_build
root@f7c2b4e9162c:/# ls -lthR /usr/local/lib/python3.11/dist-packages/synapse/assets
/usr/local/lib/python3.11/dist-packages/synapse/assets:
total 12K
drwxr-xr-x 2 root root 4.0K Sep  5 14:19 __pycache__
-rw-r--r-- 1 root root  991 Sep  5 14:19 __init__.py
drwxr-xr-x 3 root root 4.0K Sep  5 14:19 storm

/usr/local/lib/python3.11/dist-packages/synapse/assets/__pycache__:
total 4.0K
-rw-r--r-- 1 root root 2.2K Sep  5 14:19 __init__.cpython-311.pyc

/usr/local/lib/python3.11/dist-packages/synapse/assets/storm:
total 4.0K
drwxr-xr-x 2 root root 4.0K Sep  5 14:19 migrations

/usr/local/lib/python3.11/dist-packages/synapse/assets/storm/migrations:
total 12K
-rw-r--r-- 1 root root 11K Sep  5 14:19 model-0.2.28.storm
root@f7c2b4e9162c:/# 
```