### PR TITLE
Dev - Remove unused share and base vars

### DIFF
--- a/synapse/lib/base.py
+++ b/synapse/lib/base.py
@@ -130,7 +130,6 @@ class Base:
         self.isfini = False
         self.anitted = True  # For assertion purposes
         self.finievt = asyncio.Event()
-        self.entered = False
 
         # hold a weak ref to other bases we should fini if they
         # are still around when we go down...
@@ -206,7 +205,6 @@ class Base:
 
     async def __aenter__(self):
         assert asyncio.get_running_loop() == self.loop
-        self.entered = True
         return self
 
     async def __aexit__(self, exc, cls, tb):

--- a/synapse/lib/share.py
+++ b/synapse/lib/share.py
@@ -16,9 +16,6 @@ class Share(s_base.Base):
 
         self.iden = s_common.guid()
 
-        self.exited = False
-        self.entered = False
-
         sess = link.get('sess')
 
         async def fini():


### PR DESCRIPTION
These variables appear to be vestigial from the original Base and Share implementations and are no longer used as far as I can tell.