### PR TITLE
Dev ci tweak

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,6 +571,7 @@ workflows:
             branches:
               only:
                 - master
+                - dev_ci_tweak
 
       - deploy_pypi:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ commands:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            python3 -m pip install -U wheel pip setuptools twine build "importlib_metadata==7.2.1"
+            python3 -m pip install -U wheel pip setuptools twine build
             python3 -m pip install -U -r requirements_dev.txt
 
       - save_cache:
@@ -222,7 +222,7 @@ commands:
             cp dist/*.tar.gz /tmp/sdisttest
             cd /tmp/sdisttest
             . ./venv/bin/activate
-            python3 -m pip install -U pip twine setuptools "importlib_metadata==7.2.1"
+            python3 -m pip install -U pip twine setuptools
             python3 -m twine check *.tar.gz
             python3 -m pip install *.tar.gz
             python3 -c "$PYPI_SMOKE_CODE"
@@ -247,7 +247,7 @@ commands:
             cp dist/*.whl /tmp/wheeltest
             cd /tmp/wheeltest
             . ./venv/bin/activate
-            python3 -m pip install -U wheel pip twine setuptools "importlib_metadata==7.2.1"
+            python3 -m pip install -U wheel pip twine setuptools
             python3 -m twine check *.whl
             python3 -m pip install *.whl
             python3 -c "$PYPI_SMOKE_CODE"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,7 +571,6 @@ workflows:
             branches:
               only:
                 - master
-                - dev_ci_tweak
 
       - deploy_pypi:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
           command: |
             python3 -m venv --copies venv
             . venv/bin/activate
-            python3 -m pip install -U wheel pip
+            python3 -m pip install -U wheel pip setuptools
             python3 -m pip install -U -r requirements_dev.txt
 
       - run:
@@ -89,7 +89,7 @@ commands:
           command: |
             python3 -m venv --copies venv
             . venv/bin/activate
-            python3 -m pip install -U wheel pip
+            python3 -m pip install -U wheel pip setuptools
 
       - run:
           name: install synapse requirements
@@ -175,7 +175,7 @@ commands:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            python3 -m pip install -U wheel pip twine build "importlib_metadata==7.2.1"
+            python3 -m pip install -U wheel pip setuptools twine build "importlib_metadata==7.2.1"
             python3 -m pip install -U -r requirements_dev.txt
 
       - save_cache:
@@ -222,7 +222,7 @@ commands:
             cp dist/*.tar.gz /tmp/sdisttest
             cd /tmp/sdisttest
             . ./venv/bin/activate
-            python3 -m pip install -U wheel pip twine "importlib_metadata==7.2.1"
+            python3 -m pip install -U pip twine setuptools "importlib_metadata==7.2.1"
             python3 -m twine check *.tar.gz
             python3 -m pip install *.tar.gz
             python3 -c "$PYPI_SMOKE_CODE"
@@ -247,7 +247,7 @@ commands:
             cp dist/*.whl /tmp/wheeltest
             cd /tmp/wheeltest
             . ./venv/bin/activate
-            python3 -m pip install -U wheel pip twine "importlib_metadata==7.2.1"
+            python3 -m pip install -U wheel pip twine setuptools "importlib_metadata==7.2.1"
             python3 -m twine check *.whl
             python3 -m pip install *.whl
             python3 -c "$PYPI_SMOKE_CODE"


### PR DESCRIPTION
- Update setuptools so we don't use 65.5.0 !
- Remove old twine dependency pin from #3777 