### PR TITLE
3xx: Implement risk:exploitable interface on forms

### DIFF
--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -1384,6 +1384,7 @@ modeldefs = (
                 ),
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'network client'}}),
+                    ('risk:exploitable', {}),
                 ),
                 'props': (
                     ('proto', ('str:lower', {}), {
@@ -1476,6 +1477,7 @@ modeldefs = (
                 ),
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'network server'}}),
+                    ('risk:exploitable', {}),
                 ),
                 'props': (
                     ('proto', ('str:lower', {}), {
@@ -1602,6 +1604,7 @@ modeldefs = (
             ('inet:service:platform', ('guid', {}), {
                 'interfaces': (
                     ('meta:observable', {'template': {'title': 'platform'}}),
+                    ('risk:exploitable', {}),
                 ),
                 'doc': 'A network platform which provides services.'}),
 

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -643,6 +643,7 @@ modeldefs = (
                 'interfaces': (
                     ('phys:object', {}),
                     ('inet:service:object', {}),
+                    ('risk:exploitable', {}),
                 ),
                 'doc': 'A GUID that represents a host or system.'}),
 
@@ -897,6 +898,7 @@ modeldefs = (
                     ('meta:usable', {}),
                     ('meta:reported', {}),
                     ('doc:authorable', {}),
+                    ('risk:exploitable', {}),
                 ),
                 'doc': 'A software product, tool, or script.'}),
 
@@ -922,6 +924,7 @@ modeldefs = (
                 'prevnames': ('it:prod:hardware',),
                 'interfaces': (
                     ('meta:usable', {}),
+                    ('risk:exploitable', {}),
                 ),
                 'doc': 'A specification for a piece of IT hardware.'}),
 
@@ -1837,12 +1840,7 @@ modeldefs = (
                 ('vuln', ('risk:vuln', {}), {
                     'doc': 'The vulnerability detected in the asset.'}),
 
-                # TODO: should this be an interface for things that can be vulnerable?
-                ('asset', (
-                        ('risk:targetable', {}),
-                        ('meta:observable', {}),
-                        ('meta:havable', {})
-                    ), {
+                ('asset', ('risk:exploitable', {}), {
                     'doc': 'The node which is vulnerable.'}),
 
                 ('desc', ('str', {}), {

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -94,6 +94,9 @@ modeldefs = (
                 'doc': 'An asset status taxonomy.'}),
 
             ('ou:asset', ('guid', {}), {
+                'interfaces': (
+                    ('risk:exploitable', {}),
+                ),
                 'doc': 'A node for tracking assets which belong to an organization.',
                 'display': {
                     'columns': (

--- a/synapse/tests/test_model_risk.py
+++ b/synapse/tests/test_model_risk.py
@@ -388,6 +388,63 @@ class RiskModelTest(s_t_utils.SynTest):
             self.sorteq(['meta:technique', 'risk:mitigation'], [n.ndef[0] for n in nodes])
 
             nodes = await core.nodes('''
+                [ risk:vulnerable=*
+                    :node={[ it:software=* :name=vulnsoft ]}
+                ]
+            ''')
+            self.len(1, nodes)
+            self.nn(nodes[0].get('node'))
+            self.len(1, await core.nodes('risk:vulnerable :node -> it:software +:name=vulnsoft'))
+
+            nodes = await core.nodes('''
+                [ risk:vulnerable=*
+                    :node={[ inet:server=tcp://1.2.3.4:80 ]}
+                ]
+            ''')
+            self.len(1, nodes)
+            self.len(1, await core.nodes('risk:vulnerable :node -> inet:server'))
+
+            nodes = await core.nodes('''
+                [ risk:vulnerable=*
+                    :node={[ ou:asset=* :name=myasset ]}
+                ]
+            ''')
+            self.len(1, nodes)
+            self.len(1, await core.nodes('risk:vulnerable :node -> ou:asset +:name=myasset'))
+
+            nodes = await core.nodes('''
+                [ risk:vulnerable=*
+                    :node={[ it:host=* ]}
+                ]
+            ''')
+            self.len(1, nodes)
+            self.len(1, await core.nodes('risk:vulnerable :node -> it:host'))
+
+            nodes = await core.nodes('''
+                [ risk:vulnerable=*
+                    :node={[ inet:client=tcp://5.6.7.8:12345 ]}
+                ]
+            ''')
+            self.len(1, nodes)
+            self.len(1, await core.nodes('risk:vulnerable :node -> inet:client'))
+
+            nodes = await core.nodes('''
+                [ risk:vulnerable=*
+                    :node={[ inet:service:platform=* :name=myplatform ]}
+                ]
+            ''')
+            self.len(1, nodes)
+            self.len(1, await core.nodes('risk:vulnerable :node -> inet:service:platform +:name=myplatform'))
+
+            nodes = await core.nodes('''
+                [ risk:vulnerable=*
+                    :node={[ it:hardware=* :name=myhardware ]}
+                ]
+            ''')
+            self.len(1, nodes)
+            self.len(1, await core.nodes('risk:vulnerable :node -> it:hardware +:name=myhardware'))
+
+            nodes = await core.nodes('''
                 [ risk:outage=*
                     :name="The Big One"
                     :period=(2023, 2024)


### PR DESCRIPTION
## Summary
- Add `risk:exploitable` interface to `it:software`, `it:host`, `it:hardware`, `inet:server`, `inet:client`, `inet:service:platform`, and `ou:asset` forms
- Update `it:sec:vuln:scan:result:asset` polyprop to use `risk:exploitable` instead of the previous broad `(risk:targetable, meta:observable, meta:havable)` union
- Add tests for `risk:vulnerable:node` with all 7 exploitable form types

## Test plan
- [x] `test_model_risk` - all 4 tests pass
- [x] `test_model_inet` - all 40 tests pass
- [x] `test_model_orgs` - all 18 tests pass
- [x] `test_infotech_vulnscan` - passes with updated `risk:exploitable` polyprop

🤖 Generated with [Claude Code](https://claude.com/claude-code)