### PR TITLE
Dev: In Base.__init__ check the parent frame code name directly.

### DIFF
--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -1,5 +1,6 @@
 import gc
 import os
+import sys
 import atexit
 import signal
 import asyncio
@@ -82,7 +83,7 @@ class Base:
     '''
     def __init__(self):
         self.anitted = False
-        assert inspect.stack()[1].function == 'anit', 'Objects from Base must be constructed solely via "anit"'
+        assert sys._getframe(1).f_code.co_name == 'anit', 'Objects from Base must be constructed solely via "anit"'
 
     @classmethod
     async def anit(cls, *args, **kwargs):

--- a/synapse/tests/test_lib_base.py
+++ b/synapse/tests/test_lib_base.py
@@ -86,6 +86,11 @@ class BaseTest(s_t_utils.SynTest):
             await Hehe.anit(-1)
         self.eq(cm.exception.get('mesg'), 'boom')
 
+        if __debug__:
+            with self.raises(AssertionError) as cm:
+                Hehe()
+            self.eq(str(cm.exception), 'Objects from Base must be constructed solely via "anit"')
+
     async def test_coro_fini(self):
 
         event = asyncio.Event()


### PR DESCRIPTION
Inspect() is an expensive call to make in in debug mode; we can check the parent frame name directly.