### PR TITLE
Dev - Cortex.nodeeditwindows needs to be defined before oncorefini is registered

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -979,6 +979,8 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         self.axready = asyncio.Event()
         self.axoninfo = {}
 
+        self.nodeeditwindows = set()
+
         self.view = None  # The default/main view
 
         self._cortex_permdefs = []
@@ -1031,7 +1033,6 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         await self._initCoreAxon()
         await self._initJsonStor()
 
-        self.nodeeditwindows = set()
         await self._initCoreLayers()
         await self._initCoreViews()
         self.onfini(self._finiStor)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -3153,7 +3153,7 @@ class CortexBasicTest(s_t_utils.SynTest):
         conf = {'modules': [('synapse.tests.utils.TestModule', {'key': 'valu'})]}
         with self.raises(s_exc.ModAlreadyLoaded):
             async with self.getTestCore(conf=conf):
-                pass
+                await asyncio.sleep(0)
 
         async with self.getTestCore() as core:
             with self.raises(s_exc.ModAlreadyLoaded):


### PR DESCRIPTION
Cortex.nodeeditwindows needs to be defined before oncorefini is registered; otherwise it can throw an attribute error.