### PR TITLE
Fix an issue with a Cell's drive reloading its type schema validators

### DIFF
--- a/changes/fdd656f050bd769c6f2d24fad8bb6743.yaml
+++ b/changes/fdd656f050bd769c6f2d24fad8bb6743.yaml
@@ -1,0 +1,6 @@
+---
+desc: Fix an issue in the type schema enforcement of a Cell's Drive where a list of
+  types for a field would cause schema checking to always fail after a Cell reboot.
+prs: []
+type: bug
+...

--- a/synapse/lib/drive.py
+++ b/synapse/lib/drive.py
@@ -505,7 +505,7 @@ class Drive(s_base.Base):
     def getTypeSchema(self, typename):
         byts = self.slab.get(LKEY_TYPE + typename.encode(), db=self.dbname)
         if byts is not None:
-            return s_msgpack.un(byts)
+            return s_msgpack.un(byts, use_list=True)
 
     def getTypeSchemaVersion(self, typename):
         verskey = LKEY_TYPE_VERS + typename.encode()

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -29,6 +29,7 @@ import synapse.lib.coro as s_coro
 import synapse.lib.link as s_link
 import synapse.lib.drive as s_drive
 import synapse.lib.nexus as s_nexus
+import synapse.lib.config as s_config
 import synapse.lib.certdir as s_certdir
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.version as s_version
@@ -160,8 +161,9 @@ testDataSchema_v0 = {
     'properties': {
         'type': {'type': 'string'},
         'size': {'type': 'number'},
+        'stuff': {'type': ['number', 'null'], 'default': None}
     },
-    'required': ['type', 'size'],
+    'required': ['type', 'size', 'stuff'],
     'additionalProperties': False,
 }
 
@@ -170,6 +172,7 @@ testDataSchema_v1 = {
     'properties': {
         'type': {'type': 'string'},
         'size': {'type': 'number'},
+        'stuff': {'type': ['number', 'null'], 'default': None},
         'woot': {'type': 'string'},
     },
     'required': ['type', 'size', 'woot'],
@@ -180,202 +183,208 @@ class CellTest(s_t_utils.SynTest):
 
     async def test_cell_drive(self):
 
-        async with self.getTestCell() as cell:
+        with self.getTestDir() as dirn:
+            async with self.getTestCell(dirn=dirn) as cell:
 
-            with self.raises(s_exc.BadName):
-                s_drive.reqValidName('A' * 512)
+                with self.raises(s_exc.BadName):
+                    s_drive.reqValidName('A' * 512)
 
-            info = {'name': 'users'}
-            pathinfo = await cell.addDriveItem(info)
+                info = {'name': 'users'}
+                pathinfo = await cell.addDriveItem(info)
 
-            info = {'name': 'root'}
-            pathinfo = await cell.addDriveItem(info, path='users')
+                info = {'name': 'root'}
+                pathinfo = await cell.addDriveItem(info, path='users')
 
-            with self.raises(s_exc.DupIden):
-                await cell.drive.addItemInfo(pathinfo[-1], path='users')
+                with self.raises(s_exc.DupIden):
+                    await cell.drive.addItemInfo(pathinfo[-1], path='users')
 
-            rootdir = pathinfo[-1].get('iden')
-            self.eq(0, pathinfo[-1].get('kids'))
+                rootdir = pathinfo[-1].get('iden')
+                self.eq(0, pathinfo[-1].get('kids'))
 
-            info = {'name': 'win32k.sys', 'type': 'hehe'}
-            with self.raises(s_exc.NoSuchType):
+                info = {'name': 'win32k.sys', 'type': 'hehe'}
+                with self.raises(s_exc.NoSuchType):
+                    info = await cell.addDriveItem(info, reldir=rootdir)
+
+                infos = [i async for i in cell.getDriveKids(s_drive.rootdir)]
+                self.len(1, infos)
+                self.eq(1, infos[0].get('kids'))
+                self.eq('users', infos[0].get('name'))
+
+                # TODO how to handle iden match with additional property mismatch
+
+                self.true(await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=0))
+                self.true(await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=1))
+                self.false(await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=1))
+
+                with self.raises(s_exc.BadVersion):
+                    await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=0)
+
+                info = {'name': 'win32k.sys', 'type': 'woot'}
                 info = await cell.addDriveItem(info, reldir=rootdir)
 
-            infos = [i async for i in cell.getDriveKids(s_drive.rootdir)]
-            self.len(1, infos)
-            self.eq(1, infos[0].get('kids'))
-            self.eq('users', infos[0].get('name'))
+                iden = info[-1].get('iden')
 
-            # TODO how to handle iden match with additional property mismatch
+                tick = s_common.now()
+                rootuser = cell.auth.rootuser.iden
 
-            self.true(await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=0))
-            self.true(await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=1))
-            self.false(await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=1))
+                with self.raises(s_exc.SchemaViolation):
+                    versinfo = {'version': (1, 0, 0), 'updated': tick, 'updater': rootuser}
+                    await cell.setDriveData(iden, versinfo, {'newp': 'newp'})
 
-            with self.raises(s_exc.BadVersion):
-                await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=0)
+                versinfo = {'version': (1, 1, 0), 'updated': tick + 10, 'updater': rootuser}
+                info, versinfo = await cell.setDriveData(iden, versinfo, {'type': 'haha', 'size': 20, 'stuff': 12})
+                self.eq(info.get('version'), (1, 1, 0))
+                self.eq(versinfo.get('version'), (1, 1, 0))
 
-            info = {'name': 'win32k.sys', 'type': 'woot'}
-            info = await cell.addDriveItem(info, reldir=rootdir)
-
-            iden = info[-1].get('iden')
-
-            tick = s_common.now()
-            rootuser = cell.auth.rootuser.iden
-
-            with self.raises(s_exc.SchemaViolation):
                 versinfo = {'version': (1, 0, 0), 'updated': tick, 'updater': rootuser}
-                await cell.setDriveData(iden, versinfo, {'newp': 'newp'})
+                info, versinfo = await cell.setDriveData(iden, versinfo, {'type': 'hehe', 'size': 0, 'stuff': 13})
+                self.eq(info.get('version'), (1, 1, 0))
+                self.eq(versinfo.get('version'), (1, 0, 0))
 
-            versinfo = {'version': (1, 1, 0), 'updated': tick + 10, 'updater': rootuser}
-            info, versinfo = await cell.setDriveData(iden, versinfo, {'type': 'haha', 'size': 20})
-            self.eq(info.get('version'), (1, 1, 0))
-            self.eq(versinfo.get('version'), (1, 1, 0))
+                versinfo10, data10 = await cell.getDriveData(iden, vers=(1, 0, 0))
+                self.eq(versinfo10.get('updated'), tick)
+                self.eq(versinfo10.get('updater'), rootuser)
+                self.eq(versinfo10.get('version'), (1, 0, 0))
 
-            versinfo = {'version': (1, 0, 0), 'updated': tick, 'updater': rootuser}
-            info, versinfo = await cell.setDriveData(iden, versinfo, {'type': 'hehe', 'size': 0})
-            self.eq(info.get('version'), (1, 1, 0))
-            self.eq(versinfo.get('version'), (1, 0, 0))
+                versinfo11, data11 = await cell.getDriveData(iden, vers=(1, 1, 0))
+                self.eq(versinfo11.get('updated'), tick + 10)
+                self.eq(versinfo11.get('updater'), rootuser)
+                self.eq(versinfo11.get('version'), (1, 1, 0))
 
-            versinfo10, data10 = await cell.getDriveData(iden, vers=(1, 0, 0))
-            self.eq(versinfo10.get('updated'), tick)
-            self.eq(versinfo10.get('updater'), rootuser)
-            self.eq(versinfo10.get('version'), (1, 0, 0))
+                versions = [vers async for vers in cell.getDriveDataVersions(iden)]
+                self.len(2, versions)
+                self.eq(versions[0], versinfo11)
+                self.eq(versions[1], versinfo10)
 
-            versinfo11, data11 = await cell.getDriveData(iden, vers=(1, 1, 0))
-            self.eq(versinfo11.get('updated'), tick + 10)
-            self.eq(versinfo11.get('updater'), rootuser)
-            self.eq(versinfo11.get('version'), (1, 1, 0))
+                info = await cell.delDriveData(iden, vers=(0, 0, 0))
 
-            versions = [vers async for vers in cell.getDriveDataVersions(iden)]
-            self.len(2, versions)
-            self.eq(versions[0], versinfo11)
-            self.eq(versions[1], versinfo10)
+                versions = [vers async for vers in cell.getDriveDataVersions(iden)]
+                self.len(2, versions)
+                self.eq(versions[0], versinfo11)
+                self.eq(versions[1], versinfo10)
 
-            info = await cell.delDriveData(iden, vers=(0, 0, 0))
+                info = await cell.delDriveData(iden, vers=(1, 1, 0))
+                self.eq(info.get('updated'), tick)
+                self.eq(info.get('version'), (1, 0, 0))
 
-            versions = [vers async for vers in cell.getDriveDataVersions(iden)]
-            self.len(2, versions)
-            self.eq(versions[0], versinfo11)
-            self.eq(versions[1], versinfo10)
+                info = await cell.delDriveData(iden, vers=(1, 0, 0))
+                self.eq(info.get('size'), 0)
+                self.eq(info.get('version'), (0, 0, 0))
+                self.none(info.get('updated'))
+                self.none(info.get('updater'))
 
-            info = await cell.delDriveData(iden, vers=(1, 1, 0))
-            self.eq(info.get('updated'), tick)
-            self.eq(info.get('version'), (1, 0, 0))
+                # repopulate a couple data versions to test migration and delete
+                versinfo = {'version': (1, 0, 0), 'updated': tick, 'updater': rootuser}
+                info, versinfo = await cell.setDriveData(iden, versinfo, {'type': 'hehe', 'size': 0, 'stuff': 14})
+                versinfo = {'version': (1, 1, 0), 'updated': tick + 10, 'updater': rootuser}
+                info, versinfo = await cell.setDriveData(iden, versinfo, {'type': 'haha', 'size': 17, 'stuff': 15})
+                self.eq(versinfo, (await cell.getDriveData(iden))[0])
 
-            info = await cell.delDriveData(iden, vers=(1, 0, 0))
-            self.eq(info.get('size'), 0)
-            self.eq(info.get('version'), (0, 0, 0))
-            self.none(info.get('updated'))
-            self.none(info.get('updater'))
+                # This will be done by the cell in a cell storage version migration...
+                async def migrate_v1(info, versinfo, data):
+                    data['woot'] = 'woot'
+                    return data
 
-            # repopulate a couple data versions to test migration and delete
-            versinfo = {'version': (1, 0, 0), 'updated': tick, 'updater': rootuser}
-            info, versinfo = await cell.setDriveData(iden, versinfo, {'type': 'hehe', 'size': 0})
-            versinfo = {'version': (1, 1, 0), 'updated': tick + 10, 'updater': rootuser}
-            info, versinfo = await cell.setDriveData(iden, versinfo, {'type': 'haha', 'size': 17})
-            self.eq(versinfo, (await cell.getDriveData(iden))[0])
+                await cell.drive.setTypeSchema('woot', testDataSchema_v1, migrate_v1)
 
-            # This will be done by the cell in a cell storage version migration...
-            async def migrate_v1(info, versinfo, data):
-                data['woot'] = 'woot'
-                return data
+                versinfo, data = await cell.getDriveData(iden, vers=(1, 0, 0))
+                self.eq('woot', data.get('woot'))
 
-            await cell.drive.setTypeSchema('woot', testDataSchema_v1, migrate_v1)
+                versinfo, data = await cell.getDriveData(iden, vers=(1, 1, 0))
+                self.eq('woot', data.get('woot'))
 
-            versinfo, data = await cell.getDriveData(iden, vers=(1, 0, 0))
-            self.eq('woot', data.get('woot'))
+                with self.raises(s_exc.NoSuchIden):
+                    await cell.reqDriveInfo('d7d6107b200e2c039540fc627bc5537d')
 
-            versinfo, data = await cell.getDriveData(iden, vers=(1, 1, 0))
-            self.eq('woot', data.get('woot'))
+                with self.raises(s_exc.TypeMismatch):
+                    await cell.getDriveInfo(iden, typename='newp')
 
-            with self.raises(s_exc.NoSuchIden):
-                await cell.reqDriveInfo('d7d6107b200e2c039540fc627bc5537d')
+                self.nn(await cell.getDriveInfo(iden))
+                self.len(2, [vers async for vers in cell.getDriveDataVersions(iden)])
 
-            with self.raises(s_exc.TypeMismatch):
-                await cell.getDriveInfo(iden, typename='newp')
+                await cell.delDriveData(iden)
+                self.len(1, [vers async for vers in cell.getDriveDataVersions(iden)])
 
-            self.nn(await cell.getDriveInfo(iden))
-            self.len(2, [vers async for vers in cell.getDriveDataVersions(iden)])
+                await cell.delDriveInfo(iden)
 
-            await cell.delDriveData(iden)
-            self.len(1, [vers async for vers in cell.getDriveDataVersions(iden)])
+                self.none(await cell.getDriveInfo(iden))
+                self.len(0, [vers async for vers in cell.getDriveDataVersions(iden)])
 
-            await cell.delDriveInfo(iden)
+                with self.raises(s_exc.NoSuchPath):
+                    await cell.getDrivePath('users/root/win32k.sys')
 
-            self.none(await cell.getDriveInfo(iden))
-            self.len(0, [vers async for vers in cell.getDriveDataVersions(iden)])
+                pathinfo = await cell.addDrivePath('foo/bar/baz')
+                self.len(3, pathinfo)
+                self.eq('foo', pathinfo[0].get('name'))
+                self.eq(1, pathinfo[0].get('kids'))
+                self.eq('bar', pathinfo[1].get('name'))
+                self.eq(1, pathinfo[1].get('kids'))
+                self.eq('baz', pathinfo[2].get('name'))
+                self.eq(0, pathinfo[2].get('kids'))
 
-            with self.raises(s_exc.NoSuchPath):
-                await cell.getDrivePath('users/root/win32k.sys')
+                self.eq(pathinfo, await cell.addDrivePath('foo/bar/baz'))
 
-            pathinfo = await cell.addDrivePath('foo/bar/baz')
-            self.len(3, pathinfo)
-            self.eq('foo', pathinfo[0].get('name'))
-            self.eq(1, pathinfo[0].get('kids'))
-            self.eq('bar', pathinfo[1].get('name'))
-            self.eq(1, pathinfo[1].get('kids'))
-            self.eq('baz', pathinfo[2].get('name'))
-            self.eq(0, pathinfo[2].get('kids'))
+                baziden = pathinfo[2].get('iden')
+                self.eq(pathinfo, await cell.drive.getItemPath(baziden))
 
-            self.eq(pathinfo, await cell.addDrivePath('foo/bar/baz'))
+                info = await cell.setDriveInfoPerm(baziden, {'users': {rootuser: 3}, 'roles': {}})
+                self.eq(3, info['perm']['users'][rootuser])
 
-            baziden = pathinfo[2].get('iden')
-            self.eq(pathinfo, await cell.drive.getItemPath(baziden))
+                with self.raises(s_exc.NoSuchIden):
+                    # s_drive.rootdir is all 00s... ;)
+                    await cell.setDriveInfoPerm(s_drive.rootdir, {'users': {}, 'roles': {}})
 
-            info = await cell.setDriveInfoPerm(baziden, {'users': {rootuser: 3}, 'roles': {}})
-            self.eq(3, info['perm']['users'][rootuser])
+                await cell.addDrivePath('hehe/haha')
+                pathinfo = await cell.setDriveInfoPath(baziden, 'hehe/haha/hoho')
 
-            with self.raises(s_exc.NoSuchIden):
-                # s_drive.rootdir is all 00s... ;)
-                await cell.setDriveInfoPerm(s_drive.rootdir, {'users': {}, 'roles': {}})
+                self.eq('hoho', pathinfo[-1].get('name'))
+                self.eq(baziden, pathinfo[-1].get('iden'))
 
-            await cell.addDrivePath('hehe/haha')
-            pathinfo = await cell.setDriveInfoPath(baziden, 'hehe/haha/hoho')
+                self.true(await cell.drive.hasPathInfo('hehe/haha/hoho'))
+                self.false(await cell.drive.hasPathInfo('foo/bar/baz'))
 
-            self.eq('hoho', pathinfo[-1].get('name'))
-            self.eq(baziden, pathinfo[-1].get('iden'))
+                pathinfo = await cell.getDrivePath('foo/bar')
+                self.eq(0, pathinfo[-1].get('kids'))
 
-            self.true(await cell.drive.hasPathInfo('hehe/haha/hoho'))
-            self.false(await cell.drive.hasPathInfo('foo/bar/baz'))
+                pathinfo = await cell.getDrivePath('hehe/haha')
+                self.eq(1, pathinfo[-1].get('kids'))
 
-            pathinfo = await cell.getDrivePath('foo/bar')
-            self.eq(0, pathinfo[-1].get('kids'))
+                with self.raises(s_exc.DupName):
+                    iden = pathinfo[-2].get('iden')
+                    name = pathinfo[-1].get('name')
+                    cell.drive.reqFreeStep(iden, name)
 
-            pathinfo = await cell.getDrivePath('hehe/haha')
-            self.eq(1, pathinfo[-1].get('kids'))
+                walks = [item async for item in cell.drive.walkPathInfo('hehe')]
+                self.len(3, walks)
+                # confirm walked paths are yielded depth first...
+                self.eq('hoho', walks[0].get('name'))
+                self.eq('haha', walks[1].get('name'))
+                self.eq('hehe', walks[2].get('name'))
 
-            with self.raises(s_exc.DupName):
-                iden = pathinfo[-2].get('iden')
-                name = pathinfo[-1].get('name')
-                cell.drive.reqFreeStep(iden, name)
+                iden = walks[2].get('iden')
+                walks = [item async for item in cell.drive.walkItemInfo(iden)]
+                self.len(3, walks)
+                self.eq('hoho', walks[0].get('name'))
+                self.eq('haha', walks[1].get('name'))
+                self.eq('hehe', walks[2].get('name'))
 
-            walks = [item async for item in cell.drive.walkPathInfo('hehe')]
-            self.len(3, walks)
-            # confirm walked paths are yielded depth first...
-            self.eq('hoho', walks[0].get('name'))
-            self.eq('haha', walks[1].get('name'))
-            self.eq('hehe', walks[2].get('name'))
+                self.none(cell.drive.getTypeSchema('newp'))
 
-            iden = walks[2].get('iden')
-            walks = [item async for item in cell.drive.walkItemInfo(iden)]
-            self.len(3, walks)
-            self.eq('hoho', walks[0].get('name'))
-            self.eq('haha', walks[1].get('name'))
-            self.eq('hehe', walks[2].get('name'))
+                cell.drive.validators.pop('woot')
+                self.nn(cell.drive.getTypeValidator('woot'))
 
-            self.none(cell.drive.getTypeSchema('newp'))
+                # move to root dir
+                pathinfo = await cell.setDriveInfoPath(baziden, 'zipzop')
+                self.len(1, pathinfo)
+                self.eq(s_drive.rootdir, pathinfo[-1].get('parent'))
 
-            cell.drive.validators.pop('woot')
-            self.nn(cell.drive.getTypeValidator('woot'))
+                pathinfo = await cell.setDriveInfoPath(baziden, 'hehe/haha/hoho')
+                self.len(3, pathinfo)
 
-            # move to root dir
-            pathinfo = await cell.setDriveInfoPath(baziden, 'zipzop')
-            self.len(1, pathinfo)
-            self.eq(s_drive.rootdir, pathinfo[-1].get('parent'))
-
-            pathinfo = await cell.setDriveInfoPath(baziden, 'hehe/haha/hoho')
-            self.len(3, pathinfo)
+            async with self.getTestCell(dirn=dirn) as cell:
+                data = {'type': 'woot', 'size': 20, 'stuff': 12, 'woot': 'woot'}
+                s_config._JsValidators = {}
+                cell.drive.reqValidData('woot', data)
 
     async def test_cell_auth(self):
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -383,6 +383,8 @@ class CellTest(s_t_utils.SynTest):
 
             async with self.getTestCell(dirn=dirn) as cell:
                 data = {'type': 'woot', 'size': 20, 'stuff': 12, 'woot': 'woot'}
+                # explicitly clear out the cache JsValidators, otherwise we get the cached, pre-msgpack
+                # version of the validator, which will be correct and skip the point of this test.
                 s_config._JsValidators = {}
                 cell.drive.reqValidData('woot', data)
 


### PR DESCRIPTION
Otherwise we produce fun exceptions like the below on a Cell restart
```
Traceback (most recent call last):
  File "/home/infime/.pyenv/versions/optic3.11.6/lib/python3.11/site-packages/fastjsonschema/draft06.py", line 61, in generate_type
    python_types = ', '.join(JSON_TYPE_TO_PYTHON_TYPE[t] for t in types)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/infime/.pyenv/versions/optic3.11.6/lib/python3.11/site-packages/fastjsonschema/draft06.py", line 61, in <genexpr>
    python_types = ', '.join(JSON_TYPE_TO_PYTHON_TYPE[t] for t in types)
                             ~~~~~~~~~~~~~~~~~~~~~~~~^^^
KeyError: ('number', 'null')
```