### PR TITLE
make $lib.tags.prefix a no-op on null names

### DIFF
--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -1044,7 +1044,9 @@ class LibTags(Lib):
          ''',
          'type': {'type': 'function', '_funcname': 'prefix',
                   'args': (
-                      {'name': 'names', 'type': 'list', 'desc': 'A list of syn:tag:part values to normalize and prefix.'},
+                      {'name': 'names', 'type': 'list',
+                       'desc': 'A list of syn:tag:part values to normalize and prefix. '
+                               'If ``(null)``, this is a no-op and an empty list is returned.'},
                       {'name': 'prefix', 'type': 'str', 'desc': 'The string prefix to add to the syn:tag:part values.'},
                       {'name': 'ispart', 'type': 'boolean', 'default': False,
                        'desc': 'Whether the names have already been normalized. Normalization will be skipped if set to true.'},
@@ -1065,7 +1067,7 @@ class LibTags(Lib):
         tagpart = self.runt.view.core.model.type('syn:tag:part')
 
         retn = []
-        async for part in toiter(names):
+        async for part in toiter(names, noneok=True):
             if not ispart:
                 try:
                     partnorm = (await tagpart.norm(part))[0]

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -840,6 +840,9 @@ class StormTypesTest(s_test.SynTest):
             tags = await core.callStorm('return($lib.tags.prefix((foo, bar, "foo.baz"), visi, ispart=$lib.true))')
             self.eq(tags, ('visi.foo', 'visi.bar', 'visi.foo.baz'))
 
+            tags = await core.callStorm('return($lib.tags.prefix((null), visi))')
+            self.eq(tags, ())
+
             self.none(await core.callStorm('[inet:user=visi] return($node.data.cacheget(foo))'))
 
             await core.callStorm('inet:user=visi $node.data.cacheset(foo, bar)')


### PR DESCRIPTION
## Summary
- `$lib.tags.prefix` now treats a `(null)` `names` argument as a no-op and returns an empty list, matching the convention used by `$list.extend()` (`toiter(..., noneok=True)`).
- Updated the `_storm_locals` arg description to document the null behavior; autodoc picks this up.
- Added a null-input assertion next to the existing `$lib.tags.prefix` tests.

## Test plan
- [x] `python -m pytest -n auto synapse/tests/test_lib_stormtypes.py::StormTypesTest::test_storm_lib_base`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)