### PR TITLE
CSR Cleanup (SYN-7648)

### DIFF
--- a/changes/60df099ffc66cbff525ec975ea57df9c.yaml
+++ b/changes/60df099ffc66cbff525ec975ea57df9c.yaml
@@ -1,0 +1,6 @@
+---
+desc: Updated AHA provisioning to remove Certificate Signing Request files after they
+  have been used.
+prs: []
+type: feat
+...

--- a/changes/60df099ffc66cbff525ec975ea57df9c.yaml
+++ b/changes/60df099ffc66cbff525ec975ea57df9c.yaml
@@ -2,5 +2,5 @@
 desc: Updated AHA provisioning to remove Certificate Signing Request files after they
   have been used.
 prs: []
-type: feat
+type: note
 ...

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -4059,6 +4059,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 os.unlink(_csr)
             hostcsr = certdir.genHostCsr(hostname)
             certdir.saveHostCertByts(await prov.signHostCsr(hostcsr))
+            certdir.delHostCsr(hostname)
 
             userfull = f'{ahauser}@{ahanetw}'
             _crt = certdir.getUserCertPath(userfull)
@@ -4075,6 +4076,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 os.unlink(_csr)
             usercsr = certdir.genUserCsr(userfull)
             certdir.saveUserCertByts(await prov.signUserCsr(usercsr))
+            certdir.delUserCsr(userfull)
 
         with s_common.genfile(self.dirn, 'prov.done') as fd:
             fd.write(providen.encode())

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -402,6 +402,7 @@ class CertDir:
 
         Args:
             name: The name of the host CSR.
+            outp: The output buffer.
 
         Returns:
             bool: True if the CSR is deleted, False if it did not exist.
@@ -723,6 +724,7 @@ class CertDir:
 
         Args:
             name: The name of the user CSR.
+            outp: The output buffer.
 
         Returns:
             bool: True if the CSR is deleted, False if it did not exist.

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -411,7 +411,7 @@ class CertDir:
             return False
         try:
             os.unlink(path)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             raise s_exc.SynErr(mesg=f'Failed to delete CSR {path} - {e}') from e
         if outp:
             outp.printf(f'Deleted CSR at {path}')
@@ -732,7 +732,7 @@ class CertDir:
             return False
         try:
             os.unlink(path)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             raise s_exc.SynErr(mesg=f'Failed to delete CSR {path} - {e}') from e
         if outp:
             outp.printf(f'Deleted CSR at {path}')

--- a/synapse/lib/certdir.py
+++ b/synapse/lib/certdir.py
@@ -1,7 +1,6 @@
 import io
 import os
 import ssl
-import time
 import shutil
 import socket
 import logging
@@ -397,6 +396,27 @@ class CertDir:
         '''
         return self._genPkeyCsr(name, 'hosts', outp=outp)
 
+    def delHostCsr(self, name: str, outp: OutPutOrNone = None) -> bool:
+        '''
+        Delete an existing host CSR.
+
+        Args:
+            name: The name of the host CSR.
+
+        Returns:
+            bool: True if the CSR is deleted, False if it did not exist.
+        '''
+        path = self.getHostCsrPath(name)
+        if path is None:
+            return False
+        try:
+            os.unlink(path)
+        except Exception as e:
+            raise s_exc.SynErr(mesg=f'Failed to delete CSR {path} - {e}') from e
+        if outp:
+            outp.printf(f'Deleted CSR at {path}')
+        return True
+
     def genUserCert(self,
                     name: str,
                     signas: StrOrNone = None,
@@ -696,6 +716,27 @@ class CertDir:
             The bytes of the CSR.
         '''
         return self._genPkeyCsr(name, 'users', outp=outp)
+
+    def delUserCsr(self, name: str, outp: OutPutOrNone = None) -> bool:
+        '''
+        Delete an existing user CSR.
+
+        Args:
+            name: The name of the user CSR.
+
+        Returns:
+            bool: True if the CSR is deleted, False if it did not exist.
+        '''
+        path = self.getUserCsrPath(name)
+        if path is None:
+            return False
+        try:
+            os.unlink(path)
+        except Exception as e:
+            raise s_exc.SynErr(mesg=f'Failed to delete CSR {path} - {e}') from e
+        if outp:
+            outp.printf(f'Deleted CSR at {path}')
+        return True
 
     def getCaCert(self, name: str) -> CertOrNone:
         '''

--- a/synapse/tests/test_lib_certdir.py
+++ b/synapse/tests/test_lib_certdir.py
@@ -576,6 +576,10 @@ class CertDirTest(s_t_utils.SynTest):
             key = cdir.getHostKey(hostname)
             self.basic_assertions(cdir, cert, key, cacert=cacert)
 
+            self.true(cdir.delHostCsr(hostname))
+            self.false(os.path.isfile(path))
+            self.false(cdir.delHostCsr(hostname))
+
             # Per RFC5280 common-name has a length of 1 to 64 characters
             # Do not generate CSRs which exceed that name range.
             with self.raises(s_exc.CryptoErr) as cm:
@@ -609,6 +613,10 @@ class CertDirTest(s_t_utils.SynTest):
             cert = cdir.getUserCert(username)
             key = cdir.getUserKey(username)
             self.basic_assertions(cdir, cert, key, cacert=cacert)
+
+            self.true(cdir.delUserCsr(username))
+            self.false(os.path.isfile(path))
+            self.false(cdir.delUserCsr(username))
 
             # Per RFC5280 common-name has a length of 1 to 64 characters
             # Do not generate CSRs which exceed that name range.

--- a/synapse/tools/aha/easycert.py
+++ b/synapse/tools/aha/easycert.py
@@ -45,6 +45,7 @@ async def main(argv, outp=s_output.stdout):
                 cert = c_x509.load_pem_x509_certificate(certbyts.encode())
                 path = cdir._saveCertTo(cert, 'hosts', f'{name}.crt')
                 outp.printf(f'crt saved: {path}')
+                cdir.delHostCsr(name, outp=outp)
                 return 0
             else:
                 csr = cdir.genUserCsr(name, outp=outp)
@@ -52,6 +53,7 @@ async def main(argv, outp=s_output.stdout):
                 cert = c_x509.load_pem_x509_certificate(certbyts.encode())
                 path = cdir._saveCertTo(cert, 'users', f'{name}.crt')
                 outp.printf(f'crt saved: {path}')
+                cdir.delHostCsr(name, outp=outp)
                 return 0
 
 def getArgParser():

--- a/synapse/tools/aha/easycert.py
+++ b/synapse/tools/aha/easycert.py
@@ -53,7 +53,7 @@ async def main(argv, outp=s_output.stdout):
                 cert = c_x509.load_pem_x509_certificate(certbyts.encode())
                 path = cdir._saveCertTo(cert, 'users', f'{name}.crt')
                 outp.printf(f'crt saved: {path}')
-                cdir.delHostCsr(name, outp=outp)
+                cdir.delUserCsr(name, outp=outp)
                 return 0
 
 def getArgParser():

--- a/synapse/tools/aha/enroll.py
+++ b/synapse/tools/aha/enroll.py
@@ -98,6 +98,9 @@ async def main(argv, outp=s_output.stdout):
                     teleyaml['aha:servers'] = servers
                     s_common.yamlsave(teleyaml, yamlpath)
 
+            # cleanup CSR
+            certdir.delUserCsr(username)
+
     return 0
 
 async def _main(argv, outp=s_output.stdout):  # pragma: no cover


### PR DESCRIPTION
- Add delUserCsr / delHostCsr apis to Certdir.
- Cleanup CSR files signed by AHA after they are used.