### PR TITLE
Cell.adminapi - add wrapped func to struct log and fix AuthDeny

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -4651,6 +4651,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         # allow an admin to directly open the cortex hive
         # (perhaps this should be a Cell() level pattern)
         if path[0] == 'hive' and user.isAdmin():
+            s_common.deprecated('Cortex /hive telepath path', curv='2.167.0')
             return await self.hiveapi.anit(self.hive, user)
 
         if path[0] == 'layer':

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -96,16 +96,16 @@ def adminapi(log=False):
     def decrfunc(func):
 
         @functools.wraps(func)
-        def wrapped(*args, **kwargs):
+        def wrapped(self, *args, **kwargs):
 
-            if args[0].user is not None and not args[0].user.isAdmin():
-                raise s_exc.AuthDeny(mesg=f'User is not an admin [{args[0].user.name}]',
-                                     user=args[0].user.iden, username=args[0].user.name)
+            if self.user is not None and not self.user.isAdmin():
+                raise s_exc.AuthDeny(mesg=f'User is not an admin [{self.user.name}]',
+                                     user=self.user.iden, username=self.user.name)
             if log:
-                logger.info(f'Executing [{func.__qualname__}] as [{args[0].user.name}] with args [{args[1:]}[{kwargs}]',
+                logger.info(f'Executing [{func.__qualname__}] as [{self.user.name}] with args [{args}[{kwargs}]',
                             extra={'synapse': {'wrapped_func': func.__qualname__}})
 
-            return func(*args, **kwargs)
+            return func(self, *args, **kwargs)
 
         wrapped.__syn_wrapped__ = 'adminapi'
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -99,11 +99,11 @@ def adminapi(log=False):
         def wrapped(*args, **kwargs):
 
             if args[0].user is not None and not args[0].user.isAdmin():
-                raise s_exc.AuthDeny(mesg='User is not an admin.',
-                                     user=args[0].user.name)
+                raise s_exc.AuthDeny(mesg=f'User is not an admin [{args[0].user.name}]',
+                                     user=args[0].user.iden, username=args[0].user.name)
             if log:
-                logger.info('Executing [%s] as [%s] with args [%s][%s]',
-                            func.__qualname__, args[0].user.name, args[1:], kwargs)
+                logger.info(f'Executing [{func.__qualname__}] as [{args[0].user.name}] with args [{args[1:]}[{kwargs}]',
+                            extra={'synapse': {'wrapped_func': func.__qualname__}})
 
             return func(*args, **kwargs)
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -36,10 +36,6 @@ from synapse.tests.utils import alist
 
 logger = logging.getLogger(__name__)
 
-def jsonlines(text):
-    lines = [k for k in text.split('\n') if k]
-    return [json.loads(line) for line in lines]
-
 class CortexTest(s_t_utils.SynTest):
     '''
     The tests that should be run with different types of layers
@@ -8128,7 +8124,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     data = stream.getvalue()
                     self.notin('Timeout', data)
-                    msgs = jsonlines(data)
+                    msgs = s_t_utils.jsonlines(data)
                     self.len(2, msgs)
 
                     self.eq(msgs[0].get('message'), f'Offloading Storm query to mirror 01.core.{ahanet}.')
@@ -8147,7 +8143,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     data = stream.getvalue()
                     self.notin('Timeout', data)
-                    msgs = jsonlines(data)
+                    msgs = s_t_utils.jsonlines(data)
                     self.len(2, msgs)
 
                     self.eq(msgs[0].get('message'), f'Offloading Storm query to mirror 01.core.{ahanet}.')
@@ -8166,7 +8162,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     data = stream.getvalue()
                     self.notin('Timeout', data)
-                    msgs = jsonlines(data)
+                    msgs = s_t_utils.jsonlines(data)
                     self.len(2, msgs)
 
                     self.eq(msgs[0].get('message'), f'Offloading Storm query to mirror 01.core.{ahanet}.')
@@ -8185,7 +8181,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     data = stream.getvalue()
                     self.notin('Timeout', data)
-                    msgs = jsonlines(data)
+                    msgs = s_t_utils.jsonlines(data)
                     self.len(2, msgs)
 
                     self.eq(msgs[0].get('message'), f'Offloading Storm query to mirror 01.core.{ahanet}.')

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1,6 +1,5 @@
 import os
 import copy
-import json
 import time
 import asyncio
 import hashlib
@@ -1113,8 +1112,7 @@ class CortexTest(s_t_utils.SynTest):
                 ''')
                 self.true(await stream.wait(6))
 
-            buf = stream.getvalue()
-            mesg = json.loads(buf.split('\n')[0])
+            mesg = stream.jsonlines()[0]
             self.eq(mesg.get('message'), f'Running dmon {iden}')
             self.eq(mesg.get('iden'), iden)
 
@@ -3364,8 +3362,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                 await alist(core.storm('help foo', opts={'show': ('init', 'fini', 'print',)}))
                 self.true(await stream.wait(4))
 
-            buf = stream.getvalue()
-            mesg = json.loads(buf.split('\n')[0])
+            mesg = stream.jsonlines()[0]
             self.eq(mesg.get('view'), view)
 
     async def test_strict(self):
@@ -7900,8 +7897,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                     self.eq('admin', whoami)
                     self.eq('lowuser', udef.get('name'))
 
-                raw_mesgs = [m for m in stream.getvalue().split('\n') if m]
-                msgs = [json.loads(m) for m in raw_mesgs]
+                msgs = stream.jsonlines()
                 mesg = [m for m in msgs if 'Added user' in m.get('message')][0]
                 self.eq('Added user=lowuser', mesg.get('message'))
                 self.eq('admin', mesg.get('username'))
@@ -7915,8 +7911,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                         msgs.append(mesg)
                     self.stormHasNoWarnErr(msgs)
 
-                raw_mesgs = [m for m in stream.getvalue().split('\n') if m]
-                msgs = [json.loads(m) for m in raw_mesgs]
+                msgs = stream.jsonlines()
                 mesg = [m for m in msgs if 'Set admin' in m.get('message')][0]
                 self.isin('Set admin=True for lowuser', mesg.get('message'))
                 self.eq('admin', mesg.get('username'))
@@ -8124,7 +8119,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     data = stream.getvalue()
                     self.notin('Timeout', data)
-                    msgs = s_t_utils.jsonlines(data)
+                    msgs = stream.jsonlines()
                     self.len(2, msgs)
 
                     self.eq(msgs[0].get('message'), f'Offloading Storm query to mirror 01.core.{ahanet}.')
@@ -8143,7 +8138,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     data = stream.getvalue()
                     self.notin('Timeout', data)
-                    msgs = s_t_utils.jsonlines(data)
+                    msgs = stream.jsonlines()
                     self.len(2, msgs)
 
                     self.eq(msgs[0].get('message'), f'Offloading Storm query to mirror 01.core.{ahanet}.')
@@ -8162,7 +8157,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     data = stream.getvalue()
                     self.notin('Timeout', data)
-                    msgs = s_t_utils.jsonlines(data)
+                    msgs = stream.jsonlines()
                     self.len(2, msgs)
 
                     self.eq(msgs[0].get('message'), f'Offloading Storm query to mirror 01.core.{ahanet}.')
@@ -8181,7 +8176,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     data = stream.getvalue()
                     self.notin('Timeout', data)
-                    msgs = s_t_utils.jsonlines(data)
+                    msgs = stream.jsonlines()
                     self.len(2, msgs)
 
                     self.eq(msgs[0].get('message'), f'Offloading Storm query to mirror 01.core.{ahanet}.')

--- a/synapse/tests/test_lib_agenda.py
+++ b/synapse/tests/test_lib_agenda.py
@@ -1,4 +1,3 @@
-import json
 import asyncio
 import hashlib
 import datetime
@@ -9,8 +8,6 @@ import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.tests.utils as s_t_utils
 
-import synapse.lib.hive as s_hive
-import synapse.lib.lmdbslab as s_lmdbslab
 import synapse.tools.backup as s_tools_backup
 
 import synapse.lib.agenda as s_agenda
@@ -401,9 +398,7 @@ class AgendaTest(s_t_utils.SynTest):
                     self.eq((12, 'bar'), await asyncio.wait_for(core.callStorm('return($lib.queue.gen(visi).pop(wait=$lib.true))'), timeout=5))
                 core.stormlog = False
 
-                data = stream.getvalue()
-                raw_mesgs = [m for m in data.split('\n') if m]
-                msgs = [json.loads(m) for m in raw_mesgs]
+                msgs = stream.jsonlines()
                 msgs = [m for m in msgs if m['text'] == '$lib.queue.gen(visi).put(bar)']
                 self.gt(len(msgs), 0)
                 for m in msgs:

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -115,6 +115,14 @@ class EchoAuthApi(s_cell.CellApi):
         await self._reqUserAllowed(path)
         return True
 
+    @s_cell.adminapi()
+    async def adminOnly(self):
+        return True
+
+    @s_cell.adminapi(log=True)
+    async def adminOnlyLog(self, arg1, arg2, **kwargs):
+        return (arg1, arg2, kwargs)
+
 class EchoAuth(s_cell.Cell):
     cellapi = EchoAuthApi
 
@@ -428,6 +436,16 @@ class CellTest(s_t_utils.SynTest):
                     self.eq(info.get('user').get('name'), 'root')
                     self.eq(info.get('user').get('iden'), root.iden)
 
+                    # @adminApi methods are allowed
+                    self.true(await proxy.adminOnly())
+                    mesg = "Executing [EchoAuthApi.adminOnlyLog] as [root] with args [(1, 2)[{'three': 4}]"
+                    with self.getStructuredAsyncLoggerStream('synapse.lib.cell', mesg) as stream:
+                        self.eq(await proxy.adminOnlyLog(1, 2, three=4), (1, 2, {'three': 4}))
+                        self.true(await stream.wait(timeout=10))
+                    msgs = s_t_utils.jsonlines(stream.getvalue())
+                    self.len(1, msgs)
+                    self.eq('EchoAuthApi.adminOnlyLog', msgs[0].get('wrapped_func'))
+
                 visi = await echo.auth.addUser('visi')
                 await visi.setPasswd('foo')
                 await visi.addRule((True, ('foo', 'bar')))
@@ -453,6 +471,14 @@ class CellTest(s_t_utils.SynTest):
 
                     with self.raises(s_exc.NoSuchUser):
                         await proxy.getUserInfo('newp')
+
+                    # @adminApi methods are not allowed
+                    with self.raises(s_exc.AuthDeny) as cm:
+                        await proxy.adminOnly()
+                    self.eq(cm.exception.get('user'), visi.iden)
+                    self.eq(cm.exception.get('username'), visi.name)
+                    with self.raises(s_exc.AuthDeny) as cm:
+                        await proxy.adminOnlyLog(1, 2, three=4)
 
                     # User cannot get authinfo for other items since they are
                     # not an admin or do not have those roles.

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -121,7 +121,7 @@ class EchoAuthApi(s_cell.CellApi):
 
     @s_cell.adminapi(log=True)
     async def adminOnlyLog(self, arg1, arg2, **kwargs):
-        return (arg1, arg2, kwargs)
+        return arg1, arg2, kwargs
 
 class EchoAuth(s_cell.Cell):
     cellapi = EchoAuthApi
@@ -442,7 +442,7 @@ class CellTest(s_t_utils.SynTest):
                     with self.getStructuredAsyncLoggerStream('synapse.lib.cell', mesg) as stream:
                         self.eq(await proxy.adminOnlyLog(1, 2, three=4), (1, 2, {'three': 4}))
                         self.true(await stream.wait(timeout=10))
-                    msgs = s_t_utils.jsonlines(stream.getvalue())
+                    msgs = stream.jsonlines()
                     self.len(1, msgs)
                     self.eq('EchoAuthApi.adminOnlyLog', msgs[0].get('wrapped_func'))
 
@@ -3091,10 +3091,7 @@ class CellTest(s_t_utils.SynTest):
                 async with self.getTestCore(conf={'health:sysctl:checks': True}):
                     pass
 
-        stream.seek(0)
-        data = stream.getvalue()
-        raw_mesgs = [m for m in data.split('\n') if m]
-        msgs = [json.loads(m) for m in raw_mesgs]
+        msgs = stream.jsonlines()
 
         self.len(1, msgs)
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -475,6 +475,7 @@ class CellTest(s_t_utils.SynTest):
                     # @adminApi methods are not allowed
                     with self.raises(s_exc.AuthDeny) as cm:
                         await proxy.adminOnly()
+                    self.eq(cm.exception.get('mesg'), 'User is not an admin [visi]')
                     self.eq(cm.exception.get('user'), visi.iden)
                     self.eq(cm.exception.get('username'), visi.name)
                     with self.raises(s_exc.AuthDeny) as cm:

--- a/synapse/tests/test_lib_httpapi.py
+++ b/synapse/tests/test_lib_httpapi.py
@@ -1722,10 +1722,8 @@ class HttpApiTest(s_tests.SynTest):
 
     async def test_request_logging(self):
 
-        def get_mesg(stream):
-            data = stream.getvalue()
-            raw_mesgs = [m for m in data.split('\n') if m]
-            msgs = [json.loads(m) for m in raw_mesgs]
+        def get_mesg(stream: s_tests.AsyncStreamEvent) -> dict:
+            msgs = stream.jsonlines()
             self.len(1, msgs)
             return msgs[0]
 

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -1,5 +1,4 @@
 import os
-import json
 import asyncio
 import pathlib
 import multiprocessing
@@ -15,7 +14,6 @@ import synapse.lib.lmdbslab as s_lmdbslab
 import synapse.lib.thisplat as s_thisplat
 
 import synapse.tests.utils as s_t_utils
-from synapse.tests.utils import alist
 
 def getFileMapCount(filename):
     filename = str(filename)
@@ -360,8 +358,7 @@ class LmdbSlabTest(s_t_utils.SynTest):
                         slab.put(b'\xff\xff\xff\xff' + s_common.guid(i).encode('utf8'), byts, db=foo)
                 self.true(await stream.wait(timeout=1))
 
-            data = stream.getvalue()
-            msgs = [json.loads(m) for m in data.split('\\n') if m]
+            msgs = stream.jsonlines()
             self.gt(len(msgs), 0)
             self.nn(msgs[0].get('delta'))
             self.nn(msgs[0].get('path'))

--- a/synapse/tests/test_lib_stormlib_cortex.py
+++ b/synapse/tests/test_lib_stormlib_cortex.py
@@ -304,9 +304,7 @@ $request.reply(206, headers=$headers, body=({"no":"body"}))
                     resp = await sess.get(url)
                     self.eq(resp.status, 200)
                     self.true(await stream.wait(timeout=12))
-                data = stream.getvalue()
-                raw_mesgs = [m for m in data.split('\n') if m]
-                msgs = [json.loads(m) for m in raw_mesgs]
+                msgs = stream.jsonlines()
                 self.eq(msgs[0].get('httpapi'), echoiden)
                 core.stormlog = False
 

--- a/synapse/tests/test_lib_stormlib_log.py
+++ b/synapse/tests/test_lib_stormlib_log.py
@@ -1,5 +1,3 @@
-import json
-
 import synapse.exc as s_exc
 
 import synapse.tests.utils as s_test
@@ -49,10 +47,7 @@ class LogTest(s_test.SynTest):
                 await core.callStorm('$lib.log.debug("struct1 message")')
                 await core.callStorm('$lib.log.debug("struct2 message", extra=({"key": "valu"}))')
                 self.true(await stream.wait(6))
-
-            data = stream.getvalue()
-            raw_mesgs = [m for m in data.split('\n') if m]
-            msgs = [json.loads(m) for m in raw_mesgs]
+            msgs = stream.jsonlines()
             self.len(2, msgs)
             mesg = msgs[0]
             self.eq(mesg.get('logger').get('name'), 'synapse.storm.log')

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -4920,8 +4920,7 @@ class StormTypesTest(s_test.SynTest):
                         unixtime += 7 * MINSECS
                         self.eq('m3', await getNextFoo())
                         self.true(await stream.wait(6))
-                    buf = stream.getvalue()
-                    mesg = json.loads(buf.split('\n')[0])
+                    mesg = stream.jsonlines()[0]
                     self.eq(mesg['message'], f'm3 cron {guid}')
                     self.eq(mesg['iden'], guid)
 

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -1,5 +1,4 @@
 import os
-import json
 import synapse.exc as s_exc
 import synapse.common as s_common
 
@@ -253,8 +252,8 @@ class TrigTest(s_t_utils.SynTest):
             with self.getStructuredAsyncLoggerStream('synapse.storm.log', 'test trigger') as stream:
                 await core.nodes('[ test:str=logit ]')
                 self.true(await stream.wait(6))
-            buf = stream.getvalue()
-            mesg = json.loads(buf.split('\n')[-2])
+            msgs = stream.jsonlines()
+            mesg = [m for m in msgs if m.get('iden') == tdef.get('iden')][0]
             self.eq(mesg['message'], f'test trigger {tdef.get("iden")}')
             self.eq(mesg['iden'], tdef.get('iden'))
 

--- a/synapse/tests/test_utils.py
+++ b/synapse/tests/test_utils.py
@@ -134,7 +134,6 @@ class TestUtils(s_t_utils.SynTest):
         self.len(1, msgs)
         self.eq(msgs[0], {'mesg': 'Test Message'})
 
-
     def test_syntest_envars(self):
         os.environ['foo'] = '1'
         os.environ['bar'] = '2'

--- a/synapse/tests/test_utils.py
+++ b/synapse/tests/test_utils.py
@@ -138,11 +138,20 @@ class TestUtils(s_t_utils.SynTest):
         os.environ['foo'] = '1'
         os.environ['bar'] = '2'
 
-        with self.setTstEnvars(foo=1, bar='joke', baz=1234) as cm:
+        with self.setTstEnvars(foo=1, bar='joke', baz=1234, FOO_THING=1, BAR_THING=0) as cm:
             self.none(cm)
             self.eq(os.environ.get('foo'), '1')
             self.eq(os.environ.get('bar'), 'joke')
             self.eq(os.environ.get('baz'), '1234')
+
+            self.thisEnvMust('FOO_THING', 'baz')
+            self.thisEnvMustNot('BAR_THING', 'NEWP_THING')
+            with self.raises(unittest.SkipTest):
+                self.thisEnvMust('MEWP_THING')
+            with self.raises(unittest.SkipTest):
+                self.thisEnvMust('BAR_THING')
+            with self.raises(unittest.SkipTest):
+                self.thisEnvMustNot('FOO_THING')
 
         self.eq(os.environ.get('foo'), '1')
         self.eq(os.environ.get('bar'), '2')

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1141,11 +1141,23 @@ class SynTest(unittest.TestCase):
         return TstOutPut()
 
     def thisEnvMust(self, *envvars):
+        '''
+        Requires a host must have environment variables set to truthy values.
+
+        Args:
+            *envars: Environment variables to require being present.
+        '''
         for envar in envvars:
             if not s_common.envbool(envar):
                 self.skip(f'Envar {envar} is not set to a truthy value.')
 
     def thisEnvMustNot(self, *envvars):
+        '''
+        Requires a host must not have environment variables set to truthy values.
+
+        Args:
+            *envars: Environment variables to require being absent or set to falsey values.
+        '''
         for envar in envvars:
             if s_common.envbool(envar):
                 self.skip(f'Envar {envar} is set to a truthy value.')

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -21,6 +21,7 @@ import io
 import os
 import sys
 import copy
+import json
 import math
 import types
 import shutil
@@ -96,6 +97,10 @@ def norm(z):
 
 def deguidify(x):
     return regex.sub('[0-9a-f]{32}', '*' * 32, x)
+
+def jsonlines(text):
+    lines = [k for k in text.split('\n') if k]
+    return [json.loads(line) for line in lines]
 
 async def waitForBehold(core, events):
     async for mesg in core.behold():

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -25,6 +25,7 @@ import json
 import math
 import types
 import shutil
+import typing
 import asyncio
 import hashlib
 import inspect
@@ -98,7 +99,7 @@ def norm(z):
 def deguidify(x):
     return regex.sub('[0-9a-f]{32}', '*' * 32, x)
 
-def jsonlines(text):
+def jsonlines(text: str):
     lines = [k for k in text.split('\n') if k]
     return [json.loads(line) for line in lines]
 
@@ -794,6 +795,10 @@ class StreamEvent(io.StringIO, threading.Event):
         if self.mesg and self.mesg in s:
             self.set()
 
+    def jsonlines(self) -> typing.List[dict]:
+        '''Get the messages as jsonlines. May throw Json errors if the captured stream is not jsonlines.'''
+        return jsonlines(self.getvalue())
+
 class AsyncStreamEvent(io.StringIO, asyncio.Event):
     '''
     A combination of a io.StringIO object and an asyncio.Event object.
@@ -825,6 +830,10 @@ class AsyncStreamEvent(io.StringIO, asyncio.Event):
         if timeout is None:
             return await asyncio.Event.wait(self)
         return await s_coro.event_wait(self, timeout=timeout)
+
+    def jsonlines(self) -> typing.List[dict]:
+        '''Get the messages as jsonlines. May throw Json errors if the captured stream is not jsonlines.'''
+        return jsonlines(self.getvalue())
 
 class HttpReflector(s_httpapi.Handler):
     '''Test handler which reflects get/post data back to the caller'''
@@ -1724,7 +1733,7 @@ class SynTest(unittest.TestCase):
             slogger.setLevel(level)
 
     @contextlib.contextmanager
-    def getAsyncLoggerStream(self, logname, mesg=''):
+    def getAsyncLoggerStream(self, logname, mesg='') -> contextlib.AbstractContextManager[StreamEvent, None, None]:
         '''
         Async version of getLoggerStream.
 
@@ -1769,7 +1778,7 @@ class SynTest(unittest.TestCase):
             slogger.setLevel(level)
 
     @contextlib.contextmanager
-    def getStructuredAsyncLoggerStream(self, logname, mesg=''):
+    def getStructuredAsyncLoggerStream(self, logname, mesg='') -> contextlib.AbstractContextManager[AsyncStreamEvent, None, None]:
         '''
         Async version of getLoggerStream which uses structured logging.
 
@@ -1792,9 +1801,7 @@ class SynTest(unittest.TestCase):
                     # Wait for the mesg to be written to the stream
                     await stream.wait(timeout=10)
 
-                data = stream.getvalue()
-                raw_mesgs = [m for m in data.split('\n') if m]
-                msgs = [json.loads(m) for m in raw_mesgs]
+                msgs = stream.jsonlines()
                 # Do something with messages
 
         Returns:

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1140,6 +1140,16 @@ class SynTest(unittest.TestCase):
         '''
         return TstOutPut()
 
+    def thisEnvMust(self, *envvars):
+        for envar in envvars:
+            if not s_common.envbool(envar):
+                self.skip(f'Envar {envar} is not set to a truthy value.')
+
+    def thisEnvMustNot(self, *envvars):
+        for envar in envvars:
+            if s_common.envbool(envar):
+                self.skip(f'Envar {envar} is set to a truthy value.')
+
     def thisHostMust(self, **props):  # pragma: no cover
         '''
         Requires a host having a specific property.


### PR DESCRIPTION
Add wrapped func to struct log output; update it to use `self` to be easier to read.
Fix AuthDeny user and username values to be consistent in adminapi decorator.
Add missing deprecation for connect to the Cortex Hive via telepath. 
Move synapse.tests.cortex.jsonlines to synapse.tests.utils and add a jsonlines method to the StreamEvent classes.
Add SynTest.thisEnvMust and SynTest.thisEnvMustNot helper functions.

