### PR TITLE
Remove ctors section from data model declarations

### DIFF
--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -574,7 +574,6 @@ class Model:
 
         self._type_pends = collections.defaultdict(list)
         self._modeldef = {
-            'ctors': [],
             'types': [],
             'forms': [],
             'edges': [],
@@ -1060,12 +1059,12 @@ class Model:
         A model definition (mdef) is structured as follows::
 
             {
-                "ctors":(
-                    ('name', 'class.path.ctor', {}, {'doc': 'The foo thing.'}),
-                ),
-
                 "types":(
                     ('name', ('basetype', {typeopts}), {info}),
+
+                    # Types with custom Python classes use None as the base
+                    # with the 'ctor' key specifying the class path:
+                    ('name', (None, {'ctor': 'class.path', ...typeopts}), {info}),
                 ),
 
                 "forms":(
@@ -1100,15 +1099,6 @@ class Model:
         # Gather all the forms first
         for _, mdef in mods:
 
-            # Allow props declared directly on ctors to become forms...
-            for name, ctor, opts, info in mdef.get('ctors', ()):
-                if (props := info.get('props')) is not None:
-                    forminfo = {}
-                    if (ondef := info.get('on')) is not None:
-                        forminfo['on'] = ondef
-                    allforms.append((name, forminfo, props))
-                    self.forminfos[name] = forminfo
-
             # Allow props declared directly on types to become forms...
             for typename, _, typeinfo in mdef.get('types', ()):
                 if (props := typeinfo.get('props')) is not None:
@@ -1129,17 +1119,23 @@ class Model:
 
         ctors = {}
 
-        # load all the base type ctors in order...
-        for _, mdef in mods:
-
-            for name, ctor, opts, info in mdef.get('ctors', ()):
-                item = s_dyndeps.tryDynFunc(ctor, self, name, info, opts, skipinit=True)
-                self.types[name] = item
-                ctors[name] = (name, ctor, opts, info)
-
-        # load all the types in order...
+        # first pass: load ctor-based types (base type is None)
         for _, mdef in mods:
             for typename, typedef, typeinfo in mdef.get('types', ()):
+                if typedef[0] is not None:
+                    continue
+
+                typeopts = dict(typedef[1])
+                ctor = typeopts.pop('ctor')
+                item = s_dyndeps.tryDynFunc(ctor, self, typename, typeinfo, typeopts, skipinit=True)
+                self.types[typename] = item
+                ctors[typename] = ctor
+
+        # second pass: load all derived types
+        for _, mdef in mods:
+            for typename, typedef, typeinfo in mdef.get('types', ()):
+                if typedef[0] is None:
+                    continue
 
                 if isinstance(typedef[0], tuple):
                     basename = 'poly'
@@ -1152,8 +1148,10 @@ class Model:
         # finish initializing types
         for name, tobj in self.types.items():
             tobj._initType()
-            if (info := ctors.get(name)) is not None:
-                self._modeldef['ctors'].append(info)
+            if (ctor := ctors.get(name)) is not None:
+                opts = dict(tobj.opts)
+                opts['ctor'] = ctor
+                self._modeldef['types'].append((name, (None, opts), dict(tobj.info)))
             else:
                 self._modeldef['types'].append(tobj.getTypeDef())
 
@@ -1824,7 +1822,9 @@ class Model:
         Add a Type instance to the data model.
         '''
         ctor = '.'.join([item.__class__.__module__, item.__class__.__qualname__])
-        self._modeldef['ctors'].append(((item.name, ctor, dict(item.opts), dict(item.info))))
+        opts = dict(item.opts)
+        opts['ctor'] = ctor
+        self._modeldef['types'].append((item.name, (None, opts), dict(item.info)))
         self.types[item.name] = item
 
     def type(self, name):

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -18,6 +18,8 @@ import synapse.lib.types as s_types
 import synapse.lib.dyndeps as s_dyndeps
 import synapse.lib.grammar as s_grammar
 
+import synapse.models.base as s_base
+
 logger = logging.getLogger(__name__)
 
 hexre = regex.compile('^[0-9a-z]+$')
@@ -579,136 +581,8 @@ class Model:
             'edges': [],
         }
 
-        # add the primitive base types
-        info = {'doc': 'The base 64 bit signed integer type.'}
-        item = s_types.Int(self, 'int', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'The base floating point type.'}
-        item = s_types.Float(self, 'float', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'A base range type.'}
-        item = s_types.Range(self, 'range', info, {'type': ('int', {})})
-        self.addBaseType(item)
-
-        info = {'doc': 'The base string type.'}
-        item = s_types.Str(self, 'str', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'The base hex type.'}
-        item = s_types.Hex(self, 'hex', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'The base boolean type.'}
-        item = s_types.Bool(self, 'bool', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'A time precision value.'}
-        item = s_types.TimePrecision(self, 'timeprecision', info, {})
-        self.addBaseType(item)
-
-        info = {
-            'doc': 'A date/time value.',
-            'virts': (
-                ('precision', ('timeprecision', {}), {
-                    'doc': 'The precision for display and rounding the time.'}),
-            ),
-        }
-        item = s_types.Time(self, 'time', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'A duration value.'}
-        item = s_types.Duration(self, 'duration', info, {})
-        self.addBaseType(item)
-
-        info = {
-            'virts': (
-
-                ('min', ('time', {}), {
-                    'doc': 'The starting time of the interval.'}),
-
-                ('max', ('time', {}), {
-                    'doc': 'The ending time of the interval.'}),
-
-                ('duration', ('duration', {}), {
-                    'doc': 'The duration of the interval.'}),
-
-                ('precision', ('timeprecision', {}), {
-                    'doc': 'The precision for display and rounding the times.'}),
-            ),
-            'doc': 'A time window or interval.',
-        }
-        item = s_types.Ival(self, 'ival', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'The base GUID type.'}
-        item = s_types.Guid(self, 'guid', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'A tag component string.'}
-        item = s_types.TagPart(self, 'syn:tag:part', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'The base type for a synapse tag.'}
-        item = s_types.Tag(self, 'syn:tag', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'The base type for compound node fields.'}
-        item = s_types.Comp(self, 'comp', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'The base geo political location type.'}
-        item = s_types.Loc(self, 'loc', info, {})
-        self.addBaseType(item)
-
-        info = {
-            'virts': (
-                ('type', ('syn:type', {}), {
-                    'computed': True,
-                    'doc': 'The type of value which is referenced.'}),
-
-                ('value', ('data', {}), {
-                    'computed': True,
-                    'display': {'hidden': True},
-                    'doc': 'The value which is referenced.'}),
-            ),
-            'doc': 'A prop which can be of one or more types.',
-        }
-        item = s_types.Poly(self, 'poly', info, {})
-        self.addBaseType(item)
-
-        info = {
-            'virts': (
-                ('size', ('int', {}), {
-                    'computed': True,
-                    'doc': 'The number of elements in the array.'}),
-            ),
-            'doc': 'A typed array which indexes each field.'
-        }
-        item = s_types.Array(self, 'array', info, {'type': 'int'})
-        self.addBaseType(item)
-
-        info = {'doc': 'Arbitrary json compatible data.'}
-        item = s_types.Data(self, 'data', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'A potentially huge/tiny number. [x] <= 730750818665451459101842 with a fractional '
-                       'precision of 24 decimal digits.'}
-        item = s_types.HugeNum(self, 'hugenum', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'A component of a hierarchical taxonomy.'}
-        item = s_types.Taxon(self, 'taxon', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'A hierarchical taxonomy.'}
-        item = s_types.Taxonomy(self, 'taxonomy', info, {})
-        self.addBaseType(item)
-
-        info = {'doc': 'A velocity with base units in mm/sec.'}
-        item = s_types.Velocity(self, 'velocity', info, {})
-        self.addBaseType(item)
+        # load the primitive base types
+        self.addDataModels(s_base.basetypedefs)
 
         self.metatypes['created'] = self.getTypeClone(('time', {'ismin': True}))
         self.metatypes['updated'] = self.getTypeClone(('time', {}))
@@ -1816,16 +1690,6 @@ class Model:
                 self.delFormProp(kid, propname)
 
         self.childpropcache.clear()
-
-    def addBaseType(self, item):
-        '''
-        Add a Type instance to the data model.
-        '''
-        ctor = '.'.join([item.__class__.__module__, item.__class__.__qualname__])
-        opts = dict(item.opts)
-        opts['ctor'] = ctor
-        self._modeldef['types'].append((item.name, (None, opts), dict(item.info)))
-        self.types[item.name] = item
 
     def type(self, name):
         '''

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -18,8 +18,6 @@ import synapse.lib.types as s_types
 import synapse.lib.dyndeps as s_dyndeps
 import synapse.lib.grammar as s_grammar
 
-import synapse.models.base as s_base
-
 logger = logging.getLogger(__name__)
 
 hexre = regex.compile('^[0-9a-z]+$')
@@ -530,6 +528,17 @@ class Edge:
     def pack(self):
         return (self.edgetype, self.edgeinfo)
 
+def getBaseModel():
+    '''
+    Get a Model loaded with the base type definitions.
+    '''
+    import synapse.models.base as s_base
+    modl = Model()
+    name, mdef = s_base.modeldefs[0]
+    types = tuple(t for t in mdef['types'] if t[1][0] is None)
+    modl.addDataModels([(name, {'types': types})])
+    return modl
+
 class Model:
     '''
     The data model used by a Cortex hypergraph.
@@ -580,12 +589,6 @@ class Model:
             'forms': [],
             'edges': [],
         }
-
-        # load the primitive base types
-        self.addDataModels(s_base.basetypedefs)
-
-        self.metatypes['created'] = self.getTypeClone(('time', {'ismin': True}))
-        self.metatypes['updated'] = self.getTypeClone(('time', {}))
 
     def getPropsByType(self, name):
         props = self.propsbytype.get(name, {})
@@ -1064,6 +1067,11 @@ class Model:
         # now we can check the forms display settings...
         for form in self.forms.values():
             self._checkFormDisplay(form)
+
+        # initialize metatypes if the time type is available
+        if self.types.get('time') is not None:
+            self.metatypes['created'] = self.getTypeClone(('time', {'ismin': True}))
+            self.metatypes['updated'] = self.getTypeClone(('time', {}))
 
     def _getFormsMaybeIface(self, name):
 

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -2010,7 +2010,7 @@ class Parser:
             root = self
 
         if model is None:
-            model = s_datamodel.Model()
+            model = s_datamodel.getBaseModel()
         self.model = model
 
         self.prog = prog

--- a/synapse/models/auth.py
+++ b/synapse/models/auth.py
@@ -25,8 +25,8 @@ modeldefs = (
 
     ('auth', {
 
-        'ctors': (
-            ('auth:passwd', 'synapse.models.auth.Passwd', {'strip': False}, {
+        'types': (
+            ('auth:passwd', (None, {'ctor': 'synapse.models.auth.Passwd', 'strip': False}), {
                 'interfaces': (
                     ('auth:credential', {}),
                     ('crypto:hashable', {}),
@@ -34,8 +34,6 @@ modeldefs = (
                 ),
                 'doc': 'A password string.'}),
         ),
-
-        'types': (),
 
         'interfaces': (
             ('auth:credential', {

--- a/synapse/models/base.py
+++ b/synapse/models/base.py
@@ -19,7 +19,7 @@ taskstatusenums = (
     (80, 'blocked'),
 )
 
-basetypedefs = (
+modeldefs = (
     ('base', {
         'types': (
 
@@ -122,13 +122,6 @@ basetypedefs = (
 
             ('velocity', (None, {'ctor': 'synapse.lib.types.Velocity'}), {
                 'doc': 'A velocity with base units in mm/sec.'}),
-        ),
-    }),
-)
-
-modeldefs = (
-    ('base', {
-        'types': (
 
             ('date', ('time', {'precision': 'day'}), {
                 'doc': 'A date precision time value.'}),

--- a/synapse/models/base.py
+++ b/synapse/models/base.py
@@ -45,18 +45,16 @@ basetypedefs = (
                 'doc': 'A time precision value.'}),
 
             ('time', (None, {'ctor': 'synapse.lib.types.Time'}), {
-                'doc': 'A date/time value.',
                 'virts': (
                     ('precision', ('timeprecision', {}), {
                         'doc': 'The precision for display and rounding the time.'}),
                 ),
-            }),
+                'doc': 'A date/time value.'}),
 
             ('duration', (None, {'ctor': 'synapse.lib.types.Duration'}), {
                 'doc': 'A duration value.'}),
 
             ('ival', (None, {'ctor': 'synapse.lib.types.Ival'}), {
-                'doc': 'A time window or interval.',
                 'virts': (
 
                     ('min', ('time', {}), {
@@ -71,7 +69,7 @@ basetypedefs = (
                     ('precision', ('timeprecision', {}), {
                         'doc': 'The precision for display and rounding the times.'}),
                 ),
-            }),
+                'doc': 'A time window or interval.'}),
 
             ('guid', (None, {'ctor': 'synapse.lib.types.Guid'}), {
                 'doc': 'The base GUID type.'}),
@@ -89,7 +87,6 @@ basetypedefs = (
                 'doc': 'The base geo political location type.'}),
 
             ('poly', (None, {'ctor': 'synapse.lib.types.Poly'}), {
-                'doc': 'A prop which can be of one or more types.',
                 'virts': (
                     ('type', ('syn:type', {}), {
                         'computed': True,
@@ -100,16 +97,15 @@ basetypedefs = (
                         'display': {'hidden': True},
                         'doc': 'The value which is referenced.'}),
                 ),
-            }),
+                'doc': 'A prop which can be of one or more types.'}),
 
             ('array', (None, {'ctor': 'synapse.lib.types.Array', 'type': 'int'}), {
-                'doc': 'A typed array which indexes each field.',
                 'virts': (
                     ('size', ('int', {}), {
                         'computed': True,
                         'doc': 'The number of elements in the array.'}),
                 ),
-            }),
+                'doc': 'A typed array which indexes each field.'}),
 
             ('data', (None, {'ctor': 'synapse.lib.types.Data'}), {
                 'doc': 'Arbitrary json compatible data.'}),

--- a/synapse/models/base.py
+++ b/synapse/models/base.py
@@ -19,6 +19,117 @@ taskstatusenums = (
     (80, 'blocked'),
 )
 
+basetypedefs = (
+    ('base', {
+        'types': (
+
+            ('int', (None, {'ctor': 'synapse.lib.types.Int'}), {
+                'doc': 'The base 64 bit signed integer type.'}),
+
+            ('float', (None, {'ctor': 'synapse.lib.types.Float'}), {
+                'doc': 'The base floating point type.'}),
+
+            ('range', (None, {'ctor': 'synapse.lib.types.Range', 'type': ('int', {})}), {
+                'doc': 'A base range type.'}),
+
+            ('str', (None, {'ctor': 'synapse.lib.types.Str'}), {
+                'doc': 'The base string type.'}),
+
+            ('hex', (None, {'ctor': 'synapse.lib.types.Hex'}), {
+                'doc': 'The base hex type.'}),
+
+            ('bool', (None, {'ctor': 'synapse.lib.types.Bool'}), {
+                'doc': 'The base boolean type.'}),
+
+            ('timeprecision', (None, {'ctor': 'synapse.lib.types.TimePrecision'}), {
+                'doc': 'A time precision value.'}),
+
+            ('time', (None, {'ctor': 'synapse.lib.types.Time'}), {
+                'doc': 'A date/time value.',
+                'virts': (
+                    ('precision', ('timeprecision', {}), {
+                        'doc': 'The precision for display and rounding the time.'}),
+                ),
+            }),
+
+            ('duration', (None, {'ctor': 'synapse.lib.types.Duration'}), {
+                'doc': 'A duration value.'}),
+
+            ('ival', (None, {'ctor': 'synapse.lib.types.Ival'}), {
+                'doc': 'A time window or interval.',
+                'virts': (
+
+                    ('min', ('time', {}), {
+                        'doc': 'The starting time of the interval.'}),
+
+                    ('max', ('time', {}), {
+                        'doc': 'The ending time of the interval.'}),
+
+                    ('duration', ('duration', {}), {
+                        'doc': 'The duration of the interval.'}),
+
+                    ('precision', ('timeprecision', {}), {
+                        'doc': 'The precision for display and rounding the times.'}),
+                ),
+            }),
+
+            ('guid', (None, {'ctor': 'synapse.lib.types.Guid'}), {
+                'doc': 'The base GUID type.'}),
+
+            ('syn:tag:part', (None, {'ctor': 'synapse.lib.types.TagPart'}), {
+                'doc': 'A tag component string.'}),
+
+            ('syn:tag', (None, {'ctor': 'synapse.lib.types.Tag'}), {
+                'doc': 'The base type for a synapse tag.'}),
+
+            ('comp', (None, {'ctor': 'synapse.lib.types.Comp'}), {
+                'doc': 'The base type for compound node fields.'}),
+
+            ('loc', (None, {'ctor': 'synapse.lib.types.Loc'}), {
+                'doc': 'The base geo political location type.'}),
+
+            ('poly', (None, {'ctor': 'synapse.lib.types.Poly'}), {
+                'doc': 'A prop which can be of one or more types.',
+                'virts': (
+                    ('type', ('syn:type', {}), {
+                        'computed': True,
+                        'doc': 'The type of value which is referenced.'}),
+
+                    ('value', ('data', {}), {
+                        'computed': True,
+                        'display': {'hidden': True},
+                        'doc': 'The value which is referenced.'}),
+                ),
+            }),
+
+            ('array', (None, {'ctor': 'synapse.lib.types.Array', 'type': 'int'}), {
+                'doc': 'A typed array which indexes each field.',
+                'virts': (
+                    ('size', ('int', {}), {
+                        'computed': True,
+                        'doc': 'The number of elements in the array.'}),
+                ),
+            }),
+
+            ('data', (None, {'ctor': 'synapse.lib.types.Data'}), {
+                'doc': 'Arbitrary json compatible data.'}),
+
+            ('hugenum', (None, {'ctor': 'synapse.lib.types.HugeNum'}), {
+                'doc': 'A potentially huge/tiny number. [x] <= 730750818665451459101842 with a fractional '
+                       'precision of 24 decimal digits.'}),
+
+            ('taxon', (None, {'ctor': 'synapse.lib.types.Taxon'}), {
+                'doc': 'A component of a hierarchical taxonomy.'}),
+
+            ('taxonomy', (None, {'ctor': 'synapse.lib.types.Taxonomy'}), {
+                'doc': 'A hierarchical taxonomy.'}),
+
+            ('velocity', (None, {'ctor': 'synapse.lib.types.Velocity'}), {
+                'doc': 'A velocity with base units in mm/sec.'}),
+        ),
+    }),
+)
+
 modeldefs = (
     ('base', {
         'types': (

--- a/synapse/models/base.py
+++ b/synapse/models/base.py
@@ -84,7 +84,7 @@ modeldefs = (
                 'doc': 'The base type for compound node fields.'}),
 
             ('loc', (None, {'ctor': 'synapse.lib.types.Loc'}), {
-                'doc': 'The base geo political location type.'}),
+                'doc': 'The base geopolitical location type.'}),
 
             ('poly', (None, {'ctor': 'synapse.lib.types.Poly'}), {
                 'virts': (

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -95,9 +95,8 @@ modeldefs = (
         'types': (
 
             ('inet:dns:name', (None, {'ctor': 'synapse.models.dns.DnsName'}), {
-                'doc': 'A DNS query name string. Likely an FQDN but not always.',
                 'ex': 'vertex.link',
-            }),
+                'doc': 'A DNS query name string. Likely an FQDN but not always.'}),
 
             ('inet:dns:a', ('comp', {'fields': (('fqdn', 'inet:fqdn'), ('ip', 'inet:ipv4'))}), {
                 'interfaces': (

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -92,16 +92,12 @@ class DnsName(s_types.Str):
 modeldefs = (
     ('inet:dns', {
 
-        'ctors': (
+        'types': (
 
-            ('inet:dns:name', 'synapse.models.dns.DnsName', {}, {
+            ('inet:dns:name', (None, {'ctor': 'synapse.models.dns.DnsName'}), {
                 'doc': 'A DNS query name string. Likely an FQDN but not always.',
                 'ex': 'vertex.link',
             }),
-
-        ),
-
-        'types': (
 
             ('inet:dns:a', ('comp', {'fields': (('fqdn', 'inet:fqdn'), ('ip', 'inet:ipv4'))}), {
                 'interfaces': (

--- a/synapse/models/economic.py
+++ b/synapse/models/economic.py
@@ -4,7 +4,6 @@ modeldefs = (
         'types': (
 
             ('econ:price', (None, {'ctor': 'synapse.lib.types.Price'}), {
-                'doc': 'The amount of money expected, required, or given in payment for something.',
                 'ex': '2.20',
                 'virts': (
 
@@ -14,7 +13,7 @@ modeldefs = (
                     ('asof', ('time', {}), {
                         'doc': 'The time the price was sampled or recorded.'}),
                 ),
-            }),
+                'doc': 'The amount of money expected, required, or given in payment for something.'}),
 
             ('econ:pay:cvv', ('str', {'regex': '^[0-9]{1,6}$'}), {
                 'doc': 'A Card Verification Value (CVV).'}),

--- a/synapse/models/economic.py
+++ b/synapse/models/economic.py
@@ -1,8 +1,9 @@
 modeldefs = (
     ('econ', {
 
-        'ctors': (
-            ('econ:price', 'synapse.lib.types.Price', {}, {
+        'types': (
+
+            ('econ:price', (None, {'ctor': 'synapse.lib.types.Price'}), {
                 'doc': 'The amount of money expected, required, or given in payment for something.',
                 'ex': '2.20',
                 'virts': (
@@ -14,9 +15,6 @@ modeldefs = (
                         'doc': 'The time the price was sampled or recorded.'}),
                 ),
             }),
-        ),
-
-        'types': (
 
             ('econ:pay:cvv', ('str', {'regex': '^[0-9]{1,6}$'}), {
                 'doc': 'A Card Verification Value (CVV).'}),

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -232,8 +232,8 @@ modeldefs = (
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'file name'}}),
                 ),
-                'doc': 'A file name with no path.',
-                'ex': 'woot.exe'}),
+                'ex': 'woot.exe',
+                'doc': 'A file name with no path.'}),
 
             ('file:path', (None, {'ctor': 'synapse.models.files.FilePath'}), {
                 'interfaces': (
@@ -252,8 +252,8 @@ modeldefs = (
                         'computed': True,
                         'doc': 'The file extension from the path.'}),
                 ),
-                'doc': 'A normalized file path.',
-                'ex': 'c:/windows/system32/calc.exe'}),
+                'ex': 'c:/windows/system32/calc.exe',
+                'doc': 'A normalized file path.'}),
 
             ('file:bytes', ('guid', {}), {
                 'interfaces': (

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -133,36 +133,6 @@ class FilePath(s_types.Str):
 
 modeldefs = (
     ('file', {
-        'ctors': (
-
-            ('file:base', 'synapse.models.files.FileBase', {}, {
-                'interfaces': (
-                    ('meta:observable', {'template': {'title': 'file name'}}),
-                ),
-                'doc': 'A file name with no path.',
-                'ex': 'woot.exe'}),
-
-            ('file:path', 'synapse.models.files.FilePath', {}, {
-                'interfaces': (
-                    ('meta:observable', {'template': {'title': 'file path'}}),
-                ),
-                'virts': (
-                    ('dir', ('file:path', {}), {
-                        'computed': True,
-                        'doc': 'The directory from the path.'}),
-
-                    ('base', ('file:base', {}), {
-                        'computed': True,
-                        'doc': 'The file base name from the path.'}),
-
-                    ('ext', ('str', {}), {
-                        'computed': True,
-                        'doc': 'The file extension from the path.'}),
-                ),
-                'doc': 'A normalized file path.',
-                'ex': 'c:/windows/system32/calc.exe'}),
-        ),
-
         'interfaces': (
             ('file:mime:meta', {
                 'template': {'metadata': 'metadata'},
@@ -257,6 +227,33 @@ modeldefs = (
         ),
 
         'types': (
+
+            ('file:base', (None, {'ctor': 'synapse.models.files.FileBase'}), {
+                'interfaces': (
+                    ('meta:observable', {'template': {'title': 'file name'}}),
+                ),
+                'doc': 'A file name with no path.',
+                'ex': 'woot.exe'}),
+
+            ('file:path', (None, {'ctor': 'synapse.models.files.FilePath'}), {
+                'interfaces': (
+                    ('meta:observable', {'template': {'title': 'file path'}}),
+                ),
+                'virts': (
+                    ('dir', ('file:path', {}), {
+                        'computed': True,
+                        'doc': 'The directory from the path.'}),
+
+                    ('base', ('file:base', {}), {
+                        'computed': True,
+                        'doc': 'The file base name from the path.'}),
+
+                    ('ext', ('str', {}), {
+                        'computed': True,
+                        'doc': 'The file extension from the path.'}),
+                ),
+                'doc': 'A normalized file path.',
+                'ex': 'c:/windows/system32/calc.exe'}),
 
             ('file:bytes', ('guid', {}), {
                 'interfaces': (

--- a/synapse/models/geospace.py
+++ b/synapse/models/geospace.py
@@ -381,19 +381,6 @@ class LatLong(s_types.Type):
 modeldefs = (
     ('geo', {
 
-        'ctors': (
-            ('geo:dist', 'synapse.models.geospace.Dist', {}, {
-                'doc': 'A geographic distance (base unit is mm).', 'ex': '10 km'
-            }),
-            ('geo:area', 'synapse.models.geospace.Area', {}, {
-                'doc': 'A geographic area (base unit is square mm).', 'ex': '10 sq.km'
-            }),
-            ('geo:latlong', 'synapse.models.geospace.LatLong', {}, {
-                'doc': 'A Lat/Long string specifying a point on Earth.',
-                'ex': '-12.45,56.78'
-            }),
-        ),
-
         'interfaces': (
 
             ('geo:locatable', {
@@ -444,6 +431,17 @@ modeldefs = (
         ),
 
         'types': (
+
+            ('geo:dist', (None, {'ctor': 'synapse.models.geospace.Dist'}), {
+                'doc': 'A geographic distance (base unit is mm).', 'ex': '10 km'
+            }),
+            ('geo:area', (None, {'ctor': 'synapse.models.geospace.Area'}), {
+                'doc': 'A geographic area (base unit is square mm).', 'ex': '10 sq.km'
+            }),
+            ('geo:latlong', (None, {'ctor': 'synapse.models.geospace.LatLong'}), {
+                'doc': 'A Lat/Long string specifying a point on Earth.',
+                'ex': '-12.45,56.78'
+            }),
 
             ('geo:telem', ('guid', {}), {
                 'interfaces': (

--- a/synapse/models/geospace.py
+++ b/synapse/models/geospace.py
@@ -433,15 +433,14 @@ modeldefs = (
         'types': (
 
             ('geo:dist', (None, {'ctor': 'synapse.models.geospace.Dist'}), {
-                'doc': 'A geographic distance (base unit is mm).', 'ex': '10 km'
-            }),
+                'ex': '10 km',
+                'doc': 'A geographic distance (base unit is mm).'}),
             ('geo:area', (None, {'ctor': 'synapse.models.geospace.Area'}), {
-                'doc': 'A geographic area (base unit is square mm).', 'ex': '10 sq.km'
-            }),
+                'ex': '10 sq.km',
+                'doc': 'A geographic area (base unit is square mm).'}),
             ('geo:latlong', (None, {'ctor': 'synapse.models.geospace.LatLong'}), {
-                'doc': 'A Lat/Long string specifying a point on Earth.',
-                'ex': '-12.45,56.78'
-            }),
+                'ex': '-12.45,56.78',
+                'doc': 'A Lat/Long string specifying a point on Earth.'}),
 
             ('geo:telem', ('guid', {}), {
                 'interfaces': (

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -1246,9 +1246,23 @@ class Url(s_types.Str):
 
 modeldefs = (
     ('inet', {
-        'ctors': (
+        'edges': (
+            (('inet:whois:iprecord', 'has', 'inet:ip'), {
+                'doc': 'The IP whois record describes the IP address.'}),
 
-            ('inet:ip', 'synapse.models.inet.IPAddr', {}, {
+            (('inet:net', 'has', 'inet:ip'), {
+                'doc': 'The IP address range contains the IP address.'}),
+
+            (('inet:fqdn', 'uses', 'meta:technique'), {
+                'doc': 'The source FQDN was selected or created using the target technique.'}),
+
+            (('inet:url', 'uses', 'meta:technique'), {
+                'doc': 'The source URL was created using the target technique.'}),
+        ),
+
+        'types': (
+
+            ('inet:ip', (None, {'ctor': 'synapse.models.inet.IPAddr'}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'IP address'}}),
                     ('geo:locatable', {'template': {'title': 'IP address'}}),
@@ -1256,7 +1270,7 @@ modeldefs = (
                 'ex': '1.2.3.4',
                 'doc': 'An IPv4 or IPv6 address.'}),
 
-            ('inet:net', 'synapse.models.inet.IPRange', {}, {
+            ('inet:net', (None, {'ctor': 'synapse.models.inet.IPRange'}), {
                 'ex': '1.2.3.4-1.2.3.8',
                 'virts': (
                     ('mask', ('int', {}), {
@@ -1269,7 +1283,7 @@ modeldefs = (
                 ),
                 'doc': 'An IPv4 or IPv6 address range.'}),
 
-            ('inet:sockaddr', 'synapse.models.inet.SockAddr', {}, {
+            ('inet:sockaddr', (None, {'ctor': 'synapse.models.inet.SockAddr'}), {
                 'ex': 'tcp://1.2.3.4:80',
                 'virts': (
                     ('ip', ('inet:ip', {}), {
@@ -1282,13 +1296,13 @@ modeldefs = (
                 ),
                 'doc': 'A network layer URL-like format to represent tcp/udp/icmp clients and servers.'}),
 
-            ('inet:email', 'synapse.models.inet.Email', {}, {
+            ('inet:email', (None, {'ctor': 'synapse.models.inet.Email'}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'email address'}}),
                 ),
                 'doc': 'An email address.'}),
 
-            ('inet:fqdn', 'synapse.models.inet.Fqdn', {}, {
+            ('inet:fqdn', (None, {'ctor': 'synapse.models.inet.Fqdn'}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'FQDN'}}),
                 ),
@@ -1313,40 +1327,23 @@ modeldefs = (
                 'ex': 'vertex.link',
                 'doc': 'A Fully Qualified Domain Name (FQDN).'}),
 
-            ('inet:rfc2822:addr', 'synapse.models.inet.Rfc2822Addr', {}, {
+            ('inet:rfc2822:addr', (None, {'ctor': 'synapse.models.inet.Rfc2822Addr'}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'RFC 2822 address'}}),
                 ),
                 'ex': '"Visi Kenshoto" <visi@vertex.link>',
                 'doc': 'An RFC 2822 Address field.'}),
 
-            ('inet:url', 'synapse.models.inet.Url', {}, {
+            ('inet:url', (None, {'ctor': 'synapse.models.inet.Url'}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'URL'}}),
                 ),
                 'ex': 'http://www.woot.com/files/index.html',
                 'doc': 'A Universal Resource Locator (URL).'}),
 
-            ('inet:http:cookie', 'synapse.models.inet.HttpCookie', {}, {
+            ('inet:http:cookie', (None, {'ctor': 'synapse.models.inet.HttpCookie'}), {
                 'ex': 'PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3',
                 'doc': 'An individual HTTP cookie string.'}),
-        ),
-
-        'edges': (
-            (('inet:whois:iprecord', 'has', 'inet:ip'), {
-                'doc': 'The IP whois record describes the IP address.'}),
-
-            (('inet:net', 'has', 'inet:ip'), {
-                'doc': 'The IP address range contains the IP address.'}),
-
-            (('inet:fqdn', 'uses', 'meta:technique'), {
-                'doc': 'The source FQDN was selected or created using the target technique.'}),
-
-            (('inet:url', 'uses', 'meta:technique'), {
-                'doc': 'The source URL was created using the target technique.'}),
-        ),
-
-        'types': (
 
             ('inet:ipv4', ('inet:ip', {'version': 4}), {
                 'doc': 'An IPv4 address.'}),

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -608,11 +608,11 @@ attack_flow_schema_2_0_0 = s_data.getJSON('attack-flow/attack-flow-schema-2.0.0'
 
 modeldefs = (
     ('it', {
-        'ctors': (
-            ('it:semver', 'synapse.models.infotech.SemVer', {}, {
+        'types': (
+            ('it:semver', (None, {'ctor': 'synapse.models.infotech.SemVer'}), {
                 'doc': 'Semantic Version type.'}),
 
-            ('it:version', 'synapse.models.infotech.ItVersion', {}, {
+            ('it:version', (None, {'ctor': 'synapse.models.infotech.ItVersion'}), {
                 'virts': (
                     ('semver', ('it:semver', {}), {
                         'computed': True,
@@ -620,13 +620,11 @@ modeldefs = (
                 ),
                 'doc': 'A version string.'}),
 
-            ('it:sec:cpe', 'synapse.models.infotech.Cpe23Str', {}, {
+            ('it:sec:cpe', (None, {'ctor': 'synapse.models.infotech.Cpe23Str'}), {
                 'doc': 'A NIST CPE 2.3 Formatted String.'}),
 
-            ('it:sec:cpe:v2_2', 'synapse.models.infotech.Cpe22Str', {}, {
+            ('it:sec:cpe:v2_2', (None, {'ctor': 'synapse.models.infotech.Cpe22Str'}), {
                 'doc': 'A NIST CPE 2.2 Formatted String.'}),
-        ),
-        'types': (
 
             ('it:dns:resolver', ('inet:server', {'defport': 53, 'defproto': 'udp'}), {
                 'props': (),

--- a/synapse/models/risk.py
+++ b/synapse/models/risk.py
@@ -33,17 +33,15 @@ alertstatus = (
 
 modeldefs = (
     ('risk', {
-        'ctors': (
+        'types': (
             # TODO: implement type specific cmprs and virts for CVSS types
-            ('it:sec:cvss:v2', 'synapse.models.risk.CvssV2', {}, {
+            ('it:sec:cvss:v2', (None, {'ctor': 'synapse.models.risk.CvssV2'}), {
                 'ex': '(AV:L/AC:L/Au:M/C:P/I:C/A:N)',
                 'doc': 'A CVSS v2 vector string.'}),
 
-            ('it:sec:cvss:v3', 'synapse.models.risk.CvssV3', {}, {
+            ('it:sec:cvss:v3', (None, {'ctor': 'synapse.models.risk.CvssV3'}), {
                 'ex': 'AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L',
                 'doc': 'A CVSS v3.x vector string.'}),
-        ),
-        'types': (
 
             ('risk:vuln', ('guid', {}), {
                 'template': {'title': 'vulnerability'},

--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -143,17 +143,15 @@ async def _liftRuntSynTagProp(view, prop, cmprvalu=None):
 modeldefs = (
     ('syn', {
 
-        'ctors': (
-            ('syn:user', 'synapse.models.syn.SynUser', {}, {
+        'types': (
+            ('syn:user', (None, {'ctor': 'synapse.models.syn.SynUser'}), {
                 'interfaces': (
                     ('entity:actor', {}),
                 ),
                 'doc': 'A Synapse user.'}),
 
-            ('syn:role', 'synapse.models.syn.SynRole', {}, {
+            ('syn:role', (None, {'ctor': 'synapse.models.syn.SynRole'}), {
                 'doc': 'A Synapse role.'}),
-        ),
-        'types': (
             ('syn:type', ('str', {}), {
                 'doc': 'A Synapse type used for normalizing nodes and properties.',
             }),

--- a/synapse/models/telco.py
+++ b/synapse/models/telco.py
@@ -139,32 +139,28 @@ class Imei(s_types.Int):
 
 modeldefs = (
     ('tel', {
-        'ctors': (
+        'types': (
 
-            ('tel:mob:imei', 'synapse.models.telco.Imei', {}, {
+            ('tel:mob:imei', (None, {'ctor': 'synapse.models.telco.Imei'}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'IMEI'}}),
                 ),
                 'ex': '490154203237518',
                 'doc': 'An International Mobile Equipment Id.'}),
 
-            ('tel:mob:imsi', 'synapse.models.telco.Imsi', {}, {
+            ('tel:mob:imsi', (None, {'ctor': 'synapse.models.telco.Imsi'}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'IMSI'}}),
                 ),
                 'ex': '310150123456789',
                 'doc': 'An International Mobile Subscriber Id.'}),
 
-            ('tel:phone', 'synapse.models.telco.Phone', {}, {
+            ('tel:phone', (None, {'ctor': 'synapse.models.telco.Phone'}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'phone number'}}),
                 ),
                 'ex': '+15558675309',
                 'doc': 'A phone number.'}),
-
-        ),
-
-        'types': (
 
             ('tel:call', ('guid', {}), {
                 'interfaces': (

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -81,7 +81,7 @@ class DataModelTest(s_t_utils.SynTest):
                 core.model.reqType('newp:newp')
 
     async def test_datamodel_formname(self):
-        modl = s_datamodel.Model()
+        modl = s_datamodel.getBaseModel()
         mods = (
             ('hehe', {
                 'types': (
@@ -97,14 +97,14 @@ class DataModelTest(s_t_utils.SynTest):
             modl.addDataModels(mods)
 
     async def test_datamodel_virtstor(self):
-        modl = s_datamodel.Model()
+        modl = s_datamodel.getBaseModel()
         modl.addType('test:virt', 'int', {}, {})
         modl.types['test:virt'].virtstor['fake'] = lambda: None
         with self.raises(s_exc.BadFormDef):
             modl.addForm('test:virt', {}, ())
 
     async def test_datamodel_no_interface(self):
-        modl = s_datamodel.Model()
+        modl = s_datamodel.getBaseModel()
         mods = (
             ('hehe', {
                 'types': (
@@ -123,7 +123,7 @@ class DataModelTest(s_t_utils.SynTest):
 
     async def test_datamodel_dynamics(self):
 
-        modl = s_datamodel.Model()
+        modl = s_datamodel.getBaseModel()
 
         with self.raises(s_exc.NoSuchType):
             modl.addType('he:he', 'ha:ha', {}, {})
@@ -194,7 +194,7 @@ class DataModelTest(s_t_utils.SynTest):
 
     async def test_datamodel_del_prop(self):
 
-        modl = s_datamodel.Model()
+        modl = s_datamodel.getBaseModel()
 
         modl.addType('foo:bar', 'int', {}, {})
         modl.addForm('foo:bar', {}, (('x', ('int', {}), {}), ))
@@ -287,12 +287,12 @@ class DataModelTest(s_t_utils.SynTest):
         '''
         Make sure you can make a new model with the output of datamodel.getModelDefs
         '''
-        modl = s_datamodel.Model()
+        modl = s_datamodel.getBaseModel()
         modl.addIface('test:iface', {})
         modl.addType('foo:foo', 'int', {}, {'interfaces': (('test:iface', {}),)})
         modl.addForm('foo:foo', {}, ())
         mdef = modl.getModelDefs()
-        modl2 = s_datamodel.Model()
+        modl2 = s_datamodel.getBaseModel()
         modl2.addDataModels(mdef)
 
     async def test_model_comp_readonly_props(self):
@@ -332,7 +332,7 @@ class DataModelTest(s_t_utils.SynTest):
         })
 
         with self.raises(s_exc.BadTypeDef) as cm:
-            s_datamodel.Model().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addDataModels([badmodel])
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # Comp type with an indirect data field (and out of order definitions)
@@ -353,7 +353,7 @@ class DataModelTest(s_t_utils.SynTest):
         })
 
         with self.raises(s_exc.BadTypeDef) as cm:
-            s_datamodel.Model().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addDataModels([badmodel])
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # Comp type with double indirect data field
@@ -375,7 +375,7 @@ class DataModelTest(s_t_utils.SynTest):
         })
 
         with self.raises(s_exc.BadTypeDef) as cm:
-            s_datamodel.Model().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addDataModels([badmodel])
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # API direct
@@ -387,7 +387,7 @@ class DataModelTest(s_t_utils.SynTest):
         }
 
         with self.raises(s_exc.BadTypeDef) as cm:
-            s_datamodel.Model().addType('_bad:comp', 'comp', typeopts, {})
+            s_datamodel.getBaseModel().addType('_bad:comp', 'comp', typeopts, {})
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # Non-existent types
@@ -399,7 +399,7 @@ class DataModelTest(s_t_utils.SynTest):
         }
 
         with self.raises(s_exc.BadTypeDef) as cm:
-            s_datamodel.Model().addType('_bad:comp', 'comp', typeopts, {})
+            s_datamodel.getBaseModel().addType('_bad:comp', 'comp', typeopts, {})
         self.isin('Type newp is not present in datamodel.', cm.exception.get('mesg'))
 
         # deprecated types
@@ -420,7 +420,7 @@ class DataModelTest(s_t_utils.SynTest):
         })
 
         with self.getLoggerStream('synapse.lib.types') as stream:
-            s_datamodel.Model().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addDataModels([badmodel])
         stream.expect('The type _bad:comp field hehe uses a deprecated type depr:type which will be removed in 4.0.0.')
 
         # Comp type not extended does not gen deprecated warning
@@ -441,7 +441,7 @@ class DataModelTest(s_t_utils.SynTest):
         })
 
         with self.getLoggerStream('synapse.lib.types') as stream:
-            s_datamodel.Model().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addDataModels([badmodel])
         stream.noexpect('uses a deprecated type')
 
     async def test_datamodel_edges(self):
@@ -547,7 +547,7 @@ class DataModelTest(s_t_utils.SynTest):
     def test_datamodel_schema_basetypes(self):
         # N.B. This test is to keep synapse.lib.schemas.datamodel_basetypes const
         # in sync with the default s_datamodel.Datamodel().types
-        basetypes = list(s_datamodel.Model().types)
+        basetypes = list(s_datamodel.getBaseModel().types)
         self.sorteq(s_schemas.datamodel_basetypes, basetypes)
 
     async def test_datamodel_virts(self):

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -4184,7 +4184,7 @@ class StormTest(s_t_utils.SynTest):
         self.eq("Invalid value for type (int): lolz", pars.exc.errinfo['mesg'])
 
         # test time argtype
-        ttyp = s_datamodel.Model().type('time')
+        ttyp = s_datamodel.getBaseModel().type('time')
 
         pars = s_storm.Parser()
         pars.add_argument('--yada', type='time')
@@ -4201,7 +4201,7 @@ class StormTest(s_t_utils.SynTest):
         self.eq("Invalid value for type (time): hehe", pars.exc.errinfo['mesg'])
 
         # test ival argtype
-        ityp = s_datamodel.Model().type('ival')
+        ityp = s_datamodel.getBaseModel().type('ival')
 
         pars = s_storm.Parser()
         pars.add_argument('--yada', type='ival')
@@ -4277,7 +4277,7 @@ class StormTest(s_t_utils.SynTest):
 
         # choices - like defaults, choices are not normalized
         pars = s_storm.Parser()
-        ttyp = s_datamodel.Model().type('time')
+        ttyp = s_datamodel.getBaseModel().type('time')
         pars.add_argument('foo', type='time', choices=['2022', (await ttyp.norm('2023'))[0]], help='foohelp')
 
         opts = await pars.parse_args(['2023'])

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -16,7 +16,7 @@ class TypesTest(s_t_utils.SynTest):
 
     async def test_type(self):
         # Base type tests, mainly sad paths
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         t = model.type('bool')
         self.eq(t.info.get('bases'), ('base',))
         with self.raises(s_exc.NoSuchCmpr):
@@ -47,7 +47,7 @@ class TypesTest(s_t_utils.SynTest):
                 await mass.norm('newps')
 
     async def test_velocity(self):
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         velo = model.type('velocity')
 
         with self.raises(s_exc.BadTypeValu):
@@ -93,7 +93,7 @@ class TypesTest(s_t_utils.SynTest):
 
     async def test_hugenum(self):
 
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         huge = model.type('hugenum')
 
         with self.raises(s_exc.BadTypeValu):
@@ -131,7 +131,7 @@ class TypesTest(s_t_utils.SynTest):
 
     async def test_taxonomy(self):
 
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         taxo = model.type('taxonomy')
         self.eq('foo.bar.baz.', (await taxo.norm('foo.bar.baz'))[0])
         self.eq('foo.bar.baz.', (await taxo.norm('foo.bar.baz.'))[0])
@@ -222,7 +222,7 @@ class TypesTest(s_t_utils.SynTest):
             self.len(1, await core.nodes('test:taxonomy:sort=1 +:parent^=(foo, bar)'))
 
     async def test_duration(self):
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         t = model.type('duration')
 
         self.eq('2D 00:00:00', t.repr(172800000000))
@@ -249,7 +249,7 @@ class TypesTest(s_t_utils.SynTest):
             await t.norm('1:a:b')
 
     async def test_bool(self):
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         t = model.type('bool')
 
         self.eq(await t.norm(-1), (1, {}))
@@ -300,7 +300,7 @@ class TypesTest(s_t_utils.SynTest):
                 await typ.norm((123, 'haha', 'newp'))
 
     async def test_guid(self):
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
 
         guid = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
         self.eq(guid.lower(), (await model.type('guid').norm(guid))[0])
@@ -940,7 +940,7 @@ class TypesTest(s_t_utils.SynTest):
 
     async def test_int(self):
 
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         t = model.type('int')
 
         # test ranges
@@ -1063,7 +1063,7 @@ class TypesTest(s_t_utils.SynTest):
             model.type('int').clone({'ismin': True, 'ismax': True})
 
     async def test_float(self):
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         t = model.type('float')
 
         self.nn((await t.norm(1.2345))[0])
@@ -1114,7 +1114,7 @@ class TypesTest(s_t_utils.SynTest):
             self.eq(5, await core.callStorm('return($lib.cast(int, (5.5)))'))
 
     async def test_ival(self):
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         ival = model.types.get('ival')
 
         self.eq(('2016-01-01T00:00:00Z', '2017-01-01T00:00:00Z'), ival.repr((await ival.norm(('2016', '2017')))[0]))
@@ -1447,7 +1447,7 @@ class TypesTest(s_t_utils.SynTest):
                 await core.nodes('test:str:seen@=(1, 2, 3, 4)')
 
     async def test_loc(self):
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         loctype = model.types.get('loc')
 
         self.eq('us.va', (await loctype.norm('US.    VA'))[0])
@@ -1515,7 +1515,7 @@ class TypesTest(s_t_utils.SynTest):
             self.eq(0, await core.count('test:int:loc^=23'))
 
     async def test_range(self):
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         t = model.type('range')
 
         await self.asyncraises(s_exc.BadTypeValu, t.norm(1))
@@ -1590,7 +1590,7 @@ class TypesTest(s_t_utils.SynTest):
 
     async def test_str(self):
 
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
 
         lowr = model.type('str').clone({'lower': True})
         self.eq('foo', (await lowr.norm('FOO'))[0])
@@ -1663,7 +1663,7 @@ class TypesTest(s_t_utils.SynTest):
 
     async def test_syntag(self):
 
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         tagtype = model.type('syn:tag')
 
         self.eq('foo.bar', (await tagtype.norm(('FOO', ' BAR')))[0])
@@ -1715,7 +1715,7 @@ class TypesTest(s_t_utils.SynTest):
 
     async def test_time(self):
 
-        model = s_datamodel.Model()
+        model = s_datamodel.getBaseModel()
         ttime = model.types.get('time')
 
         with self.raises(s_exc.BadTypeValu):

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -262,16 +262,6 @@ class ThreeType(s_types.Type):
 testmodel = (
     ('test', {
 
-        'ctors': (
-            ('test:type', 'synapse.tests.utils.TestType', {}, {}),
-            ('test:threetype', 'synapse.tests.utils.ThreeType', {}, {}),
-            ('test:ctoronstorm', 'synapse.tests.utils.TestType', {}, {
-                'on': {'add': {'q': '[ :tick=2025 ]'}},
-                'props': (
-                    ('tick', ('time', {}), {}),
-                ),
-            }),
-        ),
         'interfaces': (
             ('test:interface', {
                 'doc': 'test interface',
@@ -294,6 +284,14 @@ testmodel = (
             ('test:unused:iface', {'doc': 'an interface applied to no forms'}),
         ),
         'types': (
+            ('test:type', (None, {'ctor': 'synapse.tests.utils.TestType'}), {}),
+            ('test:threetype', (None, {'ctor': 'synapse.tests.utils.ThreeType'}), {}),
+            ('test:ctoronstorm', (None, {'ctor': 'synapse.tests.utils.TestType'}), {
+                'on': {'add': {'q': '[ :tick=2025 ]'}},
+                'props': (
+                    ('tick', ('time', {}), {}),
+                ),
+            }),
             ('test:type10', ('test:type', {}), {
                 'doc': 'A fake type.'}),
 
@@ -592,9 +590,6 @@ testmodel = (
 
 deprmodel = (
     ('depr', {
-        'ctors': (
-            ('test:dep:str', 'synapse.lib.types.Str', {'strip': True}, {'deprecated': True}),
-        ),
         'interfaces': (
             ('test:deprinterface', {
                 'doc': 'test interface',
@@ -604,6 +599,7 @@ deprmodel = (
             }),
         ),
         'types': (
+            ('test:dep:str', (None, {'ctor': 'synapse.lib.types.Str', 'strip': True}), {'deprecated': True}),
             ('test:dep:easy', ('test:str', {}), {'deprecated': True}),
             ('test:dep:comp', ('comp', {'fields': (('int', 'test:int'), ('str', 'test:dep:easy'))}), {}),
             ('test:dep:array', ('array', {'type': 'test:dep:easy'}), {}),

--- a/synapse/tools/utils/autodoc.py
+++ b/synapse/tools/utils/autodoc.py
@@ -645,7 +645,13 @@ async def docModel(outp,
     modeldefs = await core.getModelDefs()
     _, model = modeldefs[0]
 
-    ctors = model.get('ctors')
+    ctors = []
+    for typename, typedef, typeinfo in model.get('types', ()):
+        if typedef[0] is None:
+            typeopts = dict(typedef[1])
+            ctor = typeopts.pop('ctor')
+            ctors.append((typename, ctor, typeopts, dict(typeinfo)))
+
     forms = model.get('forms')
     edges = model.get('edges')
     props = collections.defaultdict(list)


### PR DESCRIPTION
## Summary

- Removes the `ctors` key from model definition dicts and `_modeldef`
- Ctor-based types are now declared in the `types` section using `None` as the parent type name with a `ctor` key in the type options dict: `('name', (None, {'ctor': 'class.path'}), {info})`
- These types are constructed in a first-pass through the model since they are effectively base types
- `addBaseType()` also uses the new format for primitive types
- `getModelDefs()` output no longer contains a `ctors` key
- Updated `autodoc.py` to extract ctor info from the types list

## Test plan
- [x] All 17 datamodel tests pass
- [x] All 5 autodoc tests pass
- [x] All 132 cortex tests pass
- [x] All model-specific tests pass (inet, files, telco, infotech, geospace, crypto, economic, risk, dns, person)