### PR TITLE
Dev experience: allow caching docker build stages

### DIFF
--- a/docker/build_all.sh
+++ b/docker/build_all.sh
@@ -16,18 +16,48 @@
 set -e # exit on nonzero
 set -u # undefined variables
 set -o pipefail # pipefail propagate error codes
-set -x # debugging
+# set -x # debugging
 
-TAG=${1:-}
+TAG="${1:-}"
+[ -z "${TAG}" ] && echo "Tag not provided, defaulting tag to dev_build" && TAG="dev_build"
 
-[ ! $TAG ] && echo "Tag not provided, defaulting tag to dev_build" && TAG=dev_build
+declare -a DOCKER_ARGS
+
+# When building locally, a developer can override the base image via
+# SYN_BASE_IMAGE="my_awesome_synapse_image" ./docker/build_all.sh
+[ -n "${SYN_BUILD_BASE_IMAGE:-}" ] && DOCKER_ARGS+=('--build-arg' "BASE=${SYN_BUILD_BASE_IMAGE}")
+
+# By default the script will always pull the newest base image from the registry.
+# This way, once a new base image is updated in the registry, the release
+# process will ensure the new base is used. When building locally, a developer
+# might want to try a custom base image without uploading it first, and this
+# behaviour will lead to a failure. The developer can disable image pulling by
+# SYN_BUILD_PULL=0 ./docker/build_all.sh
+[ "${SYN_BUILD_PULL:-1}" != "0" ] && DOCKER_ARGS+=('--pull')
+
+# By default the script will disable cache during builds for stable CI
+# behaviour. When building locally, a developer might speed things up:
+# SYN_BUILD_USE_CACHE=1 ./docker/build_all.sh
+[ "${SYN_BUILD_USE_CACHE:-}" != "1" ] && DOCKER_ARGS+=('--no-cache')
+
+# To build locally on post-M1 Mac's with new docker, the following might be required:
+# SYN_BUILD_PLATFORM="linux/amd64" ./docker/build_all.sh
+[ -n "${SYN_BUILD_PLATFORM:-}" ] && DOCKER_ARGS+=('--platform' "${SYN_BUILD_PLATFORM}")
 
 # Build target images
-docker builder prune -a -f
-docker build --no-cache --progress plain --pull -t vertexproject/synapse:$TAG -f docker/images/synapse/Dockerfile .
-docker/build_image.sh aha $TAG
-docker/build_image.sh axon $TAG
-docker/build_image.sh cortex $TAG
-docker/build_image.sh cryotank $TAG
-docker/build_image.sh jsonstor $TAG
-docker/build_image.sh stemcell $TAG
+[ "${SYN_BUILD_USE_CACHE:-}" != "1" ] && docker builder prune --all --force
+
+docker buildx build \
+  "${DOCKER_ARGS[@]}" \
+  --progress plain \
+  --tag "vertexproject/synapse:${TAG}" \
+  --file docker/images/synapse/Dockerfile \
+  --load \
+  .
+
+docker/build_image.sh aha "${TAG}"
+docker/build_image.sh axon "${TAG}"
+docker/build_image.sh cortex "${TAG}"
+docker/build_image.sh cryotank "${TAG}"
+docker/build_image.sh jsonstor "${TAG}"
+docker/build_image.sh stemcell "${TAG}"

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -12,9 +12,6 @@
 # A second argument may be provided, including the tag to build.
 # A default tag will be used if one is not provided.
 #
-# This will build a base image, if it does not exist, using the
-# ./docker/build_base.sh script.
-#
 ##############################################################################
 
 set -e # exit on nonzero
@@ -22,20 +19,50 @@ set -u # undefined variables
 set -o pipefail # pipefail propagate error codes
 # set -x # debugging
 
-IMAGE=${1:-}
-if [ ${IMAGE} == "synapse" ]
+IMAGE="${1:-}"
+if [ "${IMAGE}" == "synapse" ]
 then
     echo "The vertexproject/synapse image is not built with this script."
     false
 fi
-IMAGE_DIR=docker/images/${IMAGE}
-[ ! -d $IMAGE_DIR ] && echo "$IMAGE_DIR does not exist." && false
 
-TAG=${2:-}
+IMAGE_DIR="docker/images/${IMAGE}"
+[ ! -d "${IMAGE_DIR}" ] && echo "${IMAGE_DIR} does not exist." && false
 
-[ ! $TAG ] && echo "Tag not provided, defaulting tag to dev_build" && TAG=dev_build
+TAG="${2:-}"
+[ -z "${TAG}" ] && echo "Tag not provided, defaulting tag to dev_build" && TAG="dev_build"
+
+declare -a DOCKER_ARGS
+
+# When building locally, a developer can override the base image via
+# SYN_BUILD_BASE_IMAGE="my_awesome_synapse_image" ./docker/build_image.sh cortex
+[ -n "${SYN_BUILD_BASE_IMAGE:-}" ] && DOCKER_ARGS+=('--build-arg' "BASE=${SYN_BUILD_BASE_IMAGE}")
+
+# By default the script will always pull the newest base image from the registry.
+# This way, once a new base image is updated in the registry, the release
+# process will ensure the new base is used. When building locally, a developer
+# might want to try a custom base image without uploading it first, and this
+# behaviour will lead to a failure. The developer can disable image pulling by
+# SYN_BUILD_PULL=0 ./docker/build_image.sh cortex
+[ "${SYN_BUILD_PULL:-1}" != "0" ] && DOCKER_ARGS+=('--pull')
+
+# By default the script will disable cache during builds for stable CI
+# behaviour. When building locally, a developer might speed things up:
+# SYN_BUILD_USE_CACHE=1 ./docker/build_image.sh cortex
+[ "${SYN_BUILD_USE_CACHE:-}" != "1" ] && DOCKER_ARGS+=('--no-cache')
+
+# To build locally on post-M1 Mac's with new docker, the following might be required:
+# SYN_BUILD_PLATFORM="linux/amd64" ./docker/build_image.sh cortex
+[ -n "${SYN_BUILD_PLATFORM:-}" ] && DOCKER_ARGS+=('--platform' "${SYN_BUILD_PLATFORM}")
 
 # Build target image
-echo "Building from docker/images/$IMAGE/Dockerfile"
-docker builder prune -a -f
-docker build  --no-cache --progress plain --pull -t vertexproject/synapse-$IMAGE:$TAG -f docker/images/$IMAGE/Dockerfile .
+echo "Building from docker/images/${IMAGE}/Dockerfile"
+[ "${SYN_BUILD_USE_CACHE:-}" != "1" ] && docker builder prune --all --force
+
+docker buildx build  \
+    "${DOCKER_ARGS[@]}" \
+    --progress plain \
+    --tag "vertexproject/synapse-${IMAGE}:${TAG}" \
+    --file "docker/images/${IMAGE}/Dockerfile" \
+    --load \
+    .

--- a/docker/images/aha/Dockerfile
+++ b/docker/images/aha/Dockerfile
@@ -1,15 +1,17 @@
 # vim:set ft=dockerfile:
-FROM vertexproject/vtx-base-image:py311
+ARG BASE="vertexproject/vtx-base-image:py311"
+
+FROM ${BASE}
 
 COPY synapse /build/synapse/synapse
 COPY README.rst /build/synapse/README.rst
 COPY pyproject.toml /build/synapse/pyproject.toml
-
 COPY docker/rmlist.txt /build/synapse/rmlist.txt
 COPY docker/bootstrap.sh /build/synapse/bootstrap.sh
-COPY docker/images/aha/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 RUN /build/synapse/bootstrap.sh
+
+COPY docker/images/aha/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 EXPOSE 4443
 EXPOSE 27492
@@ -18,4 +20,6 @@ VOLUME /vertex/storage
 
 ENTRYPOINT ["tini", "--", "/vertex/synapse/entrypoint.sh"]
 
-HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/
+HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s \
+    CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/
+

--- a/docker/images/axon/Dockerfile
+++ b/docker/images/axon/Dockerfile
@@ -1,15 +1,17 @@
 # vim:set ft=dockerfile:
-FROM vertexproject/vtx-base-image:py311
+ARG BASE="vertexproject/vtx-base-image:py311"
+
+FROM ${BASE}
 
 COPY synapse /build/synapse/synapse
 COPY README.rst /build/synapse/README.rst
 COPY pyproject.toml /build/synapse/pyproject.toml
-
 COPY docker/rmlist.txt /build/synapse/rmlist.txt
 COPY docker/bootstrap.sh /build/synapse/bootstrap.sh
-COPY docker/images/axon/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 RUN /build/synapse/bootstrap.sh
+
+COPY docker/images/axon/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 EXPOSE 4443
 EXPOSE 27492
@@ -18,4 +20,5 @@ VOLUME /vertex/storage
 
 ENTRYPOINT ["tini", "--", "/vertex/synapse/entrypoint.sh"]
 
-HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/
+HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s \
+    CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/

--- a/docker/images/cortex/Dockerfile
+++ b/docker/images/cortex/Dockerfile
@@ -1,15 +1,17 @@
 # vim:set ft=dockerfile:
-FROM vertexproject/vtx-base-image:py311
+ARG BASE="vertexproject/vtx-base-image:py311"
+
+FROM ${BASE}
 
 COPY synapse /build/synapse/synapse
 COPY README.rst /build/synapse/README.rst
 COPY pyproject.toml /build/synapse/pyproject.toml
-
 COPY docker/rmlist.txt /build/synapse/rmlist.txt
 COPY docker/bootstrap.sh /build/synapse/bootstrap.sh
-COPY docker/images/cortex/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 RUN /build/synapse/bootstrap.sh
+
+COPY docker/images/cortex/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 EXPOSE 4443
 EXPOSE 27492
@@ -18,4 +20,5 @@ VOLUME /vertex/storage
 
 ENTRYPOINT ["tini", "--", "/vertex/synapse/entrypoint.sh"]
 
-HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/
+HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s \
+    CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/

--- a/docker/images/cryotank/Dockerfile
+++ b/docker/images/cryotank/Dockerfile
@@ -1,15 +1,17 @@
 # vim:set ft=dockerfile:
-FROM vertexproject/vtx-base-image:py311
+ARG BASE="vertexproject/vtx-base-image:py311"
+
+FROM ${BASE}
 
 COPY synapse /build/synapse/synapse
 COPY README.rst /build/synapse/README.rst
 COPY pyproject.toml /build/synapse/pyproject.toml
-
 COPY docker/rmlist.txt /build/synapse/rmlist.txt
 COPY docker/bootstrap.sh /build/synapse/bootstrap.sh
-COPY docker/images/cryotank/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 RUN /build/synapse/bootstrap.sh
+
+COPY docker/images/cryotank/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 EXPOSE 4443
 EXPOSE 27492
@@ -18,4 +20,5 @@ VOLUME /vertex/storage
 
 ENTRYPOINT ["tini", "--", "/vertex/synapse/entrypoint.sh"]
 
-HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/
+HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s \
+    CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/

--- a/docker/images/jsonstor/Dockerfile
+++ b/docker/images/jsonstor/Dockerfile
@@ -1,15 +1,17 @@
 # vim:set ft=dockerfile:
-FROM vertexproject/vtx-base-image:py311
+ARG BASE="vertexproject/vtx-base-image:py311"
+
+FROM ${BASE}
 
 COPY synapse /build/synapse/synapse
 COPY README.rst /build/synapse/README.rst
 COPY pyproject.toml /build/synapse/pyproject.toml
-
 COPY docker/rmlist.txt /build/synapse/rmlist.txt
 COPY docker/bootstrap.sh /build/synapse/bootstrap.sh
-COPY docker/images/jsonstor/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 RUN /build/synapse/bootstrap.sh
+
+COPY docker/images/jsonstor/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 EXPOSE 4443
 EXPOSE 27492
@@ -18,4 +20,5 @@ VOLUME /vertex/storage
 
 ENTRYPOINT ["tini", "--", "/vertex/synapse/entrypoint.sh"]
 
-HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/
+HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s \
+    CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/

--- a/docker/images/stemcell/Dockerfile
+++ b/docker/images/stemcell/Dockerfile
@@ -1,15 +1,17 @@
 # vim:set ft=dockerfile:
-FROM vertexproject/vtx-base-image:py311
+ARG BASE="vertexproject/vtx-base-image:py311"
+
+FROM ${BASE}
 
 COPY synapse /build/synapse/synapse
 COPY README.rst /build/synapse/README.rst
 COPY pyproject.toml /build/synapse/pyproject.toml
-
 COPY docker/rmlist.txt /build/synapse/rmlist.txt
 COPY docker/bootstrap.sh /build/synapse/bootstrap.sh
-COPY docker/images/stemcell/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 RUN /build/synapse/bootstrap.sh
+
+COPY docker/images/stemcell/entrypoint.sh /vertex/synapse/entrypoint.sh
 
 EXPOSE 4443
 EXPOSE 27492
@@ -18,4 +20,5 @@ VOLUME /vertex/storage
 
 ENTRYPOINT ["tini", "--", "/vertex/synapse/entrypoint.sh"]
 
-HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/
+HEALTHCHECK --start-period=10s --retries=1 --timeout=10s --interval=30s \
+    CMD python -m synapse.tools.healthcheck -c cell:///vertex/storage/

--- a/docker/images/synapse/Dockerfile
+++ b/docker/images/synapse/Dockerfile
@@ -4,16 +4,18 @@
 # synapse and its dependencies pre-installed.  It does not start any
 # services.
 
-FROM vertexproject/vtx-base-image:py311
+ARG BASE="vertexproject/vtx-base-image:py311"
 
-ENV SYN_LOG_LEVEL="INFO"
+FROM ${BASE}
 
 COPY synapse /build/synapse/synapse
 COPY README.rst /build/synapse/README.rst
 COPY pyproject.toml /build/synapse/pyproject.toml
-
 COPY docker/rmlist.txt /build/synapse/rmlist.txt
 COPY docker/bootstrap.sh /build/synapse/bootstrap.sh
+
 RUN /build/synapse/bootstrap.sh
+
+ENV SYN_LOG_LEVEL="INFO"
 
 VOLUME /vertex/storage

--- a/docs/synapse/contributing/contributing.rst
+++ b/docs/synapse/contributing/contributing.rst
@@ -386,6 +386,74 @@ data from cells. This results in cleaner diffs for .ipynb files over time.
       [some-branch f254f5bf] Demo commit
        1 file changed, 3 insertions(+), 2 deletions(-)
 
+Building `docker` Images
+------------------------
+
+Two scripts in `./docker` directory are used to build Synapse images.
+
+* `./docker/builld_all.sh` will build all Synapse images.
+
+* `./docker/build_image.sh` can be used to build individual components.
+
+These scripts are used in project's CI system, but can be invoked manually.
+
+#. Building all images.
+
+   ::
+
+       # build all images and with :dev_build tag
+       ./docker/build_all.sh
+
+       # build all images with a custom tag
+       ./docker/build_all.sh custom_tag
+
+#. Building individual components. The `synapse` image (used primarily for tests) cannot be
+   build using this command.
+
+   ::
+
+       # build Cortex image with :dev_build tag
+       ./docker/build_image.sh cortex
+
+       # build Jsonstor image with a :v4.0a tag
+       ./docker/build_image.sh jsonstor v4.0a
+
+#. Environment variables for local development.
+
+   One can set a few environment variables to tune local builds. Setting these flags
+   can improve local build time, but will likely to produce inconsistent results, so
+   these should not be used in production.
+
+   * `SYN_BUILD_BASE_IMAGE`. When building locally, a developer can override the
+     base image used in Synapse builds via
+     ::
+
+         SYN_BASE_IMAGE="my_awesome_synapse_image" ./docker/build_all.sh
+         SYN_BASE_IMAGE="vertexproject/vtx-base-image:py311" ./docker/build_image.sh cortex
+
+   * `SYN_BUILD_PULL`. By default the scripts will always pull the newest base
+     image from the registry. This way, once a new base image is updated in
+     the registry, the release process will ensure the new base is used.
+     When building locally, a developer might want to try a custom base image
+     without uploading it first, and this behaviour will lead to a failure.
+     The developer can disable image pulling by
+     ::
+
+         SYN_BUILD_PULL=0 ./docker/build_all.sh
+         SYN_BUILD_PULL=0 ./docker/build_image.sh axon dev_cached_base
+
+   * `SYN_BUILD_USE_CACHE`. By default the script will disable cache during builds
+     for stable CI behaviour. When building locally, a developer might speed things up
+     by allowing docker to cache intermediate stages
+     ::
+
+         SYN_BUILD_USE_CACHE=1 ./docker/build_all.sh
+
+   * `SYN_BUILD_PLATFORM`. Target images platform. To build locally on post-M1 Mac's
+     with new `docker`/`colima`/`podman`, the following might be required:
+     ::
+
+         SYN_BUILD_PLATFORM="linux/amd64" ./docker/build_all.sh
 
 Contribution Process
 --------------------


### PR DESCRIPTION
This contribution is provided on the basis of Apache License v2.0.

Introduce support for `SYN_BUILD_*` environment variables in `docker` build scripts.

Explicitly use `buildx` in both scripts. (Until this PR, `buildx` was assumed implicitly through the `--progress` flag.)