### PR TITLE
Move drive utils to 2.x and migrate perms

### DIFF
--- a/changes/152e5aecbd335e4217b9d331d7ce332d.yaml
+++ b/changes/152e5aecbd335e4217b9d331d7ce332d.yaml
@@ -1,0 +1,5 @@
+---
+desc: Fixed Drive's incompatibility with the EasyPerms API.
+prs: []
+type: bug
+...

--- a/changes/e7b9fce9ed5812c947b15c23ce8edc9e.yaml
+++ b/changes/e7b9fce9ed5812c947b15c23ce8edc9e.yaml
@@ -1,0 +1,5 @@
+---
+desc: Added more utility APIs for working with the Drive class.
+prs: []
+type: feat
+...

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1890,6 +1890,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         if self.drive.hasItemInfo(iden): # pragma: no cover
             return await self.drive.getItemPath(iden)
 
+        # TODO: Remove this in synapse-3xx
         perm = info.pop('perm', None)
         if perm:
             perm.setdefault('users', {})

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1498,6 +1498,11 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         logger.warning(f'...Cell ({self.getCellType()}) auth migration complete!')
 
+    async def _drivePermMigration(self):
+        for lkey, lval in self.slab.scanByPref(s_drive.LKEY_INFO, db=self.drive.dbname):
+            breakpoint()
+            info = s_msgpack.un(lval)
+
     def getPermDef(self, perm):
         perm = tuple(perm)
         if self.permlook is None:
@@ -1855,6 +1860,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
     async def initCellStorage(self):
         self.drive = await s_drive.Drive.anit(self.slab, 'celldrive')
+        await self._bumpCellVers('drive:storage', (
+            (1, self._drivePermMigration)
+        ), nexs=False)
+
         self.onfini(self.drive.fini)
 
     async def addDriveItem(self, info, path=None, reldir=s_drive.rootdir):

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1890,6 +1890,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         if self.drive.hasItemInfo(iden): # pragma: no cover
             return await self.drive.getItemPath(iden)
 
+        perm = info.pop('perm', None)
+        if perms:
+            info['permissions'] = perm
+
         return await self.drive.addItemInfo(info, path=path, reldir=reldir)
 
     async def getDriveInfo(self, iden, typename=None):

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1892,6 +1892,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         perm = info.pop('perm', None)
         if perm:
+            perm.setdefault('users', {})
+            perm.setdefault('roles', {})
             info['permissions'] = perm
 
         return await self.drive.addItemInfo(info, path=path, reldir=reldir)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1891,7 +1891,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             return await self.drive.getItemPath(iden)
 
         perm = info.pop('perm', None)
-        if perms:
+        if perm:
             info['permissions'] = perm
 
         return await self.drive.addItemInfo(info, path=path, reldir=reldir)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1921,7 +1921,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
             info = {
                 'name': name,
-                'perm': perm,
+                'permissions': perm,
                 'iden': s_common.guid(),
                 'created': tick,
                 'creator': user,
@@ -1950,6 +1950,50 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
     @s_nexus.Pusher.onPushAuto('drive:set:perm')
     async def setDriveInfoPerm(self, iden, perm):
         return self.drive.setItemPerm(iden, perm)
+
+    @s_nexus.Pusher.onPushAuto('drive:data:path:set')
+    async def setDriveItemProp(self, iden, vers, path, valu):
+        if isinstance(path, str):
+            path = (path,)
+
+        data = await self.getDriveData(iden)
+        if data is None:
+            mesg = f'No drive item with ID {iden}.'
+            raise s_exc.NoSuchIden(mesg=mesg)
+
+        _, item = data
+
+        try:
+            step = item
+            for p in path[:-1]:
+                step = step[p]
+            step[path[-1]] = valu
+        except (KeyError, IndexError) as exc:
+            raise s_exc.BadArg(mesg=f'Invalid path {path}')
+
+        return await self.drive.setItemData(iden, vers, item)
+
+    @s_nexus.Pusher.onPushAuto('drive:data:path:del')
+    async def delDriveItemProp(self, iden, vers, path):
+        if isinstance(path, str):
+            path = (path,)
+
+        data = await self.getDriveData(iden)
+        if data is None:
+            mesg = f'No drive item with ID {iden}.'
+            raise s_exc.NoSuchIden(mesg=mesg)
+
+        _, item = data
+
+        try:
+            step = item
+            for p in path[:-1]:
+                step = step[p]
+            del step[path[-1]]
+        except (KeyError, IndexError) as exc:
+            raise s_exc.BadArg(mesg=f'Invalid path {path}')
+
+        return await self.drive.setItemData(iden, vers, item)
 
     @s_nexus.Pusher.onPushAuto('drive:set:path')
     async def setDriveInfoPath(self, iden, path):

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1968,7 +1968,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             for p in path[:-1]:
                 step = step[p]
             step[path[-1]] = valu
-        except (KeyError, IndexError) as exc:
+        except (KeyError, IndexError):
             raise s_exc.BadArg(mesg=f'Invalid path {path}')
 
         return await self.drive.setItemData(iden, vers, item)
@@ -1990,8 +1990,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             for p in path[:-1]:
                 step = step[p]
             del step[path[-1]]
-        except (KeyError, IndexError) as exc:
-            raise s_exc.BadArg(mesg=f'Invalid path {path}')
+        except (KeyError, IndexError):
+            return
 
         return await self.drive.setItemData(iden, vers, item)
 

--- a/synapse/lib/drive.py
+++ b/synapse/lib/drive.py
@@ -69,6 +69,9 @@ class Drive(s_base.Base):
 
     def getItemInfo(self, iden, typename=None):
         info = self._getItemInfo(s_common.uhex(iden))
+        if not info:
+            return
+
         if typename is not None:
             self._reqInfoType(info, typename)
         return info
@@ -210,7 +213,7 @@ class Drive(s_base.Base):
 
     def _setItemPerm(self, bidn, perm):
         info = self._reqItemInfo(bidn)
-        info['perm'] = perm
+        info['permissions'] = perm
         s_schemas.reqValidDriveInfo(info)
         self.slab.put(LKEY_INFO + bidn, s_msgpack.en(info), db=self.dbname)
         return info
@@ -286,7 +289,7 @@ class Drive(s_base.Base):
         info['kids'] = 0
         info['parent'] = pariden
 
-        info.setdefault('perm', {'users': {}, 'roles': {}})
+        info.setdefault('permissions', {'users': {}, 'roles': {}})
         info.setdefault('version', (0, 0, 0))
 
         s_schemas.reqValidDriveInfo(info)
@@ -447,6 +450,8 @@ class Drive(s_base.Base):
 
         if vers is None:
             info = self._getItemInfo(bidn)
+            if info is None:
+                return None
             vers = info.get('version')
 
         versindx = getVersIndx(vers)

--- a/synapse/lib/schemas.py
+++ b/synapse/lib/schemas.py
@@ -469,7 +469,8 @@ driveInfoSchema = {
         'parent': {'type': 'string', 'pattern': s_config.re_iden},
         'type': {'type': 'string', 'pattern': re_drivename},
         'name': {'type': 'string', 'pattern': re_drivename},
-        'perm': s_msgpack.deepcopy(easyPermSchema),
+        # TODO: This used to be called `perm`, so migrate this as part of the big migration from 2.x
+        'permissions': s_msgpack.deepcopy(easyPermSchema),
         'kids': {'type': 'number', 'minimum': 0},
         'created': {'type': 'number'},
         'creator': {'type': 'string', 'pattern': s_config.re_iden},

--- a/synapse/lib/schemas.py
+++ b/synapse/lib/schemas.py
@@ -469,7 +469,6 @@ driveInfoSchema = {
         'parent': {'type': 'string', 'pattern': s_config.re_iden},
         'type': {'type': 'string', 'pattern': re_drivename},
         'name': {'type': 'string', 'pattern': re_drivename},
-        # TODO: This used to be called `perm`, so migrate this as part of the big migration from 2.x
         'permissions': s_msgpack.deepcopy(easyPermSchema),
         'kids': {'type': 'number', 'minimum': 0},
         'created': {'type': 'number'},

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -704,6 +704,20 @@ class CellTest(s_t_utils.SynTest):
                 with self.raises(s_exc.NeedConfValu):
                     await echo.reqAhaProxy()
 
+    async def test_cell_drive_perm_migration(self):
+        with self.getTestDir() as dirn:
+            with mock.patch('synapse.lib.schemas.reqValidDriveInfo'):
+                async with self.getTestCell(dirn=dirn) as cell:
+                    info = {
+                        'name': 'bigdog',
+                    }
+                    await cell.addDriveItem(info)
+
+                    await cell.setCellVers('drive:storage', 0)
+
+            async with self.getTestCell(dirn=dirn) as cell:
+                pass
+
     async def test_cell_unix_sock(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -362,7 +362,7 @@ class CellTest(s_t_utils.SynTest):
 
                 await self.asyncraises(s_exc.NoSuchIden, cell.delDriveItemProp(s_common.guid(), versinfo, 'blorp'))
 
-                await self.asyncraises(s_exc.BadArg, cell.delDriveItemProp(iden, versinfo, ('lolnope', 'nopath')))
+                self.none(await cell.delDriveItemProp(iden, versinfo, ('lolnope', 'nopath')))
 
                 versinfo, data = await cell.getDriveData(iden, vers=(1, 0, 0))
                 self.eq('woot', data.get('woot'))

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -258,8 +258,13 @@ class CellTest(s_t_utils.SynTest):
                 with self.raises(s_exc.BadVersion):
                     await cell.drive.setTypeSchema('woot', testDataSchema_v0, vers=0)
 
-                info = {'name': 'win32k.sys', 'type': 'woot'}
+                info = {'name': 'win32k.sys', 'type': 'woot', 'perm': {'users': {}}}
                 info = await cell.addDriveItem(info, reldir=rootdir)
+                self.notin('perm', info)
+                self.eq(info[0]['permissions'], {
+                    'users': {},
+                    'roles': {}
+                })
 
                 iden = info[-1].get('iden')
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -741,8 +741,8 @@ class CellTest(s_t_utils.SynTest):
                     },
                     'default': s_cell.PERM_EDIT
                 })
-                cell._hasEasyPerm(info, user, s_cell.PERM_ADMIN)
-                cell._hasEasyPerm(info, dog, s_cell.PERM_EDIT)
+                self.true(cell._hasEasyPerm(info, user, s_cell.PERM_ADMIN))
+                self.true(cell._hasEasyPerm(info, dog, s_cell.PERM_EDIT))
 
     async def test_cell_unix_sock(self):
 


### PR DESCRIPTION
Most of this was cherry-picked from the 3.x PRs, but this one does include the migration for `perm` -> `permissions` for all the drive info items.