### PR TITLE
Make $lib.cast and $lib.trycast always return NodeRef values

### DIFF
--- a/synapse/lib/stormlib/stix.py
+++ b/synapse/lib/stormlib/stix.py
@@ -832,7 +832,7 @@ stixingest = {
                 if $object.country {
                     ($ok, $iso) = $lib.trycast(iso:3166:alpha2, $object.country)
                     if $ok {
-                        $geodict.loc = $iso
+                        $geodict."country:code" = $iso
                     }
                 }
 

--- a/synapse/lib/stormtypes.py
+++ b/synapse/lib/stormtypes.py
@@ -1532,9 +1532,13 @@ class LibBase(Lib):
         # TODO an eventual mapping between model types and storm prims
 
         norm, info = await typeitem.norm(valu)
+        if typeitem.isarray:
+            return await typeitem.tostorm(norm)
+
         if typeitem.ispoly:
             return NodeRef((norm, info.get('virts')))
-        return fromprim(norm, basetypes=False)
+
+        return NodeRef(((typeitem.name, norm), info.get('virts')))
 
     @stormfunc(readonly=True)
     async def trycast(self, name, valu):
@@ -1545,9 +1549,14 @@ class LibBase(Lib):
 
         try:
             norm, info = await typeitem.norm(valu)
+            if typeitem.isarray:
+                return True, await typeitem.tostorm(norm)
+
             if typeitem.ispoly:
-                return (True, NodeRef((norm, info.get('virts'))))
-            return (True, fromprim(norm, basetypes=False))
+                return True, NodeRef((norm, info.get('virts')))
+
+            return True, NodeRef(((typeitem.name, norm), info.get('virts')))
+
         except s_exc.BadTypeValu as exc:
             return False, s_common.excinfo(exc)
 
@@ -5525,17 +5534,16 @@ class Number(Prim):
         return float(self.value())
 
     def __hash__(self):
-        return hash((self._storm_typename, self.value()))
+        return hash(self.value())
 
     def __eq__(self, othr):
         if isinstance(othr, float):
             othr = s_common.hugenum(othr)
             return self.value() == othr
-        elif isinstance(othr, (int, decimal.Decimal)):
-            return self.value() == othr
         elif isinstance(othr, Number):
             return self.value() == othr.value()
-        return False
+
+        return self.value() == othr
 
     def __lt__(self, othr):
         if isinstance(othr, float):
@@ -10140,6 +10148,9 @@ async def tonumber(valu, noneok=False):
 
     if isinstance(valu, Number):
         return valu
+
+    if isinstance(valu, NodeRef):
+        return Number(valu.valu[1])
 
     if isinstance(valu, (float, decimal.Decimal)) or (isinstance(valu, str) and '.' in valu):
         return Number(valu)

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -1185,13 +1185,7 @@ class HugeNum(Type):
         return self._norm(huge)
 
     async def _normPyInt(self, valu, view=None):
-        try:
-            huge = s_common.hugenum(valu)
-        except decimal.DecimalException as e:
-            mesg = f'Invalid hugenum: {e}'
-            raise s_exc.BadTypeValu(name=self.name, valu=valu, mesg=mesg) from None
-
-        return self._norm(huge)
+        return self._norm(s_common.hugenum(valu))
 
     async def _normNumber(self, valu, view=None):
         return self._norm(valu.valu)

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -1133,6 +1133,11 @@ class HugeNum(Type):
         self.setCmprCtor('>=', self._ctorCmprGe)
         self.setCmprCtor('<=', self._ctorCmprLe)
 
+        self.setNormFunc(str, self._normPyStr)
+        self.setNormFunc(int, self._normPyInt)
+        self.setNormFunc(float, self._normPyInt)
+        self.setNormFunc(s_stormtypes.Number, self._normNumber)
+
         self.storlifts.update({
             '<': self._storLiftNorm,
             '>': self._storLiftNorm,
@@ -1152,7 +1157,7 @@ class HugeNum(Type):
         if modulo is not None:
             self.modulo = s_common.hugenum(modulo)
 
-    async def _normHugeText(self, rawtext, view=None):
+    async def _normPyStr(self, rawtext, view=None):
 
         text = rawtext.lower().strip()
         text = text.replace(',', '').replace(' ', '')
@@ -1163,7 +1168,11 @@ class HugeNum(Type):
             mesg = f'Value does not start with a number: "{rawtext}"'
             raise s_exc.BadTypeValu(mesg=mesg)
 
-        huge = s_common.hugenum(valu)
+        try:
+            huge = s_common.hugenum(valu)
+        except decimal.DecimalException as e:
+            mesg = f'Invalid hugenum: {e}'
+            raise s_exc.BadTypeValu(name=self.name, valu=valu, mesg=mesg) from None
 
         unit, off = s_grammar.nom(text, off, s_grammar.unitset)
         if unit:
@@ -1173,40 +1182,36 @@ class HugeNum(Type):
                 raise s_exc.BadTypeValu(mesg=mesg)
             huge = s_common.hugemul(huge, mult)
 
-        return huge
+        return self._norm(huge)
 
-    async def norm(self, valu, view=None):
-
-        if valu is None:
-            mesg = 'Hugenum type may not be null.'
-            raise s_exc.BadTypeValu(mesg=mesg)
-
+    async def _normPyInt(self, valu, view=None):
         try:
-            if isinstance(valu, s_stormtypes.Number):
-                huge = valu.valu
-            elif isinstance(valu, str):
-                huge = await self._normHugeText(valu)
-            else:
-                huge = s_common.hugenum(valu)
-
-            # behave modulo like int/float
-            if self.modulo is not None:
-                _, huge = s_common.hugemod(huge, self.modulo)
-                if huge < 0:
-                    huge = s_common.hugeadd(huge, self.modulo)
-
-                huge = s_common.hugeround(huge)
-
+            huge = s_common.hugenum(valu)
         except decimal.DecimalException as e:
             mesg = f'Invalid hugenum: {e}'
             raise s_exc.BadTypeValu(name=self.name, valu=valu, mesg=mesg) from None
 
+        return self._norm(huge)
+
+    async def _normNumber(self, valu, view=None):
+        return self._norm(valu.valu)
+
+    def _norm(self, huge):
+
+        # behave modulo like int/float
+        if self.modulo is not None:
+            _, huge = s_common.hugemod(huge, self.modulo)
+            if huge < 0:
+                huge = s_common.hugeadd(huge, self.modulo)
+
+            huge = s_common.hugeround(huge)
+
         if huge > hugemax:
-            mesg = f'Value ({valu}) is too large for hugenum.'
+            mesg = f'Value ({huge}) is too large for hugenum.'
             raise s_exc.BadTypeValu(mesg=mesg)
 
         if abs(huge) > hugemax:
-            mesg = f'Value ({valu}) is too small for hugenum.'
+            mesg = f'Value ({huge}) is too small for hugenum.'
             raise s_exc.BadTypeValu(mesg=mesg)
 
         huge = s_common.hugeround(huge).normalize(s_common.hugectx)

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -2432,7 +2432,7 @@ class Poly(Type):
         if form is not None:
             if valu.exists:
                 return valu.valu, {'skipadd': True, 'virts': valu.virts}
-            elif await view.getNodeByNdef(valu.valu) is not None:
+            elif view is not None and await view.getNodeByNdef(valu.valu) is not None:
                 valu.exists = True
                 return valu.valu, {'skipadd': True, 'virts': valu.virts}
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -399,7 +399,7 @@ class Type:
         if func is None:
             raise s_exc.BadTypeValu(name=self.name, mesg='no norm for type: %r.' % (type(valu),))
 
-        return await func(valu, view=None)
+        return await func(valu, view=view)
 
     def repr(self, norm):
         '''

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -8426,7 +8426,7 @@ class CortexBasicTest(s_t_utils.SynTest):
                 # Add a cron job and immediately disable it
                 q = '''
                 cron.add hourly@:00 {
-                    $now = $lib.cast(time, now)
+                    $now = $lib.cast(test:time, now)
                     $lib.log.warning(`SAFEMODE CRON: {$now}`)
                     [ test:str=CRON :tick=$now ]
                 } |

--- a/synapse/tests/test_lib_stormlib_stix.py
+++ b/synapse/tests/test_lib_stormlib_stix.py
@@ -462,7 +462,7 @@ class StormLibStixTest(s_test.SynTest):
             gloc = await core.nodes('geo:place', opts=opts)
             self.len(3, gloc)
 
-            place = await core.nodes('geo:place:loc=cn', opts=opts)
+            place = await core.nodes('geo:place:country:code=cn', opts=opts)
             self.len(1, place)
             self.propeq(place[0], 'name', 'china')
 

--- a/synapse/tests/test_lib_stormtypes.py
+++ b/synapse/tests/test_lib_stormtypes.py
@@ -2746,7 +2746,7 @@ class StormTypesTest(s_test.SynTest):
             $lib.print(`There are {$lib.len($set)} items in the set`)
             '''
             msgs = await core.stormlist(q)
-            self.stormIsInPrint('There are 13 items in the set', msgs)
+            self.stormIsInPrint('There are 10 items in the set', msgs)
 
     async def test_storm_path(self):
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_types.py
+++ b/synapse/tests/test_lib_types.py
@@ -129,6 +129,9 @@ class TypesTest(s_t_utils.SynTest):
         big2 = '-730750818665451459101841.0000000000000000000000015'
         self.eq(bign, (await huge.norm(big2))[0])
 
+        with self.raises(s_exc.BadTypeValu):
+            await huge.norm('1e+99999999999999999999999999999')
+
     async def test_taxonomy(self):
 
         model = s_datamodel.getBaseModel()
@@ -1112,6 +1115,13 @@ class TypesTest(s_t_utils.SynTest):
             self.len(1, await core.nodes('[ test:float=42.0 :open=359.0]'))
 
             self.eq(5, await core.callStorm('return($lib.cast(int, (5.5)))'))
+
+            valu = await core.callStorm('return($lib.cast(test:arrayprop:ints, (1, 2, 3)))')
+            self.eq(valu, (1, 2, 3))
+
+            ok, valu = await core.callStorm('return($lib.trycast(test:arrayprop:ints, (1, 2, 3)))')
+            self.true(ok)
+            self.eq(valu, (1, 2, 3))
 
     async def test_ival(self):
         model = s_datamodel.getBaseModel()


### PR DESCRIPTION
Also tweaks Number handling a bit in Storm and gets rid of the `norm()` override on HugeNum