### PR TITLE
Add MITRE ATT&CK ID forms to polyprop definitions

### DIFF
--- a/synapse/models/base.py
+++ b/synapse/models/base.py
@@ -294,12 +294,6 @@ modeldefs = (
             ('int:min1', ('int', {'min': 1}), {
                 'doc': 'A positive integer.'}),
 
-            ('meta:technique:id', (
-                    ('it:mitre:attack:technique:id', {}),
-                    ('base:id', {})
-                ), {
-                'doc': 'A unique ID given to a technique.'}),
-
             ('meta:technique', ('guid', {}), {
                 'template': {'title': 'technique'},
                 'doc': 'A specific technique used to achieve a goal.',
@@ -817,11 +811,14 @@ modeldefs = (
 
             ('meta:technique', {}, (
 
-                ('id', ('meta:technique:id', {}), {
+                ('id', (
+                    ('it:mitre:attack:technique:id', {}),
+                    ('base:id', {}),
+                ), {
                     'alts': ('ids',),
                     'doc': 'A unique ID given to the technique.'}),
 
-                ('ids', ('array', {'type': 'meta:technique:id'}), {
+                ('ids', ('array', {'type': (('it:mitre:attack:technique:id', {}), ('base:id', {}))}), {
                     'doc': 'An array of alternate IDs given to the technique.'}),
 
                 ('type', ('meta:technique:type:taxonomy', {}), {

--- a/synapse/models/base.py
+++ b/synapse/models/base.py
@@ -294,6 +294,12 @@ modeldefs = (
             ('int:min1', ('int', {'min': 1}), {
                 'doc': 'A positive integer.'}),
 
+            ('meta:technique:id', (
+                    ('it:mitre:attack:technique:id', {}),
+                    ('base:id', {})
+                ), {
+                'doc': 'A unique ID given to a technique.'}),
+
             ('meta:technique', ('guid', {}), {
                 'template': {'title': 'technique'},
                 'doc': 'A specific technique used to achieve a goal.',
@@ -810,6 +816,13 @@ modeldefs = (
             )),
 
             ('meta:technique', {}, (
+
+                ('id', ('meta:technique:id', {}), {
+                    'alts': ('ids',),
+                    'doc': 'A unique ID given to the technique.'}),
+
+                ('ids', ('array', {'type': 'meta:technique:id'}), {
+                    'doc': 'An array of alternate IDs given to the technique.'}),
 
                 ('type', ('meta:technique:type:taxonomy', {}), {
                     'doc': 'The taxonomy classification of the technique.'}),

--- a/synapse/models/entity.py
+++ b/synapse/models/entity.py
@@ -341,12 +341,6 @@ modeldefs = (
                 ),
                 'doc': 'A hierarchical taxonomy of campaign statuses.'}),
 
-            ('entity:campaign:id', (
-                    ('it:mitre:attack:campaign:id', {}),
-                    ('base:id', {})
-                ), {
-                'doc': 'A unique ID given to a campaign.'}),
-
             ('entity:campaign', ('guid', {}), {
                 'template': {'title': 'campaign'},
                 'interfaces': (
@@ -713,11 +707,14 @@ modeldefs = (
 
             ('entity:campaign', {}, (
 
-                ('id', ('entity:campaign:id', {}), {
+                ('id', (
+                    ('it:mitre:attack:campaign:id', {}),
+                    ('base:id', {}),
+                ), {
                     'alts': ('ids',),
                     'doc': 'A unique ID given to the campaign.'}),
 
-                ('ids', ('array', {'type': 'entity:campaign:id'}), {
+                ('ids', ('array', {'type': (('it:mitre:attack:campaign:id', {}), ('base:id', {}))}), {
                     'doc': 'An array of alternate IDs given to the campaign.'}),
 
                 ('slogan', ('lang:phrase', {}), {

--- a/synapse/models/entity.py
+++ b/synapse/models/entity.py
@@ -341,6 +341,12 @@ modeldefs = (
                 ),
                 'doc': 'A hierarchical taxonomy of campaign statuses.'}),
 
+            ('entity:campaign:id', (
+                    ('it:mitre:attack:campaign:id', {}),
+                    ('base:id', {})
+                ), {
+                'doc': 'A unique ID given to a campaign.'}),
+
             ('entity:campaign', ('guid', {}), {
                 'template': {'title': 'campaign'},
                 'interfaces': (
@@ -706,6 +712,13 @@ modeldefs = (
                 'prevnames': ('ou:camptype',)}, ()),
 
             ('entity:campaign', {}, (
+
+                ('id', ('entity:campaign:id', {}), {
+                    'alts': ('ids',),
+                    'doc': 'A unique ID given to the campaign.'}),
+
+                ('ids', ('array', {'type': 'entity:campaign:id'}), {
+                    'doc': 'An array of alternate IDs given to the campaign.'}),
 
                 ('slogan', ('lang:phrase', {}), {
                     'doc': 'The slogan used by the campaign.'}),

--- a/synapse/models/planning.py
+++ b/synapse/models/planning.py
@@ -34,6 +34,12 @@ modeldefs = (
             ('plan:procedure:step', ('guid', {}), {
                 'doc': 'A step within a procedure.'}),
 
+            ('plan:phase:id', (
+                    ('it:mitre:attack:tactic:id', {}),
+                    ('base:id', {})
+                ), {
+                'doc': 'A unique ID given to a phase.'}),
+
             ('plan:procedure:link', ('guid', {}), {
                 'doc': 'A link between steps in a procedure.'}),
         ),
@@ -71,6 +77,13 @@ modeldefs = (
                     'doc': 'The primary URL which documents the planning system.'}),
             )),
             ('plan:phase', {}, (
+
+                ('id', ('plan:phase:id', {}), {
+                    'alts': ('ids',),
+                    'doc': 'The phase ID.'}),
+
+                ('ids', ('array', {'type': 'plan:phase:id'}), {
+                    'doc': 'An array of alternate IDs for the phase.'}),
 
                 ('title', ('str', {}), {
                     'ex': 'Reconnaissance Phase',

--- a/synapse/models/planning.py
+++ b/synapse/models/planning.py
@@ -34,12 +34,6 @@ modeldefs = (
             ('plan:procedure:step', ('guid', {}), {
                 'doc': 'A step within a procedure.'}),
 
-            ('plan:phase:id', (
-                    ('it:mitre:attack:tactic:id', {}),
-                    ('base:id', {})
-                ), {
-                'doc': 'A unique ID given to a phase.'}),
-
             ('plan:procedure:link', ('guid', {}), {
                 'doc': 'A link between steps in a procedure.'}),
         ),
@@ -78,11 +72,14 @@ modeldefs = (
             )),
             ('plan:phase', {}, (
 
-                ('id', ('plan:phase:id', {}), {
+                ('id', (
+                    ('it:mitre:attack:tactic:id', {}),
+                    ('base:id', {}),
+                ), {
                     'alts': ('ids',),
                     'doc': 'The phase ID.'}),
 
-                ('ids', ('array', {'type': 'plan:phase:id'}), {
+                ('ids', ('array', {'type': (('it:mitre:attack:tactic:id', {}), ('base:id', {}))}), {
                     'doc': 'An array of alternate IDs for the phase.'}),
 
                 ('title', ('str', {}), {

--- a/synapse/models/risk.py
+++ b/synapse/models/risk.py
@@ -68,24 +68,6 @@ modeldefs = (
                 ), {
                 'doc': 'A unique ID given to a vulnerability.'}),
 
-            ('risk:threat:id', (
-                    ('it:mitre:attack:group:id', {}),
-                    ('base:id', {})
-                ), {
-                'doc': 'A unique ID given to a threat cluster.'}),
-
-            ('risk:tool:software:id', (
-                    ('it:mitre:attack:software:id', {}),
-                    ('base:id', {})
-                ), {
-                'doc': 'A unique ID given to a software tool.'}),
-
-            ('risk:mitigation:id', (
-                    ('it:mitre:attack:mitigation:id', {}),
-                    ('base:id', {})
-                ), {
-                'doc': 'A unique ID given to a mitigation.'}),
-
             ('risk:vuln:type:taxonomy', ('taxonomy', {}), {
                 'interfaces': (
                     ('meta:taxonomy', {}),
@@ -450,11 +432,14 @@ modeldefs = (
 
             ('risk:threat', {}, (
 
-                ('id', ('risk:threat:id', {}), {
+                ('id', (
+                    ('it:mitre:attack:group:id', {}),
+                    ('base:id', {}),
+                ), {
                     'alts': ('ids',),
                     'doc': 'A unique ID given to the threat.'}),
 
-                ('ids', ('array', {'type': 'risk:threat:id'}), {
+                ('ids', ('array', {'type': (('it:mitre:attack:group:id', {}), ('base:id', {}))}), {
                     'doc': 'An array of alternate IDs given to the threat.'}),
 
                 ('name', ('entity:name', {}), {
@@ -487,11 +472,14 @@ modeldefs = (
             # FIXME extend it:software form?
             ('risk:tool:software', {}, (
 
-                ('id', ('risk:tool:software:id', {}), {
+                ('id', (
+                    ('it:mitre:attack:software:id', {}),
+                    ('base:id', {}),
+                ), {
                     'alts': ('ids',),
                     'doc': 'A unique ID given to the tool.'}),
 
-                ('ids', ('array', {'type': 'risk:tool:software:id'}), {
+                ('ids', ('array', {'type': (('it:mitre:attack:software:id', {}), ('base:id', {}))}), {
                     'doc': 'An array of alternate IDs given to the tool.'}),
 
                 ('name', ('it:softwarename', {}), {
@@ -520,11 +508,14 @@ modeldefs = (
             )),
             ('risk:mitigation', {}, (
 
-                ('id', ('risk:mitigation:id', {}), {
+                ('id', (
+                    ('it:mitre:attack:mitigation:id', {}),
+                    ('base:id', {}),
+                ), {
                     'alts': ('ids',),
                     'doc': 'A unique ID given to the mitigation.'}),
 
-                ('ids', ('array', {'type': 'risk:mitigation:id'}), {
+                ('ids', ('array', {'type': (('it:mitre:attack:mitigation:id', {}), ('base:id', {}))}), {
                     'doc': 'An array of alternate IDs given to the mitigation.'}),
             )),
 

--- a/synapse/models/risk.py
+++ b/synapse/models/risk.py
@@ -68,6 +68,24 @@ modeldefs = (
                 ), {
                 'doc': 'A unique ID given to a vulnerability.'}),
 
+            ('risk:threat:id', (
+                    ('it:mitre:attack:group:id', {}),
+                    ('base:id', {})
+                ), {
+                'doc': 'A unique ID given to a threat cluster.'}),
+
+            ('risk:tool:software:id', (
+                    ('it:mitre:attack:software:id', {}),
+                    ('base:id', {})
+                ), {
+                'doc': 'A unique ID given to a software tool.'}),
+
+            ('risk:mitigation:id', (
+                    ('it:mitre:attack:mitigation:id', {}),
+                    ('base:id', {})
+                ), {
+                'doc': 'A unique ID given to a mitigation.'}),
+
             ('risk:vuln:type:taxonomy', ('taxonomy', {}), {
                 'interfaces': (
                     ('meta:taxonomy', {}),
@@ -432,6 +450,13 @@ modeldefs = (
 
             ('risk:threat', {}, (
 
+                ('id', ('risk:threat:id', {}), {
+                    'alts': ('ids',),
+                    'doc': 'A unique ID given to the threat.'}),
+
+                ('ids', ('array', {'type': 'risk:threat:id'}), {
+                    'doc': 'An array of alternate IDs given to the threat.'}),
+
                 ('name', ('entity:name', {}), {
                     'alts': ('names',),
                     'doc': 'The primary name of the threat according to the source.'}),
@@ -462,6 +487,13 @@ modeldefs = (
             # FIXME extend it:software form?
             ('risk:tool:software', {}, (
 
+                ('id', ('risk:tool:software:id', {}), {
+                    'alts': ('ids',),
+                    'doc': 'A unique ID given to the tool.'}),
+
+                ('ids', ('array', {'type': 'risk:tool:software:id'}), {
+                    'doc': 'An array of alternate IDs given to the tool.'}),
+
                 ('name', ('it:softwarename', {}), {
                     'alts': ('names',),
                     'doc': 'The primary name of the tool according to the source.'}),
@@ -486,7 +518,15 @@ modeldefs = (
                     'prevnames': ('soft',),
                     'doc': 'The authoritative software family for the tool.'}),
             )),
-            ('risk:mitigation', {}, ()),
+            ('risk:mitigation', {}, (
+
+                ('id', ('risk:mitigation:id', {}), {
+                    'alts': ('ids',),
+                    'doc': 'A unique ID given to the mitigation.'}),
+
+                ('ids', ('array', {'type': 'risk:mitigation:id'}), {
+                    'doc': 'An array of alternate IDs given to the mitigation.'}),
+            )),
 
             ('risk:vuln:type:taxonomy', {}, ()),
 

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -1994,27 +1994,33 @@ class InfotechModelTest(s_t_utils.SynTest):
             self.eq('C0028', nodes[0].ndef[1])
             await self.asyncraises(s_exc.BadTypeValu, core.nodes('[ it:mitre:attack:campaign:id=foo ]'))
 
-            # Test that MITRE ATT&CK IDs can be set on :id properties of related forms
-            nodes = await core.nodes('[ risk:threat=* :id=G0100 ]')
+            # Test that MITRE ATT&CK IDs can be set on :id/:ids properties of related forms
+            nodes = await core.nodes('[ risk:threat=* :id=G0100 :ids=(G0101,) ]')
             self.len(1, nodes)
             self.propeq(nodes[0], 'id', 'G0100', form='it:mitre:attack:group:id')
+            self.eq((('it:mitre:attack:group:id', 'G0101'),), nodes[0].get('ids'))
 
-            nodes = await core.nodes('[ entity:campaign=* :id=C0028 ]')
+            nodes = await core.nodes('[ entity:campaign=* :id=C0028 :ids=(C0029,) ]')
             self.len(1, nodes)
             self.propeq(nodes[0], 'id', 'C0028', form='it:mitre:attack:campaign:id')
+            self.eq((('it:mitre:attack:campaign:id', 'C0029'),), nodes[0].get('ids'))
 
-            nodes = await core.nodes('[ risk:tool:software=* :id=S0154 ]')
+            nodes = await core.nodes('[ risk:tool:software=* :id=S0154 :ids=(S0155,) ]')
             self.len(1, nodes)
             self.propeq(nodes[0], 'id', 'S0154', form='it:mitre:attack:software:id')
+            self.eq((('it:mitre:attack:software:id', 'S0155'),), nodes[0].get('ids'))
 
-            nodes = await core.nodes('[ meta:technique=* :id=T1548 ]')
+            nodes = await core.nodes('[ meta:technique=* :id=T1548 :ids=(T1549,) ]')
             self.len(1, nodes)
             self.propeq(nodes[0], 'id', 'T1548', form='it:mitre:attack:technique:id')
+            self.eq((('it:mitre:attack:technique:id', 'T1549'),), nodes[0].get('ids'))
 
-            nodes = await core.nodes('[ risk:mitigation=* :id=M1036 ]')
+            nodes = await core.nodes('[ risk:mitigation=* :id=M1036 :ids=(M1037,) ]')
             self.len(1, nodes)
             self.propeq(nodes[0], 'id', 'M1036', form='it:mitre:attack:mitigation:id')
+            self.eq((('it:mitre:attack:mitigation:id', 'M1037'),), nodes[0].get('ids'))
 
-            nodes = await core.nodes('[ plan:phase=* :id=TA0040 ]')
+            nodes = await core.nodes('[ plan:phase=* :id=TA0040 :ids=(TA0041,) ]')
             self.len(1, nodes)
             self.propeq(nodes[0], 'id', 'TA0040', form='it:mitre:attack:tactic:id')
+            self.eq((('it:mitre:attack:tactic:id', 'TA0041'),), nodes[0].get('ids'))

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -1993,3 +1993,28 @@ class InfotechModelTest(s_t_utils.SynTest):
             self.len(1, nodes)
             self.eq('C0028', nodes[0].ndef[1])
             await self.asyncraises(s_exc.BadTypeValu, core.nodes('[ it:mitre:attack:campaign:id=foo ]'))
+
+            # Test that MITRE ATT&CK IDs can be set on :id properties of related forms
+            nodes = await core.nodes('[ risk:threat=* :id=G0100 ]')
+            self.len(1, nodes)
+            self.propeq(nodes[0], 'id', 'G0100', form='it:mitre:attack:group:id')
+
+            nodes = await core.nodes('[ entity:campaign=* :id=C0028 ]')
+            self.len(1, nodes)
+            self.propeq(nodes[0], 'id', 'C0028', form='it:mitre:attack:campaign:id')
+
+            nodes = await core.nodes('[ risk:tool:software=* :id=S0154 ]')
+            self.len(1, nodes)
+            self.propeq(nodes[0], 'id', 'S0154', form='it:mitre:attack:software:id')
+
+            nodes = await core.nodes('[ meta:technique=* :id=T1548 ]')
+            self.len(1, nodes)
+            self.propeq(nodes[0], 'id', 'T1548', form='it:mitre:attack:technique:id')
+
+            nodes = await core.nodes('[ risk:mitigation=* :id=M1036 ]')
+            self.len(1, nodes)
+            self.propeq(nodes[0], 'id', 'M1036', form='it:mitre:attack:mitigation:id')
+
+            nodes = await core.nodes('[ plan:phase=* :id=TA0040 ]')
+            self.len(1, nodes)
+            self.propeq(nodes[0], 'id', 'TA0040', form='it:mitre:attack:tactic:id')


### PR DESCRIPTION
## Summary
- Define named poly types (`risk:threat:id`, `entity:campaign:id`, `risk:tool:software:id`, `meta:technique:id`, `risk:mitigation:id`, `plan:phase:id`) that include the corresponding MITRE ATT&CK ID form with `base:id` fallback
- Override `:id` and `:ids` properties on `risk:threat`, `entity:campaign`, `risk:tool:software`, `meta:technique`, `risk:mitigation`, and `plan:phase` to use the new poly types
- Add tests in `test_model_infotech.py` verifying MITRE IDs resolve to the correct forms

## Test plan
- [x] Existing tests pass unchanged (`test_model_risk`, `test_model_entity`, `test_model_planning`)
- [x] New `test_infotech_mitre` assertions verify each MITRE ID form resolves correctly on its target form's `:id` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)