### PR TITLE
Fix ambiguous value error message

### DIFF
--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2064,7 +2064,7 @@ class Runtime(s_base.Base):
                     continue
 
                 if len(nodes) == 1:
-                    mesg = 'Ambiguous value for single node lookup: {propname}^={valu}'
+                    mesg = f'Ambiguous value for single node lookup: {propname}^={valu}'
                     raise s_exc.StormRuntimeError(mesg=mesg)
 
                 nodes.append(node)

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2064,7 +2064,7 @@ class Runtime(s_base.Base):
                     continue
 
                 if len(nodes) == 1:
-                    mesg = f'Ambiguous value for single node lookup: {propname}^={valu}'
+                    mesg = f'Ambiguous value for single node lookup: {propname}{cmpr}{valu}'
                     raise s_exc.StormRuntimeError(mesg=mesg)
 
                 nodes.append(node)


### PR DESCRIPTION
# PR Summary
This small PR fixes the `Ambiguous value for single node lookup` error message to include the missing information.