### PR TITLE
SYN-10621: Run cortex automation concurrently with live model migrations

### DIFF
--- a/changes/78d72c52956bde9eb895cd9e41521308.yaml
+++ b/changes/78d72c52956bde9eb895cd9e41521308.yaml
@@ -1,0 +1,9 @@
+---
+desc: Cortex view triggers, view merges, layer mirror and upstream sync loops, and
+  Storm package onloads now start concurrently with live model migrations on cortex
+  startup or mirror promotion, so customer automation is no longer silently disabled
+  while migrations run.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/changes/78d72c52956bde9eb895cd9e41521308.yaml
+++ b/changes/78d72c52956bde9eb895cd9e41521308.yaml
@@ -1,9 +1,9 @@
 ---
 desc: Cortex view triggers, view merges, layer mirror and upstream sync loops, and
   Storm package onloads now start concurrently with live model migrations on cortex
-  startup or mirror promotion, so customer automation is no longer silently disabled
+  startup or mirror promotion, so automation is no longer silently disabled
   while migrations run.
 desc:literal: false
 prs: []
-type: bug
+type: feat
 ...

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1755,22 +1755,20 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
                 if __debug__:
                     self._migration_evnt.set()
 
-        async def _runAutomation():
-            if self.safemode:
-                return
-
-            for view in self.views.values():
-                await view.initTrigTask()
-                await view.initMergeTask()
-
-            for layer in self.layers.values():
-                await layer.initLayerActive()
-
-            for pkgdef in list(self.stormpkgs.values()):
-                self._runStormPkgOnload(pkgdef)
-
         self.runActiveTask(_runMigrations())
-        self.runActiveTask(_runAutomation())
+
+        if self.safemode:
+            return
+
+        for view in self.views.values():
+            await view.initTrigTask()
+            await view.initMergeTask()
+
+        for layer in self.layers.values():
+            await layer.initLayerActive()
+
+        for pkgdef in list(self.stormpkgs.values()):
+            self._runStormPkgOnload(pkgdef)
 
     async def initServicePassive(self):
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -944,7 +944,8 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         self.migration = False
         self._migration_lock = asyncio.Lock()
-        self._migration_evnt = asyncio.Event()
+        if __debug__:
+            self._migration_evnt = asyncio.Event()
 
         self.stormmods = {}     # name: mdef
         self.stormpkgs = {}     # name: pkgdef
@@ -1735,16 +1736,29 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
     async def initServiceActive(self):
 
         await self.stormdmons.start()
+        await self.initStormPool()
 
         async def _runMigrations():
+            if self.safemode:
+                if __debug__:
+                    self._migration_evnt.set()
+                return
+
             await self.boss.promote('cortex:migration:layers', self.auth.rootuser, background=True, protected=True)
 
             # Run migrations when this cortex becomes active. This is to prevent
             # migrations getting skipped in a zero-downtime upgrade path
             # (upgrade mirror, promote mirror).
-            await self._checkLayerModels()
+            try:
+                await self._checkLayerModels()
+            finally:
+                if __debug__:
+                    self._migration_evnt.set()
 
-            # Once migrations are complete, start the view and layer tasks.
+        async def _runAutomation():
+            if self.safemode:
+                return
+
             for view in self.views.values():
                 await view.initTrigTask()
                 await view.initMergeTask()
@@ -1755,15 +1769,13 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             for pkgdef in list(self.stormpkgs.values()):
                 self._runStormPkgOnload(pkgdef)
 
-            self._migration_evnt.set()
-
-        await self.initStormPool()
-
         self.runActiveTask(_runMigrations())
+        self.runActiveTask(_runAutomation())
 
     async def initServicePassive(self):
 
-        self._migration_evnt.clear()
+        if __debug__:
+            self._migration_evnt.clear()
 
         await self.stormdmons.stop()
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1739,11 +1739,6 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         await self.initStormPool()
 
         async def _runMigrations():
-            if self.safemode:
-                if __debug__:
-                    self._migration_evnt.set()
-                return
-
             await self.boss.promote('cortex:migration:layers', self.auth.rootuser, background=True, protected=True)
 
             # Run migrations when this cortex becomes active. This is to prevent
@@ -1755,9 +1750,9 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
                 if __debug__:
                     self._migration_evnt.set()
 
-        self.runActiveTask(_runMigrations())
-
         if self.safemode:
+            if __debug__:
+                self._migration_evnt.set()
             return
 
         for view in self.views.values():
@@ -1769,6 +1764,8 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         for pkgdef in list(self.stormpkgs.values()):
             self._runStormPkgOnload(pkgdef)
+
+        self.runActiveTask(_runMigrations())
 
     async def initServicePassive(self):
 

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -1611,7 +1611,7 @@ class View(s_nexus.Pusher):  # type: ignore
 
     async def runTagAdd(self, node, tag, valu, useriden):
 
-        if self.core.migration or self.core.safemode:
+        if self.core.safemode:
             return
 
         # Run any trigger handlers
@@ -1619,21 +1619,21 @@ class View(s_nexus.Pusher):  # type: ignore
 
     async def runTagDel(self, node, tag, valu, useriden):
 
-        if self.core.migration or self.core.safemode:
+        if self.core.safemode:
             return
 
         await self.triggers.runTagDel(node, tag, useriden)
 
     async def runNodeAdd(self, node, useriden):
 
-        if self.core.migration or self.core.safemode:
+        if self.core.safemode:
             return
 
         await self.triggers.runNodeAdd(node, useriden)
 
     async def runNodeDel(self, node, useriden):
 
-        if self.core.migration or self.core.safemode:
+        if self.core.safemode:
             return
 
         await self.triggers.runNodeDel(node, useriden)
@@ -1642,21 +1642,21 @@ class View(s_nexus.Pusher):  # type: ignore
         '''
         Handle when a prop set trigger event fired
         '''
-        if self.core.migration or self.core.safemode:
+        if self.core.safemode:
             return
 
         await self.triggers.runPropSet(node, prop, oldv, useriden)
 
     async def runEdgeAdd(self, n1, edge, n2, useriden):
 
-        if self.core.migration or self.core.safemode:
+        if self.core.safemode:
             return
 
         await self.triggers.runEdgeAdd(n1, edge, n2, useriden)
 
     async def runEdgeDel(self, n1, edge, n2, useriden):
 
-        if self.core.migration or self.core.safemode:
+        if self.core.safemode:
             return
 
         await self.triggers.runEdgeDel(n1, edge, n2, useriden)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -8109,6 +8109,9 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     self.true(await core01.isCellActive())
 
+                    # automation tasks start concurrently with the migration
+                    self.nn(core01.view.trigtask)
+
                     emesg = 'Task cortex:migration:layers is protected.'
 
                     # cannot kill through exposed Storm APIs
@@ -8140,6 +8143,37 @@ class CortexBasicTest(s_t_utils.SynTest):
                     self.nn(rtask := core01.boss.get(task['iden']))
                     await rtask.kill(safe=False)
                     self.none(core01.boss.get(task['iden']))
+
+    async def test_cortex_automation_during_migration(self):
+
+        evnt = asyncio.Event()
+
+        async def dummy(self):
+            await evnt.wait()
+
+        with self.getTestDir() as dirn:
+
+            async with self.getTestCore(dirn=dirn) as core00:
+                tdef = {'cond': 'node:add', 'form': 'inet:fqdn', 'storm': '[test:str=triggered]'}
+                await core00.view.addTrigger(tdef)
+                await self.waitForActiveMigration(core00)
+
+            with patch('synapse.lib.modelrev.ModelRev.revCoreLayers', dummy):
+                conf01 = {'mirror': 'tcp://root:root@127.0.0.1:0'}
+                async with self.getTestCore(dirn=dirn, conf=conf01) as core01:
+
+                    await core01.promote(graceful=False)
+                    await asyncio.sleep(0)
+
+                    # trigger fires during migration (not silently dropped)
+                    await core01.nodes('[inet:fqdn=vertex.link]')
+                    self.len(1, await core01.nodes('test:str=triggered'))
+
+                    # trigger task is alive while migration is blocked
+                    self.nn(core01.view.trigtask)
+
+                    evnt.set()
+                    await self.waitForActiveMigration(core01)
 
     async def test_cortex_vaults(self):
         '''

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -399,8 +399,8 @@ class TrigTest(s_t_utils.SynTest):
             self.nn(nodes[0].getTag('bar'))
             self.nn(nodes[0].getTag('faz'))
 
-            # coverage for migration mode
-            await core.nodes('[inet:fqdn=vertex.link +#foo]') # for additional migration mode trigger tests below
+            # triggers fire normally even when enterMigrationMode() is active
+            await core.nodes('[inet:fqdn=vertex.link +#foo]')
             async with core.enterMigrationMode():
                 await core.nodes('inet:fqdn=vertex.link [ +#bar -#foo ]')
 
@@ -813,7 +813,7 @@ class TrigTest(s_t_utils.SynTest):
             async with core.enterMigrationMode():
                 nodes = await core.nodes('[test:int=123 +(foo:beep:boop)> { [test:str=neato] }]')
                 self.len(1, nodes)
-                self.notin('foo', nodes[0].tags)
+                self.isin('foo', nodes[0].tags)
 
             nodes = await core.nodes('[test:int=123 +(foo:bar:baz)> { [test:str=neato] }]')
             self.len(1, nodes)
@@ -873,7 +873,7 @@ class TrigTest(s_t_utils.SynTest):
             async with core.enterMigrationMode():
                 nodes = await core.nodes('test:int=123 | [ -(foo:beep:boop)> { test:str=neato } ]')
                 self.len(1, nodes)
-                self.notin('del.none', nodes[0].tags)
+                self.isin('del.none', nodes[0].tags)
 
             nodes = await core.nodes('test:int=123 | [ -(foo:bar:baz)> { test:str=neato } ]')
             self.len(1, nodes)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Split `initServiceActive` into two concurrent active tasks: `_runMigrations` and `_runAutomation`, so view triggers, view merges, layer mirror/upstream loops, and storm package onloads start at the same time as `cortex:migration:layers` instead of after it completes.
- Remove `self.core.migration` guards from view trigger fan-out methods (`runTagAdd/Del`, `runNodeAdd/Del`, `runPropSet`, `runEdgeAdd/Del`) so triggers fire normally during migration. Safemode guards are retained.
- Skip both migrations and automation in safemode.
- Guard `_migration_evnt` with `__debug__` since it is only consumed by test helpers (`waitForActiveMigration`).

## Test plan

- [ ] `test_cortex_modelrev_task` — asserts `cortex:migration:layers` task is protected/background and that `view.trigtask` is alive while migration is hung
- [ ] `test_cortex_automation_during_migration` — new test: blocks `revCoreLayers`, verifies a trigger fires and produces its result node during migration, then releases and confirms migration completes
- [ ] `test_trigger_basics`, `test_trigger_edge_globs` — updated to assert triggers fire inside `enterMigrationMode()` (previously asserted they were dropped)
- [ ] `test_lib_modelrev`, `test_lib_nexus`, `test_lib_view`, `test_lib_trigger` full suites
EOF
)