### PR TITLE
Update meta:usable to extend meta:observable (SYN-10511)

### DIFF
--- a/synapse/models/base.py
+++ b/synapse/models/base.py
@@ -523,6 +523,9 @@ modeldefs = (
 
             ('meta:usable', {
                 'template': {'title': 'item'},
+                'interfaces': (
+                    ('meta:observable', {}),
+                ),
                 'doc': 'An interface implemented by forms which can be used by an actor.'}),
 
             ('meta:matchish', {
@@ -635,9 +638,6 @@ modeldefs = (
 
             (('meta:rule', 'matches', None), {
                 'doc': 'The rule matched on the target node.'}),
-
-            (('meta:rule', 'detects', 'meta:usable'), {
-                'doc': 'The rule is designed to detect the target node.'}),
 
             (('meta:rule', 'detects', 'meta:observable'), {
                 'doc': 'The rule is designed to detect the target node.'}),

--- a/synapse/models/entity.py
+++ b/synapse/models/entity.py
@@ -579,17 +579,11 @@ modeldefs = (
 
         'edges': (
 
-            (('entity:actor', 'used', 'meta:usable'), {
-                'doc': 'The actor used the target node.'}),
-
             (('entity:actor', 'used', 'meta:observable'), {
                 'doc': 'The actor used the target node.'}),
 
             (('entity:contactlist', 'has', 'entity:contact'), {
                 'doc': 'The contact list contains the contact.'}),
-
-            (('entity:action', 'used', 'meta:usable'), {
-                'doc': 'The action was taken using the target node.'}),
 
             (('entity:action', 'used', 'meta:observable'), {
                 'doc': 'The action was taken using the target node.'}),

--- a/synapse/tests/test_lib_stormlib_gen.py
+++ b/synapse/tests/test_lib_stormlib_gen.py
@@ -212,6 +212,9 @@ class StormLibGenTest(s_test.SynTest):
             self.eq(nodes00[0].ndef, nodes01[0].ndef)
             self.eq(nodes00[0].getProps(), nodes01[0].getProps())
 
+            self.len(1, nodes := await core.nodes('risk:tool:software:name=blackcat [ :seen=(20230101, 20230601) ]'))
+            self.nn(nodes[0].get('seen'))
+
             self.len(1, nodes := await core.nodes('risk:tool:software:name=blackcat :reporter -> ou:org'))
             self.eq(vtxguid, nodes[0].ndef[1])
 

--- a/synapse/tests/test_lib_stormlib_model.py
+++ b/synapse/tests/test_lib_stormlib_model.py
@@ -46,7 +46,7 @@ class StormlibModelTest(s_test.SynTest):
 
             self.eq('entity:action', await core.callStorm('return($lib.model.edge(risk:attack, used, risk:vuln).n1form)'))
             self.eq('used', await core.callStorm('return($lib.model.edge(risk:attack, used, risk:vuln).verb)'))
-            self.eq('meta:usable', await core.callStorm('return($lib.model.edge(risk:attack, used, risk:vuln).n2form)'))
+            self.eq('meta:observable', await core.callStorm('return($lib.model.edge(risk:attack, used, risk:vuln).n2form)'))
             self.none(await core.callStorm('return($lib.model.edge(risk:attack, newp, risk:vuln))'))
 
             self.true(await core.callStorm('return(($lib.model.prop(".created").form = $lib.null))'))
@@ -85,7 +85,7 @@ class StormlibModelTest(s_test.SynTest):
             self.stormIsInPrint("model:type: ('int', ('base'", mesgs)
 
             mesgs = await core.stormlist('$lib.print($lib.model.edge(risk:attack, used, risk:vuln))')
-            self.stormIsInPrint("model:edge: (('entity:action', 'used', 'meta:usable'), {'doc':", mesgs)
+            self.stormIsInPrint("model:edge: (('entity:action', 'used', 'meta:observable'), {'doc':", mesgs)
 
             self.false(await core.callStorm('return($lib.model.type(int).mutable)'))
             self.false(await core.callStorm('return($lib.model.type(str).mutable)'))

--- a/synapse/tests/test_model_base.py
+++ b/synapse/tests/test_model_base.py
@@ -130,6 +130,7 @@ class BaseTest(s_t_utils.SynTest):
                     :type=foo.bar
                     :text="while TRUE { BAD }"
                     :id=WOOT-20 :url=https://vertex.link/rules/WOOT-20
+                    :seen=(20200101, 20200201)
                     <(has)+ { meta:ruleset }
                     +(matches)> { [inet:ip=123.123.123.123] }
                 ]
@@ -145,6 +146,7 @@ class BaseTest(s_t_utils.SynTest):
             self.propeq(nodes[0], 'text', 'while TRUE { BAD }')
             self.propeq(nodes[0], 'url', 'https://vertex.link/rules/WOOT-20')
             self.propeq(nodes[0], 'id', 'WOOT-20')
+            self.nn(nodes[0].get('seen'))
 
             self.len(1, await core.nodes('meta:rule -> entity:contact'))
             self.len(1, await core.nodes('meta:rule -> meta:rule:type:taxonomy'))

--- a/synapse/tests/test_model_entity.py
+++ b/synapse/tests/test_model_entity.py
@@ -202,6 +202,7 @@ class EntityModelTest(s_t_utils.SynTest):
                     :reporter={[ ou:org=({"name": "vertex"}) ]}
                     :reporter:name=vertex
                     :parent={[ meta:technique=* :name=metawoot ]}
+                    :seen=(20210101, 20210201)
                 ]
             ''')
             self.len(1, nodes)
@@ -215,6 +216,7 @@ class EntityModelTest(s_t_utils.SynTest):
             self.propeq(nodes[0], 'sophistication', 40)
             self.propeq(nodes[0], 'reporter:name', 'vertex')
             self.nn(nodes[0].get('parent'))
+            self.nn(nodes[0].get('seen'))
             self.len(1, await core.nodes('meta:technique -> syn:tag'))
             self.len(1, await core.nodes('meta:technique -> meta:technique:type:taxonomy'))
             self.len(1, await core.nodes('meta:technique :reporter -> ou:org'))

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -557,6 +557,7 @@ class InfotechModelTest(s_t_utils.SynTest):
                     :version=V1.0.1-beta+exp.sha.5114f85
                     :released="2018-04-03 08:44:22"
                     :risk:score=highest
+                    :seen=(20180101, 20190101)
                     +(runson)> {[ it:software=({"name": "linux"}) ]}
                     +(runson)> {[ it:hardware=({"name": "amd64"}) ]}
             ]''')
@@ -569,6 +570,7 @@ class InfotechModelTest(s_t_utils.SynTest):
             self.propeq(node, 'released', 1522745062000000)
             self.propeq(node, 'version', 'V1.0.1-beta+exp.sha.5114f85')
             self.propeq(node, 'risk:score', 50)
+            self.nn(node.get('seen'))
             self.len(1, await core.nodes('it:software:name="balloon maker" -> it:software:type:taxonomy'))
             self.len(2, await core.nodes('it:softwarename="balloon maker" -> it:software -> it:softwarename'))
             self.len(1, await core.nodes('it:software:id=Foo -(runson)> it:software +:name=linux'))
@@ -738,10 +740,12 @@ class InfotechModelTest(s_t_utils.SynTest):
                     :released=20220202
                     :cpe=cpe:2.3:h:dell:xps13:*:*:*:*:*:*:*:*
                     :parts = (*, *)
+                    :seen=20220101
             ]''')
             self.propeq(nodes[0], 'desc', 'WootWoot')
             self.propeq(nodes[0], 'model', 'xps13')
             self.propeq(nodes[0], 'version', '1.2.3')
+            self.nn(nodes[0].get('seen'))
             self.propeq(nodes[0], 'version.semver', 1099513724931)
             self.propeq(nodes[0], 'cpe', 'cpe:2.3:h:dell:xps13:*:*:*:*:*:*:*:*')
             self.propeq(nodes[0], 'released', 1643760000000000)

--- a/synapse/tests/test_model_risk.py
+++ b/synapse/tests/test_model_risk.py
@@ -95,6 +95,7 @@ class RiskModelTest(s_t_utils.SynTest):
                     :discoverer={[ entity:contact=({"name": "visi"}) ]}
                     :vendor:notified=2020-01-14
                     :vendor:fixed=2020-01-14
+                    :seen=(20200101, 20200601)
 
                     :id = CVE-2013-0000
                     :ids = (VISI-B-0000,)
@@ -122,6 +123,7 @@ class RiskModelTest(s_t_utils.SynTest):
             self.propeq(nodes[0], 'vendor:notified', 1578960000000000)
             self.propeq(nodes[0], 'vendor:fixed', 1578960000000000)
             self.propeq(nodes[0], 'published', 1578960000000000)
+            self.nn(nodes[0].get('seen'))
 
             self.propeq(nodes[0], 'id', 'CVE-2013-0000', form='it:sec:cve')
             self.propeq(nodes[0], 'ids', ('VISI-B-0000',))


### PR DESCRIPTION
## Summary
- `meta:usable` interface now extends `meta:observable`, inheriting the `:seen` (ival) property
- All 6 forms implementing `meta:usable` (`meta:rule`, `meta:technique`, `it:software`, `it:hardware`, `risk:vuln`, `risk:tool:software`) gain a `:seen` property
- Removed duplicate edge definitions (`detects`, `used`) that referenced both `meta:usable` and `meta:observable`, keeping the `meta:observable` versions

## Test plan
- [x] Added `:seen` test coverage for all 6 `meta:usable` forms
- [x] Updated edge assertions in `test_lib_stormlib_model.py`
- [x] Full test suite passes (1461 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)