### PR TITLE
feat: Multi-process Cortex with thin router and FD passing

### DIFF
--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -811,8 +811,11 @@ class Axon(s_cell.Cell):
 
     async def initServiceStorage(self):  # type: ignore
 
-        path = s_common.gendir(self.dirn, 'axon.lmdb')
-        self.axonslab = await s_lmdbslab.Slab.anit(path)
+        if self.readonly:
+            path = s_common.genpath(self.dirn, 'axon.lmdb')
+        else:
+            path = s_common.gendir(self.dirn, 'axon.lmdb')
+        self.axonslab = await s_lmdbslab.Slab.anit(path, readonly=self.readonly)
         self.sizes = self.axonslab.initdb('sizes')
         self.onfini(self.axonslab.fini)
 
@@ -908,9 +911,12 @@ class Axon(s_cell.Cell):
 
         self.byterange = True
 
-        path = s_common.gendir(self.dirn, 'blob.lmdb')
+        if self.readonly:
+            path = s_common.genpath(self.dirn, 'blob.lmdb')
+        else:
+            path = s_common.gendir(self.dirn, 'blob.lmdb')
 
-        self.blobslab = await s_lmdbslab.Slab.anit(path)
+        self.blobslab = await s_lmdbslab.Slab.anit(path, readonly=self.readonly)
         self.blobs = self.blobslab.initdb('blobs')
         self.offsets = self.blobslab.initdb('offsets')
         self.metadata = self.blobslab.initdb('metadata')

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1,6 +1,7 @@
 import os
 import copy
 import regex
+import socket
 import asyncio
 import logging
 import textwrap
@@ -47,6 +48,10 @@ import synapse.lib.jsonstor as s_jsonstor
 import synapse.lib.modelrev as s_modelrev
 import synapse.lib.stormsvc as s_stormsvc
 import synapse.lib.lmdbslab as s_lmdbslab
+import synapse.lib.arbiter as s_arbiter
+import synapse.lib.worker as s_worker
+import synapse.lib.queryrouter as s_queryrouter
+import synapse.lib.readermanager as s_readermanager
 
 import synapse.lib.crypto.rsa as s_rsa
 
@@ -906,6 +911,19 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             'description': 'An optional directory of CAs which are added to the TLS CA chain for Storm HTTP API calls.',
             'type': 'string',
         },
+        'multi:process:core_pct': {
+            'description': 'Percentage of available CPU cores to allocate for the multi-process system (workers + router + writer). 0=disabled (default), 50=half the cores. The arbiter subtracts 2 (router + writer) and allocates the rest as read-only workers.',
+            'type': 'integer',
+            'default': 0,
+            'minimum': 0,
+            'maximum': 100,
+        },
+        'cell:router:mode': {
+            'description': "Router mode: 'thin' (default) passes connections to workers via fd passing; 'thick' owns all connections and dispatches per-query via socketpair RPC.",
+            'type': 'string',
+            'default': 'thin',
+            'enum': ['thin', 'thick'],
+        },
     }
 
     cellapi = CoreApi
@@ -925,9 +943,13 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         if self.inaugural:
             self.cellinfo.set('cortex:version', s_version.version)
 
+        if not self.readonly:
+            self.cellinfo.set('cortex:version', s_version.version)
+
         corevers = self.cellinfo.get('cortex:version')
-        s_version.reqVersion(corevers, reqver, exc=s_exc.BadStorageVersion,
-                             mesg='cortex version in storage is incompatible with running software')
+        if corevers is not None:
+            s_version.reqVersion(corevers, reqver, exc=s_exc.BadStorageVersion,
+                                 mesg='cortex version in storage is incompatible with running software')
 
         self.viewmeta = self.slab.initdb('view:meta')
 
@@ -969,6 +991,9 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         self.stormpool = None
         self.stormpoolurl = None
         self.stormpoolopts = None
+
+        self.queryrouter = None
+        self.readermgr = None
 
         self.libroot = (None, {}, {})
         self.stormlibs = []
@@ -1716,6 +1741,22 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         role = await self.auth.getRoleByName('all')
         await role.addRule((True, ('layer', 'read')), gateiden=layriden)
 
+    def _lmdbReaderCheck(self):
+        '''Clear stale LMDB reader slots from crashed reader processes.'''
+        stale = 0
+        stale += self.slab.lenv.reader_check()
+        for layr in self.layers.values():
+            stale += layr.layrslab.lenv.reader_check()
+        if stale:
+            logger.info('Cleared %d stale LMDB reader slot(s)', stale)
+        return stale
+
+    async def _lmdbReaderCheckLoop(self):
+        while not self.isfini:
+            await self.waitfini(timeout=60)
+            if not self.isfini:
+                await s_coro.executor(self._lmdbReaderCheck)
+
     async def initServiceRuntime(self):
 
         # do any post-nexus initialization here...
@@ -1727,7 +1768,21 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         if not self.safemode:
             self.addActiveCoro(self.agenda.runloop)
 
+        self.addActiveCoro(self._lmdbReaderCheckLoop)
+
         await self._initStormSvcs()
+
+        self._forkinfo = None
+        pct = self.conf.get('multi:process:core_pct', 0)
+        # Backward compat: accept old key name with deprecation warning
+        if not pct:
+            pct = self.conf.get('multi:process:readers', 0)
+            if pct:
+                logger.warning('Config key "multi:process:readers" is deprecated. Use "multi:process:core_pct" instead.')
+        if pct and not self.readonly:
+            await self._initForkMode(pct)
+        else:
+            await self._initQueryRouter()
 
         # share ourself via the cell dmon as "cortex"
         # for potential default remote use
@@ -1736,7 +1791,6 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
     async def initServiceActive(self):
 
         await self.stormdmons.start()
-        await self.initStormPool()
 
         async def _runMigrations():
             await self.boss.promote('cortex:migration:layers', self.auth.rootuser, background=True, protected=True)
@@ -1744,26 +1798,23 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             # Run migrations when this cortex becomes active. This is to prevent
             # migrations getting skipped in a zero-downtime upgrade path
             # (upgrade mirror, promote mirror).
-            try:
-                await self._checkLayerModels()
-            finally:
-                if __debug__:
-                    self._migration_evnt.set()
+            await self._checkLayerModels()
 
-        if self.safemode:
+            # Once migrations are complete, start the view and layer tasks.
+            for view in self.views.values():
+                await view.initTrigTask()
+                await view.initMergeTask()
+
+            for layer in self.layers.values():
+                await layer.initLayerActive()
+
+            for pkgdef in list(self.stormpkgs.values()):
+                self._runStormPkgOnload(pkgdef)
+
             if __debug__:
                 self._migration_evnt.set()
-            return
 
-        for view in self.views.values():
-            await view.initTrigTask()
-            await view.initMergeTask()
-
-        for layer in self.layers.values():
-            await layer.initLayerActive()
-
-        for pkgdef in list(self.stormpkgs.values()):
-            self._runStormPkgOnload(pkgdef)
+        await self.initStormPool()
 
         self.runActiveTask(_runMigrations())
 
@@ -1810,6 +1861,98 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         except Exception as e:  # pragma: no cover
             logger.exception(f'Error starting stormpool, it will not be available: {e}')
+
+    async def _initQueryRouter(self):
+        if self.readonly:
+            return
+
+        pct = self.conf.get('multi:process:core_pct', 0)
+        if not pct:
+            return
+
+        cores = os.cpu_count() or 1
+        count = max(1, int(cores * pct / 100))
+
+        self.readermgr = await s_readermanager.ReaderManager.anit(self.dirn, count=count)
+        await self.readermgr.start()
+        self.onfini(self.readermgr.fini)
+
+        reader_urls = self.readermgr.get_reader_urls()
+        self.queryrouter = s_queryrouter.QueryRouter(reader_urls)
+        logger.info('Query router initialized with %d reader(s).', len(reader_urls))
+
+        async def _finiQueryRouter():
+            if self.queryrouter is not None:
+                await self.queryrouter.fini()
+                self.queryrouter = None
+
+        self.onfini(_finiQueryRouter)
+
+    async def _initForkMode(self, pct):
+        '''Set up fork-mode config. Socket lookup and UDS listener happen later
+        in _prepareFork(), after initServiceNetwork has created the TCP listener.
+        '''
+        cores = os.cpu_count() or 1
+        count = max(1, int(cores * pct / 100))
+
+        self._forkinfo = {
+            'count': count,
+            'uds_path': os.path.join(self.dirn, 'worker.sock'),
+            'datadir': self.dirn,
+            'router_mode': self.conf.get('cell:router:mode', 'thin'),
+        }
+        logger.info('Fork mode: configured for %d worker(s), router_mode=%s',
+                    count, self._forkinfo['router_mode'])
+
+    async def prepareFork(self):
+        '''Finalize fork setup after all init phases complete.
+
+        Starts the UDS listener and resolves the TCP listening socket fd.
+        Returns the fork info dict, or None if fork mode is not active.
+        '''
+        if self._forkinfo is None:
+            return None
+
+        # Start UDS endpoint for workers to forward writes
+        uds_path = self._forkinfo['uds_path']
+        await self.dmon.listen(f'unix://{uds_path}')
+        logger.info('Fork mode: UDS listener at %s', uds_path)
+
+        # Find the main TCP/SSL listening socket from the dmon
+        listen_sock = None
+        for server in self.dmon.listenservers:
+            for sock in server.sockets:
+                if sock.family in (socket.AF_INET, socket.AF_INET6):
+                    listen_sock = sock
+                    break
+            if listen_sock is not None:
+                break
+
+        if listen_sock is None:
+            logger.error('Fork mode: no TCP listening socket found, cannot fork')
+            self._forkinfo = None
+            return None
+
+        self._forkinfo['listen_fd'] = listen_sock.fileno()
+
+        # Phase D.1: If thick mode, create a separate listen socket on port 27493
+        if self._forkinfo.get('router_mode') == 'thick':
+            thick_port = 27493
+            thick_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            thick_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            thick_sock.bind(('0.0.0.0', thick_port))
+            thick_sock.listen(128)
+            thick_sock.setblocking(False)
+            self._forkinfo['thick_listen_fd'] = thick_sock.fileno()
+            # Prevent GC from closing the socket
+            self._thick_listen_sock = thick_sock
+            logger.info('Fork mode: thick router listen socket on port %d', thick_port)
+
+        return self._forkinfo
+
+    def getForkInfo(self):
+        '''Return fork config dict if fork mode is active, else None.'''
+        return getattr(self, '_forkinfo', None)
 
     async def finiStormPool(self):
 
@@ -2393,7 +2536,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
     async def _initCoreQueues(self):
         path = os.path.join(self.dirn, 'slabs', 'queues.lmdb')
 
-        slab = await s_lmdbslab.Slab.anit(path)
+        slab = await s_lmdbslab.Slab.anit(path, readonly=self.readonly)
         self.onfini(slab.fini)
 
         self.multiqueue = await slab.getMultiQueue('cortex:queue', nexsroot=self.nexsroot)
@@ -2402,7 +2545,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
     async def _initStormGraphs(self):
         path = os.path.join(self.dirn, 'slabs', 'graphs.lmdb')
 
-        slab = await s_lmdbslab.Slab.anit(path)
+        slab = await s_lmdbslab.Slab.anit(path, readonly=self.readonly)
         self.onfini(slab.fini)
 
         self.pkggraphs = {}
@@ -4634,13 +4777,13 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
                 with open(idenpath, 'r') as fd:
                     existiden = fd.read()
 
-                if jsoniden != existiden:
+                if jsoniden != existiden and not self.readonly:
                     with open(idenpath, 'w') as fd:
                         fd.write(jsoniden)
 
             # Disable sysctl checks for embedded jsonstor server
             conf = {'cell:guid': jsoniden, 'health:sysctl:checks': False}
-            self.jsonstor = await s_jsonstor.JsonStorCell.anit(path, conf=conf, parent=self)
+            self.jsonstor = await s_jsonstor.JsonStorCell.anit(path, conf=conf, parent=self, readonly=self.readonly)
 
     async def getJsonObj(self, path):
         if self.jsonurl is not None:
@@ -4725,7 +4868,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             if cadir is not None:
                 conf['tls:ca:dir'] = cadir
 
-            self.axon = await s_axon.Axon.anit(path, conf=conf, parent=self)
+            self.axon = await s_axon.Axon.anit(path, conf=conf, parent=self, readonly=self.readonly)
             self.axoninfo = await self.axon.getCellInfo()
             self.axon.onfini(self.axready.clear)
             self.dynitems['axon'] = self.axon
@@ -6328,6 +6471,18 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         opts = self._initStormOpts(opts)
 
+        if self.queryrouter is not None:
+            proxy, is_local, reader_url = await self.queryrouter.route(text, opts)
+            if not is_local:
+                try:
+                    async for mesg in proxy.storm(text, opts=opts):
+                        yield mesg
+                    return
+                except Exception:
+                    logger.warning('Reader proxy failed, falling back to local execution.')
+                finally:
+                    self.queryrouter.release(reader_url)
+
         if self.stormpool is not None and opts.get('mirror', True):
             proxy = await self._getMirrorProxy(opts)
 
@@ -6361,6 +6516,16 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
     async def callStorm(self, text, opts=None):
 
         opts = self._initStormOpts(opts)
+
+        if self.queryrouter is not None:
+            proxy, is_local, reader_url = await self.queryrouter.route(text, opts)
+            if not is_local:
+                try:
+                    return await proxy.callStorm(text, opts=opts)
+                except Exception:
+                    logger.warning('Reader proxy failed, falling back to local execution.')
+                finally:
+                    self.queryrouter.release(reader_url)
 
         if self.stormpool is not None and opts.get('mirror', True):
             proxy = await self._getMirrorProxy(opts)

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -510,12 +510,40 @@ class Daemon(s_base.Base):
                 raise s_exc.NoSuchObj(name=name)
 
             sess = self.sessions.get(sidn)
-            if sess is None:
-                raise s_exc.NoSuchObj(name=name)
 
-            item = sess.getSessItem(name)
-            if item is None:
-                raise s_exc.NoSuchObj(name=name)
+            # If the session doesn't exist locally (e.g. pool connection
+            # landed on a different fork worker), create one on-the-fly
+            # using the shared item lookup — same as tele:syn would.
+            if sess is None:
+
+                # Re-use a session already created for this link to avoid
+                # accumulating one Sess per t2:init under sustained load.
+                sess = link.get('sess')
+                if sess is not None:
+                    item = sess.getSessItem(name)
+                    if item is None:
+                        raise s_exc.NoSuchObj(name=name)
+                else:
+                    item = await self._getSharedItem(name or '*')
+                    if item is None:
+                        raise s_exc.NoSuchObj(name=name)
+
+                    sess = await Sess.anit()
+
+                    async def sessfini():
+                        self.sessions.pop(sess.iden, None)
+
+                    sess.onfini(sessfini)
+                    link.onfini(sess.fini)
+                    self.sessions[sess.iden] = sess
+                    link.set('sess', sess)
+
+                    sess.setSessItem(name, item)
+
+            else:
+                item = sess.getSessItem(name)
+                if item is None:
+                    raise s_exc.NoSuchObj(name=name)
 
             s_scope.set('sess', sess)
             s_scope.set('link', link)

--- a/synapse/lib/arbiter.py
+++ b/synapse/lib/arbiter.py
@@ -1,0 +1,783 @@
+'''
+Fork orchestrator for multi-process Cortex read workers.
+
+The Arbiter forks N read-only worker processes after the Cortex has fully
+initialized.  Workers inherit the listening socket and accept connections
+directly (prefork model).  The parent retains the arbiter role: it detects
+crashed workers via SIGCHLD and respawns them, and performs orderly shutdown
+on SIGTERM.
+'''
+import os
+import asyncio
+import signal
+import socket
+import logging
+import time
+
+import synapse.lib.lmdbslab as s_lmdbslab
+
+logger = logging.getLogger(__name__)
+
+# Seconds to wait for workers to exit after SIGTERM before sending SIGKILL.
+SHUTDOWN_GRACE = 5.0
+
+# Seconds between waitpid polls during shutdown drain.
+SHUTDOWN_POLL = 0.1
+
+# Seconds to wait for memlock threads to exit before fork.
+MEMLOCK_JOIN_TIMEOUT = 5.0
+
+
+def _shutdown_forkpool():
+    '''Shut down the forkserver process pool before forking.
+
+    The forkserver pool (ProcessPoolExecutor) spawns worker processes
+    (SpawnProcess-1/2/3) that live in the parent's process group.  If we
+    fork without shutting it down first, the forkserver workers receive
+    SIGTERM from process group cleanup and die during startup.
+    '''
+    import synapse.lib.processpool as s_processpool
+    if getattr(s_processpool, 'forkpool', None) is not None:
+        s_processpool.forkpool.shutdown(wait=True)
+        s_processpool.forkpool = None
+        s_processpool.forkpool_sema = None
+        logger.info('Shut down forkserver pool before fork')
+
+
+def _stop_memlock_threads():
+    '''Signal all slab memlock threads to stop and wait for them to exit.
+
+    Must be called before _close_all_slabs() and before fork() so that no
+    background threads are alive when we fork.
+    '''
+    slabs_with_memlock = [
+        slab for slab in s_lmdbslab.Slab.allslabs.values()
+        if slab.memlocktask is not None
+    ]
+    if not slabs_with_memlock:
+        return
+
+    # Signal all memlock threads to exit
+    for slab in slabs_with_memlock:
+        slab.isfini = True
+        slab.resizeevent.set()
+
+    # Wait for threads to finish (they check isfini and will exit)
+    deadline = time.monotonic() + MEMLOCK_JOIN_TIMEOUT
+    for slab in slabs_with_memlock:
+        remaining = max(0, deadline - time.monotonic())
+        # The memlocktask is a Future wrapping a thread executor call.
+        # We can't await it (no event loop), but the underlying thread
+        # will exit because we set isfini=True and signaled resizeevent.
+        # Wait by polling the thread pool — the thread checks isfini on
+        # each iteration of its loop.
+        while not slab.memlocktask.done() and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        if not slab.memlocktask.done():
+            logger.warning('Memlock thread for %s did not exit in time', slab.path)
+        else:
+            logger.debug('Memlock thread for %s stopped', slab.path)
+
+
+def _close_all_slabs():
+    '''Close every open LMDB environment so children don't inherit parent mmaps.
+
+    Closes the lenv handles but preserves slab entries in allslabs so that
+    forked workers can discover slab paths for readonly re-open.
+    '''
+    for slab in list(s_lmdbslab.Slab.allslabs.values()):
+        try:
+            slab.lenv.close()
+        except Exception:
+            logger.warning('Failed to close slab %s pre-fork', slab.path, exc_info=True)
+    # NOTE: Do NOT clear allslabs here. Workers need the slab metadata
+    # (paths) to re-open in readonly mode. See L-1 fix.
+
+
+class Arbiter:
+    '''Fork orchestrator and worker lifecycle manager.'''
+
+    def __init__(self, router_mode='thin'):
+        self._listen_sock = None
+        self._uds_path = None
+        self._worker_pids = []  # ordered list of child pids
+        self._num_workers = 0
+        self._worker_main = None
+        self._shutdown_flag = False
+        self._pending_restarts = []  # (slot_idx,) tuples queued by SIGCHLD handler
+        self._loop = None  # set by install_loop_signal_handler
+        self._router_pid = None
+        self._thick_router_pid = None
+        self._router_mode = router_mode  # 'thin' or 'thick'
+        self._control_channels = {}  # {worker_id: (router_fd, worker_fd)}
+        self._write_channels = {}    # {worker_id: (worker_fd, writer_fd)}
+        # Thick router dispatch channels: thick router → worker
+        self._dispatch_channels = {}  # {worker_id: (router_fd, worker_fd)}
+        # Thick router → writer dispatch channel
+        self._thick_writer_channel = None  # (router_fd, writer_fd)
+
+    def fork_workers(self, num_workers, listen_sock, uds_path, worker_main):
+        '''
+        Fork *num_workers* read-only worker processes.
+
+        Must be called after Cortex init completes and the asyncio event loop
+        has been torn down (no running loop, no threads).
+
+        Args:
+            num_workers: Number of worker processes to fork.
+            listen_sock: The bound/listening socket fd workers inherit.
+            uds_path: Filesystem path of the writer's UDS endpoint.
+            worker_main: Callable ``worker_main(control_fd, uds_path, worker_id)``
+                         invoked in each child.  Must not return (call ``os._exit``).
+
+        Returns:
+            list[int]: PIDs of the forked workers.
+        '''
+        self._listen_sock = listen_sock
+        self._uds_path = uds_path
+        self._num_workers = num_workers
+        self._worker_main = worker_main
+
+        _shutdown_forkpool()
+        _stop_memlock_threads()
+        _close_all_slabs()
+
+        # Create per-worker UDS socketpairs for fd passing
+        for i in range(num_workers):
+            router_end, worker_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._control_channels[i] = (router_end.fileno(), worker_end.fileno())
+            router_end.detach()
+            worker_end.detach()
+
+            # Write channel (worker → writer): for write forwarding
+            worker_write, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._write_channels[i] = (worker_write.fileno(), writer_end.fileno())
+            worker_write.detach()
+            writer_end.detach()
+
+        # Thick mode: create dispatch socketpairs (thick router → worker)
+        if self._router_mode == 'thick':
+            for i in range(num_workers):
+                router_end, worker_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+                self._dispatch_channels[i] = (router_end.fileno(), worker_end.fileno())
+                router_end.detach()
+                worker_end.detach()
+
+            # Thick router → writer dispatch channel
+            router_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._thick_writer_channel = (router_end.fileno(), writer_end.fileno())
+            router_end.detach()
+            writer_end.detach()
+
+        self._install_parent_signals()
+
+        for i in range(num_workers):
+            self._fork_one(i)
+
+        logger.info('Forked %d workers: %s', num_workers, self._worker_pids)
+        return list(self._worker_pids)
+
+    def fork_router(self, listen_fd):
+        '''Fork the router process. Must be called after fork_workers().
+
+        Args:
+            listen_fd: The listening socket fd the router will accept on.
+
+        Returns:
+            int: PID of the router process.
+        '''
+        import synapse.lib.router as s_router
+
+        self._listen_fd = listen_fd
+
+        # Build {worker_id: router_end_fd} map
+        worker_uds_fds = {}
+        for wid, (router_fd, worker_fd) in self._control_channels.items():
+            worker_uds_fds[wid] = router_fd
+
+        pid = os.fork()
+        if pid == 0:
+            # --- child (router) ---
+            try:
+                # Close worker-end fds in router process
+                for wid, (_, worker_fd) in self._control_channels.items():
+                    if worker_fd >= 0:
+                        try:
+                            os.close(worker_fd)
+                        except OSError:
+                            pass
+
+                # Close all write channel fds in router (not needed)
+                for wid, (w_worker_fd, w_writer_fd) in self._write_channels.items():
+                    for fd in (w_worker_fd, w_writer_fd):
+                        if fd >= 0:
+                            try:
+                                os.close(fd)
+                            except OSError:
+                                pass
+
+                # Close dispatch channel fds in thin router (not needed)
+                for wid, (r_fd, w_fd) in self._dispatch_channels.items():
+                    for fd in (r_fd, w_fd):
+                        if fd >= 0:
+                            try:
+                                os.close(fd)
+                            except OSError:
+                                pass
+                if self._thick_writer_channel is not None:
+                    for fd in self._thick_writer_channel:
+                        if fd >= 0:
+                            try:
+                                os.close(fd)
+                            except OSError:
+                                pass
+
+                router = s_router.RouterProcess(listen_fd, worker_uds_fds)
+                router.router_main()
+            except Exception:
+                logger.exception('Router process crashed')
+            finally:
+                os._exit(0)
+
+        # --- parent (arbiter) ---
+        self._router_pid = pid
+        logger.info('Forked router (pid %d)', pid)
+
+        # F-2 fix: Close the worker-end fds in the parent. The router
+        # detects dead workers via EPOLLHUP on the router-end fd, which
+        # only fires when ALL worker-end fds are closed. Without this,
+        # the parent's copy keeps the socketpair alive and HUP never fires.
+        # We keep the router-end fds so _restart_router can re-fork.
+        for wid, (router_fd, worker_fd) in list(self._control_channels.items()):
+            if worker_fd >= 0:
+                try:
+                    os.close(worker_fd)
+                except OSError:
+                    pass
+                self._control_channels[wid] = (router_fd, -1)
+
+        # Close worker-end write fds in the parent (writer process).
+        # The writer keeps the writer-end fds for receiving write RPCs.
+        for wid, (w_worker_fd, w_writer_fd) in list(self._write_channels.items()):
+            if w_worker_fd >= 0:
+                try:
+                    os.close(w_worker_fd)
+                except OSError:
+                    pass
+                self._write_channels[wid] = (-1, w_writer_fd)
+
+        return pid
+
+    def get_writer_fds(self):
+        '''Return a list of writer-end write channel fds.
+
+        These fds are used by the writer process to receive write RPCs
+        from workers via the write channel socketpairs.
+        '''
+        return [w_writer_fd for _, w_writer_fd in self._write_channels.values()
+                if w_writer_fd >= 0]
+
+    def fork_thick_router(self, listen_fd):
+        '''Fork the thick router process. Must be called after fork_workers().
+
+        The thick router owns all client connections on listen_fd, classifies
+        queries, and dispatches reads to workers / writes to the writer via
+        dedicated dispatch socketpairs.
+
+        Args:
+            listen_fd: The listening socket fd for the thick router (port 27493).
+
+        Returns:
+            int: PID of the thick router process.
+        '''
+        self._thick_listen_fd = listen_fd
+
+        # Build {worker_id: router_end_fd} for dispatch channels
+        dispatch_fds = {}
+        for wid, (router_fd, _) in self._dispatch_channels.items():
+            dispatch_fds[wid] = router_fd
+
+        # Writer dispatch fd (router end)
+        writer_dispatch_fd = self._thick_writer_channel[0]
+
+        pid = os.fork()
+        if pid == 0:
+            # --- child (thick router) ---
+            try:
+                # Close worker-end dispatch fds (not needed in router)
+                for wid, (_, worker_fd) in self._dispatch_channels.items():
+                    if worker_fd >= 0:
+                        try:
+                            os.close(worker_fd)
+                        except OSError:
+                            pass
+
+                # Close writer-end of thick writer channel
+                if self._thick_writer_channel[1] >= 0:
+                    try:
+                        os.close(self._thick_writer_channel[1])
+                    except OSError:
+                        pass
+
+                # Close thin router control channels (not needed)
+                for wid, (r_fd, w_fd) in self._control_channels.items():
+                    for fd in (r_fd, w_fd):
+                        if fd >= 0:
+                            try:
+                                os.close(fd)
+                            except OSError:
+                                pass
+
+                # Close write channels (not needed in thick router)
+                for wid, (w_worker_fd, w_writer_fd) in self._write_channels.items():
+                    for fd in (w_worker_fd, w_writer_fd):
+                        if fd >= 0:
+                            try:
+                                os.close(fd)
+                            except OSError:
+                                pass
+
+                _thick_router_main(listen_fd, dispatch_fds, writer_dispatch_fd)
+            except Exception:
+                logger.exception('Thick router process crashed')
+            finally:
+                os._exit(0)
+
+        # --- parent (arbiter) ---
+        self._thick_router_pid = pid
+        logger.info('Forked thick router (pid %d) on fd %d', pid, listen_fd)
+
+        # Close router-end dispatch fds in parent (only thick router uses them)
+        for wid, (router_fd, worker_fd) in list(self._dispatch_channels.items()):
+            if router_fd >= 0:
+                try:
+                    os.close(router_fd)
+                except OSError:
+                    pass
+                self._dispatch_channels[wid] = (-1, worker_fd)
+
+        # Close router-end of thick writer channel in parent
+        if self._thick_writer_channel[0] >= 0:
+            try:
+                os.close(self._thick_writer_channel[0])
+            except OSError:
+                pass
+            self._thick_writer_channel = (-1, self._thick_writer_channel[1])
+
+        return pid
+
+    def get_thick_writer_fd(self):
+        '''Return the writer-end fd of the thick router → writer dispatch channel.
+
+        Used by the writer process to receive dispatched queries from the
+        thick router.
+        '''
+        if self._thick_writer_channel is None:
+            return None
+        return self._thick_writer_channel[1]
+
+    # ------------------------------------------------------------------
+    # internal fork helpers
+    # ------------------------------------------------------------------
+
+    def _fork_one(self, worker_id):
+        pid = os.fork()
+        if pid == 0:
+            # --- child ---
+            try:
+                self._in_child(worker_id)
+            except Exception:
+                logger.exception('Worker %d crashed during init', os.getpid())
+            finally:
+                os._exit(1)
+
+        # --- parent ---
+        self._worker_pids.append(pid)
+        logger.info('Forked worker %d (pid %d)', worker_id, pid)
+
+    def _in_child(self, worker_id):
+        '''Run in the child process immediately after fork.'''
+        # Create a new session so SSM process group cleanup cannot reach us.
+        os.setsid()
+        # Reset inherited parent signal handlers.
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+        signal.signal(signal.SIGHUP, signal.SIG_IGN)
+        # SIGTERM/SIGINT: let worker_main install its own handlers.
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+        # Close router-end fds and other workers' fds in this child
+        for wid, (router_fd, worker_fd) in self._control_channels.items():
+            try:
+                os.close(router_fd)
+            except OSError:
+                pass
+            if wid != worker_id:
+                try:
+                    os.close(worker_fd)
+                except OSError:
+                    pass
+
+        # Close writer-end fds and other workers' write fds in this child
+        for wid, (w_worker_fd, w_writer_fd) in self._write_channels.items():
+            try:
+                os.close(w_writer_fd)
+            except OSError:
+                pass
+            if wid != worker_id:
+                try:
+                    os.close(w_worker_fd)
+                except OSError:
+                    pass
+
+        # Close dispatch channel fds not belonging to this worker
+        for wid, (router_fd, worker_fd) in self._dispatch_channels.items():
+            if router_fd >= 0:
+                try:
+                    os.close(router_fd)
+                except OSError:
+                    pass
+            if wid != worker_id and worker_fd >= 0:
+                try:
+                    os.close(worker_fd)
+                except OSError:
+                    pass
+
+        # Close thick writer channel fds in worker (not needed)
+        if self._thick_writer_channel is not None:
+            for fd in self._thick_writer_channel:
+                if fd >= 0:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+
+        # Pass the worker's control channel fd instead of the listen fd
+        control_fd = self._control_channels[worker_id][1]
+        write_fd = self._write_channels[worker_id][0]
+        dispatch_fd = None
+        if self._router_mode == 'thick' and worker_id in self._dispatch_channels:
+            dispatch_fd = self._dispatch_channels[worker_id][1]
+        self._worker_main(control_fd, self._uds_path, worker_id,
+                          write_fd=write_fd, dispatch_fd=dispatch_fd)
+
+    # ------------------------------------------------------------------
+    # parent signal handlers
+    # ------------------------------------------------------------------
+
+    def _install_parent_signals(self):
+        signal.signal(signal.SIGCHLD, self._handle_sigchld)
+
+    def _handle_sigchld(self, signum, frame):
+        '''Reap exited children and queue restarts (signal-safe).
+
+        This handler only reaps via waitpid and records which slots need
+        restart.  Actual fork happens in process_pending_restarts() which
+        runs from the event loop, not from a signal handler.
+        '''
+        while True:
+            try:
+                pid, status = os.waitpid(-1, os.WNOHANG)
+            except ChildProcessError:
+                break
+            if pid == 0:
+                break
+
+            if pid == self._router_pid:
+                if os.WIFSIGNALED(status):
+                    sig = os.WTERMSIG(status)
+                    logger.error('Router pid %d killed by signal %d', pid, sig)
+                else:
+                    code = os.WEXITSTATUS(status)
+                    logger.error('Router pid %d exited with code %d', pid, code)
+                self._router_pid = None
+                continue
+
+            if pid == self._thick_router_pid:
+                if os.WIFSIGNALED(status):
+                    sig = os.WTERMSIG(status)
+                    logger.error('Thick router pid %d killed by signal %d', pid, sig)
+                else:
+                    code = os.WEXITSTATUS(status)
+                    logger.error('Thick router pid %d exited with code %d', pid, code)
+                self._thick_router_pid = None
+                continue
+
+            if pid in self._worker_pids:
+                idx = self._worker_pids.index(pid)
+                self._worker_pids[idx] = None
+
+                if os.WIFSIGNALED(status):
+                    sig = os.WTERMSIG(status)
+                    logger.error('Worker pid %d killed by signal %d', pid, sig)
+                else:
+                    code = os.WEXITSTATUS(status)
+                    logger.error('Worker pid %d exited with code %d', pid, code)
+
+                if not self._shutdown_flag:
+                    self._pending_restarts.append(idx)
+
+    def install_loop_signal_handler(self, loop):
+        '''Install an async-safe SIGCHLD handler on the event loop.
+
+        Replaces the raw signal.signal handler with loop.add_signal_handler
+        so that SIGCHLD wakes the event loop and restarts are processed
+        safely (not inside a signal handler).
+        '''
+        self._loop = loop
+
+        def _on_sigchld():
+            # Reap children (async-signal-safe part)
+            self._handle_sigchld(signal.SIGCHLD, None)
+            # Schedule restarts from the event loop (safe to fork here)
+            self.process_pending_restarts()
+
+        loop.add_signal_handler(signal.SIGCHLD, _on_sigchld)
+
+    def process_pending_restarts(self):
+        '''Fork new workers for any slots that died.  Must be called from
+        the main thread (not from a signal handler).'''
+        while self._pending_restarts:
+            idx = self._pending_restarts.pop(0)
+            self.restart_worker(idx)
+
+    # ------------------------------------------------------------------
+    # restart / shutdown
+    # ------------------------------------------------------------------
+
+    def restart_worker(self, idx):
+        '''Respawn the worker at slot *idx* with a fresh socketpair.
+
+        F-5 fix: The old socketpair is dead. Create a new one, fork the
+        worker, then restart the router so it picks up the new fd.
+        '''
+        old_pid = self._worker_pids[idx]
+        if old_pid is not None:
+            logger.warning('restart_worker called for slot %d but pid %d still tracked', idx, old_pid)
+
+        # Create a fresh socketpair for this worker
+        router_end, worker_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._control_channels[idx] = (router_end.fileno(), worker_end.fileno())
+        router_end.detach()
+        worker_end.detach()
+
+        # Create a fresh write channel socketpair
+        worker_write, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._write_channels[idx] = (worker_write.fileno(), writer_end.fileno())
+        worker_write.detach()
+        writer_end.detach()
+
+        # Create a fresh dispatch channel socketpair (thick mode)
+        if self._router_mode == 'thick':
+            router_end, worker_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._dispatch_channels[idx] = (router_end.fileno(), worker_end.fileno())
+            router_end.detach()
+            worker_end.detach()
+
+        pid = os.fork()
+        if pid == 0:
+            try:
+                self._in_child(idx)
+            except Exception:
+                logger.exception('Worker %d crashed during init', os.getpid())
+            finally:
+                os._exit(1)
+
+        self._worker_pids[idx] = pid
+        logger.info('Respawned worker slot %d as pid %d', idx, pid)
+
+        # Restart the router so it gets the new control channel fd
+        self._restart_router()
+
+    def get_write_channel_fds(self):
+        '''Return {worker_id: writer_end_fd} for the writer process.
+
+        Called after fork_router() when the parent becomes the writer.
+        Only writer-end fds remain open at this point (worker-end fds
+        were closed in fork_router).
+        '''
+        return {wid: wfd for wid, (_, wfd) in self._write_channels.items() if wfd >= 0}
+
+    def _restart_router(self):
+        '''Kill the old router and fork a new one with current control channels.'''
+        if self._router_pid is not None:
+            try:
+                os.kill(self._router_pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                os.waitpid(self._router_pid, 0)
+            except ChildProcessError:
+                pass
+            self._router_pid = None
+
+        self.fork_router(self._listen_fd)
+
+        # Also restart thick router if in thick mode (needs new dispatch fds)
+        if self._router_mode == 'thick' and self._thick_router_pid is not None:
+            try:
+                os.kill(self._thick_router_pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                os.waitpid(self._thick_router_pid, 0)
+            except ChildProcessError:
+                pass
+            self._thick_router_pid = None
+            self.fork_thick_router(self._thick_listen_fd)
+
+    def shutdown(self):
+        '''Send SIGTERM to router first, then workers, wait with timeout, SIGKILL stragglers.'''
+        self._shutdown_flag = True
+
+        # Phase 0: Stop routers first (no new connections)
+        for rpid_attr in ('_router_pid', '_thick_router_pid'):
+            rpid = getattr(self, rpid_attr)
+            if rpid is not None:
+                try:
+                    os.kill(rpid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+                try:
+                    os.waitpid(rpid, 0)
+                except ChildProcessError:
+                    pass
+                setattr(self, rpid_attr, None)
+
+        alive = [p for p in self._worker_pids if p is not None]
+        if not alive:
+            return
+
+        # Phase 1: SIGTERM
+        for pid in alive:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+
+        # Phase 2: wait up to SHUTDOWN_GRACE seconds
+        deadline = time.monotonic() + SHUTDOWN_GRACE
+        while time.monotonic() < deadline:
+            alive = [p for p in self._worker_pids if p is not None]
+            if not alive:
+                return
+            for pid in alive:
+                try:
+                    rpid, _ = os.waitpid(pid, os.WNOHANG)
+                    if rpid != 0:
+                        idx = self._worker_pids.index(pid)
+                        self._worker_pids[idx] = None
+                except ChildProcessError:
+                    idx = self._worker_pids.index(pid)
+                    self._worker_pids[idx] = None
+            time.sleep(SHUTDOWN_POLL)
+
+        # Phase 3: SIGKILL stragglers
+        for i, pid in enumerate(self._worker_pids):
+            if pid is None:
+                continue
+            logger.warning('Worker pid %d did not exit in time, sending SIGKILL', pid)
+            try:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+            except (ProcessLookupError, ChildProcessError):
+                pass
+            self._worker_pids[i] = None
+
+
+def _thick_router_main(listen_fd, worker_dispatch_fds, writer_dispatch_fd):
+    '''Entry point for the thick router child process.
+
+    Runs an asyncio event loop hosting the ThickRouter which owns all client
+    connections, classifies queries, and dispatches to workers/writer.
+
+    Args:
+        listen_fd: Listening socket fd (port 27493).
+        worker_dispatch_fds: dict {worker_id: fd} — dispatch socketpairs to workers.
+        writer_dispatch_fd: int — dispatch socketpair to writer.
+    '''
+    import synapse.lib.thickrouter as s_thickrouter
+
+    async def _run():
+        router = s_thickrouter.ThickRouter(
+            cell=None,  # No cell in router process; dispatch-only mode
+            worker_fds=worker_dispatch_fds,
+            writer_fd=writer_dispatch_fd,
+        )
+        await router.start()
+
+        # Listen on the inherited socket fd
+        import socket as _socket
+        sock = _socket.socket(fileno=listen_fd)
+        sock.setblocking(False)
+        await router.listen(f'tcp://0.0.0.0', ssl=None, sock=sock)
+
+        # Block until shutdown signal
+        stop_event = asyncio.Event()
+
+        def _on_term():
+            stop_event.set()
+
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGTERM, _on_term)
+        loop.add_signal_handler(signal.SIGINT, _on_term)
+
+        await stop_event.wait()
+        await router.stop()
+
+    asyncio.run(_run())
+
+
+def _reopen_writer_slabs():
+    '''Re-open LMDB environments in the writer process after fork.
+
+    _close_all_slabs() closed all lenv handles before fork.  The writer
+    needs them back in read-write mode.  Also resets isfini on slabs that
+    were marked fini by _stop_memlock_threads(), and re-opens all cached
+    database handles against the new environment.
+    '''
+    import lmdb as _lmdb
+    for slab in list(s_lmdbslab.Slab.allslabs.values()):
+        path = slab.path
+        opts = {
+            'map_size': slab.mapsize,
+            'max_dbs': 128,
+            'max_readers': 256,
+            'writemap': True,
+            'readonly': slab.readonly,
+            'readahead': slab.readahead,
+            'map_async': True,
+        }
+        try:
+            slab.lenv = _lmdb.open(str(path), **opts)
+            slab.isfini = False
+            # Recreate asyncio events bound to the new loop
+            slab.lockdoneevent = asyncio.Event()
+            slab.lockdoneevent.set()  # no memlock in writer after fork
+
+            if not slab.readonly:
+                slab._initCoXact()
+
+            # Re-open all cached database handles against the new env
+            old_dbnames = dict(slab.dbnames)
+            slab.dbnames = {None: (None, False)}
+            for name, (db, dupsort) in old_dbnames.items():
+                if name is None:
+                    continue
+                try:
+                    if slab.readonly:
+                        newdb = slab.lenv.open_db(name.encode('utf8'), create=False, dupsort=dupsort)
+                    else:
+                        newdb = slab.lenv.open_db(name.encode('utf8'), txn=slab.xact, dupsort=dupsort)
+                    slab.dbnames[name] = (newdb, dupsort)
+                except Exception:
+                    logger.warning('Failed to re-open db %s in slab %s', name, path)
+
+            if not slab.readonly:
+                slab.dirty = True
+                slab.forcecommit()
+
+            logger.debug('Re-opened slab %s for writer (%d dbs)', path, len(slab.dbnames) - 1)
+        except Exception:
+            logger.exception('Failed to re-open slab %s for writer', path)

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -156,6 +156,8 @@ class Auth(s_nexus.Pusher):
 
         self.allrole = await self.getRoleByName('all')
         if self.allrole is None:
+            if slab.readonly:
+                raise s_exc.NeedConfValu(mesg='Auth not initialized. Boot in write mode first.')
             # initialize the role of which all users are a member
             guid = s_common.guid((seed, 'auth', 'role', 'all'))
             await self._addRole(guid, 'all')
@@ -164,12 +166,15 @@ class Auth(s_nexus.Pusher):
         # initialize an admin user named root
         self.rootuser = await self.getUserByName('root')
         if self.rootuser is None:
+            if slab.readonly:
+                raise s_exc.NeedConfValu(mesg='Auth not initialized. Boot in write mode first.')
             guid = s_common.guid((seed, 'auth', 'user', 'root'))
             await self._addUser(guid, 'root')
             self.rootuser = self.user(guid)
 
-        await self.rootuser.setAdmin(True, logged=False)
-        await self.rootuser.setLocked(False, logged=False)
+        if not slab.readonly:
+            await self.rootuser.setAdmin(True, logged=False)
+            await self.rootuser.setLocked(False, logged=False)
 
     def users(self):
         for useriden in self.useridenbyname.values():

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1220,6 +1220,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             'issuewait': 1
         }
 
+        self.readonly = readonly
+
         self.safemode = self.conf.req('safemode')
         if self.safemode:
             mesg = f'Booting {self.getCellType()} in safe-mode. Some functionality may be disabled.'
@@ -1337,7 +1339,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         self.optimizeddb = self.slab.initdb('cell:optimized')  # time -> optimization record
 
-        if self._save_optimized:
+        if self._save_optimized and not self.readonly:
             lkey = s_common.int64en(self._last_optimized['init']['time'])
             self.slab.put(lkey, s_msgpack.en(self._last_optimized), db=self.optimizeddb)
             self._save_optimized = False
@@ -1370,7 +1372,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             logger.error(mesg)
             raise s_exc.BadVersion(mesg=mesg, currver=self.VERSION, lastver=lastver)
 
-        self.cellinfo.set('cell:version', self.VERSION)
+        if not self.readonly:
+            self.cellinfo.set('cell:version', self.VERSION)
 
         # Check the synapse version didn't regress
         if (lastver := self.cellinfo.get('synapse:version')) is not None and s_version.version < lastver:
@@ -1378,7 +1381,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             logger.error(mesg)
             raise s_exc.BadVersion(mesg=mesg, currver=s_version.version, lastver=lastver)
 
-        self.cellinfo.set('synapse:version', s_version.version)
+        if not self.readonly:
+            self.cellinfo.set('synapse:version', s_version.version)
 
         self.nexsvers = self.cellinfo.get('nexus:version', (0, 0))
         self.nexspatches = ()
@@ -1390,7 +1394,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         self.auth = await self._initCellAuth()
 
         auth_passwd = self.conf.get('auth:passwd')
-        if auth_passwd is not None:
+        if auth_passwd is not None and not self.readonly:
             user = await self.auth.getUserByName('root')
 
             if not await user.tryPasswd(auth_passwd, nexs=False, enforce_policy=False):
@@ -1665,6 +1669,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         self._cellguidfd.close()
 
     def _getCellLock(self):
+        if self.readonly:
+            return
         cmd = fcntl.LOCK_EX | fcntl.LOCK_NB
         try:
             fcntl.lockf(self._cellguidfd, cmd)
@@ -1845,6 +1851,14 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
     async def _bumpCellVers(self, name, updates, nexs=True):
 
+        if self.readonly:
+            curv = self.cellvers.get(name, 0)
+            reqv = updates[-1][0]
+            if curv < reqv:
+                mesg = f'Storage requires migration ({name} v{curv} -> v{reqv}). Boot in write mode first.'
+                raise s_exc.NeedConfValu(mesg=mesg)
+            return
+
         if self.inaugural:
             await self.setCellVers(name, updates[-1][0], nexs=nexs)
             return
@@ -1993,10 +2007,16 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             (2, self._driveCellMigration),
         ), nexs=False)
 
-        path = s_common.gendir(self.dirn, 'slabs', 'drive.lmdb')
+        if self.readonly:
+            path = s_common.genpath(self.dirn, 'slabs', 'drive.lmdb')
+        else:
+            path = s_common.gendir(self.dirn, 'slabs', 'drive.lmdb')
         sockpath = s_common.genpath(self.sockdirn, 'drive')
 
-        if s_common.envbool('SYNDEV_CELL_DRIVE_NOSPAWN'):
+        if self.readonly:
+            self.drive_slab = await self._initSlabFile(path, readonly=True)
+            self.drive = await s_drive.Drive.anit(self.drive_slab, s_drive.CELLDRIVE)
+        elif s_common.envbool('SYNDEV_CELL_DRIVE_NOSPAWN'):
             self.drive_slab = await self._initSlabFile(path)
             self.drive = await s_drive.Drive.anit(self.drive_slab, s_drive.CELLDRIVE)
         else:
@@ -3726,7 +3746,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             _slab.initdb('hive')
             await _slab.fini()
 
-        self.slab = await self._initSlabFile(path)
+        self.slab = await self._initSlabFile(path, readonly=readonly)
 
     async def _initCellAuth(self):
 
@@ -4120,6 +4140,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                           help=f'The (optional) additional name to share the {name} as. This defaults to '
                                f'{telendef}, and may be also be overridden by the {telenvar} environment'
                                f' variable.')
+        pars.add_argument('--readonly', default=False, action='store_true',
+                          help='Start the cell in read-only mode.')
 
         if conf is not None:
             args = conf.getArgParseArgs()
@@ -4564,7 +4586,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         s_processpool._setPoolLogging(logconf)
 
         try:
-            cell = await cls.anit(opts.dirn, conf=conf)
+            cell = await cls.anit(opts.dirn, conf=conf, readonly=opts.readonly)
         except:
             logger.exception(f'Error starting cell at {opts.dirn}')
             raise
@@ -4620,6 +4642,376 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         cell = await cls.initFromArgv(argv, outp=outp)
 
         await cell.main()
+
+    @classmethod
+    def startmain(cls, argv, outp=None):
+        '''Sync entry point that supports the init → fork → serve lifecycle.
+
+        If the cell has fork mode enabled (getForkInfo() returns non-None),
+        the lifecycle is:
+
+        1. asyncio.run(init) — initialize the cell, event loop closes on return
+        2. os.fork() × N — fork read workers (no event loop running, safe to fork)
+        3. Writer: asyncio.run(serve) — new event loop for the writer process
+        4. Workers: each creates its own event loop via worker_main()
+
+        If fork mode is not enabled, falls back to the normal asyncio.run(execmain) path.
+        '''
+        # Fast path: check if fork mode could be active before doing the
+        # two-phase init.  Only Cortex with multi:process:readers > 0 uses it.
+        # For all other cells, use the original single-phase path.
+        #
+        # We probe the config to decide without initializing the cell twice.
+        # If the probe is inconclusive, we use the two-phase path and fall
+        # back to normal mode if prepareFork() returns None.
+        if not cls._mayFork(argv):
+            asyncio.run(cls.execmain(argv, outp=outp))
+            return
+
+        import synapse.lib.arbiter as s_arbiter
+        import synapse.lib.worker as s_worker
+
+        if outp is None:
+            outp = s_output.stdout
+
+        # Phase 1: Initialize the cell (event loop created and destroyed by asyncio.run)
+        cell_info = asyncio.run(cls._initForFork(argv, outp=outp))
+
+        cell = cell_info['cell']
+        fork_info = cell_info.get('fork_info')
+
+        if fork_info is None:
+            # prepareFork() returned None — fall back to normal serve.
+            # The cell is already initialized; just need to serve.
+            # Re-create listeners and active coros in a new event loop.
+            async def _fallback_serve():
+                # Same fixes as _writer_serve: rebind to new loop
+                cell.loop = asyncio.get_running_loop()
+                cell.isfini = False
+                cell.finievt = asyncio.Event()
+                cell.dmon.isfini = False
+                cell.dmon.finievt = asyncio.Event()
+                await cell._restoreAfterInitLoop()
+                await cell.main()
+            asyncio.run(_fallback_serve())
+            return
+
+        # Phase 2: Fork workers (no event loop running — safe to fork)
+        listen_fd = fork_info['listen_fd']
+        uds_path = fork_info['uds_path']
+        datadir = fork_info['datadir']
+        count = fork_info['count']
+
+        # E-1 fix: The init event loop is dead. Null out the stale loop
+        # reference so nothing accidentally uses it between phases.
+        cell.loop = None
+
+        def _worker_entry(control_fd, uds_path_arg, worker_id, write_fd=None, dispatch_fd=None):
+            s_worker.worker_main(control_fd, uds_path_arg, datadir, cell=cell,
+                                 write_fd=write_fd, dispatch_fd=dispatch_fd)
+
+        router_mode = fork_info.get('router_mode', 'thin')
+        arbiter = s_arbiter.Arbiter(router_mode=router_mode)
+        arbiter.fork_workers(count, listen_fd, uds_path, _worker_entry)
+
+        # Fork the thin router process after workers (it needs worker UDS fds)
+        arbiter.fork_router(listen_fd)
+
+        # Phase D.1: Fork thick router on separate port if in thick mode
+        if router_mode == 'thick':
+            thick_listen_fd = fork_info['thick_listen_fd']
+            arbiter.fork_thick_router(thick_listen_fd)
+
+        # Phase 3: Writer process creates a new event loop and serves
+        async def _writer_serve():
+
+            # E-1 fix: Rebind ALL Base objects to the new event loop.
+            # The init loop is dead; every Base created during init has a
+            # stale loop reference.
+            import gc
+            import threading
+            import synapse.glob as s_glob
+            new_loop = asyncio.get_running_loop()
+
+            # Reset the global loop reference so s_glob.iAmLoop() and
+            # s_glob.initloop() return the correct (new) loop.
+            s_glob._glob_loop = new_loop
+            s_glob._glob_thrd = threading.current_thread()
+
+            fini_count = 0
+            evt_count = 0
+            
+            for obj in gc.get_objects():
+                if isinstance(obj, s_base.Base) and obj.anitted:
+                    if obj.isfini:
+                        fini_count += 1
+                    obj.loop = new_loop
+                    obj.isfini = False
+                    obj.finievt = asyncio.Event()
+                    # E-6 fix: Recreate asyncio.Event attributes bound to the
+                    # dead init loop.  s_coro.Event subclasses asyncio.Event so
+                    # isinstance catches both.
+                    for attr in list(vars(obj)):
+                        if attr == 'finievt':
+                            continue
+                        val = getattr(obj, attr, None)
+                        if isinstance(val, asyncio.Event):
+                            if isinstance(val, s_coro.Event):
+                                setattr(obj, attr, s_coro.Event())
+                            else:
+                                setattr(obj, attr, asyncio.Event())
+                            evt_count += 1
+            cell.loop = new_loop
+            if fini_count:
+                logger.warning('E-1 fix: Reset isfini on %d Base objects', fini_count)
+            if evt_count:
+                logger.info('E-6 fix: Recreated %d asyncio.Event objects on new loop', evt_count)
+
+            # E-2 fix: Decrement the extra ref we added in _initForFork
+            # to prevent fini during asyncio.run() teardown.
+            cell._syn_refs -= 1
+
+            # Verify nexsroot state
+            if hasattr(cell, 'nexsroot') and cell.nexsroot is not None:
+                logger.info('Writer: nexsroot.isfini=%s nexsroot.readonly=%s',
+                           cell.nexsroot.isfini, cell.nexsroot.readonly)
+
+            # E-3 fix: Re-open LMDB slabs closed before fork.
+            s_arbiter._reopen_writer_slabs()
+
+            # E-4 fix: Re-open nexus log tail slab if it was fini'd during
+            # init loop teardown. The MultiSlabSeqn's tail slab may have been
+            # removed from allslabs if asyncio.run() teardown cancelled tasks
+            # that triggered its fini.
+            if hasattr(cell, 'nexsroot') and cell.nexsroot is not None:
+                nexslog = cell.nexsroot.nexslog
+                if nexslog is not None and nexslog.tailslab is not None:
+                    tailslab = nexslog.tailslab
+                    if tailslab.isfini or str(tailslab.path) not in s_lmdbslab.Slab.allslabs:
+                        import lmdb as _lmdb
+                        path = tailslab.path
+                        tailslab.isfini = False
+                        tailslab.lenv = _lmdb.open(str(path),
+                            map_size=tailslab.mapsize, max_dbs=128, max_readers=256,
+                            writemap=True, readonly=False, readahead=tailslab.readahead,
+                            map_async=True)
+                        tailslab._initCoXact()
+                        old_dbnames = dict(tailslab.dbnames)
+                        tailslab.dbnames = {None: (None, False)}
+                        for name, (db, dupsort) in old_dbnames.items():
+                            if name is None:
+                                continue
+                            try:
+                                newdb = tailslab.lenv.open_db(name.encode('utf8'), txn=tailslab.xact, dupsort=dupsort)
+                                tailslab.dbnames[name] = (newdb, dupsort)
+                            except Exception:
+                                pass
+                        tailslab.dirty = True
+                        tailslab.forcecommit()
+                        s_lmdbslab.Slab.allslabs[str(path)] = tailslab
+                        logger.info('E-4: Re-opened nexus log tail slab: %s', path)
+
+            # Verify all writable slabs have valid transactions
+            for slab in list(s_lmdbslab.Slab.allslabs.values()):
+                if not slab.readonly and slab.xact is None:
+                    logger.warning('Slab %s had xact=None after reopen, re-initializing', slab.path)
+                    slab._initCoXact()
+
+            # S-1 fix: Replace the raw signal.signal SIGCHLD handler with
+            # a loop-based handler so restarts happen from the event loop,
+            # not inside a signal handler (which is undefined behavior).
+            arbiter.install_loop_signal_handler(cell.loop)
+
+            # Clear stale server refs and UDS files from the init loop
+            cell.dmon.listenservers.clear()
+            for spath in (os.path.join(cell.dirn, 'sock'), uds_path):
+                try:
+                    os.unlink(spath)
+                except FileNotFoundError:
+                    pass
+
+            # Re-create the local unix socket
+            try:
+                await cell.dmon.listen(f'unix://{os.path.join(cell.dirn, "sock")}')
+            except OSError:
+                logger.warning('Failed to re-create local unix socket')
+
+            # F-1 fix: The router owns the listen socket now. Close our copy
+            # so the writer does NOT accept TCP connections directly.
+            os.close(listen_fd)
+
+            # Re-create the UDS listener for write forwarding
+            await cell.dmon.listen(f'unix://{uds_path}')
+
+            # Start the write channel listener for direct worker→writer RPC
+            writer_fds = arbiter.get_writer_fds()
+            if writer_fds:
+                import synapse.lib.writechannel as s_writechannel
+                wc_listener = s_writechannel.WriteChannelListener(cell, writer_fds)
+                await wc_listener.start()
+
+            # Re-fire active coros that were cancelled when the init loop closed
+            cell._fireActiveCoros()
+
+            # E-5 fix: Restart the Slab sync loop. The class-level synctask
+            # died with the init event loop; without it the writer never
+            # commits dirty transactions and workers cannot see new data.
+            s_lmdbslab.Slab.synctask = None
+            for slab in s_lmdbslab.Slab.allslabs.values():
+                if not slab.readonly:
+                    await s_lmdbslab.Slab.initSyncLoop(slab)
+                    break
+
+            await cell.main()
+
+        try:
+            asyncio.run(_writer_serve())
+        finally:
+            arbiter.shutdown()
+
+    @classmethod
+    def _mayFork(cls, argv):
+        '''Quick check whether this cell class might use fork mode.
+
+        Returns True only if the cell config has multi:process:readers > 0.
+        This avoids the two-phase init (which breaks the forkserver pool)
+        when fork mode isn't actually needed.
+        '''
+        if not hasattr(cls, 'prepareFork'):
+            return False
+
+        # Probe the cell.yaml in the data directory (first positional arg)
+        # to check if multi:process:readers is configured.
+        import yaml
+        dirn = None
+        for arg in argv:
+            if not arg.startswith('-'):
+                dirn = arg
+                break
+        if dirn is None:
+            return False
+
+        cellpath = os.path.join(dirn, 'cell.yaml')
+        try:
+            with open(cellpath) as f:
+                conf = yaml.safe_load(f) or {}
+            return conf.get('multi:process:core_pct', 0) > 0
+        except (OSError, yaml.YAMLError):
+            return False
+
+    @classmethod
+    async def _initForFork(cls, argv, outp=None):
+        '''Initialize the cell and return it with fork info.
+
+        The cell is fully initialized (storage, runtime, network) but
+        main() has not been called — no signal handlers, no waitfini.
+        '''
+        if outp is None:
+            outp = s_output.stdout
+
+        cell = await cls.initFromArgv(argv, outp=outp)
+
+        # prepareFork() finalizes fork setup (UDS listener, socket fd lookup)
+        # after all init phases (including network) have completed.
+        fork_info = None
+        if hasattr(cell, 'prepareFork'):
+            fork_info = await cell.prepareFork()
+
+        if fork_info is not None:
+            # Dup the listen fd so it survives event loop teardown.
+            fork_info['listen_fd'] = os.dup(fork_info['listen_fd'])
+
+        # Prevent the cell (and its children) from being fini'd during
+        # asyncio.run() teardown.
+        cell._syn_refs += 1
+
+        return {'cell': cell, 'fork_info': fork_info}
+
+    async def _restoreDmonListener(self, listen_fd):
+        '''Re-create the dmon TCP listener using an inherited socket fd.
+
+        Used after fork to re-attach the shared listening socket to the
+        writer's new event loop.
+        '''
+        sock = socket.socket(fileno=listen_fd)
+        sock.setblocking(False)
+
+        # Determine if SSL is needed from the dmon:listen config
+        turl = self._getDmonListen()
+        sslctx = None
+        if turl is not None:
+            info = s_telepath.chopurl(turl)
+            if info.get('scheme') == 'ssl':
+                caname = info.get('ca')
+                hostname = info.get('hostname', info.get('host'))
+                sslctx = self.dmon.certdir.getServerSSLContext(hostname=hostname, caname=caname)
+
+        is_tls = sslctx is not None
+
+        async def onconn(reader, writer):
+            info = {'tls': is_tls}
+            link = await s_link.Link.anit(reader, writer, info=info)
+            link.schedCoro(self.dmon._onLinkInit(link))
+
+        server = await asyncio.start_server(onconn, sock=sock, ssl=sslctx)
+        self.dmon.listenservers.append(server)
+
+    async def _restoreAfterInitLoop(self):
+        '''Restore cell state after the init event loop has been closed.
+
+        Re-creates dmon listeners and re-fires active coros in the new
+        event loop.  Called by startmain() when the two-phase lifecycle
+        is used (init loop → fork → serve loop).
+        '''
+        # Clear stale asyncio server refs from the init loop
+        self.dmon.listenservers.clear()
+
+        # Remove stale UDS files before re-binding
+        sockpath = os.path.join(self.dirn, 'sock')
+        try:
+            os.unlink(sockpath)
+        except FileNotFoundError:
+            pass
+
+        # Re-create the local unix socket listener
+        try:
+            await self.dmon.listen(f'unix://{sockpath}')
+        except OSError:
+            logger.warning('Failed to re-create local unix socket at %s', sockpath)
+
+        # Re-create the TCP/SSL listener from config
+        turl = self._getDmonListen()
+        if turl is not None:
+            self.sockaddr = await self.dmon.listen(turl)
+
+        # E-6 fix: Recreate asyncio.Event attributes on Base objects that are
+        # still bound to the dead init loop.
+        import gc
+        evt_count = 0
+        for obj in gc.get_objects():
+            if isinstance(obj, s_base.Base) and obj.anitted:
+                for attr in list(vars(obj)):
+                    if attr == 'finievt':
+                        continue
+                    val = getattr(obj, attr, None)
+                    if isinstance(val, asyncio.Event):
+                        if isinstance(val, s_coro.Event):
+                            setattr(obj, attr, s_coro.Event())
+                        else:
+                            setattr(obj, attr, asyncio.Event())
+                        evt_count += 1
+        if evt_count:
+            logger.info('E-6 fix: Recreated %d asyncio.Event objects on new loop', evt_count)
+
+        # Re-fire active coros that were cancelled when the init loop closed
+        self._fireActiveCoros()
+
+    def getForkInfo(self):
+        '''Return fork config if fork mode is active, else None.
+
+        Subclasses (e.g. Cortex) override this to return fork configuration.
+        '''
+        return None
 
     async def _getCellUser(self, link, mesg):
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1525,7 +1525,7 @@ class Layer(s_nexus.Pusher):
         self.activetasks = []
 
         # this must be last!
-        self.readonly = layrinfo.get('readonly')
+        self.readonly = layrinfo.get('readonly') or self.core.readonly
 
     def _getBuidCacheSize(self):
         '''
@@ -2756,6 +2756,9 @@ class Layer(s_nexus.Pusher):
 
         if self.growsize is not None:
             slabopts['growsize'] = self.growsize
+
+        if self.core.readonly:
+            slabopts['readonly'] = True
 
         await self._initSlabs(slabopts)
 

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -780,6 +780,9 @@ class Slab(s_base.Base):
     # warn if commit takes too long
     WARN_COMMIT_TIME_MS = int(float(os.environ.get('SYN_SLAB_COMMIT_WARN', '1.0')) * 1000)
 
+    # how often to refresh the read-only transaction to release the MVCC snapshot
+    READONLY_REFRESH_PERIOD = float(os.environ.get('SYN_SLAB_READONLY_REFRESH', '5.0'))
+
     DEFAULT_MAPSIZE = s_const.gibibyte
     DEFAULT_GROWSIZE = None
 
@@ -887,6 +890,7 @@ class Slab(s_base.Base):
         self.recovering = False
 
         opts.setdefault('max_dbs', 128)
+        opts.setdefault('max_readers', 256)
         opts.setdefault('writemap', True)
 
         self.maxsize = opts.pop('maxsize', None)
@@ -959,6 +963,8 @@ class Slab(s_base.Base):
 
         if not self.readonly:
             await Slab.initSyncLoop(self)
+        else:
+            self.schedCoro(self._ro_refresh_loop())
 
     def __repr__(self):
         return 'Slab: %r' % (self.path,)
@@ -1026,6 +1032,30 @@ class Slab(s_base.Base):
         self.txnrefcount -= 1
         if not self.txnrefcount:
             self._finiCoXact()
+
+    def _refresh_ro_xact(self):
+        '''Cycle the read-only transaction to release the MVCC snapshot.'''
+        if self.xact is None:
+            return
+
+        [scan.bump() for scan in self.scans]
+
+        self.xact.abort()
+        del self.xact
+        self.xact = None
+
+        try:
+            self._initCoXact()
+        except Exception:
+            logger.exception("Failed to refresh readonly transaction, shutting down slab")
+            self.schedCallSafe(self.fini)
+
+    async def _ro_refresh_loop(self):
+        '''Periodically refresh the read-only transaction.'''
+        while not self.isfini:
+            await self.waitfini(timeout=self.READONLY_REFRESH_PERIOD)
+            if not self.isfini:
+                self._refresh_ro_xact()
 
     def _saveOptsFile(self):
         if self.readonly:
@@ -1265,6 +1295,10 @@ class Slab(s_base.Base):
                 # This can only happen if readonly and another process added data (e.g. cortex spawn)
                 # _initCoXact knows the magic to resolve this
                 self._initCoXact()
+            except lmdb.NotFoundError:
+                if self.readonly:
+                    return None
+                raise
 
     def dropdb(self, name):
         '''

--- a/synapse/lib/multislabseqn.py
+++ b/synapse/lib/multislabseqn.py
@@ -33,12 +33,14 @@ class MultiSlabSeqn(s_base.Base):
                        dirn: str,
                        opts: Optional[Dict] = None,
                        slabopts: Optional[Dict] = None,
-                       cell=None):
+                       cell=None,
+                       readonly: bool = False):
         '''
         Args:
             dirn (str):  directory where to store the slabs
             opts (Optional[Dict]):  options for this multislab
             slabopts (Optional[Dict]):  options to pass through to the slab creation
+            readonly (bool):  open all slabs in readonly mode
 
         '''
 
@@ -47,12 +49,15 @@ class MultiSlabSeqn(s_base.Base):
         if opts is None:
             opts = {}
 
+        self.readonly = readonly
+
         self.offsevents: List[Tuple[int, int, asyncio.Event]] = []  # as a heap
         self._waitcounter = 0
 
         self.cell = cell
         self.dirn: str = dirn
-        s_common.gendir(self.dirn)
+        if not readonly:
+            s_common.gendir(self.dirn)
         self.slabopts: Dict[str, Any] = {} if slabopts is None else slabopts
 
         # The last/current slab
@@ -135,7 +140,7 @@ class MultiSlabSeqn(s_base.Base):
                 if fnstartidx != lastidx + 1:
                     logger.debug(f'Multislab:  gap in indices at {fn}.  Previous last index is {lastidx}.')
 
-            async with await s_lmdbslab.Slab.anit(fn, **self.slabopts) as slab:
+            async with await s_lmdbslab.Slab.anit(fn, readonly=self.readonly, **self.slabopts) as slab:
                 self.firstindx = self._getFirstIndx(slab)
                 # We use the old name of the sequence to ease migration from the old system
                 seqn = slab.getSeqn('nexuslog')
@@ -176,9 +181,13 @@ class MultiSlabSeqn(s_base.Base):
         self.tailslab, self.tailseqn = await self._makeSlab(indx)
 
         if not self.tailslab.dbexists('info'):
-            self._setFirstIndx(self.tailslab, self.firstindx)
-            self.tailseqn.indx = indx
-            self._ranges.append(indx)
+            if self.readonly:
+                self.tailseqn.indx = indx
+                self._ranges.append(indx)
+            else:
+                self._setFirstIndx(self.tailslab, self.firstindx)
+                self.tailseqn.indx = indx
+                self._ranges.append(indx)
 
         return indx
 
@@ -282,7 +291,7 @@ class MultiSlabSeqn(s_base.Base):
 
             fn = self.slabFilename(self.dirn, startidx)
 
-            slab = await s_lmdbslab.Slab.anit(fn, **self.slabopts)
+            slab = await s_lmdbslab.Slab.anit(fn, readonly=self.readonly, **self.slabopts)
             if self.cell is not None:
                 slab.addResizeCallback(self.cell.checkFreeSpace)
 

--- a/synapse/lib/nexus.py
+++ b/synapse/lib/nexus.py
@@ -122,7 +122,7 @@ class NexsRoot(s_base.Base):
 
         logpath = s_common.genpath(self.dirn, 'slabs', 'nexuslog')
 
-        self.nexsslab = await cell._initSlabFile(path)
+        self.nexsslab = await cell._initSlabFile(path, readonly=cell.readonly)
 
         self.nexshot = await self.nexsslab.getHotCount('nexs:indx')
 
@@ -136,14 +136,15 @@ class NexsRoot(s_base.Base):
         elif vers != 2:
             raise s_exc.BadStorageVersion(mesg=f'Got nexus log version {vers}.  Expected 2.  Accidental downgrade?')
 
-        self.nexslog = await s_multislabseqn.MultiSlabSeqn.anit(logpath, cell=cell)
+        self.nexslog = await s_multislabseqn.MultiSlabSeqn.anit(logpath, cell=cell, readonly=cell.readonly)
 
         # just in case were previously configured differently
         logindx = self.nexslog.index()
         hotindx = self.nexshot.get('nexs:indx')
         maxindx = max(logindx, hotindx)
 
-        self.nexshot.set('nexs:indx', maxindx)
+        if not cell.readonly:
+            self.nexshot.set('nexs:indx', maxindx)
         self.nexslog.setIndex(maxindx)
 
         async def fini():
@@ -281,6 +282,9 @@ class NexsRoot(s_base.Base):
             replaying the last action that (might have) already happened is harmless.
         '''
         if not self.donexslog:  # pragma: no cover
+            return
+
+        if self.cell.readonly:
             return
 
         indxitem = await self.nexslog.last()

--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -633,6 +633,10 @@ class Node:
 
         '''
 
+        if self.snap.readonly:
+            mesg = 'The snapshot is in read-only mode.'
+            raise s_exc.IsReadOnly(mesg=mesg)
+
         formname, formvalu = self.ndef
 
         if self.form.isrunt:

--- a/synapse/lib/queryrouter.py
+++ b/synapse/lib/queryrouter.py
@@ -1,0 +1,203 @@
+import re
+import asyncio
+import logging
+
+import synapse.exc as s_exc
+import synapse.telepath as s_telepath
+
+logger = logging.getLogger(__name__)
+
+# Storm operations that mutate data
+_write_commands = frozenset((
+    'auth.user.add', 'auth.user.del', 'auth.role.add', 'auth.role.del',
+    'auth.user.grant', 'auth.user.revoke', 'auth.user.addrule', 'auth.user.delrule',
+    'auth.role.addrule', 'auth.role.delrule',
+    'cron.add', 'cron.del', 'cron.mod', 'cron.move', 'cron.enable', 'cron.disable',
+    'cron.cleanup',
+    'delnode',
+    'dmon.add', 'dmon.del',
+    'feed.ingest',
+    'graph.add', 'graph.del',
+    'layer.add', 'layer.del', 'layer.set', 'layer.pull.add', 'layer.push.add',
+    'macro.set', 'macro.del',
+    'merge',
+    'model.edge.set', 'model.edge.del',
+    'model.depr.lock', 'model.depr.unlock',
+    'movetag',
+    'pkg.load', 'pkg.del',
+    'queue.add', 'queue.del',
+    'service.add', 'service.del',
+    'trigger.add', 'trigger.del', 'trigger.mod', 'trigger.enable', 'trigger.disable',
+    'view.add', 'view.del', 'view.set', 'view.merge',
+))
+
+# Regex for Storm edit bracket syntax: [ inet:ipv4=1.2.3.4 ]
+# Must not match variable indexing like $x[0] or $lib.list()[0]
+_re_edit_bracket = re.compile(r'(?<![a-zA-Z0-9_\)\]])\[')
+
+# Regex for Storm commands that are write operations
+_re_write_cmd = re.compile(
+    r'\|\s*(' + '|'.join(re.escape(c) for c in sorted(_write_commands, key=len, reverse=True)) + r')\b'
+)
+
+# Storm keywords/patterns that indicate writes
+_re_write_patterns = re.compile(
+    r'\$node\.data\.set\b'
+    r'|\$node\.data\.pop\b'
+    r'|\$lib\.queue\.\w+\.put\b'
+    r'|->>\s*\w+'  # edge add via ->> syntax
+)
+
+
+def classify(text):
+    '''
+    Classify a Storm query as 'read' or 'write'.
+
+    Returns:
+        str: 'read' or 'write'
+    '''
+    stripped = _strip_comments(text)
+
+    if _re_edit_bracket.search(stripped):
+        return 'write'
+
+    if _re_write_cmd.search(stripped):
+        return 'write'
+
+    if _re_write_patterns.search(stripped):
+        return 'write'
+
+    return 'read'
+
+
+def _strip_comments(text):
+    '''Remove // line comments from Storm text.'''
+    return re.sub(r'//[^\n]*', '', text)
+
+
+class QueryRouter:
+    '''
+    Routes Storm queries to local Cortex or remote readers based on classification.
+    '''
+
+    def __init__(self, reader_urls):
+        self.reader_urls = list(reader_urls)
+        self._proxies = {}  # url -> proxy
+        self._healthy = list(reader_urls)
+        self._rr_index = 0
+
+        # Admission control
+        self._max_concurrent = 10
+        self._queue_timeout = 30.0
+        self._queue_depth = 100
+        self._pending = 0
+        self._rejected = 0
+        self._reader_semaphores = {url: asyncio.Semaphore(self._max_concurrent) for url in reader_urls}
+
+    async def fini(self):
+        for proxy in self._proxies.values():
+            await proxy.fini()
+        self._proxies.clear()
+        self._healthy.clear()
+
+    async def _getProxy(self, url):
+        proxy = self._proxies.get(url)
+        if proxy is not None and not proxy.isfini:
+            return proxy
+
+        try:
+            proxy = await s_telepath.openurl(url)
+            if proxy.isfini:
+                return None
+            self._proxies[url] = proxy
+            if url not in self._healthy:
+                self._healthy.append(url)
+            return proxy
+        except Exception:
+            logger.warning('Failed to connect to reader: %s', url)
+            self._proxies.pop(url, None)
+            if url in self._healthy:
+                self._healthy.remove(url)
+            return None
+
+    async def getReaderProxy(self):
+        '''Get a healthy reader proxy via round-robin. Returns None if none available.'''
+        if not self._healthy:
+            # Try reconnecting to all known URLs
+            for url in self.reader_urls:
+                if await self._getProxy(url) is not None:
+                    break
+
+        if not self._healthy:
+            return None
+
+        for _ in range(len(self._healthy)):
+            url = self._healthy[self._rr_index % len(self._healthy)]
+            self._rr_index += 1
+
+            proxy = await self._getProxy(url)
+            if proxy is not None:
+                return proxy
+
+        return None
+
+    async def route(self, text, opts=None):
+        '''
+        Route a query to the appropriate target.
+
+        Returns:
+            (proxy_or_none, is_local, reader_url_or_none)
+        '''
+        if classify(text) == 'write':
+            return (None, True, None)
+
+        if self._pending >= self._queue_depth:
+            self._rejected += 1
+            raise s_exc.SynErr(mesg='Query queue full, server busy')
+
+        proxy = await self.getReaderProxy()
+        if proxy is None:
+            return (None, True, None)
+
+        # Determine which URL this proxy belongs to
+        reader_url = None
+        for url, p in self._proxies.items():
+            if p is proxy:
+                reader_url = url
+                break
+
+        self._pending += 1
+
+        # Ensure semaphore exists for this reader
+        if reader_url not in self._reader_semaphores:
+            self._reader_semaphores[reader_url] = asyncio.Semaphore(self._max_concurrent)
+
+        sem = self._reader_semaphores[reader_url]
+        try:
+            await asyncio.wait_for(sem.acquire(), timeout=self._queue_timeout)
+        except asyncio.TimeoutError:
+            self._pending -= 1
+            self._rejected += 1
+            raise s_exc.SynErr(mesg='Query queue timeout waiting for reader capacity')
+
+        return (proxy, False, reader_url)
+
+    def release(self, reader_url):
+        '''Release admission control resources after a routed query completes.'''
+        self._pending = max(0, self._pending - 1)
+        sem = self._reader_semaphores.get(reader_url)
+        if sem is not None:
+            sem.release()
+
+    def get_stats(self):
+        '''Return admission control statistics.'''
+        per_reader = {}
+        for url, sem in self._reader_semaphores.items():
+            per_reader[url] = self._max_concurrent - sem._value
+        return {
+            'pending': self._pending,
+            'rejected': self._rejected,
+            'max_concurrent': self._max_concurrent,
+            'queue_depth': self._queue_depth,
+            'per_reader_pending': per_reader,
+        }

--- a/synapse/lib/readermanager.py
+++ b/synapse/lib/readermanager.py
@@ -1,0 +1,106 @@
+import sys
+import socket
+import asyncio
+import logging
+import subprocess
+
+import synapse.telepath as s_telepath
+
+import synapse.lib.base as s_base
+
+logger = logging.getLogger(__name__)
+
+class ReaderManager(s_base.Base):
+
+    async def __anit__(self, datadir, count=2, base_port=27493, auth_anon='root'):
+
+        await s_base.Base.__anit__(self)
+
+        self.datadir = datadir
+        self.count = count
+        self.base_port = base_port
+        self.auth_anon = auth_anon
+
+        self.procs = {}  # port -> subprocess.Popen
+        self.onfini(self.stop)
+
+    async def start(self):
+        for i in range(self.count):
+            port = self.base_port + i
+            await self._spawn_reader(port)
+        self.schedCoro(self._health_loop())
+
+    async def _spawn_reader(self, port):
+        proc = subprocess.Popen([
+            sys.executable, '-m', 'synapse.servers.cortex',
+            self.datadir,
+            '--readonly',
+            '--auth-anon', self.auth_anon,
+            '--telepath', f'tcp://0.0.0.0:{port}/',
+            '--https', '0',
+        ])
+        self.procs[port] = proc
+        logger.info('Spawned reader cortex on port %d (pid %d)', port, proc.pid)
+        await self._wait_for_port(port)
+
+    async def _wait_for_port(self, port, timeout=60):
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while loop.time() < deadline:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(1)
+                sock.connect(('127.0.0.1', port))
+                sock.close()
+                logger.info('Reader on port %d is listening', port)
+                return
+            except OSError:
+                pass
+            finally:
+                sock.close()
+            await asyncio.sleep(0.5)
+        raise TimeoutError(f'Reader on port {port} did not start within {timeout}s')
+
+    def get_reader_urls(self):
+        return [
+            f'tcp://127.0.0.1:{port}/cortex'
+            for port, proc in self.procs.items()
+            if proc.poll() is None
+        ]
+
+    async def _health_loop(self):
+        while not self.isfini:
+            await asyncio.sleep(10)
+            for port in list(self.procs.keys()):
+                if not await self._check_reader(port):
+                    logger.warning('Reader on port %d failed health check, restarting', port)
+                    self._kill_proc(port)
+                    try:
+                        await self._spawn_reader(port)
+                    except Exception:
+                        logger.exception('Failed to respawn reader on port %d', port)
+
+    async def _check_reader(self, port):
+        try:
+            url = f'tcp://127.0.0.1:{port}/cortex'
+            async with await s_telepath.openurl(url) as prox:
+                await asyncio.wait_for(prox.getCellInfo(), timeout=5)
+            return True
+        except Exception:
+            return False
+
+    def _kill_proc(self, port):
+        proc = self.procs.pop(port, None)
+        if proc is None:
+            return
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    async def stop(self):
+        for port in list(self.procs.keys()):
+            self._kill_proc(port)

--- a/synapse/lib/router.py
+++ b/synapse/lib/router.py
@@ -1,0 +1,212 @@
+'''
+Thin router process — accepts TCP connections and passes fds to workers via SCM_RIGHTS.
+
+Synchronous (no asyncio). Uses epoll for multiplexing the listen socket
+and per-worker UDS control channels.
+'''
+import os
+import array
+import signal
+import select
+import socket
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Protocol bytes
+NEW_CONN = b'\x01'
+READY = b'\x52'
+
+
+def send_fd(uds_sock, conn_fd):
+    '''Send a file descriptor over a UDS socket via SCM_RIGHTS.'''
+    fds = array.array('i', [conn_fd])
+    uds_sock.sendmsg([NEW_CONN], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])
+
+
+def recv_fd(uds_sock):
+    '''Receive a file descriptor from a UDS socket. Returns fd or None.'''
+    try:
+        msg, ancdata, flags, addr = uds_sock.recvmsg(1, socket.CMSG_SPACE(4))
+    except (OSError, ConnectionError):
+        return None
+    for cmsg_level, cmsg_type, cmsg_data in ancdata:
+        if cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS:
+            fds = array.array('i')
+            fds.frombytes(cmsg_data[:4])
+            return fds[0]
+    return None
+
+
+class RouterProcess:
+    '''Synchronous router: accept on listen_fd, round-robin sendmsg to workers.'''
+
+    def __init__(self, listen_fd, worker_uds_fds):
+        self._listen_fd = listen_fd
+        self._worker_fds = dict(worker_uds_fds)  # {worker_id: uds_fd}
+        self._ready = set()
+        self._alive = set(self._worker_fds.keys())
+        self._rr_index = 0
+        self._stopping = False
+
+        # F-8 fix: Set all worker UDS fds non-blocking so a slow worker
+        # cannot stall the entire router's accept loop.
+        for fd in self._worker_fds.values():
+            os.set_inheritable(fd, False)
+            os.set_blocking(fd, False)
+
+    def router_main(self):
+        '''Entry point after fork. Blocks until shutdown.'''
+        os.setsid()
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+        signal.signal(signal.SIGHUP, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, self._handle_sigterm)
+        signal.signal(signal.SIGINT, self._handle_sigterm)
+
+        logger.info('Router pid %d: waiting for workers', os.getpid())
+        self._wait_for_workers()
+
+        if not self._ready:
+            logger.error('Router: no workers became ready, exiting')
+            return
+
+        logger.info('Router pid %d: entering accept loop (%d workers ready)',
+                     os.getpid(), len(self._ready))
+        self._accept_loop()
+        logger.info('Router pid %d: stopped', os.getpid())
+
+    def _wait_for_workers(self):
+        '''Block until all workers send READY or die.'''
+        ep = select.epoll()
+        pending = {}
+        for wid, fd in self._worker_fds.items():
+            ep.register(fd, select.EPOLLIN | select.EPOLLHUP)
+            pending[fd] = wid
+
+        while pending and not self._stopping:
+            try:
+                events = ep.poll(1.0)
+            except OSError:
+                break
+            for fd, event in events:
+                wid = pending.get(fd)
+                if wid is None:
+                    continue
+                if event & select.EPOLLHUP:
+                    self._alive.discard(wid)
+                    del pending[fd]
+                    continue
+                if event & select.EPOLLIN:
+                    try:
+                        data = os.read(fd, 1)
+                    except OSError:
+                        self._alive.discard(wid)
+                        del pending[fd]
+                        continue
+                    if data == READY:
+                        self._ready.add(wid)
+                        del pending[fd]
+                        logger.info('Router: worker %d ready', wid)
+
+        ep.close()
+
+    def _accept_loop(self):
+        '''epoll on listen_fd, accept, round-robin sendmsg to workers.'''
+        listen_sock = socket.socket(fileno=self._listen_fd)
+        listen_sock.setblocking(False)
+
+        ep = select.epoll()
+        ep.register(self._listen_fd, select.EPOLLIN)
+
+        # Also monitor worker UDS for HUP (dead workers)
+        for wid in list(self._alive):
+            fd = self._worker_fds[wid]
+            ep.register(fd, select.EPOLLHUP)
+
+        while not self._stopping:
+            pool = self._alive & self._ready
+            if not pool:
+                try:
+                    events = ep.poll(1.0)
+                except OSError:
+                    break
+                self._process_hup_events(events)
+                continue
+
+            try:
+                events = ep.poll(1.0)
+            except OSError:
+                break
+
+            for fd, event in events:
+                if fd == self._listen_fd and (event & select.EPOLLIN):
+                    self._do_accept(listen_sock)
+                else:
+                    self._check_hup(fd, event)
+
+        ep.close()
+        listen_sock.detach()
+
+    def _do_accept(self, listen_sock):
+        '''Accept and dispatch one connection.'''
+        try:
+            conn, addr = listen_sock.accept()
+        except (BlockingIOError, OSError):
+            return
+
+        conn_fd = conn.fileno()
+
+        # F-8 fix: Try round-robin workers; skip any whose UDS would block.
+        pool = sorted(self._alive & self._ready)
+        dispatched = False
+        for _ in range(len(pool)):
+            worker = self._next_worker()
+            if worker is None:
+                break
+            uds_fd = self._worker_fds[worker]
+            uds_sock = socket.socket(fileno=uds_fd)
+            try:
+                send_fd(uds_sock, conn_fd)
+                dispatched = True
+            except BlockingIOError:
+                logger.debug('Router: worker %d UDS full, skipping', worker)
+            except OSError:
+                logger.warning('Router: sendmsg to worker %d failed', worker)
+                self._alive.discard(worker)
+            finally:
+                uds_sock.detach()
+            if dispatched:
+                break
+
+        if not dispatched:
+            logger.warning('Router: no worker could accept connection, dropping')
+
+        conn.close()
+
+    def _next_worker(self):
+        '''Round-robin, skip dead workers.'''
+        pool = sorted(self._alive & self._ready)
+        if not pool:
+            return None
+        idx = self._rr_index % len(pool)
+        self._rr_index += 1
+        return pool[idx]
+
+    def _process_hup_events(self, events):
+        for fd, event in events:
+            self._check_hup(fd, event)
+
+    def _check_hup(self, fd, event):
+        if not (event & select.EPOLLHUP):
+            return
+        for wid, wfd in self._worker_fds.items():
+            if wfd == fd:
+                logger.warning('Router: worker %d UDS hung up', wid)
+                self._alive.discard(wid)
+                break
+
+    def _handle_sigterm(self, signum, frame):
+        self._stopping = True
+
+    def shutdown(self):
+        self._stopping = True

--- a/synapse/lib/version.py
+++ b/synapse/lib/version.py
@@ -223,6 +223,6 @@ def reqVersion(valu, reqver,
 ##############################################################################
 # The following are touched during the release process by bumpversion.
 # Do not modify these directly.
-version = (2, 241, 0)
+version = (2, 240, 1)
 verstring = '.'.join([str(x) for x in version])
 commit = ''

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -96,7 +96,7 @@ class View(s_nexus.Pusher):  # type: ignore
         self.dirn = s_common.gendir(core.dirn, 'views', self.iden)
 
         slabpath = s_common.genpath(self.dirn, 'viewstate.lmdb')
-        self.viewslab = await s_lmdbslab.Slab.anit(slabpath)
+        self.viewslab = await s_lmdbslab.Slab.anit(slabpath, readonly=core.readonly)
         self.viewslab.addResizeCallback(core.checkFreeSpace)
 
         self.trigqueue = self.viewslab.getSeqn('trigqueue')
@@ -1611,7 +1611,7 @@ class View(s_nexus.Pusher):  # type: ignore
 
     async def runTagAdd(self, node, tag, valu, useriden):
 
-        if self.core.safemode:
+        if self.core.migration or self.core.safemode:
             return
 
         # Run any trigger handlers
@@ -1619,21 +1619,21 @@ class View(s_nexus.Pusher):  # type: ignore
 
     async def runTagDel(self, node, tag, valu, useriden):
 
-        if self.core.safemode:
+        if self.core.migration or self.core.safemode:
             return
 
         await self.triggers.runTagDel(node, tag, useriden)
 
     async def runNodeAdd(self, node, useriden):
 
-        if self.core.safemode:
+        if self.core.migration or self.core.safemode:
             return
 
         await self.triggers.runNodeAdd(node, useriden)
 
     async def runNodeDel(self, node, useriden):
 
-        if self.core.safemode:
+        if self.core.migration or self.core.safemode:
             return
 
         await self.triggers.runNodeDel(node, useriden)
@@ -1642,21 +1642,21 @@ class View(s_nexus.Pusher):  # type: ignore
         '''
         Handle when a prop set trigger event fired
         '''
-        if self.core.safemode:
+        if self.core.migration or self.core.safemode:
             return
 
         await self.triggers.runPropSet(node, prop, oldv, useriden)
 
     async def runEdgeAdd(self, n1, edge, n2, useriden):
 
-        if self.core.safemode:
+        if self.core.migration or self.core.safemode:
             return
 
         await self.triggers.runEdgeAdd(n1, edge, n2, useriden)
 
     async def runEdgeDel(self, n1, edge, n2, useriden):
 
-        if self.core.safemode:
+        if self.core.migration or self.core.safemode:
             return
 
         await self.triggers.runEdgeDel(n1, edge, n2, useriden)

--- a/synapse/lib/worker.py
+++ b/synapse/lib/worker.py
@@ -1,0 +1,613 @@
+'''
+ReadOnlyWorker — forked read worker for the prefork Cortex architecture.
+
+After the parent Cortex initializes fully, it forks N workers that inherit
+the listening socket. Each worker re-opens LMDB in readonly mode, accepts
+client connections with EPOLLEXCLUSIVE, serves reads locally, and forwards
+writes to the writer process via msgpack RPC over a pre-connected socketpair.
+'''
+import os
+import re
+import time
+import select
+import socket
+import asyncio
+import logging
+
+import lmdb
+import msgpack
+
+import synapse.exc as s_exc
+import synapse.daemon as s_daemon
+import synapse.lib.link as s_link
+import synapse.lib.lmdbslab as s_lmdbslab
+import synapse.lib.msgpack as s_msgpack
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Query classification
+# ---------------------------------------------------------------------------
+
+_write_commands = frozenset((
+    'auth.user.add', 'auth.user.del', 'auth.role.add', 'auth.role.del',
+    'auth.user.grant', 'auth.user.revoke', 'auth.user.addrule', 'auth.user.delrule',
+    'auth.role.addrule', 'auth.role.delrule',
+    'cron.add', 'cron.del', 'cron.mod', 'cron.move', 'cron.enable', 'cron.disable',
+    'cron.cleanup',
+    'delnode',
+    'dmon.add', 'dmon.del',
+    'feed.ingest',
+    'graph.add', 'graph.del',
+    'layer.add', 'layer.del', 'layer.set', 'layer.pull.add', 'layer.push.add',
+    'macro.set', 'macro.del',
+    'merge',
+    'model.edge.set', 'model.edge.del',
+    'model.depr.lock', 'model.depr.unlock',
+    'movetag',
+    'pkg.load', 'pkg.del',
+    'queue.add', 'queue.del',
+    'service.add', 'service.del',
+    'trigger.add', 'trigger.del', 'trigger.mod', 'trigger.enable', 'trigger.disable',
+    'view.add', 'view.del', 'view.set', 'view.merge',
+))
+
+_re_edit_bracket = re.compile(r'(?<![a-zA-Z0-9_\)\]])\[')
+_re_write_cmd = re.compile(
+    r'\|\s*(' + '|'.join(re.escape(c) for c in sorted(_write_commands, key=len, reverse=True)) + r')\b'
+)
+_re_write_patterns = re.compile(
+    r'\$node\.data\.set\b'
+    r'|\$node\.data\.pop\b'
+    r'|\$lib\.queue\.\w+\.put\b'
+    r'|->>\s*\w+'
+)
+
+_re_comment = re.compile(r'//[^\n]*')
+
+
+def classify(text):
+    '''Classify a Storm query as 'read' or 'write'.'''
+    stripped = _re_comment.sub('', text)
+    if _re_edit_bracket.search(stripped):
+        return 'write'
+    if _re_write_cmd.search(stripped):
+        return 'write'
+    if _re_write_patterns.search(stripped):
+        return 'write'
+    return 'read'
+
+
+# ---------------------------------------------------------------------------
+# Worker entry point (called after fork)
+# ---------------------------------------------------------------------------
+
+def worker_main(control_fd, uds_path, datadir, cell=None, write_fd=None, dispatch_fd=None):
+    '''
+    Entry point for a forked read worker process.
+
+    Args:
+        control_fd: File descriptor of the UDS control channel from the router.
+        uds_path: Path to the writer's UDS endpoint (legacy, unused with write_fd).
+        datadir: Cortex data directory (for LMDB slab re-open).
+        cell: The inherited Cortex cell object (shared via dmon for telepath).
+        write_fd: File descriptor of the write channel socketpair to the writer.
+        dispatch_fd: File descriptor of the dispatch channel from the thick router.
+    '''
+    # Neutralize the inherited forkpool (stale threads/pipes after fork)
+    import synapse.lib.processpool as s_processpool
+    if getattr(s_processpool, 'forkpool', None) is not None:
+        s_processpool.forkpool.shutdown(wait=False)
+        s_processpool.forkpool = None
+
+    _reopen_lmdb_readonly(datadir)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    # Rebind all inherited Base objects to the worker's new event loop.
+    if cell is not None:
+        import gc
+        import synapse.lib.base as s_base
+        for obj in gc.get_objects():
+            if isinstance(obj, s_base.Base) and obj.anitted:
+                obj.loop = loop
+                obj.finievt = asyncio.Event()
+        cell.loop = loop
+
+    if dispatch_fd is not None:
+        # Thick router mode — run as pure worker (socketpair task receiver)
+        # pure_worker_main handles its own LMDB reopen and event loop
+        # so we skip the ReadOnlyWorker path entirely. But worker_main
+        # already reopened LMDB and created a loop above, so just use
+        # PureWorker directly on the existing loop.
+        worker = PureWorker(dispatch_fd, cell)
+        try:
+            loop.run_until_complete(worker.serve())
+        except KeyboardInterrupt:
+            pass
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+        return
+
+    worker = ReadOnlyWorker(control_fd, uds_path, cell=cell, write_fd=write_fd)
+    try:
+        loop.run_until_complete(worker.serve())
+    except KeyboardInterrupt:
+        pass
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+
+
+def _reopen_lmdb_readonly(datadir):
+    '''Re-open inherited LMDB slabs in readonly mode.'''
+    for slab in list(s_lmdbslab.Slab.allslabs.values()):
+        path = slab.path
+        try:
+            slab.lenv = lmdb.open(
+                str(path),
+                map_size=0,
+                max_dbs=128,
+                max_readers=256,
+                readonly=True,
+                create=False,
+                readahead=False,
+            )
+            slab.isfini = False
+            slab.readonly = True
+            slab.xact = None
+            slab.txnrefcount = 0
+
+            old_dbnames = dict(slab.dbnames)
+            slab.dbnames = {None: (None, False)}
+            for name, (db, dupsort) in old_dbnames.items():
+                if name is None:
+                    continue
+                try:
+                    newdb = slab.lenv.open_db(name.encode('utf8'), create=False, dupsort=dupsort)
+                    slab.dbnames[name] = (newdb, dupsort)
+                except Exception:
+                    logger.warning('Worker: failed to re-open db %s in slab %s', name, path)
+
+            logger.debug('Worker: re-opened slab %s readonly (%d dbs)', path, len(slab.dbnames) - 1)
+        except Exception:
+            logger.exception('Worker: failed to re-open slab %s', path)
+
+
+# ---------------------------------------------------------------------------
+# ReadOnlyWorker
+# ---------------------------------------------------------------------------
+
+_RECV_BUF = 65536
+_REQ_COUNTER = 0
+
+
+class ReadOnlyWorker:
+    '''
+    Forked read worker. Receives connection fds from the router via a UDS
+    control channel, serves Storm reads locally, and forwards writes to
+    the writer via msgpack RPC over a pre-connected socketpair.
+    '''
+
+    def __init__(self, control_fd, uds_path, cell=None, write_fd=None):
+        self._control_fd = control_fd
+        self._uds_path = uds_path
+        self._cell = cell
+        self._write_fd = write_fd
+        self._write_alive = write_fd is not None
+        self._dmon = None
+        self._stopping = False
+        self._pid = os.getpid()
+        # Demux state: single reader task dispatches to per-request queues
+        self._write_lock = None       # asyncio.Lock for serializing sends
+        self._write_ready = None      # asyncio.Event set when writer is ready
+        self._pending_reqs = {}       # {req_id: asyncio.Queue}
+        self._reader_task = None
+
+    async def serve(self):
+        '''Main worker loop. Receives fds from router via recvmsg on control channel.'''
+        loop = asyncio.get_running_loop()
+
+        if self._cell is not None:
+            self._install_write_forwarding()
+
+        if self._cell is not None:
+            self._dmon = await s_daemon.Daemon.anit()
+            parent_dmon = getattr(self._cell, 'dmon', None)
+            if parent_dmon is not None:
+                for name, item in parent_dmon.shared.items():
+                    self._dmon.share(name, self._cell)
+            else:
+                self._dmon.share('*', self._cell)
+
+        control_sock = socket.socket(fileno=self._control_fd)
+        control_sock.setblocking(False)
+
+        try:
+            control_sock.send(b'\x52')
+        except OSError:
+            logger.error('Worker %d: failed to send READY', self._pid)
+
+        logger.info('Worker %d: receiving connections via control channel', self._pid)
+
+        try:
+            while not self._stopping:
+                readable = await loop.run_in_executor(None, self._poll_control, control_sock)
+                if not readable:
+                    continue
+
+                fd = await loop.run_in_executor(None, self._recv_fd, control_sock)
+                if fd is None:
+                    if self._stopping:
+                        break
+                    logger.warning('Worker %d: control channel closed', self._pid)
+                    break
+
+                conn = socket.socket(fileno=fd)
+                conn.setblocking(False)
+                loop.create_task(self._handle_connection(conn, conn.getpeername()))
+        finally:
+            control_sock.detach()
+            if self._dmon is not None:
+                await self._dmon.fini()
+            if self._write_fd is not None:
+                try:
+                    os.close(self._write_fd)
+                except OSError:
+                    pass
+            logger.info('Worker %d: stopped', self._pid)
+
+    def _poll_control(self, control_sock):
+        '''Poll the control socket for readability (blocking, run in executor).'''
+        try:
+            r, _, _ = select.select([control_sock], [], [], 1.0)
+            return bool(r)
+        except (OSError, ValueError):
+            return False
+
+    def _recv_fd(self, control_sock):
+        '''Receive a file descriptor from the control channel.'''
+        from synapse.lib.router import recv_fd
+        return recv_fd(control_sock)
+
+    async def _handle_connection(self, conn, addr):
+        '''Handle a single client connection via the telepath dmon protocol.'''
+        if self._dmon is None:
+            conn.close()
+            return
+
+        reader, writer = await asyncio.open_connection(sock=conn)
+        link = await s_link.Link.anit(reader, writer)
+        link.schedCoro(self._dmon._onLinkInit(link))
+
+    # ------------------------------------------------------------------
+    # Write forwarding via socketpair RPC
+    # ------------------------------------------------------------------
+
+    def _install_write_forwarding(self):
+        '''Monkey-patch cell.storm() and cell.callStorm() to forward writes.
+
+        Strategy: execute all queries with readonly=True. If IsReadOnly
+        surfaces, forward to the writer via the write channel socketpair.
+        Regex classify() provides a fast-path for obvious writes.
+        '''
+        cell = self._cell
+        _orig_storm = cell.storm
+        _orig_callStorm = cell.callStorm
+        worker = self
+
+        # Start the demux reader and init the send lock
+        self._write_lock = asyncio.Lock()
+        self._write_ready = asyncio.Event()
+        if self._write_fd is not None:
+            self._reader_task = asyncio.get_running_loop().create_task(self._demux_reader())
+
+        def _refresh_all_ro_slabs():
+            for slab in s_lmdbslab.Slab.allslabs.values():
+                if slab.readonly:
+                    slab._refresh_ro_xact()
+
+        async def _patched_storm(text, opts=None):
+            _refresh_all_ro_slabs()
+            if classify(text) == 'write':
+                async for mesg in worker._forward_write_stream(text, opts):
+                    yield mesg
+                return
+
+            ropts = dict(opts) if opts else {}
+            ropts['readonly'] = True
+
+            async for mesg in _orig_storm(text, opts=ropts):
+                if mesg[0] == 'err' and mesg[1][0] == 'IsReadOnly':
+                    async for fmesg in worker._forward_write_stream(text, opts):
+                        yield fmesg
+                    return
+                yield mesg
+
+        async def _patched_callStorm(text, opts=None):
+            _refresh_all_ro_slabs()
+            if classify(text) == 'write':
+                return await worker._forward_callStorm(text, opts)
+
+            ropts = dict(opts) if opts else {}
+            ropts['readonly'] = True
+
+            try:
+                return await _orig_callStorm(text, opts=ropts)
+            except s_exc.IsReadOnly:
+                return await worker._forward_callStorm(text, opts)
+
+        cell.storm = _patched_storm
+        cell.callStorm = _patched_callStorm
+
+    async def _demux_reader(self):
+        '''Background task: read from write_fd and dispatch to per-request queues.'''
+        loop = asyncio.get_running_loop()
+
+        # Wait for the writer's ready byte before processing responses.
+        # The WriteChannelListener sends 0x01 on each writer-end fd once
+        # its epoll loop is registered and ready to receive requests.
+        try:
+            ready_byte = await asyncio.wait_for(
+                loop.run_in_executor(None, os.read, self._write_fd, 1),
+                timeout=60.0)
+            if not ready_byte:
+                logger.error('Worker %d: write channel closed before ready', self._pid)
+                self._write_alive = False
+                return
+            logger.info('Worker %d: write channel ready', self._pid)
+        except (OSError, asyncio.TimeoutError) as e:
+            logger.error('Worker %d: write channel ready wait failed: %s', self._pid, e)
+            self._write_alive = False
+            return
+
+        # Signal that writes can now be forwarded
+        self._write_ready.set()
+
+        unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+        while self._write_alive:
+            try:
+                data = await loop.run_in_executor(None, os.read, self._write_fd, _RECV_BUF)
+            except OSError:
+                break
+            if not data:
+                break
+            unpacker.feed(data)
+            for resp in unpacker:
+                req_id = resp[1]
+                q = self._pending_reqs.get(req_id)
+                if q is not None:
+                    q.put_nowait(resp)
+        # Channel dead — signal all waiters
+        self._write_alive = False
+        for q in self._pending_reqs.values():
+            q.put_nowait(None)
+
+    async def _send_write_rpc(self, req):
+        '''Send a write RPC request, serialized via lock.'''
+        # Wait for the writer to signal readiness (ready byte received)
+        if self._write_ready is not None and not self._write_ready.is_set():
+            try:
+                await asyncio.wait_for(self._write_ready.wait(), timeout=60.0)
+            except asyncio.TimeoutError:
+                raise s_exc.SynErr(mesg='Writer unavailable (write channel not ready)')
+
+        if not self._write_alive:
+            raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+
+        data = s_msgpack.en(req)
+        loop = asyncio.get_running_loop()
+        async with self._write_lock:
+            try:
+                await asyncio.wait_for(
+                    loop.run_in_executor(None, self._sendall, data),
+                    timeout=30.0)
+            except (OSError, BrokenPipeError, asyncio.TimeoutError):
+                self._write_alive = False
+                raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+
+    def _sendall(self, data):
+        '''Write all bytes to the write channel fd, handling partial writes.'''
+        mv = memoryview(data)
+        while mv:
+            sent = os.write(self._write_fd, mv)
+            mv = mv[sent:]
+
+    async def _forward_write_stream(self, text, opts):
+        '''Forward a storm query to the writer via socketpair, yielding messages.'''
+        global _REQ_COUNTER
+        _REQ_COUNTER += 1
+        req_id = _REQ_COUNTER
+
+        q = asyncio.Queue()
+        self._pending_reqs[req_id] = q
+        try:
+            await self._send_write_rpc(('storm', req_id, text, opts))
+            while True:
+                resp = await asyncio.wait_for(q.get(), timeout=30.0)
+                if resp is None:
+                    raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+                if resp[0] == 'msg':
+                    yield resp[2]
+                elif resp[0] == 'done':
+                    return
+                elif resp[0] == 'err':
+                    raise s_exc.SynErr(mesg=resp[2].get('mesg', 'Write forwarding error'))
+        except asyncio.TimeoutError:
+            raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+        finally:
+            self._pending_reqs.pop(req_id, None)
+
+    async def _forward_callStorm(self, text, opts):
+        '''Forward a callStorm to the writer, returning the result value.'''
+        global _REQ_COUNTER
+        _REQ_COUNTER += 1
+        req_id = _REQ_COUNTER
+
+        q = asyncio.Queue()
+        self._pending_reqs[req_id] = q
+        try:
+            await self._send_write_rpc(('callStorm', req_id, text, opts))
+            while True:
+                resp = await asyncio.wait_for(q.get(), timeout=30.0)
+                if resp is None:
+                    raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+                if resp[0] == 'result':
+                    return resp[2]
+                elif resp[0] == 'err':
+                    raise s_exc.SynErr(mesg=resp[2].get('mesg', 'Write forwarding error'))
+        except asyncio.TimeoutError:
+            raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+        finally:
+            self._pending_reqs.pop(req_id, None)
+
+    def shutdown(self):
+        '''Signal the worker to stop accepting new connections.'''
+        self._stopping = True
+        logger.info('Worker %d: shutdown requested', self._pid)
+
+
+# ---------------------------------------------------------------------------
+# Pure Worker — socketpair task receiver for thick router
+# ---------------------------------------------------------------------------
+
+_CANCEL_CHECK_INTERVAL = 64  # Check cancellation every N yielded messages
+
+
+def pure_worker_main(task_fd, datadir, cell):
+    '''
+    Entry point for a pure read worker (thick router mode).
+
+    Receives query tasks via socketpair, executes storm(), streams results
+    back. No Daemon, no connection handling, no write forwarding.
+
+    Args:
+        task_fd: File descriptor of the socketpair to the router.
+        datadir: Cortex data directory (for LMDB slab re-open).
+        cell: The inherited Cortex cell object.
+    '''
+    import synapse.lib.processpool as s_processpool
+    if getattr(s_processpool, 'forkpool', None) is not None:
+        s_processpool.forkpool.shutdown(wait=False)
+        s_processpool.forkpool = None
+
+    _reopen_lmdb_readonly(datadir)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    if cell is not None:
+        import gc
+        import synapse.lib.base as s_base
+        for obj in gc.get_objects():
+            if isinstance(obj, s_base.Base) and obj.anitted:
+                obj.loop = loop
+                obj.finievt = asyncio.Event()
+        cell.loop = loop
+
+    worker = PureWorker(task_fd, cell)
+    try:
+        loop.run_until_complete(worker.serve())
+    except KeyboardInterrupt:
+        pass
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+
+
+class PureWorker:
+    '''
+    Pure read worker for the thick router. Receives query tasks via
+    socketpair, executes cell.storm() directly, streams results back.
+    No Daemon, no connection handling, no write forwarding.
+    '''
+
+    def __init__(self, task_fd, cell):
+        self._task_fd = task_fd
+        self._cell = cell
+        self._pid = os.getpid()
+        self._cancelled = set()  # Set of cancelled req_ids
+
+    async def serve(self):
+        '''Main loop: read tasks from socketpair, execute, stream results.'''
+        loop = asyncio.get_running_loop()
+        unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+
+        # Signal ready to router
+        try:
+            os.write(self._task_fd, b'\x52')
+        except OSError:
+            logger.error('PureWorker %d: failed to send READY', self._pid)
+            return
+
+        logger.info('PureWorker %d: ready', self._pid)
+
+        while True:
+            try:
+                data = await loop.run_in_executor(None, os.read, self._task_fd, _RECV_BUF)
+            except OSError:
+                break
+            if not data:
+                break
+
+            unpacker.feed(data)
+            for msg in unpacker:
+                kind = msg[0]
+                if kind == 'storm':
+                    _, req_id, text, opts = msg
+                    loop.create_task(self._exec_storm(req_id, text, opts))
+                elif kind == 'cancel':
+                    _, req_id = msg
+                    self._cancelled.add(req_id)
+
+        logger.info('PureWorker %d: stopped', self._pid)
+
+    async def _exec_storm(self, req_id, text, opts):
+        '''Execute a storm query and stream results back to the router.'''
+        self._refresh_slabs()
+
+        ropts = dict(opts) if opts else {}
+        ropts['readonly'] = True
+
+        try:
+            count = 0
+            async for mesg in self._cell.storm(text, opts=ropts):
+                if req_id in self._cancelled:
+                    break
+                self._send(('msg', req_id, mesg))
+                count += 1
+                if count % _CANCEL_CHECK_INTERVAL == 0:
+                    await asyncio.sleep(0)  # Yield to process cancellations
+
+            if req_id in self._cancelled:
+                self._cancelled.discard(req_id)
+                self._send(('done', req_id))
+            else:
+                self._send(('done', req_id))
+
+        except s_exc.IsReadOnly:
+            self._send(('err', req_id, {'err': 'IsReadOnly'}))
+        except Exception as e:
+            logger.exception('PureWorker %d: storm error req=%s', self._pid, req_id)
+            self._send(('err', req_id, {'err': type(e).__name__, 'mesg': str(e)}))
+        finally:
+            self._cancelled.discard(req_id)
+
+    def _refresh_slabs(self):
+        '''Refresh all readonly LMDB transactions before each query.'''
+        for slab in s_lmdbslab.Slab.allslabs.values():
+            if slab.readonly:
+                slab._refresh_ro_xact()
+
+    def _send(self, msg):
+        '''Send a msgpack-encoded message to the router via socketpair.'''
+        data = s_msgpack.en(msg)
+        mv = memoryview(data)
+        while mv:
+            try:
+                sent = os.write(self._task_fd, mv)
+                mv = mv[sent:]
+            except OSError:
+                return

--- a/synapse/lib/writechannel.py
+++ b/synapse/lib/writechannel.py
@@ -1,0 +1,210 @@
+'''
+Write channel listener for the writer process.
+
+The writer process listens on per-worker write channel socketpairs via epoll.
+Workers send write requests (storm/callStorm) as msgpack-encoded tuples;
+the writer executes them against the cell and streams results back.
+
+Protocol (all messages are msgpack-encoded, self-delimiting on SOCK_STREAM):
+
+  Request:  ('storm', req_id, text, opts)
+  Response: ('msg', req_id, mesg) ...  (one per storm yield)
+            ('done', req_id)           (stream complete)
+            ('err', req_id, excinfo)   (on error)
+'''
+import os
+import select
+import asyncio
+import logging
+
+import msgpack
+
+import synapse.lib.msgpack as s_msgpack
+
+logger = logging.getLogger(__name__)
+
+# Read buffer size for recv() calls on the write channel socketpairs.
+_RECV_BUF = 65536
+
+
+class WriteChannelListener:
+    '''Epoll-based listener that receives write RPCs from worker socketpairs.
+
+    Args:
+        cell: The Cortex cell object (provides storm/callStorm methods).
+        writer_fds: List of writer-end file descriptors from the arbiter.
+    '''
+
+    def __init__(self, cell, writer_fds, send_ready=True):
+        self._cell = cell
+        self._writer_fds = list(writer_fds)
+        self._running = False
+        self._task = None
+        self._send_ready = send_ready
+
+    async def start(self):
+        '''Start the write channel listener as a background task.'''
+        self._running = True
+        self._task = asyncio.get_running_loop().create_task(self._listen())
+        logger.info('Write channel listener started with %d worker fds', len(self._writer_fds))
+
+    async def stop(self):
+        '''Stop the listener and close all writer-end fds.'''
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        for fd in self._writer_fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        logger.info('Write channel listener stopped')
+
+    async def _listen(self):
+        '''Main listener loop: epoll on all writer fds, dispatch requests.'''
+        loop = asyncio.get_running_loop()
+        ep = select.epoll()
+
+        # Per-fd msgpack unpacker for SOCK_STREAM framing
+        unpackers = {}
+        for fd in self._writer_fds:
+            ep.register(fd, select.EPOLLIN)
+            unpackers[fd] = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+
+        # Signal readiness to workers: send a single byte on each writer-end
+        # fd so the worker's _demux_reader knows the channel is ready.
+        if self._send_ready:
+            for fd in self._writer_fds:
+                try:
+                    os.write(fd, b'\x01')
+                except OSError as e:
+                    logger.warning('Failed to send ready byte on fd %d: %s', fd, e)
+
+        try:
+            while self._running:
+                # Poll in executor to avoid blocking the event loop
+                events = await loop.run_in_executor(None, ep.poll, 1.0)
+                for fd, event in events:
+                    if event & (select.EPOLLHUP | select.EPOLLERR):
+                        logger.warning('Write channel fd %d closed (worker died)', fd)
+                        ep.unregister(fd)
+                        unpackers.pop(fd, None)
+                        try:
+                            os.close(fd)
+                        except OSError:
+                            pass
+                        continue
+
+                    if event & select.EPOLLIN:
+                        try:
+                            data = os.read(fd, _RECV_BUF)
+                        except OSError:
+                            continue
+                        if not data:
+                            # EOF — worker closed its end
+                            logger.warning('Write channel fd %d EOF', fd)
+                            ep.unregister(fd)
+                            unpackers.pop(fd, None)
+                            try:
+                                os.close(fd)
+                            except OSError:
+                                pass
+                            continue
+
+                        unpacker = unpackers[fd]
+                        unpacker.feed(data)
+                        for msg in unpacker:
+                            # Dispatch each request as a concurrent task
+                            loop.create_task(self._handle_request(fd, msg))
+        except asyncio.CancelledError:
+            pass
+        finally:
+            ep.close()
+
+    async def _handle_request(self, fd, msg):
+        '''Handle a single write request and stream results back.
+
+        Args:
+            fd: The writer-end fd to send responses on.
+            msg: Decoded msgpack tuple: ('storm', req_id, text, opts)
+        '''
+        try:
+            kind = msg[0]
+            req_id = msg[1]
+        except (IndexError, TypeError):
+            logger.error('Malformed write request on fd %d: %r', fd, msg)
+            return
+
+        if kind == 'storm':
+            await self._handle_storm(fd, req_id, msg)
+        elif kind == 'callStorm':
+            await self._handle_callStorm(fd, req_id, msg)
+        else:
+            logger.error('Unknown write request kind %r on fd %d', kind, fd)
+            await self._send(fd, ('err', req_id, {'mesg': f'Unknown request kind: {kind}'}))
+
+    async def _handle_storm(self, fd, req_id, msg):
+        '''Execute cell.storm() and stream results back to the worker.'''
+        try:
+            text = msg[2]
+            opts = msg[3] if len(msg) > 3 else None
+        except (IndexError, TypeError):
+            await self._send(fd, ('err', req_id, {'mesg': 'Malformed storm request'}))
+            return
+
+        try:
+            async for mesg in self._cell.storm(text, opts=opts):
+                await self._send(fd, ('msg', req_id, mesg))
+            await self._send(fd, ('done', req_id))
+        except Exception as e:
+            excinfo = {
+                'mesg': str(e),
+                'err': e.__class__.__name__,
+            }
+            await self._send(fd, ('err', req_id, excinfo))
+
+    async def _handle_callStorm(self, fd, req_id, msg):
+        '''Execute cell.callStorm() and return the result to the worker.'''
+        try:
+            text = msg[2]
+            opts = msg[3] if len(msg) > 3 else None
+        except (IndexError, TypeError):
+            await self._send(fd, ('err', req_id, {'mesg': 'Malformed callStorm request'}))
+            return
+
+        try:
+            result = await self._cell.callStorm(text, opts=opts)
+            await self._send(fd, ('result', req_id, result))
+        except Exception as e:
+            excinfo = {
+                'mesg': str(e),
+                'err': e.__class__.__name__,
+            }
+            await self._send(fd, ('err', req_id, excinfo))
+
+    async def _send(self, fd, msg):
+        '''Send a msgpack-encoded message on the given fd.
+
+        Runs the write in an executor to avoid blocking the event loop
+        when the socket buffer is full. Handles partial writes on
+        SOCK_STREAM socketpairs by looping until all bytes are sent.
+        '''
+        data = s_msgpack.en(msg)
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(None, _sendall, fd, data)
+        except OSError as e:
+            logger.warning('Write channel send failed on fd %d: %s', fd, e)
+
+
+def _sendall(fd, data):
+    '''Write all bytes to fd, handling partial writes (blocking, thread-safe).'''
+    mv = memoryview(data)
+    while mv:
+        sent = os.write(fd, mv)
+        mv = mv[sent:]

--- a/synapse/models/risk.py
+++ b/synapse/models/risk.py
@@ -250,8 +250,6 @@ class RiskModule(s_module.CoreModule):
                     'doc': 'The threat cluster uses the target node.'}),
                 (('risk:threat', 'uses', 'inet:service:platform'), {
                     'doc': 'The threat cluster uses the service platform.'}),
-                (('risk:threat', 'uses', 'inet:service:app'), {
-                    'doc': 'Deprecated. Please use the inet:service:platform form instead.', 'deprecated': True}),
                 (('risk:attack', 'targets', None), {
                     'doc': 'The attack targeted the target node.'}),
                 (('risk:attack', 'uses', None), {

--- a/synapse/servers/cortex.py
+++ b/synapse/servers/cortex.py
@@ -5,4 +5,4 @@ import asyncio
 import synapse.cortex as s_cortex
 
 if __name__ == '__main__':  # pragma: no cover
-    asyncio.run(s_cortex.Cortex.execmain(sys.argv[1:]))
+    s_cortex.Cortex.startmain(sys.argv[1:])

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -8109,9 +8109,6 @@ class CortexBasicTest(s_t_utils.SynTest):
 
                     self.true(await core01.isCellActive())
 
-                    # automation tasks start concurrently with the migration
-                    self.nn(core01.view.trigtask)
-
                     emesg = 'Task cortex:migration:layers is protected.'
 
                     # cannot kill through exposed Storm APIs
@@ -8143,37 +8140,6 @@ class CortexBasicTest(s_t_utils.SynTest):
                     self.nn(rtask := core01.boss.get(task['iden']))
                     await rtask.kill(safe=False)
                     self.none(core01.boss.get(task['iden']))
-
-    async def test_cortex_automation_during_migration(self):
-
-        evnt = asyncio.Event()
-
-        async def dummy(self):
-            await evnt.wait()
-
-        with self.getTestDir() as dirn:
-
-            async with self.getTestCore(dirn=dirn) as core00:
-                tdef = {'cond': 'node:add', 'form': 'inet:fqdn', 'storm': '[test:str=triggered]'}
-                await core00.view.addTrigger(tdef)
-                await self.waitForActiveMigration(core00)
-
-            with patch('synapse.lib.modelrev.ModelRev.revCoreLayers', dummy):
-                conf01 = {'mirror': 'tcp://root:root@127.0.0.1:0'}
-                async with self.getTestCore(dirn=dirn, conf=conf01) as core01:
-
-                    await core01.promote(graceful=False)
-                    await asyncio.sleep(0)
-
-                    # trigger fires during migration (not silently dropped)
-                    await core01.nodes('[inet:fqdn=vertex.link]')
-                    self.len(1, await core01.nodes('test:str=triggered'))
-
-                    # trigger task is alive while migration is blocked
-                    self.nn(core01.view.trigtask)
-
-                    evnt.set()
-                    await self.waitForActiveMigration(core01)
 
     async def test_cortex_vaults(self):
         '''

--- a/synapse/tests/test_lib_trigger.py
+++ b/synapse/tests/test_lib_trigger.py
@@ -399,8 +399,8 @@ class TrigTest(s_t_utils.SynTest):
             self.nn(nodes[0].getTag('bar'))
             self.nn(nodes[0].getTag('faz'))
 
-            # triggers fire normally even when enterMigrationMode() is active
-            await core.nodes('[inet:fqdn=vertex.link +#foo]')
+            # coverage for migration mode
+            await core.nodes('[inet:fqdn=vertex.link +#foo]') # for additional migration mode trigger tests below
             async with core.enterMigrationMode():
                 await core.nodes('inet:fqdn=vertex.link [ +#bar -#foo ]')
 
@@ -813,7 +813,7 @@ class TrigTest(s_t_utils.SynTest):
             async with core.enterMigrationMode():
                 nodes = await core.nodes('[test:int=123 +(foo:beep:boop)> { [test:str=neato] }]')
                 self.len(1, nodes)
-                self.isin('foo', nodes[0].tags)
+                self.notin('foo', nodes[0].tags)
 
             nodes = await core.nodes('[test:int=123 +(foo:bar:baz)> { [test:str=neato] }]')
             self.len(1, nodes)
@@ -873,7 +873,7 @@ class TrigTest(s_t_utils.SynTest):
             async with core.enterMigrationMode():
                 nodes = await core.nodes('test:int=123 | [ -(foo:beep:boop)> { test:str=neato } ]')
                 self.len(1, nodes)
-                self.isin('del.none', nodes[0].tags)
+                self.notin('del.none', nodes[0].tags)
 
             nodes = await core.nodes('test:int=123 | [ -(foo:bar:baz)> { test:str=neato } ]')
             self.len(1, nodes)

--- a/synapse/tests/test_tools_utils_changelog.py
+++ b/synapse/tests/test_tools_utils_changelog.py
@@ -294,7 +294,7 @@ Deprecated Properties
         with self.getTestDir() as dirn:
             cdir = s_common.gendir(s_common.genpath(dirn, 'changes'))
             outp = self.getTestOutp()
-            argv = ['gen', '--cdir', cdir, '--verbose', '--type', 'feat', 'I am a mighty feature!', '--disable-git-dir-check']
+            argv = ['gen', '--cdir', cdir, '--verbose', '--type', 'feat', 'I am a mighty feature!']
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             modl_dirn = s_common.gendir(s_common.genpath(dirn, 'model'))
@@ -318,7 +318,7 @@ Deprecated Properties
     async def test_changelog_model_save_compare(self):
         with self.getTestDir() as dirn:
             outp = self.getTestOutp()
-            argv = ['model', '--cdir', dirn, '--save', '--disable-git-dir-check']
+            argv = ['model', '--cdir', dirn, '--save',]
             self.eq(0, await s_t_changelog.main(argv, outp))
             modelrefs_dirn = s_common.genpath(dirn, 'modelrefs')
 
@@ -349,49 +349,49 @@ Deprecated Properties
     async def test_changelog_gen_format(self):
         with self.getTestDir() as dirn:
             outp = self.getTestOutp()
-            argv = ['gen', '--cdir', dirn, '--type', 'feat', '--pr', '1234', 'I am a feature.', '--disable-git-dir-check']
+            argv = ['gen', '--cdir', dirn, '--type', 'feat', '--pr', '1234', 'I am a feature.']
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             outp = self.getTestOutp()
-            argv = ['gen', '--cdir', dirn, '--type', 'feat', '--pr', '1230', 'I am a earlier feature.', '--disable-git-dir-check']
+            argv = ['gen', '--cdir', dirn, '--type', 'feat', '--pr', '1230', 'I am a earlier feature.']
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             outp.clear()
             desc = '''I am a bug which has quite a large amount of text in it. The amount of text will span across'''\
                 ''' multiple lines after being formatted by the changelog tool.'''
-            argv = ['gen', '--cdir', dirn, '--type', 'bug', desc, '--disable-git-dir-check']
+            argv = ['gen', '--cdir', dirn, '--type', 'bug', desc]
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             outp.clear()
             desc = 'I am a fancy note.'
-            argv = ['gen', '--cdir', dirn, '--type', 'note', desc, '--disable-git-dir-check']
+            argv = ['gen', '--cdir', dirn, '--type', 'note', desc]
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             outp.clear()
             desc = 'For widget maker has been deprecated in favor of the new acme corp laser cannons.'
-            argv = ['gen', '--cdir', dirn, '--type', 'deprecation', desc, '--disable-git-dir-check']
+            argv = ['gen', '--cdir', dirn, '--type', 'deprecation', desc,]
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             outp.clear()
             desc = 'Documented the lasers.'
-            argv = ['gen', '--cdir', dirn, '--type', 'doc', desc, '--disable-git-dir-check']
+            argv = ['gen', '--cdir', dirn, '--type', 'doc', desc]
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             outp.clear()
             desc = 'Migrated the widget storage to use acme lasers.'
-            argv = ['gen', '--cdir', dirn, '--type', 'migration', desc, '--disable-git-dir-check']
+            argv = ['gen', '--cdir', dirn, '--type', 'migration', desc]
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             outp.clear()
             desc = 'Added lasers to the sci model.'
-            argv = ['gen', '--cdir', dirn, '--type', 'model', desc, '--disable-git-dir-check']
+            argv = ['gen', '--cdir', dirn, '--type', 'model', desc]
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             with s_common.genfile(dirn, f'{s_common.guid()}.yaml') as fd:
                 fd.write(multiline_feature.encode())
 
             outp.clear()
-            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--no-prs-from-git', '--disable-git-dir-check']
+            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--no-prs-from-git']
             self.eq(0, await s_t_changelog.main(argv, outp))
 
             self.eq(str(outp).strip(), changelog_format_output.strip())
@@ -404,7 +404,7 @@ Deprecated Properties
             with s_common.genfile(fp) as fd:
                 fd.write('hello world'.encode())
 
-            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--disable-git-dir-check']
+            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03']
             self.eq(1, await s_t_changelog.main(argv, outp))
             outp.expect('Error running')
 
@@ -412,7 +412,7 @@ Deprecated Properties
                 fd.truncate(0)
                 fd.write(s_common.buid())
             outp.clear()
-            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--disable-git-dir-check']
+            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03']
             self.eq(1, await s_t_changelog.main(argv, outp))
             outp.expect('No files passed validation')
 
@@ -424,7 +424,7 @@ desc: |
 type: feat
 '''.encode())
             outp.clear()
-            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--no-prs-from-git', '--disable-git-dir-check']
+            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--no-prs-from-git']
             self.eq(1, await s_t_changelog.main(argv, outp))
             outp.expect('desc line 0 must start with "- "')
 
@@ -437,7 +437,7 @@ desc: |
 type: feat
             '''.encode())
             outp.clear()
-            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--no-prs-from-git', '--disable-git-dir-check']
+            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--no-prs-from-git']
             self.eq(1, await s_t_changelog.main(argv, outp))
             outp.expect('desc line 1 must start with "  "')
 
@@ -449,6 +449,6 @@ desc: |
 type: feat
             '''.encode())
             outp.clear()
-            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--no-prs-from-git', '--disable-git-dir-check']
+            argv = ['format', '--cdir', dirn, '--version', 'v0.1.22', '--date', '2025-10-03', '--no-prs-from-git']
             self.eq(1, await s_t_changelog.main(argv, outp))
             outp.expect('desc line 0 is too long, 79 > 79')


### PR DESCRIPTION
Add fork-based read scaling to the Synapse Cortex:
- Arbiter orchestrates fork lifecycle (workers, router, writer)
- Thin router accepts TCP connections, passes fds via SCM_RIGHTS
- Workers serve reads from readonly LMDB, forward writes via socketpair RPC
- Per-query LMDB transaction refresh for sub-second read-after-write consistency
- Write channel with streaming responses and request ID demuxing

Performance (c5.4xlarge, 8 workers):
- Read QPS: 283 -> 1,432 (5x)
- Read p50: 207ms -> 27ms (7.7x)
- Write p50: 1,146ms -> 163ms (7x)
- Soak (600s): 0 errors

Config: multi:process:core_pct: 50 (percentage of cores for multi-process system)