### PR TITLE
Make layer.read and layer.write perms checks consistently use the Layer gate (SYN-10476)

### DIFF
--- a/changes/8df0a693cd12c4c9150a54f870029f96.yaml
+++ b/changes/8df0a693cd12c4c9150a54f870029f96.yaml
@@ -1,0 +1,7 @@
+---
+desc: Updated the ``layer.read`` and ``layer.write`` perms to always be checked on the Layer
+  gate.
+desc:literal: false
+prs: []
+type: feat
+...

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -535,7 +535,7 @@ class CoreApi(s_cell.CellApi):
         Returns:
             AsyncIterator[Tuple(nid, valu)]
         '''
-        self.user.confirm(('layer', 'read', layriden))
+        self.user.confirm(('layer', 'read'), gateiden=layriden)
         async for item in self.cell.iterFormRows(layriden, form, stortype=stortype, startvalu=startvalu):
             yield item
 
@@ -553,7 +553,7 @@ class CoreApi(s_cell.CellApi):
         Returns:
             AsyncIterator[Tuple(nid, valu)]
         '''
-        self.user.confirm(('layer', 'read', layriden))
+        self.user.confirm(('layer', 'read'), gateiden=layriden)
         async for item in self.cell.iterPropRows(layriden, form, prop, stortype=stortype, startvalu=startvalu):
             yield item
 
@@ -570,7 +570,7 @@ class CoreApi(s_cell.CellApi):
         Returns:
             AsyncIterator[Tuple(nid, valu)]
         '''
-        self.user.confirm(('layer', 'read', layriden))
+        self.user.confirm(('layer', 'read'), gateiden=layriden)
         async for item in self.cell.iterTagRows(layriden, tag, form=form, starttupl=starttupl):
             yield item
 
@@ -589,7 +589,7 @@ class CoreApi(s_cell.CellApi):
         Returns:
             AsyncIterator[Tuple(nid, valu)]
         '''
-        self.user.confirm(('layer', 'read', layriden))
+        self.user.confirm(('layer', 'read'), gateiden=layriden)
         async for item in self.cell.iterTagPropRows(layriden, tag, prop, form=form, stortype=stortype,
                                                     startvalu=startvalu):
             yield item
@@ -1084,12 +1084,10 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
              'desc': 'Controls all layer permissions.'},
             {'perm': ('layer', 'add'), 'gate': 'cortex',
              'desc': 'Controls the ability to add Layers to the cortex.'},
-            {'perm': ('layer', 'del'), 'gate': 'cortex',
-             'desc': 'Controls the ability to remove Layers from the cortex.'},
+            {'perm': ('layer', 'del'), 'gate': 'layer',
+             'desc': 'Controls the ability to delete a Layer.'},
             {'perm': ('layer', 'read'), 'gate': 'layer',
              'desc': 'Controls the ability to read/lift from a Layer.'},
-            {'perm': ('layer', 'read', '<layer>'), 'gate': 'cortex',
-             'desc': 'Controls the ability to read/lift from a specific Layer.'},
 
             {'perm': ('layer', 'set'), 'gate': 'layer',
              'desc': 'Controls setting any layer property.'},
@@ -1102,8 +1100,6 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
             {'perm': ('layer', 'write'), 'gate': 'layer',
              'desc': 'Controls the ability to write to a Layer.'},
-            {'perm': ('layer', 'write', '<layer>'), 'gate': 'cortex',
-             'desc': 'Controls the ability to write to a specific Layer.'},
 
             {'perm': ('model', 'admin'), 'gate': 'cortex',
              'desc': 'Controls the ability to modify the extended data model.'},

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -117,15 +117,14 @@ class LayerApi(s_cell.CellApi):
         await s_cell.CellApi.__anit__(self, core, link, user)
 
         self.layr = layr
-        self.readperm = ('layer', 'read', self.layr.iden)
-        self.writeperm = ('layer', 'write', self.layr.iden)
+        self.readperm = ('layer', 'read')
+        self.writeperm = ('layer', 'write')
 
     async def iterLayerNodeEdits(self, *, meta=False):
         '''
         Scan the full layer and yield artificial nodeedit sets.
         '''
-
-        await self._reqUserAllowed(self.readperm)
+        self.user.confirm(self.readperm, gateiden=self.layr.iden)
         async for item in self.layr.iterLayerNodeEdits(meta=meta):
             yield item
             await asyncio.sleep(0)
@@ -140,7 +139,7 @@ class LayerApi(s_cell.CellApi):
 
     async def storNodeEdits(self, nodeedits, *, meta=None):
 
-        await self._reqUserAllowed(self.writeperm)
+        self.user.confirm(self.writeperm, gateiden=self.layr.iden)
 
         if meta is None:
             meta = {'time': s_common.now(), 'user': self.user.iden}
@@ -149,7 +148,7 @@ class LayerApi(s_cell.CellApi):
 
     async def storNodeEditsNoLift(self, nodeedits, *, meta=None):
 
-        await self._reqUserAllowed(self.writeperm)
+        self.user.confirm(self.writeperm, gateiden=self.layr.iden)
 
         if meta is None:
             meta = {'time': s_common.now(), 'user': self.user.iden}
@@ -162,7 +161,7 @@ class LayerApi(s_cell.CellApi):
 
         Once caught up with storage, yield them in realtime.
         '''
-        await self._reqUserAllowed(self.readperm)
+        self.user.confirm(self.readperm, gateiden=self.layr.iden)
 
         async for item in self.layr.syncNodeEdits(offs, wait=wait, compat=compat, withmeta=withmeta):
             yield item
@@ -172,11 +171,11 @@ class LayerApi(s_cell.CellApi):
         '''
         Return the offset of the last edit entry for this layer. Returns -1 if the layer is empty.
         '''
-        await self._reqUserAllowed(self.readperm)
+        self.user.confirm(self.readperm, gateiden=self.layr.iden)
         return self.layr.getEditIndx()
 
     async def getIden(self):
-        await self._reqUserAllowed(self.readperm)
+        self.user.confirm(self.readperm, gateiden=self.layr.iden)
         return self.layr.iden
 
 NID_CACHE_SIZE = 10000

--- a/synapse/tests/test_lib_layer.py
+++ b/synapse/tests/test_lib_layer.py
@@ -803,6 +803,21 @@ class LayerTest(s_t_utils.SynTest):
                 sode = layer0.getStorNode(s_common.int64en(nid))
                 self.eq((), await layer0._editMetaSet(nid, None, metaedit[0], sode, None))
 
+            user = await core0.auth.addUser('lowuser')
+            url = core0.getLocalUrl(user='lowuser', share='*/layer')
+            async with await s_telepath.openurl(url) as layrprox:
+
+                with self.raises(s_exc.AuthDeny):
+                    await layrprox.storNodeEdits(nodeedits)
+
+                with self.raises(s_exc.AuthDeny):
+                    await layrprox.storNodeEditsNoLift(nodeedits)
+
+                await user.addRule((True, ('layer', 'write')), gateiden=layer0.iden)
+
+                await layrprox.storNodeEdits(nodeedits)
+                await layrprox.storNodeEditsNoLift(nodeedits)
+
     async def test_layer_tombstone(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -4590,7 +4590,6 @@ class StormTypesTest(s_test.SynTest):
         async with self.getTestCore() as core:
 
             visi = await core.auth.addUser('visi')
-            await visi.addRule((True, ('layer', 'read')))
 
             layr0 = core.getLayer()
             ldef1 = await core.addLayer()


### PR DESCRIPTION
Currently we have a mix of checking layer.read/write on the layer gate and also checking layer.read.<iden> on the cortex in some places.