### PR TITLE
Fix greedy user defined storm functions (SYN-7910)

### DIFF
--- a/changes/8cbac59e13f162569cb4c2aa736ffa24.yaml
+++ b/changes/8cbac59e13f162569cb4c2aa736ffa24.yaml
@@ -1,0 +1,6 @@
+---
+desc: Fix an issue where user defined Storm functions could be be greedy with the
+  IO loop.
+prs: []
+type: bug
+...

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -4899,6 +4899,7 @@ class Function(AstNode):
                 subr.funcscope = True
 
                 try:
+                    await asyncio.sleep(0)
                     async for item in subr.execute():
                         await asyncio.sleep(0)
 
@@ -4913,10 +4914,12 @@ class Function(AstNode):
                 subr.funcscope = True
                 try:
                     if self.hasemit:
+                        await asyncio.sleep(0)
                         async with contextlib.aclosing(await subr.emitter()) as agen:
                             async for item in agen:
                                 yield item
                     else:
+                        await asyncio.sleep(0)
                         async with contextlib.aclosing(subr.execute()) as agen:
                             async for node, path in agen:
                                 yield node, path

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -4918,6 +4918,7 @@ class Function(AstNode):
                         async with contextlib.aclosing(await subr.emitter()) as agen:
                             async for item in agen:
                                 yield item
+                                await asyncio.sleep(0)
                     else:
                         await asyncio.sleep(0)
                         async with contextlib.aclosing(subr.execute()) as agen:

--- a/synapse/tests/test_lib_stormlib_iters.py
+++ b/synapse/tests/test_lib_stormlib_iters.py
@@ -109,8 +109,11 @@ class StormLibItersTest(s_test.SynTest):
                     }
                     '''
                     msgs = await core.stormlist(q)
-                    err = "$lib.iters.zip() encountered errors in 3 iterators during iteration: " \
-                          "(foo: bar), " \
-                          "(NoSuchVar: Missing variable: newp), " \
-                          "(NameError: name 'newp' is not defined)"
-                    self.stormIsInErr(err, msgs)
+                    errs = (
+                        "$lib.iters.zip() encountered errors in 3 iterators during iteration: ",
+                        "(foo: bar)",
+                        "(NoSuchVar: Missing variable: newp)",
+                        "(NameError: name 'newp' is not defined)",
+                    )
+                    for errchunk in errs:
+                        self.stormIsInErr(errchunk, msgs)

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -6408,9 +6408,9 @@ words\tword\twrd'''
             self.eq(2, await core.callStorm('return($lib.math.number(1.23).toint(rounding=ROUND_UP))'))
 
             with self.raises(s_exc.BadCast):
-                    await core.callStorm('return($lib.math.number((null)))')
+                await core.callStorm('return($lib.math.number((null)))')
             with self.raises(s_exc.BadCast):
-                    await core.callStorm('return($lib.math.number(newp))')
+                await core.callStorm('return($lib.math.number(newp))')
 
             with self.raises(s_exc.StormRuntimeError):
                 await core.callStorm('return($lib.math.number(1.23).toint(rounding=NEWP))')


### PR DESCRIPTION
This sleeps before we enter into the subr.execute() for any user defined function. This was more narrow in scope than sleeping in FuncCall.compute where we would be pausing before every function call, including those to Python library functions which should be responsible for not being greedy themselves.