### PR TITLE
SynTest - remove unused withStableUids helpers, test coverage for helpers, fix lmdb test

### DIFF
--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -338,9 +338,9 @@ class LmdbSlabTest(s_t_utils.SynTest):
 
             # Ensure that our envar override for memory locking is acknowledged
             with self.setTstEnvars(SYN_LOCKMEM_DISABLE='1'):
-                slab = await s_lmdbslab.Slab.anit(path, map_size=1000000, lockmemory=True)
-                self.false(slab.lockmemory)
-                self.none(slab.memlocktask)
+                async with await s_lmdbslab.Slab.anit(path, map_size=1000000, lockmemory=True) as slab:
+                    self.false(slab.lockmemory)
+                    self.none(slab.memlocktask)
 
     def simplenow(self):
         self._nowtime += 1000

--- a/synapse/tests/test_utils.py
+++ b/synapse/tests/test_utils.py
@@ -244,24 +244,6 @@ class TestUtils(s_t_utils.SynTest):
             with self.raises(AssertionError):
                 self.stormHasNoWarnErr(msgs)
 
-    async def test_stable_uids(self):
-        with self.withStableUids():
-            guid = s_common.guid()
-            self.eq('000000', guid[:6])
-            guid2 = s_common.guid()
-            self.ne(guid, guid2)
-
-            guid = s_common.guid(42)
-            self.ne('000000', guid[:6])
-
-            buid = s_common.buid()
-            self.eq(b'\00\00\00\00\00\00', buid[:6])
-            buid2 = s_common.buid()
-            self.ne(buid, buid2)
-
-            buid = s_common.buid(42)
-            self.ne(b'\00\00\00\00\00\00', buid[:6])
-
     def test_utils_certdir(self):
         oldcertdirn = s_certdir.getCertDirn()
         oldcertdir = s_certdir.getCertDir()
@@ -297,3 +279,20 @@ class TestUtils(s_t_utils.SynTest):
         # Patch is removed and singleton behavior is restored
         self.true(oldcertdir is s_certdir.getCertDir())
         self.eq(oldcertdirn, s_certdir.getCertDirn())
+
+    async def test_checknode(self):
+        async with self.getTestCore() as core:
+            nodes = await core.nodes('[test:comp=(1, test)]')
+            self.len(1, nodes)
+            self.checkNode(nodes[0], (('test:comp', (1, 'test')), {'hehe': 1, 'haha': 'test'}))
+            with self.raises(AssertionError):
+                self.checkNode(nodes[0], (('test:comp', (1, 'newp')), {'hehe': 1, 'haha': 'test'}))
+            with self.raises(AssertionError):
+                self.checkNode(nodes[0], (('test:comp', (1, 'test')), {'hehe': 1, 'haha': 'newp'}))
+            with self.getAsyncLoggerStream('synapse.tests.utils', 'untested properties') as stream:
+                self.checkNode(nodes[0], (('test:comp', (1, 'test')), {'hehe': 1}))
+                self.true(await stream.wait(timeout=12))
+
+            await self.checkNodes(core, [('test:comp', (1, 'test')),])
+            with self.raises(AssertionError):
+                await self.checkNodes(core, [('test:comp', (1, 'newp')),])

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1005,8 +1005,6 @@ class SynTest(unittest.TestCase):
     '''
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        self._NextBuid = 0
-        self._NextGuid = 0
 
         for s in dir(self):
             attr = getattr(self, s, None)
@@ -2376,39 +2374,6 @@ class SynTest(unittest.TestCase):
             async with await s_hive.openurl(turl) as hive:
 
                 yield hive
-
-    def stablebuid(self, valu=None):
-        '''
-        A stable buid generation for testing purposes
-        '''
-        if valu is None:
-            retn = self._NextBuid.to_bytes(32, 'big')
-            self._NextBuid += 1
-            return retn
-
-        byts = s_msgpack.en(valu)
-        return hashlib.sha256(byts).digest()
-
-    def stableguid(self, valu=None):
-        '''
-        A stable guid generation for testing purposes
-        '''
-        if valu is None:
-            retn = s_common.ehex(self._NextGuid.to_bytes(16, 'big'))
-            self._NextGuid += 1
-            return retn
-
-        byts = s_msgpack.en(valu)
-        return hashlib.md5(byts, usedforsecurity=False).hexdigest()
-
-    @contextlib.contextmanager
-    def withStableUids(self):
-        '''
-        A context manager that generates guids and buids in sequence so that successive test runs use the same
-        data
-        '''
-        with mock.patch('synapse.common.guid', self.stableguid), mock.patch('synapse.common.buid', self.stablebuid):
-            yield
 
     async def runCoreNodes(self, core, query, opts=None):
         '''


### PR DESCRIPTION
Remove withStableUid helpers. No internal or public use of this method is found.
Add tests for checkNode helpers.
Fix LMDB slab test to use a slab as a context manager.

These were QOL changes from #4063