### PR TITLE
Ensure that getUserDef / getRoleDef is deepcopied (SYN-8627)

### DIFF
--- a/changes/3c38d224d8b0667a7eec4b3a5ea8f89d.yaml
+++ b/changes/3c38d224d8b0667a7eec4b3a5ea8f89d.yaml
@@ -1,0 +1,6 @@
+---
+desc: Fixed an issue where certain User and Role properties could be modified via
+  Storm and adversly affect the in-memory representation of those objects.
+prs: []
+type: bug
+...

--- a/changes/3c38d224d8b0667a7eec4b3a5ea8f89d.yaml
+++ b/changes/3c38d224d8b0667a7eec4b3a5ea8f89d.yaml
@@ -1,6 +1,6 @@
 ---
 desc: Fixed an issue where certain User and Role properties could be modified via
-  Storm and adversly affect the in-memory representation of those objects.
+  Storm and adversely affect the in-memory representation of those objects.
 prs: []
 type: bug
 ...

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -881,13 +881,14 @@ class Role(Ruler):
     set of rules can be applied to multiple users.
     '''
     def pack(self):
-        return {
+        ret = {
             'type': 'role',
             'iden': self.iden,
             'name': self.name,
             'rules': self.info.get('rules'),
             'authgates': self.authgates,
         }
+        return s_msgpack.deepcopy(ret)
 
     async def _setRulrInfo(self, name, valu, gateiden=None, nexs=True, mesg=None):
         if nexs:
@@ -956,7 +957,7 @@ class User(Ruler):
                 _roles.append(role.pack())
             roles = _roles
 
-        return {
+        ret = {
             'type': 'user',
             'iden': self.iden,
             'name': self.name,
@@ -968,6 +969,7 @@ class User(Ruler):
             'archived': self.info.get('archived'),
             'authgates': self.authgates,
         }
+        return s_msgpack.deepcopy(ret)
 
     async def _setRulrInfo(self, name, valu, gateiden=None, nexs=True, mesg=None):
         if nexs:

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1127,8 +1127,18 @@ class CellTest(s_t_utils.SynTest):
                 await proxy.addUserRole(visi['iden'], ninjas['iden'])
                 await proxy.setUserEmail(visi['iden'], 'visi@vertex.link')
 
+                def1 = await core.getUserDef(visi['iden'])
+                def2 = await core.getUserDef(visi['iden'])
+                self.false(def1['authgates'] is def2['authgates'])
+                self.eq(def1, def2)
+
                 visi = await proxy.getUserDefByName('visi')
                 self.eq(visi['email'], 'visi@vertex.link')
+
+                def1 = await core.getRoleDef(ninjas['iden'])
+                def2 = await core.getRoleDef(ninjas['iden'])
+                self.false(def1['authgates'] is def2['authgates'])
+                self.eq(def1, def2)
 
                 self.true(await proxy.isUserAllowed(visi['iden'], ('foo', 'bar')))
                 self.true(await proxy.isUserAllowed(visi['iden'], ('hehe', 'haha')))


### PR DESCRIPTION
These API results values should be unique and changes to them should not reflect back on any in-memory structures.