### PR TITLE
DEV: Convert one of the assertions in test_cell_minspace to use an asyncLoggerStream

### DIFF
--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -2580,10 +2580,10 @@ class CellTest(s_t_utils.SynTest):
                     viewiden = view.get('iden')
 
                     opts = {'view': viewiden}
-                    with self.getLoggerStream('synapse.lib.lmdbslab',
+                    with self.getAsyncLoggerStream('synapse.lib.lmdbslab',
                                               'Error during slab resize callback - foo') as stream:
-                        nodes = await core.stormlist('for $x in $lib.range(200) {[inet:ipv4=$x]}', opts=opts)
-                        self.true(stream.wait(1))
+                        msgs = await core.stormlist('for $x in $lib.range(200) {[test:int=$x]}', opts=opts)
+                        self.true(await stream.wait(timeout=30))
 
         async with self.getTestCore() as core:
 


### PR DESCRIPTION

This is a backport of some changes from c4c7a66a30c1b0b74a57c798f5d9ff3c9b83d703. When merging this into synapse-3xx we will need to prefer this implemention since it has a clearly await timeout + assertion that the message was seen in the log stream.