### PR TITLE
Remove vestigial names from modeldefs and rename getModelDef

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10484,7 +10484,7 @@ Features and Enhancements
   (`#2089 <https://github.com/vertexproject/synapse/pull/2089>`_)
 - Add ``aha:svcinfo`` configuration option for the base Cell.
   (`#2089 <https://github.com/vertexproject/synapse/pull/2089>`_)
-- Add interfaces to the output of ``model.getModelDefs()`` and the
+- Add interfaces to the output of ``model.getModelDef()`` and the
   ``getModelDict()`` APIs.
   (`#2092 <https://github.com/vertexproject/synapse/pull/2092>`_)
 - Update pylmdb to ``v1.1.1``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10484,7 +10484,7 @@ Features and Enhancements
   (`#2089 <https://github.com/vertexproject/synapse/pull/2089>`_)
 - Add ``aha:svcinfo`` configuration option for the base Cell.
   (`#2089 <https://github.com/vertexproject/synapse/pull/2089>`_)
-- Add interfaces to the output of ``model.getModelDef()`` and the
+- Add interfaces to the output of ``model.getModelDefs()`` and the
   ``getModelDict()`` APIs.
   (`#2092 <https://github.com/vertexproject/synapse/pull/2092>`_)
 - Update pylmdb to ``v1.1.1``.

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -214,8 +214,8 @@ class CoreApi(s_cell.CellApi):
         '''
         return await self.cell.getModelDict()
 
-    async def getModelDefs(self):
-        return await self.cell.getModelDefs()
+    async def getModelDef(self):
+        return await self.cell.getModelDef()
 
     def getCoreInfo(self):
         '''
@@ -4055,8 +4055,8 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
     async def getModelDict(self):
         return self.model.getModelDict()
 
-    async def getModelDefs(self):
-        return self.model.getModelDefs()
+    async def getModelDef(self):
+        return self.model.getModelDef()
 
     async def getFormCounts(self):
         '''

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -2939,10 +2939,10 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             if (defs := s_dyndeps.getDynLocal(path)) is not None:
                 mdefs.extend(defs)
 
-        self.model.addDataModels(mdefs)
+        self.model.addModelDefs(mdefs)
 
-    async def _addDataModels(self, mods):
-        self.model.addDataModels(mods)
+    async def _addModelDefs(self, mods):
+        self.model.addModelDefs(mods)
         await self._initDeprLocks()
         await self._warnDeprLocks()
 

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -536,7 +536,7 @@ def getBaseModel():
     modl = Model()
     mdef = s_base.modeldefs[0]
     types = tuple(t for t in mdef['types'] if t[1][0] is None)
-    modl.addDataModels([{'types': types}])
+    modl.addModelDefs([{'types': types}])
     return modl
 
 class Model:
@@ -929,7 +929,7 @@ class Model:
 
         return tuple(realdefs)
 
-    def addDataModels(self, mods):
+    def addModelDefs(self, mods):
         '''
         Add a list of model definition dictionaries.
 

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -534,9 +534,9 @@ def getBaseModel():
     '''
     import synapse.models.base as s_base
     modl = Model()
-    name, mdef = s_base.modeldefs[0]
+    mdef = s_base.modeldefs[0]
     types = tuple(t for t in mdef['types'] if t[1][0] is None)
-    modl.addDataModels([(name, {'types': types})])
+    modl.addDataModels([{'types': types}])
     return modl
 
 class Model:
@@ -825,10 +825,10 @@ class Model:
 
         return base.clone(typedef[1])
 
-    def getModelDefs(self):
+    def getModelDef(self):
         '''
         Returns:
-            A list of one model definition compatible with addDataModels that represents the current data model
+            A model definition dictionary representing the current data model.
         '''
         mdef = self._modeldef.copy()
         # dynamically generate form defs due to extended props
@@ -836,7 +836,7 @@ class Model:
         mdef['tagprops'] = [t.getTagPropDef() for t in self.tagprops.values()]
         mdef['interfaces'] = list(self.ifaces.items())
         mdef['edges'] = [e.pack() for e in self.edges.values()]
-        return [('all', mdef)]
+        return mdef
 
     def _getResolvedIfaces(self):
         '''Return a copy of interfaces with default template values resolved in docs and types.'''
@@ -931,7 +931,7 @@ class Model:
 
     def addDataModels(self, mods):
         '''
-        Add a list of (name, mdef) tuples.
+        Add a list of model definition dictionaries.
 
         A model definition (mdef) is structured as follows::
 
@@ -962,7 +962,7 @@ class Model:
             }
 
         Args:
-            mods (list):  The list of tuples.
+            mods (list):  The list of model definition dicts.
 
         Returns:
             None
@@ -974,7 +974,7 @@ class Model:
         allforms = []
 
         # Gather all the forms first
-        for _, mdef in mods:
+        for mdef in mods:
 
             # Allow props declared directly on types to become forms...
             for typename, _, typeinfo in mdef.get('types', ()):
@@ -990,14 +990,14 @@ class Model:
                 self.forminfos[formname] = forminfo
 
         # load all the interfaces...
-        for _, mdef in mods:
+        for mdef in mods:
             for name, info in mdef.get('interfaces', ()):
                 self.addIface(name, info)
 
         ctors = {}
 
         # first pass: load ctor-based types (base type is None)
-        for _, mdef in mods:
+        for mdef in mods:
             for typename, typedef, typeinfo in mdef.get('types', ()):
                 if typedef[0] is not None:
                     continue
@@ -1009,7 +1009,7 @@ class Model:
                 ctors[typename] = ctor
 
         # second pass: load all derived types
-        for _, mdef in mods:
+        for mdef in mods:
             for typename, typedef, typeinfo in mdef.get('types', ()):
                 if typedef[0] is None:
                     continue
@@ -1033,7 +1033,7 @@ class Model:
                 self._modeldef['types'].append(tobj.getTypeDef())
 
         # Load all the tagprops
-        for _, mdef in mods:
+        for mdef in mods:
             for tpname, typedef, tpinfo in mdef.get('tagprops', ()):
                 self.addTagProp(tpname, typedef, tpinfo)
 
@@ -1060,7 +1060,7 @@ class Model:
         addForms(allforms)
 
         # now we can load edge definitions...
-        for _, mdef in mods:
+        for mdef in mods:
             for etype, einfo in mdef.get('edges', ()):
                 self.addEdge(etype, einfo)
 

--- a/synapse/models/auth.py
+++ b/synapse/models/auth.py
@@ -23,7 +23,7 @@ class Passwd(s_types.Str):
 
 modeldefs = (
 
-    ('auth', {
+    {
 
         'types': (
             ('auth:passwd', (None, {'ctor': 'synapse.models.auth.Passwd', 'strip': False}), {
@@ -57,5 +57,5 @@ modeldefs = (
             )),
         ),
 
-    }),
+    },
 )

--- a/synapse/models/base.py
+++ b/synapse/models/base.py
@@ -20,7 +20,7 @@ taskstatusenums = (
 )
 
 modeldefs = (
-    ('base', {
+    {
         'types': (
 
             ('int', (None, {'ctor': 'synapse.lib.types.Int'}), {
@@ -833,5 +833,5 @@ modeldefs = (
             ('meta:technique:type:taxonomy', {}, ()),
 
         ),
-    }),
+    },
 )

--- a/synapse/models/belief.py
+++ b/synapse/models/belief.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('belief', {
+    {
         'types': (
 
             ('belief:system', ('guid', {}), {
@@ -58,5 +58,5 @@ modeldefs = (
                 'doc': 'The belief system includes the tenet.'}),
 
         ),
-    }),
+    },
 )

--- a/synapse/models/biz.py
+++ b/synapse/models/biz.py
@@ -2,7 +2,7 @@
 Model elements related to sales / bizdev / procurement
 '''
 modeldefs = (
-    ('biz', {
+    {
         'types': (
 
             ('biz:rfp:type:taxonomy', ('taxonomy', {}), {
@@ -198,5 +198,5 @@ modeldefs = (
                     'doc': 'The price of the product.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/crypto.py
+++ b/synapse/models/crypto.py
@@ -10,7 +10,7 @@ x509vers = (
 )
 
 modeldefs = (
-    ('crypto', {
+    {
         'types': (
 
             ('crypto:currency:transaction', ('guid', {}), {
@@ -762,5 +762,5 @@ modeldefs = (
 
             )),
         )
-    }),
+    },
 )

--- a/synapse/models/dns.py
+++ b/synapse/models/dns.py
@@ -90,7 +90,7 @@ class DnsName(s_types.Str):
         return norm, {'subs': subs}
 
 modeldefs = (
-    ('inet:dns', {
+    {
 
         'types': (
 
@@ -369,5 +369,5 @@ modeldefs = (
                     'doc': 'The network client address used to register the dynamic FQDN.'}),
             )),
         )
-    }),
+    },
 )

--- a/synapse/models/doc.py
+++ b/synapse/models/doc.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('doc', {
+    {
         'interfaces': (
 
             ('doc:authorable', {
@@ -273,5 +273,5 @@ modeldefs = (
                     'doc': 'A URL for the reference.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/economic.py
+++ b/synapse/models/economic.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('econ', {
+    {
 
         'types': (
 
@@ -539,5 +539,5 @@ modeldefs = (
                     'doc': 'The account number.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/entity.py
+++ b/synapse/models/entity.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('entity', {
+    {
 
         'interfaces': (
 
@@ -764,5 +764,5 @@ modeldefs = (
             )),
 
         ),
-    }),
+    },
 )

--- a/synapse/models/files.py
+++ b/synapse/models/files.py
@@ -132,7 +132,7 @@ class FilePath(s_types.Str):
         return fullpath, {'adds': adds, 'virts': virts}
 
 modeldefs = (
-    ('file', {
+    {
         'interfaces': (
             ('file:mime:meta', {
                 'template': {'metadata': 'metadata'},
@@ -802,5 +802,5 @@ modeldefs = (
                     'doc': 'The NetBIOS name of the machine where the link target was last located.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/geopol.py
+++ b/synapse/models/geopol.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('pol', {
+    {
 
         'types': (
 
@@ -251,5 +251,5 @@ modeldefs = (
             )),
         ),
 
-    }),
+    },
 )

--- a/synapse/models/geospace.py
+++ b/synapse/models/geospace.py
@@ -379,7 +379,7 @@ class LatLong(s_types.Type):
         return f'{norm[0]},{norm[1]}'
 
 modeldefs = (
-    ('geo', {
+    {
 
         'interfaces': (
 
@@ -539,5 +539,5 @@ modeldefs = (
                     'doc': 'The image file to use as the primary image of the place.'}),
             )),
         )
-    }),
+    },
 )

--- a/synapse/models/gov.py
+++ b/synapse/models/gov.py
@@ -16,14 +16,7 @@ modeldefs = (
                     ('entity:identifier', {}),
                 ),
                 'doc': 'A Chinese PLA MUCD.'}),
-        ),
-        'forms': (
-            ('gov:cn:icp', {}, ()),
-            ('gov:cn:mucd', {}, ()),
-        )
-    },
-    {
-        'types': (
+
             ('iso:oid', ('str', {'regex': '^([0-2])((\\.0)|(\\.[1-9][0-9]*))*$'}), {
                 'doc': 'An ISO Object Identifier string.'}),
 
@@ -44,24 +37,6 @@ modeldefs = (
 
             ('gov:intl:un:m49', ('int', {'min': 1, 'max': 999}), {
                 'doc': 'UN M49 Numeric Country Code.'}),
-        ),
-
-        'forms': (
-            ('iso:oid', {}, (
-
-                ('desc', ('str', {}), {
-                    'doc': 'A description of the value or meaning of the OID.'}),
-
-                ('identifier', ('str', {}), {
-                    'doc': 'The string identifier for the deepest tree element.'}),
-            )),
-            ('iso:3166:alpha2', {}, ()),
-            ('iso:3166:alpha3', {}, ()),
-            ('iso:3166:numeric3', {}, ()),
-        ),
-    },
-    {
-        'types': (
 
             ('gov:us:ssn', ('str', {'regex': '^[0-9]{3}-[0-9]{2}-[0-9]{4}'}), {
                 'interfaces': (
@@ -80,6 +55,21 @@ modeldefs = (
         ),
 
         'forms': (
+            ('gov:cn:icp', {}, ()),
+            ('gov:cn:mucd', {}, ()),
+
+            ('iso:oid', {}, (
+
+                ('desc', ('str', {}), {
+                    'doc': 'A description of the value or meaning of the OID.'}),
+
+                ('identifier', ('str', {}), {
+                    'doc': 'The string identifier for the deepest tree element.'}),
+            )),
+            ('iso:3166:alpha2', {}, ()),
+            ('iso:3166:alpha3', {}, ()),
+            ('iso:3166:numeric3', {}, ()),
+
             ('gov:us:cage', {}, (
                 ('org', ('ou:org', {}), {
                     'doc': 'The organization which was issued the CAGE code.'}),

--- a/synapse/models/gov.py
+++ b/synapse/models/gov.py
@@ -2,7 +2,7 @@
 icpregex = '^(皖|京|渝|闽|粤|甘|桂|黔|豫|鄂|冀|琼|港|黑|湘|吉|苏|赣|辽|澳|蒙|宁|青|川|鲁|沪|陕|晋|津|台|新|藏|滇|浙)ICP(备|证)[0-9]{8}号$'
 
 modeldefs = (
-    ('gov:cn', {
+    {
         'types': (
 
             ('gov:cn:icp', ('str', {'regex': icpregex}), {
@@ -21,8 +21,8 @@ modeldefs = (
             ('gov:cn:icp', {}, ()),
             ('gov:cn:mucd', {}, ()),
         )
-    }),
-    ('gov:intl', {
+    },
+    {
         'types': (
             ('iso:oid', ('str', {'regex': '^([0-2])((\\.0)|(\\.[1-9][0-9]*))*$'}), {
                 'doc': 'An ISO Object Identifier string.'}),
@@ -59,8 +59,8 @@ modeldefs = (
             ('iso:3166:alpha3', {}, ()),
             ('iso:3166:numeric3', {}, ()),
         ),
-    }),
-    ('gov:us', {
+    },
+    {
         'types': (
 
             ('gov:us:ssn', ('str', {'regex': '^[0-9]{3}-[0-9]{2}-[0-9]{4}'}), {
@@ -118,5 +118,5 @@ modeldefs = (
             ('gov:us:ssn', {}, []),
             ('gov:us:zip', {}, []),
         ),
-    }),
+    },
 )

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -1245,7 +1245,7 @@ class Url(s_types.Str):
         return norm, {'subs': subs}
 
 modeldefs = (
-    ('inet', {
+    {
         'edges': (
             (('inet:whois:iprecord', 'has', 'inet:ip'), {
                 'doc': 'The IP whois record describes the IP address.'}),
@@ -3186,5 +3186,5 @@ modeldefs = (
                     'doc': 'The subscriber who owns the subscription.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -607,7 +607,7 @@ suslevels = (
 attack_flow_schema_2_0_0 = s_data.getJSON('attack-flow/attack-flow-schema-2.0.0')
 
 modeldefs = (
-    ('it', {
+    {
         'types': (
             ('it:semver', (None, {'ctor': 'synapse.models.infotech.SemVer'}), {
                 'doc': 'Semantic Version type.'}),
@@ -2813,5 +2813,5 @@ modeldefs = (
                     'doc': 'An array of HTTP headers that the sample should transmit to the C2 server.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/language.py
+++ b/synapse/models/language.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('lang', {
+    {
 
         'interfaces': (
             ('lang:transcript', {
@@ -101,5 +101,5 @@ modeldefs = (
             )),
         ),
 
-    }),
+    },
 )

--- a/synapse/models/material.py
+++ b/synapse/models/material.py
@@ -27,7 +27,7 @@ massunits = {
 }
 
 modeldefs = (
-    ('mat', {
+    {
 
         'interfaces': (
 
@@ -140,5 +140,5 @@ modeldefs = (
                     'doc': 'The taxonomy type for the specification.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/math.py
+++ b/synapse/models/math.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('math', {
+    {
         'types': (
 
             ('math:algorithm', ('guid', {}), {
@@ -44,5 +44,5 @@ modeldefs = (
                     'doc': 'The time that the algorithm was authored.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/orgs.py
+++ b/synapse/models/orgs.py
@@ -9,7 +9,7 @@ contracttypes = (
 )
 
 modeldefs = (
-    ('ou', {
+    {
 
         'interfaces': (
 
@@ -745,5 +745,5 @@ modeldefs = (
                     'doc': 'The scope of responsbility for the assignee to enact the document.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('ps', {
+    {
         'types': (
             ('edu:course', ('guid', {}), {
                 'template': {'title': 'course'},
@@ -189,5 +189,5 @@ modeldefs = (
                     'doc': 'The type of skill as a taxonomy.'})
             )),
         )
-    }),
+    },
 )

--- a/synapse/models/planning.py
+++ b/synapse/models/planning.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('plan', {
+    {
         'types': (
             ('plan:system', ('guid', {}), {
                 'template': {'title': 'planning system'},
@@ -151,5 +151,5 @@ modeldefs = (
                     'doc': 'The procedure which defines the link.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/proj.py
+++ b/synapse/models/proj.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('proj', {
+    {
 
         'types': (
 
@@ -107,5 +107,5 @@ modeldefs = (
                     'ex': 'bug'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/risk.py
+++ b/synapse/models/risk.py
@@ -32,7 +32,7 @@ alertstatus = (
 )
 
 modeldefs = (
-    ('risk', {
+    {
         'types': (
             # TODO: implement type specific cmprs and virts for CVSS types
             ('it:sec:cvss:v2', (None, {'ctor': 'synapse.models.risk.CvssV2'}), {
@@ -763,5 +763,5 @@ modeldefs = (
                     'doc': 'The total price paid by the target of the extortion.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/science.py
+++ b/synapse/models/science.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('sci', {
+    {
         'types': (
             ('sci:hypothesis:type:taxonomy', ('taxonomy', {}), {
                 'interfaces': (
@@ -109,5 +109,5 @@ modeldefs = (
                     'doc': 'Set to true if the evidence refutes the hypothesis or false if it supports the hypothesis.'}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/syn.py
+++ b/synapse/models/syn.py
@@ -141,7 +141,7 @@ async def _liftRuntSynTagProp(view, prop, cmprvalu=None):
 
 
 modeldefs = (
-    ('syn', {
+    {
 
         'types': (
             ('syn:user', (None, {'ctor': 'synapse.models.syn.SynUser'}), {
@@ -273,5 +273,5 @@ modeldefs = (
                     'doc': 'The layer storage nodes for the node that was deleted.', 'computed': True}),
             )),
         ),
-    }),
+    },
 )

--- a/synapse/models/telco.py
+++ b/synapse/models/telco.py
@@ -138,7 +138,7 @@ class Imei(s_types.Int):
                                 mesg='Failed to norm IMEI')
 
 modeldefs = (
-    ('tel', {
+    {
         'types': (
 
             ('tel:mob:imei', (None, {'ctor': 'synapse.models.telco.Imei'}), {
@@ -396,5 +396,5 @@ modeldefs = (
                     'doc': 'The app used to report the mobile telemetry sample.'}),
             )),
         )
-    }),
+    },
 )

--- a/synapse/models/transport.py
+++ b/synapse/models/transport.py
@@ -1,5 +1,5 @@
 modeldefs = (
-    ('transport', {
+    {
         'types': (
 
             ('transport:trip:status', ('str', {'enums': 'scheduled,cancelled,in-progress,completed,aborted,failed,unknown'}), {
@@ -587,5 +587,5 @@ modeldefs = (
 
             ('transport:shipping:container', {}, ()),
         ),
-    }),
+    },
 )

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -4644,7 +4644,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
         async with self.getTestCore() as core0:
 
-            await core0._addDataModels(s_t_utils.deprmodel)
+            await core0._addModelDefs(s_t_utils.deprmodel)
 
             podes = []
 
@@ -4672,7 +4672,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
         async with self.getTestCore() as core1:
 
-            await core1._addDataModels(s_t_utils.deprmodel)
+            await core1._addModelDefs(s_t_utils.deprmodel)
 
             await core1.addFeedData(podes)
             self.len(4, await core1.nodes('test:int'))
@@ -7381,7 +7381,7 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                 async with self.getTestCore(dirn=dirn) as core:
 
-                    await core._addDataModels(s_t_utils.deprmodel)
+                    await core._addModelDefs(s_t_utils.deprmodel)
 
                     # Create a test:deprprop so it doesn't generate a warning
                     await core.callStorm('[test:dep:easy=foobar :guid=*]')
@@ -7402,7 +7402,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                 here = stream.tell()
 
                 async with self.getTestCore(dirn=dirn) as core:
-                    await core._addDataModels(s_t_utils.deprmodel)
+                    await core._addModelDefs(s_t_utils.deprmodel)
 
                 # Check that the warnings are gone now
                 stream.seek(here)

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -94,7 +94,7 @@ class DataModelTest(s_t_utils.SynTest):
         )
 
         with self.raises(s_exc.BadFormDef):
-            modl.addDataModels(mods)
+            modl.addModelDefs(mods)
 
     async def test_datamodel_virtstor(self):
         modl = s_datamodel.getBaseModel()
@@ -119,7 +119,7 @@ class DataModelTest(s_t_utils.SynTest):
         )
 
         with self.raises(s_exc.NoSuchIface):
-            modl.addDataModels(mods)
+            modl.addModelDefs(mods)
 
     async def test_datamodel_dynamics(self):
 
@@ -242,7 +242,7 @@ class DataModelTest(s_t_utils.SynTest):
             with self.getAsyncLoggerStream('synapse.lib.types') as tstream, \
                     self.getAsyncLoggerStream('synapse.datamodel') as dstream:
                 core = await s_cortex.Cortex.anit(dirn)
-                await core._addDataModels(s_t_utils.testmodel + s_t_utils.deprmodel)
+                await core._addModelDefs(s_t_utils.testmodel + s_t_utils.deprmodel)
 
             dstream.expect('type test:dep:easy is based on a deprecated type test:dep:easy')
             dstream.noexpect('type test:dep:comp field str uses a deprecated type test:dep:easy')
@@ -279,7 +279,7 @@ class DataModelTest(s_t_utils.SynTest):
             # with deprecated types in them. This is a coverage test for extended properties.
             with self.getAsyncLoggerStream('synapse.cortex', mesg) as cstream:
                 async with await s_cortex.Cortex.anit(dirn) as core:
-                    await core._addDataModels(s_t_utils.testmodel + s_t_utils.deprmodel)
+                    await core._addModelDefs(s_t_utils.testmodel + s_t_utils.deprmodel)
                     await core._loadExtModel()
                     # self.true(await cstream.wait(6))
 
@@ -293,7 +293,7 @@ class DataModelTest(s_t_utils.SynTest):
         modl.addForm('foo:foo', {}, ())
         mdef = modl.getModelDef()
         modl2 = s_datamodel.getBaseModel()
-        modl2.addDataModels([mdef])
+        modl2.addModelDefs([mdef])
 
     async def test_model_comp_readonly_props(self):
         async with self.getTestCore() as core:
@@ -332,7 +332,7 @@ class DataModelTest(s_t_utils.SynTest):
         }
 
         with self.raises(s_exc.BadTypeDef) as cm:
-            s_datamodel.getBaseModel().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addModelDefs([badmodel])
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # Comp type with an indirect data field (and out of order definitions)
@@ -353,7 +353,7 @@ class DataModelTest(s_t_utils.SynTest):
         }
 
         with self.raises(s_exc.BadTypeDef) as cm:
-            s_datamodel.getBaseModel().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addModelDefs([badmodel])
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # Comp type with double indirect data field
@@ -375,7 +375,7 @@ class DataModelTest(s_t_utils.SynTest):
         }
 
         with self.raises(s_exc.BadTypeDef) as cm:
-            s_datamodel.getBaseModel().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addModelDefs([badmodel])
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # API direct
@@ -420,7 +420,7 @@ class DataModelTest(s_t_utils.SynTest):
         }
 
         with self.getLoggerStream('synapse.lib.types') as stream:
-            s_datamodel.getBaseModel().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addModelDefs([badmodel])
         stream.expect('The type _bad:comp field hehe uses a deprecated type depr:type which will be removed in 4.0.0.')
 
         # Comp type not extended does not gen deprecated warning
@@ -441,7 +441,7 @@ class DataModelTest(s_t_utils.SynTest):
         }
 
         with self.getLoggerStream('synapse.lib.types') as stream:
-            s_datamodel.getBaseModel().addDataModels([badmodel])
+            s_datamodel.getBaseModel().addModelDefs([badmodel])
         stream.noexpect('uses a deprecated type')
 
     async def test_datamodel_edges(self):
@@ -514,7 +514,7 @@ class DataModelTest(s_t_utils.SynTest):
 
         async with self.getTestCore() as core:
 
-            await core._addDataModels(s_t_utils.deprmodel)
+            await core._addModelDefs(s_t_utils.deprmodel)
 
             nodes = await core.nodes('[ test:deprsub=bar :range=(1, 5) ]')
             self.propeq(nodes[0], 'range:min', 1)

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -83,14 +83,14 @@ class DataModelTest(s_t_utils.SynTest):
     async def test_datamodel_formname(self):
         modl = s_datamodel.getBaseModel()
         mods = (
-            ('hehe', {
+            {
                 'types': (
                     ('derp', ('int', {}), {}),
                 ),
                 'forms': (
                     ('derp', {}, ()),
                 ),
-            }),
+            },
         )
 
         with self.raises(s_exc.BadFormDef):
@@ -106,7 +106,7 @@ class DataModelTest(s_t_utils.SynTest):
     async def test_datamodel_no_interface(self):
         modl = s_datamodel.getBaseModel()
         mods = (
-            ('hehe', {
+            {
                 'types': (
                     ('test:derp', ('int', {}), {
                         'interfaces': (('foo:bar', {}),),
@@ -115,7 +115,7 @@ class DataModelTest(s_t_utils.SynTest):
                 'forms': (
                     ('test:derp', {}, ()),
                 ),
-            }),
+            },
         )
 
         with self.raises(s_exc.NoSuchIface):
@@ -285,15 +285,15 @@ class DataModelTest(s_t_utils.SynTest):
 
     async def test_datamodel_getmodeldefs(self):
         '''
-        Make sure you can make a new model with the output of datamodel.getModelDefs
+        Make sure you can make a new model with the output of datamodel.getModelDef
         '''
         modl = s_datamodel.getBaseModel()
         modl.addIface('test:iface', {})
         modl.addType('foo:foo', 'int', {}, {'interfaces': (('test:iface', {}),)})
         modl.addForm('foo:foo', {}, ())
-        mdef = modl.getModelDefs()
+        mdef = modl.getModelDef()
         modl2 = s_datamodel.getBaseModel()
-        modl2.addDataModels(mdef)
+        modl2.addDataModels([mdef])
 
     async def test_model_comp_readonly_props(self):
         async with self.getTestCore() as core:
@@ -316,7 +316,7 @@ class DataModelTest(s_t_utils.SynTest):
         mutmesg = 'Comp types with mutable fields (_bad:comp:hehe) are not allowed'
 
         # Comp type with a direct data field
-        badmodel = ('badmodel', {
+        badmodel = {
             'types': (
                 ('_bad:comp', ('comp', {'fields': (
                     ('hehe', 'data'),
@@ -329,14 +329,14 @@ class DataModelTest(s_t_utils.SynTest):
                     ('haha', ('int', {}), {}),
                 )),
             ),
-        })
+        }
 
         with self.raises(s_exc.BadTypeDef) as cm:
             s_datamodel.getBaseModel().addDataModels([badmodel])
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # Comp type with an indirect data field (and out of order definitions)
-        badmodel = ('badmodel', {
+        badmodel = {
             'types': (
                 ('_bad:comp', ('comp', {'fields': (
                     ('hehe', 'bad:data'),
@@ -350,14 +350,14 @@ class DataModelTest(s_t_utils.SynTest):
                     ('haha', ('int', {}), {}),
                 )),
             ),
-        })
+        }
 
         with self.raises(s_exc.BadTypeDef) as cm:
             s_datamodel.getBaseModel().addDataModels([badmodel])
         self.isin(mutmesg, cm.exception.get('mesg'))
 
         # Comp type with double indirect data field
-        badmodel = ('badmodel', {
+        badmodel = {
             'types': (
                 ('bad:data00', ('data', {}), {}),
                 ('bad:data01', ('bad:data00', {}), {}),
@@ -372,7 +372,7 @@ class DataModelTest(s_t_utils.SynTest):
                     ('haha', ('int', {}), {}),
                 )),
             ),
-        })
+        }
 
         with self.raises(s_exc.BadTypeDef) as cm:
             s_datamodel.getBaseModel().addDataModels([badmodel])
@@ -403,7 +403,7 @@ class DataModelTest(s_t_utils.SynTest):
         self.isin('Type newp is not present in datamodel.', cm.exception.get('mesg'))
 
         # deprecated types
-        badmodel = ('badmodel', {
+        badmodel = {
             'types': (
                 ('depr:type', ('int', {}), {'deprecated': True}),
                 ('_bad:comp', ('comp', {'fields': (
@@ -417,14 +417,14 @@ class DataModelTest(s_t_utils.SynTest):
                     ('haha', ('int', {}), {}),
                 )),
             ),
-        })
+        }
 
         with self.getLoggerStream('synapse.lib.types') as stream:
             s_datamodel.getBaseModel().addDataModels([badmodel])
         stream.expect('The type _bad:comp field hehe uses a deprecated type depr:type which will be removed in 4.0.0.')
 
         # Comp type not extended does not gen deprecated warning
-        badmodel = ('badmodel', {
+        badmodel = {
             'types': (
                 ('depr:type', ('int', {}), {'deprecated': True}),
                 ('bad:comp', ('comp', {'fields': (
@@ -438,7 +438,7 @@ class DataModelTest(s_t_utils.SynTest):
                     ('haha', ('int', {}), {}),
                 )),
             ),
-        })
+        }
 
         with self.getLoggerStream('synapse.lib.types') as stream:
             s_datamodel.getBaseModel().addDataModels([badmodel])
@@ -500,7 +500,7 @@ class DataModelTest(s_t_utils.SynTest):
             taxprops = {p[0]: p for p in taxinfo['props']}
             self.eq(taxprops['parent'][1][0], 'meta:taxonomy')
 
-            model = (await core.getModelDefs())[0][1]
+            model = await core.getModelDef()
             self.isin(('test:interface', 'matches', None), [e[0] for e in model['edges']])
 
             self.nn(core.model.edge(('test:interface', 'matches', None)))

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -1525,7 +1525,7 @@ class StormTest(s_t_utils.SynTest):
 
         async with self.getTestCore() as core:
 
-            core.model.addDataModels(s_t_utils.deprmodel)
+            core.model.addModelDefs(s_t_utils.deprmodel)
 
             await core.nodes('$lib.model.ext.addFormProp(test:deprprop, _str, (str, ({})), ({}))')
 

--- a/synapse/tests/test_lib_stormlib_model.py
+++ b/synapse/tests/test_lib_stormlib_model.py
@@ -122,7 +122,7 @@ class StormlibModelTest(s_test.SynTest):
 
             async with self.getTestCore(dirn=dirn) as core:
 
-                await core._addDataModels(s_test.deprmodel)
+                await core._addModelDefs(s_test.deprmodel)
 
                 # create both a deprecated form and a node with a deprecated prop
                 await core.nodes('[ test:deprform=* :deprprop2=foo test:deprprop=baz ]')
@@ -162,7 +162,7 @@ class StormlibModelTest(s_test.SynTest):
             # ensure that the locks persisted and got loaded correctly
             async with self.getTestCore(dirn=dirn) as core:
 
-                await core._addDataModels(s_test.deprmodel)
+                await core._addModelDefs(s_test.deprmodel)
 
                 mesgs = await core.stormlist('model.deprecated.check')
                 # warn due to unlocked
@@ -187,7 +187,7 @@ class StormlibModelTest(s_test.SynTest):
 
         async with self.getTestCore() as core:
 
-            await core._addDataModels(s_test.deprmodel)
+            await core._addModelDefs(s_test.deprmodel)
 
             mesgs = await core.stormlist('model.deprecated.check')
 

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -2122,7 +2122,7 @@ class TypesTest(s_t_utils.SynTest):
         }
         async with self.getTestCore() as core:
 
-            core.model.addDataModels([('asdf', mdef)])
+            core.model.addDataModels([mdef])
 
             with self.raises(s_exc.BadTypeDef):
                 await core.addFormProp('test:int', '_hehe', ('array', {'type': 'array'}), {})

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -2122,7 +2122,7 @@ class TypesTest(s_t_utils.SynTest):
         }
         async with self.getTestCore() as core:
 
-            core.model.addDataModels([mdef])
+            core.model.addModelDefs([mdef])
 
             with self.raises(s_exc.BadTypeDef):
                 await core.addFormProp('test:int', '_hehe', ('array', {'type': 'array'}), {})

--- a/synapse/tests/test_model_geospace.py
+++ b/synapse/tests/test_model_geospace.py
@@ -359,7 +359,7 @@ class GeoTest(s_t_utils.SynTest):
 
         async with self.getTestCore() as core:
 
-            await core._addDataModels(geotestmodel)
+            await core._addModelDefs(geotestmodel)
 
             # Lift behavior for a node whose has a latlong as their primary property
             nodes = await core.nodes('[(test:latlong=(10, 10) :dist=10m) '
@@ -416,7 +416,7 @@ class GeoTest(s_t_utils.SynTest):
 
         async with self.getTestCore() as core:
 
-            await core._addDataModels(geotestmodel)
+            await core._addModelDefs(geotestmodel)
             nodes = await core.nodes('[ test:distoff=-3cm ]')
             self.eq(970, nodes[0].ndef[1])
             self.eq('-3.0 cm', await core.callStorm('test:distoff return($node.repr())'))

--- a/synapse/tests/test_model_geospace.py
+++ b/synapse/tests/test_model_geospace.py
@@ -4,7 +4,7 @@ import synapse.common as s_common
 import synapse.tests.utils as s_t_utils
 
 geotestmodel = (
-    ('geo:test', {
+    {
 
         'types': (
             ('test:latlong', ('geo:latlong', {}), {}),
@@ -20,7 +20,7 @@ geotestmodel = (
             )),
             ('test:distoff', {}, ()),
         ),
-    }),
+    },
 )
 
 geojson0 = {

--- a/synapse/tests/test_model_syn.py
+++ b/synapse/tests/test_model_syn.py
@@ -368,7 +368,7 @@ class SynModelTest(s_t_utils.SynTest):
                 nodes = await core.nodes('syn:form=syn:tag')
                 self.len(1, nodes)
 
-                await core._addDataModels(s_t_utils.testmodel)
+                await core._addModelDefs(s_t_utils.testmodel)
 
                 nodes = await core.nodes('syn:prop:form="test:str" +:extmodel=True')
                 self.len(0, nodes)

--- a/synapse/tests/test_tools_cortex_docmodel.py
+++ b/synapse/tests/test_tools_cortex_docmodel.py
@@ -464,7 +464,7 @@ class DocModelTest(s_t_utils.SynTest):
         # the no-doc branch in the genFormMarkdown interfaces table
 
         async with self.getTestCore() as core:
-            core.model.addDataModels([{
+            core.model.addModelDefs([{
                 'interfaces': (
                     ('test:nodoc:iface', {
                         'props': (),
@@ -492,7 +492,7 @@ class DocModelTest(s_t_utils.SynTest):
         # "## Implementing Forms" section in genIfaceMarkdown
 
         async with self.getTestCore() as core:
-            core.model.addDataModels([{
+            core.model.addModelDefs([{
                 'interfaces': (
                     ('test:impl:iface', {
                         'doc': 'A test interface with an implementing form.',

--- a/synapse/tests/test_tools_cortex_docmodel.py
+++ b/synapse/tests/test_tools_cortex_docmodel.py
@@ -464,7 +464,7 @@ class DocModelTest(s_t_utils.SynTest):
         # the no-doc branch in the genFormMarkdown interfaces table
 
         async with self.getTestCore() as core:
-            core.model.addDataModels([('test', {
+            core.model.addDataModels([{
                 'interfaces': (
                     ('test:nodoc:iface', {
                         'props': (),
@@ -480,7 +480,7 @@ class DocModelTest(s_t_utils.SynTest):
                 'forms': (
                     ('test:nodoc:form', {}, ()),
                 ),
-            })])
+            }])
 
             text = await s_docmodel.genFormMarkdown(core, 'test:nodoc:form')
             self.isin('`test:nodoc:iface`', text)
@@ -492,7 +492,7 @@ class DocModelTest(s_t_utils.SynTest):
         # "## Implementing Forms" section in genIfaceMarkdown
 
         async with self.getTestCore() as core:
-            core.model.addDataModels([('test', {
+            core.model.addDataModels([{
                 'interfaces': (
                     ('test:impl:iface', {
                         'doc': 'A test interface with an implementing form.',
@@ -510,7 +510,7 @@ class DocModelTest(s_t_utils.SynTest):
                 'forms': (
                     ('test:impl:form', {}, ()),
                 ),
-            })])
+            }])
 
             text = await s_docmodel.genIfaceMarkdown(core, 'test:impl:iface')
             self.isin('# `test:impl:iface`', text)

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -260,7 +260,7 @@ class ThreeType(s_types.Type):
         return '3'
 
 testmodel = (
-    ('test', {
+    {
 
         'interfaces': (
             ('test:interface', {
@@ -585,11 +585,11 @@ testmodel = (
                 'doc': 'The node matched on the target node.'}),
             ((None, 'test', None), {'doc': 'Test edge'}),
         ),
-    }),
+    },
 )
 
 deprmodel = (
-    ('depr', {
+    {
         'interfaces': (
             ('test:deprinterface', {
                 'doc': 'test interface',
@@ -646,7 +646,7 @@ deprmodel = (
                 ('beep', ('test:dep:str', {}), {}),
             )),
         ),
-    }),
+    },
 )
 
 class TestCmd(s_storm.Cmd):

--- a/synapse/tests/utils.py
+++ b/synapse/tests/utils.py
@@ -1449,7 +1449,7 @@ class SynTest(unittest.IsolatedAsyncioTestCase):
 
                     if not hasattr(self, 'patched'):
                         self.patched = True
-                        await self._addDataModels(testmodel)
+                        await self._addModelDefs(testmodel)
 
                 with mock.patch('synapse.cortex.Cortex._loadModels', _loadTestModel):
                     async with await s_cortex.Cortex.anit(dirn, conf=conf) as core:

--- a/synapse/tools/utils/autodoc.py
+++ b/synapse/tools/utils/autodoc.py
@@ -642,8 +642,7 @@ def lookupedgesforform(form: str, edges: Edges) -> Dict[str, Edges]:
 
 async def docModel(outp,
                    core):
-    modeldefs = await core.getModelDefs()
-    _, model = modeldefs[0]
+    model = await core.getModelDef()
 
     ctors = []
     for typename, typedef, typeinfo in model.get('types', ()):


### PR DESCRIPTION
## Summary
- Remove the vestigial name string from all `modeldefs` declarations across 27 model modules, converting `(name, dict)` tuples to plain dicts
- Rename `addDataModels()` to `addModelDefs()` to accept a list of dicts instead of `(name, dict)` tuples
- Rename `getModelDefs()` to `getModelDef()` and return the singular model definition dictionary directly
- Update all consumers: `CoreApi`, `Cortex`, `autodoc`, and tests

## Test plan
- [x] `test_datamodel.py` — 17 tests pass
- [x] `test_tools_cortex_docmodel.py` — 28 tests pass
- [x] `test_model_geospace.py` — 7 tests pass
- [x] `test_lib_types.py` array test passes
- [x] `test_model_syn.py` — 6 tests pass
- [x] `test_lib_stormlib_model.py` — 4 tests pass
- [x] `test_cortex.py` deprecation test passes
- [x] `test_lib_storm.py` model test passes
- [x] No remaining references to `getModelDefs` or `addDataModels` in codebase