### PR TITLE
feat(multi-process): Add multi-process read scaling with thick router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ venv
 # Linter files
 .mypy_cache/
 
+
+# Dolt database files (added by bd init)
+.dolt/
+*.db

--- a/synapse/axon.py
+++ b/synapse/axon.py
@@ -811,8 +811,11 @@ class Axon(s_cell.Cell):
 
     async def initServiceStorage(self):  # type: ignore
 
-        path = s_common.gendir(self.dirn, 'axon.lmdb')
-        self.axonslab = await s_lmdbslab.Slab.anit(path)
+        if self.readonly:
+            path = s_common.genpath(self.dirn, 'axon.lmdb')
+        else:
+            path = s_common.gendir(self.dirn, 'axon.lmdb')
+        self.axonslab = await s_lmdbslab.Slab.anit(path, readonly=self.readonly)
         self.sizes = self.axonslab.initdb('sizes')
         self.onfini(self.axonslab.fini)
 
@@ -908,9 +911,12 @@ class Axon(s_cell.Cell):
 
         self.byterange = True
 
-        path = s_common.gendir(self.dirn, 'blob.lmdb')
+        if self.readonly:
+            path = s_common.genpath(self.dirn, 'blob.lmdb')
+        else:
+            path = s_common.gendir(self.dirn, 'blob.lmdb')
 
-        self.blobslab = await s_lmdbslab.Slab.anit(path)
+        self.blobslab = await s_lmdbslab.Slab.anit(path, readonly=self.readonly)
         self.blobs = self.blobslab.initdb('blobs')
         self.offsets = self.blobslab.initdb('offsets')
         self.metadata = self.blobslab.initdb('metadata')

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -1,6 +1,7 @@
 import os
 import copy
 import regex
+import socket
 import asyncio
 import logging
 import textwrap
@@ -47,6 +48,9 @@ import synapse.lib.jsonstor as s_jsonstor
 import synapse.lib.modelrev as s_modelrev
 import synapse.lib.stormsvc as s_stormsvc
 import synapse.lib.lmdbslab as s_lmdbslab
+import synapse.lib.arbiter as s_arbiter
+import synapse.lib.worker as s_worker
+
 
 import synapse.lib.crypto.rsa as s_rsa
 
@@ -906,6 +910,13 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             'description': 'An optional directory of CAs which are added to the TLS CA chain for Storm HTTP API calls.',
             'type': 'string',
         },
+        'multi:process:core_pct': {
+            'description': 'Percentage of available CPU cores to allocate for the multi-process system (workers + router + writer). 0=disabled (default), 50=half the cores. The arbiter subtracts 2 (router + writer) and allocates the rest as read-only workers.',
+            'type': 'integer',
+            'default': 0,
+            'minimum': 0,
+            'maximum': 100,
+        },
     }
 
     cellapi = CoreApi
@@ -925,9 +936,13 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         if self.inaugural:
             self.cellinfo.set('cortex:version', s_version.version)
 
+        if not self.readonly:
+            self.cellinfo.set('cortex:version', s_version.version)
+
         corevers = self.cellinfo.get('cortex:version')
-        s_version.reqVersion(corevers, reqver, exc=s_exc.BadStorageVersion,
-                             mesg='cortex version in storage is incompatible with running software')
+        if corevers is not None:
+            s_version.reqVersion(corevers, reqver, exc=s_exc.BadStorageVersion,
+                                 mesg='cortex version in storage is incompatible with running software')
 
         self.viewmeta = self.slab.initdb('view:meta')
 
@@ -969,6 +984,8 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         self.stormpool = None
         self.stormpoolurl = None
         self.stormpoolopts = None
+
+
 
         self.libroot = (None, {}, {})
         self.stormlibs = []
@@ -1716,6 +1733,22 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         role = await self.auth.getRoleByName('all')
         await role.addRule((True, ('layer', 'read')), gateiden=layriden)
 
+    def _lmdbReaderCheck(self):
+        '''Clear stale LMDB reader slots from crashed reader processes.'''
+        stale = 0
+        stale += self.slab.lenv.reader_check()
+        for layr in self.layers.values():
+            stale += layr.layrslab.lenv.reader_check()
+        if stale:
+            logger.info('Cleared %d stale LMDB reader slot(s)', stale)
+        return stale
+
+    async def _lmdbReaderCheckLoop(self):
+        while not self.isfini:
+            await self.waitfini(timeout=60)
+            if not self.isfini:
+                await s_coro.executor(self._lmdbReaderCheck)
+
     async def initServiceRuntime(self):
 
         # do any post-nexus initialization here...
@@ -1727,7 +1760,19 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         if not self.safemode:
             self.addActiveCoro(self.agenda.runloop)
 
+        self.addActiveCoro(self._lmdbReaderCheckLoop)
+
         await self._initStormSvcs()
+
+        self._forkinfo = None
+        pct = self.conf.get('multi:process:core_pct', 0)
+        # Backward compat: accept old key name with deprecation warning
+        if not pct:
+            pct = self.conf.get('multi:process:readers', 0)
+            if pct:
+                logger.warning('Config key "multi:process:readers" is deprecated. Use "multi:process:core_pct" instead.')
+        if pct and not self.readonly:
+            await self._initForkMode(pct)
 
         # share ourself via the cell dmon as "cortex"
         # for potential default remote use
@@ -1810,6 +1855,70 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         except Exception as e:  # pragma: no cover
             logger.exception(f'Error starting stormpool, it will not be available: {e}')
+
+    async def _initForkMode(self, pct):
+        '''Set up fork-mode config. Socket lookup and UDS listener happen later
+        in _prepareFork(), after initServiceNetwork has created the TCP listener.
+        '''
+        cores = os.cpu_count() or 1
+        count = max(1, int(cores * pct / 100))
+
+        self._forkinfo = {
+            'count': count,
+            'uds_path': os.path.join(self.dirn, 'worker.sock'),
+            'datadir': self.dirn,
+        }
+        logger.info('Fork mode: configured for %d worker(s)',
+                    count)
+
+    async def prepareFork(self):
+        '''Finalize fork setup after all init phases complete.
+
+        Starts the UDS listener and resolves the TCP listening socket fd.
+        Returns the fork info dict, or None if fork mode is not active.
+        '''
+        if self._forkinfo is None:
+            return None
+
+        # Start UDS endpoint for workers to forward writes
+        uds_path = self._forkinfo['uds_path']
+        await self.dmon.listen(f'unix://{uds_path}')
+        logger.info('Fork mode: UDS listener at %s', uds_path)
+
+        # Find the main TCP/SSL listening socket from the dmon
+        listen_sock = None
+        for server in self.dmon.listenservers:
+            for sock in server.sockets:
+                if sock.family in (socket.AF_INET, socket.AF_INET6):
+                    listen_sock = sock
+                    break
+            if listen_sock is not None:
+                break
+
+        if listen_sock is None:
+            logger.error('Fork mode: no TCP listening socket found, cannot fork')
+            self._forkinfo = None
+            return None
+
+        self._forkinfo['listen_fd'] = listen_sock.fileno()
+
+        # Create a separate listen socket for the thick router
+        thick_port = 27493
+        thick_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        thick_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        thick_sock.bind(('0.0.0.0', thick_port))
+        thick_sock.listen(128)
+        thick_sock.setblocking(False)
+        self._forkinfo['thick_listen_fd'] = thick_sock.fileno()
+        # Prevent GC from closing the socket
+        self._thick_listen_sock = thick_sock
+        logger.info('Fork mode: thick router listen socket on port %d', thick_port)
+
+        return self._forkinfo
+
+    def getForkInfo(self):
+        '''Return fork config dict if fork mode is active, else None.'''
+        return getattr(self, '_forkinfo', None)
 
     async def finiStormPool(self):
 
@@ -2393,7 +2502,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
     async def _initCoreQueues(self):
         path = os.path.join(self.dirn, 'slabs', 'queues.lmdb')
 
-        slab = await s_lmdbslab.Slab.anit(path)
+        slab = await s_lmdbslab.Slab.anit(path, readonly=self.readonly)
         self.onfini(slab.fini)
 
         self.multiqueue = await slab.getMultiQueue('cortex:queue', nexsroot=self.nexsroot)
@@ -2402,7 +2511,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
     async def _initStormGraphs(self):
         path = os.path.join(self.dirn, 'slabs', 'graphs.lmdb')
 
-        slab = await s_lmdbslab.Slab.anit(path)
+        slab = await s_lmdbslab.Slab.anit(path, readonly=self.readonly)
         self.onfini(slab.fini)
 
         self.pkggraphs = {}
@@ -4634,13 +4743,13 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
                 with open(idenpath, 'r') as fd:
                     existiden = fd.read()
 
-                if jsoniden != existiden:
+                if jsoniden != existiden and not self.readonly:
                     with open(idenpath, 'w') as fd:
                         fd.write(jsoniden)
 
             # Disable sysctl checks for embedded jsonstor server
             conf = {'cell:guid': jsoniden, 'health:sysctl:checks': False}
-            self.jsonstor = await s_jsonstor.JsonStorCell.anit(path, conf=conf, parent=self)
+            self.jsonstor = await s_jsonstor.JsonStorCell.anit(path, conf=conf, parent=self, readonly=self.readonly)
 
     async def getJsonObj(self, path):
         if self.jsonurl is not None:
@@ -4725,7 +4834,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             if cadir is not None:
                 conf['tls:ca:dir'] = cadir
 
-            self.axon = await s_axon.Axon.anit(path, conf=conf, parent=self)
+            self.axon = await s_axon.Axon.anit(path, conf=conf, parent=self, readonly=self.readonly)
             self.axoninfo = await self.axon.getCellInfo()
             self.axon.onfini(self.axready.clear)
             self.dynitems['axon'] = self.axon

--- a/synapse/daemon.py
+++ b/synapse/daemon.py
@@ -268,6 +268,7 @@ class Daemon(s_base.Base):
         info.update(opts)
 
         scheme = info.get('scheme')
+        sock = info.get('sock')
 
         if scheme == 'unix':
             path = info.get('path')
@@ -294,7 +295,7 @@ class Daemon(s_base.Base):
 
                 sslctx = self.certdir.getServerSSLContext(hostname=hostname, caname=caname)
 
-            server = await s_link.listen(host, port, self._onLinkInit, ssl=sslctx)
+            server = await s_link.listen(host, port, self._onLinkInit, ssl=sslctx, sock=sock)
 
         self.listenservers.append(server)
         ret = server.sockets[0].getsockname()
@@ -510,12 +511,40 @@ class Daemon(s_base.Base):
                 raise s_exc.NoSuchObj(name=name)
 
             sess = self.sessions.get(sidn)
-            if sess is None:
-                raise s_exc.NoSuchObj(name=name)
 
-            item = sess.getSessItem(name)
-            if item is None:
-                raise s_exc.NoSuchObj(name=name)
+            # If the session doesn't exist locally (e.g. pool connection
+            # landed on a different fork worker), create one on-the-fly
+            # using the shared item lookup — same as tele:syn would.
+            if sess is None:
+
+                # Re-use a session already created for this link to avoid
+                # accumulating one Sess per t2:init under sustained load.
+                sess = link.get('sess')
+                if sess is not None:
+                    item = sess.getSessItem(name)
+                    if item is None:
+                        raise s_exc.NoSuchObj(name=name)
+                else:
+                    item = await self._getSharedItem(name or '*')
+                    if item is None:
+                        raise s_exc.NoSuchObj(name=name)
+
+                    sess = await Sess.anit()
+
+                    async def sessfini():
+                        self.sessions.pop(sess.iden, None)
+
+                    sess.onfini(sessfini)
+                    link.onfini(sess.fini)
+                    self.sessions[sess.iden] = sess
+                    link.set('sess', sess)
+
+                    sess.setSessItem(name, item)
+
+            else:
+                item = sess.getSessItem(name)
+                if item is None:
+                    raise s_exc.NoSuchObj(name=name)
 
             s_scope.set('sess', sess)
             s_scope.set('link', link)

--- a/synapse/lib/arbiter.py
+++ b/synapse/lib/arbiter.py
@@ -1,0 +1,506 @@
+'''
+Fork orchestrator for multi-process Cortex read workers.
+
+The Arbiter forks N read-only worker processes after the Cortex has fully
+initialized.  Workers inherit the listening socket and accept connections
+directly (prefork model).  The parent retains the arbiter role: it detects
+crashed workers via SIGCHLD and respawns them, and performs orderly shutdown
+on SIGTERM.
+'''
+from __future__ import annotations
+
+import os
+import asyncio
+import signal
+import socket
+import logging
+import time
+from typing import Callable, Optional
+
+import synapse.lib.lmdbslab as s_lmdbslab
+
+logger = logging.getLogger(__name__)
+
+SHUTDOWN_GRACE = 5.0
+SHUTDOWN_POLL = 0.1
+MEMLOCK_JOIN_TIMEOUT = 5.0
+
+
+def _close_fd(fd: int) -> None:
+    '''Close a file descriptor, ignoring errors.'''
+    if fd >= 0:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+def _shutdown_forkpool() -> None:
+    '''Shut down the forkserver process pool before forking.'''
+    import synapse.lib.processpool as s_processpool
+    if getattr(s_processpool, 'forkpool', None) is not None:
+        s_processpool.forkpool.shutdown(wait=True)
+        s_processpool.forkpool = None
+        s_processpool.forkpool_sema = None
+        logger.info('Shut down forkserver pool before fork')
+
+
+def _stop_memlock_threads() -> None:
+    '''Signal all slab memlock threads to stop and wait for them to exit.'''
+    slabs_with_memlock = [
+        slab for slab in s_lmdbslab.Slab.allslabs.values()
+        if slab.memlocktask is not None
+    ]
+    if not slabs_with_memlock:
+        return
+
+    for slab in slabs_with_memlock:
+        slab.isfini = True
+        slab.resizeevent.set()
+
+    deadline = time.monotonic() + MEMLOCK_JOIN_TIMEOUT
+    for slab in slabs_with_memlock:
+        while not slab.memlocktask.done() and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        if not slab.memlocktask.done():
+            logger.warning('Memlock thread for %s did not exit in time', slab.path)
+        else:
+            logger.debug('Memlock thread for %s stopped', slab.path)
+
+
+def _close_all_slabs() -> None:
+    '''Close every open LMDB environment so children don't inherit parent mmaps.'''
+    for slab in list(s_lmdbslab.Slab.allslabs.values()):
+        try:
+            slab.lenv.close()
+        except Exception:
+            logger.warning('Failed to close slab %s pre-fork', slab.path, exc_info=True)
+
+
+class Arbiter:
+    '''Fork orchestrator and worker lifecycle manager.'''
+
+    def __init__(self) -> None:
+        self._listen_sock: Optional[socket.socket] = None
+        self._uds_path: Optional[str] = None
+        self._worker_pids: list[Optional[int]] = []
+        self._num_workers: int = 0
+        self._worker_main: Optional[Callable] = None
+        self._shutdown_flag: bool = False
+        self._pending_restarts: list[int] = []
+        self._pending_thick_router_restart: bool = False
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thick_router_pid: Optional[int] = None
+        self._write_channels: dict[int, tuple[int, int]] = {}
+        self._dispatch_channels: dict[int, tuple[int, int]] = {}
+        self._thick_writer_channel: Optional[tuple[int, int]] = None
+
+    def fork_workers(
+        self,
+        num_workers: int,
+        listen_sock: int,
+        uds_path: str,
+        worker_main: Callable,
+    ) -> list[int]:
+        '''
+        Fork *num_workers* read-only worker processes.
+
+        Must be called after Cortex init completes and the asyncio event loop
+        has been torn down (no running loop, no threads).
+
+        Returns:
+            List of PIDs of the forked workers.
+        '''
+        self._listen_sock = listen_sock
+        self._uds_path = uds_path
+        self._num_workers = num_workers
+        self._worker_main = worker_main
+
+        _shutdown_forkpool()
+        _stop_memlock_threads()
+        _close_all_slabs()
+
+        # Create per-worker write channel socketpairs
+        for i in range(num_workers):
+            worker_write, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._write_channels[i] = (worker_write.fileno(), writer_end.fileno())
+            worker_write.detach()
+            writer_end.detach()
+
+        # Create dispatch socketpairs (thick router → worker)
+        for i in range(num_workers):
+            router_end, worker_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._dispatch_channels[i] = (router_end.fileno(), worker_end.fileno())
+            router_end.detach()
+            worker_end.detach()
+
+        # Thick router → writer dispatch channel
+        router_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._thick_writer_channel = (router_end.fileno(), writer_end.fileno())
+        router_end.detach()
+        writer_end.detach()
+
+        self._install_parent_signals()
+
+        for i in range(num_workers):
+            self._fork_one(i)
+
+        logger.info('Forked %d workers: %s', num_workers, self._worker_pids)
+        return list(self._worker_pids)
+
+    def fork_thick_router(self, listen_fd: int) -> int:
+        '''
+        Fork the thick router process.
+
+        The thick router owns all client connections on listen_fd, classifies
+        queries, and dispatches reads to workers / writes to the writer via
+        dedicated dispatch socketpairs.
+
+        Returns:
+            PID of the thick router process.
+        '''
+        self._thick_listen_fd = listen_fd
+
+        dispatch_fds = {}
+        for wid, (router_fd, _) in self._dispatch_channels.items():
+            dispatch_fds[wid] = router_fd
+
+        writer_dispatch_fd = self._thick_writer_channel[0]
+
+        pid = os.fork()
+        if pid == 0:
+            # --- child (thick router) ---
+            try:
+                for wid, (_, worker_fd) in self._dispatch_channels.items():
+                    _close_fd(worker_fd)
+
+                _close_fd(self._thick_writer_channel[1])
+
+                for wid, (w_worker_fd, w_writer_fd) in self._write_channels.items():
+                    _close_fd(w_worker_fd)
+                    _close_fd(w_writer_fd)
+
+                _thick_router_main(listen_fd, dispatch_fds, writer_dispatch_fd)
+            except Exception:
+                logger.exception('Thick router process crashed')
+            finally:
+                os._exit(0)
+
+        # --- parent (arbiter) ---
+        self._thick_router_pid = pid
+        logger.info('Forked thick router (pid %d) on fd %d', pid, listen_fd)
+        return pid
+
+    def get_writer_fds(self) -> list[int]:
+        '''Return a list of writer-end write channel fds.'''
+        return [w_writer_fd for _, w_writer_fd in self._write_channels.values()
+                if w_writer_fd >= 0]
+
+    def get_thick_writer_fd(self) -> Optional[int]:
+        '''Return the writer-end fd of the thick router → writer dispatch channel.'''
+        if self._thick_writer_channel is None:
+            return None
+        return self._thick_writer_channel[1]
+
+    # ------------------------------------------------------------------
+    # internal fork helpers
+    # ------------------------------------------------------------------
+
+    def _fork_one(self, worker_id: int) -> None:
+        pid = os.fork()
+        if pid == 0:
+            try:
+                self._in_child(worker_id)
+            except Exception:
+                logger.exception('Worker %d crashed during init', os.getpid())
+            finally:
+                os._exit(1)
+
+        self._worker_pids.append(pid)
+        logger.info('Forked worker %d (pid %d)', worker_id, pid)
+
+    def _in_child(self, worker_id: int) -> None:
+        '''Run in the child process immediately after fork.'''
+        os.setsid()
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+        signal.signal(signal.SIGHUP, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+        # Close writer-end fds and other workers' write fds
+        for wid, (w_worker_fd, w_writer_fd) in self._write_channels.items():
+            _close_fd(w_writer_fd)
+            if wid != worker_id:
+                _close_fd(w_worker_fd)
+
+        # Close dispatch channel fds not belonging to this worker
+        for wid, (router_fd, worker_fd) in self._dispatch_channels.items():
+            _close_fd(router_fd)
+            if wid != worker_id:
+                _close_fd(worker_fd)
+
+        # Close thick writer channel fds (not needed in worker)
+        if self._thick_writer_channel is not None:
+            _close_fd(self._thick_writer_channel[0])
+            _close_fd(self._thick_writer_channel[1])
+
+        write_fd = self._write_channels[worker_id][0]
+        dispatch_fd = self._dispatch_channels[worker_id][1] if worker_id in self._dispatch_channels else None
+        self._worker_main(None, self._uds_path, worker_id,
+                          write_fd=write_fd, dispatch_fd=dispatch_fd)
+
+    # ------------------------------------------------------------------
+    # parent signal handlers
+    # ------------------------------------------------------------------
+
+    def _install_parent_signals(self) -> None:
+        signal.signal(signal.SIGCHLD, self._handle_sigchld)
+
+    def _handle_sigchld(self, signum, frame) -> None:
+        '''Reap only arbiter-managed children. Leave SpawnProcess children
+        for multiprocessing to handle.'''
+        # Check thick router
+        if self._thick_router_pid is not None:
+            try:
+                pid, status = os.waitpid(self._thick_router_pid, os.WNOHANG)
+                if pid != 0:
+                    if os.WIFSIGNALED(status):
+                        sig = os.WTERMSIG(status)
+                        logger.error('Thick router pid %d killed by signal %d', pid, sig)
+                    else:
+                        code = os.WEXITSTATUS(status)
+                        logger.error('Thick router pid %d exited with code %d', pid, code)
+                    self._thick_router_pid = None
+                    if not self._shutdown_flag:
+                        self._pending_thick_router_restart = True
+            except ChildProcessError:
+                pass
+
+        # Check each worker
+        for idx, wpid in enumerate(self._worker_pids):
+            if wpid is None:
+                continue
+            try:
+                pid, status = os.waitpid(wpid, os.WNOHANG)
+                if pid != 0:
+                    self._worker_pids[idx] = None
+                    if os.WIFSIGNALED(status):
+                        sig = os.WTERMSIG(status)
+                        logger.error('Worker pid %d killed by signal %d', pid, sig)
+                    else:
+                        code = os.WEXITSTATUS(status)
+                        logger.error('Worker pid %d exited with code %d', pid, code)
+                    if not self._shutdown_flag:
+                        self._pending_restarts.append(idx)
+            except ChildProcessError:
+                pass
+
+    def install_loop_signal_handler(self, loop: asyncio.AbstractEventLoop) -> None:
+        '''Install an async-safe SIGCHLD handler on the event loop.'''
+        self._loop = loop
+
+        def _on_sigchld():
+            self._handle_sigchld(signal.SIGCHLD, None)
+            self.process_pending_restarts()
+
+        loop.add_signal_handler(signal.SIGCHLD, _on_sigchld)
+
+    def process_pending_restarts(self) -> None:
+        '''Fork new workers for any slots that died.'''
+        if self._pending_thick_router_restart:
+            self._pending_thick_router_restart = False
+            logger.info('Respawning thick router...')
+            self.fork_thick_router(self._thick_listen_fd)
+        while self._pending_restarts:
+            idx = self._pending_restarts.pop(0)
+            self.restart_worker(idx)
+
+    # ------------------------------------------------------------------
+    # restart / shutdown
+    # ------------------------------------------------------------------
+
+    def restart_worker(self, idx: int) -> None:
+        '''Respawn the worker at slot *idx* with a fresh socketpair.'''
+        # Create a fresh write channel socketpair
+        worker_write, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._write_channels[idx] = (worker_write.fileno(), writer_end.fileno())
+        worker_write.detach()
+        writer_end.detach()
+
+        # Create a fresh dispatch channel socketpair
+        router_end, worker_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._dispatch_channels[idx] = (router_end.fileno(), worker_end.fileno())
+        router_end.detach()
+        worker_end.detach()
+
+        pid = os.fork()
+        if pid == 0:
+            try:
+                self._in_child(idx)
+            except Exception:
+                logger.exception('Worker %d crashed during init', os.getpid())
+            finally:
+                os._exit(1)
+
+        self._worker_pids[idx] = pid
+        logger.info('Respawned worker slot %d as pid %d', idx, pid)
+
+        self._restart_router()
+
+    def get_write_channel_fds(self) -> dict[int, int]:
+        '''Return {worker_id: writer_end_fd} for the writer process.'''
+        return {wid: wfd for wid, (_, wfd) in self._write_channels.items() if wfd >= 0}
+
+    def _restart_router(self) -> None:
+        '''Kill the old thick router and fork a new one with current dispatch channels.'''
+        if self._thick_router_pid is not None:
+            try:
+                os.kill(self._thick_router_pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                os.waitpid(self._thick_router_pid, os.WNOHANG)
+            except ChildProcessError:
+                pass
+            self._thick_router_pid = None
+            self.fork_thick_router(self._thick_listen_fd)
+
+    def shutdown(self) -> None:
+        '''Send SIGTERM to thick router first, then workers, wait with timeout, SIGKILL stragglers.'''
+        self._shutdown_flag = True
+
+        # Stop thick router first
+        if self._thick_router_pid is not None:
+            try:
+                os.kill(self._thick_router_pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                os.waitpid(self._thick_router_pid, 0)
+            except ChildProcessError:
+                pass
+            self._thick_router_pid = None
+
+        alive = [p for p in self._worker_pids if p is not None]
+        if not alive:
+            return
+
+        for pid in alive:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+
+        deadline = time.monotonic() + SHUTDOWN_GRACE
+        while time.monotonic() < deadline:
+            alive = [p for p in self._worker_pids if p is not None]
+            if not alive:
+                return
+            for pid in alive:
+                try:
+                    rpid, _ = os.waitpid(pid, os.WNOHANG)
+                    if rpid != 0:
+                        idx = self._worker_pids.index(pid)
+                        self._worker_pids[idx] = None
+                except ChildProcessError:
+                    idx = self._worker_pids.index(pid)
+                    self._worker_pids[idx] = None
+            time.sleep(SHUTDOWN_POLL)
+
+        for i, pid in enumerate(self._worker_pids):
+            if pid is None:
+                continue
+            logger.warning('Worker pid %d did not exit in time, sending SIGKILL', pid)
+            try:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+            except (ProcessLookupError, ChildProcessError):
+                pass
+            self._worker_pids[i] = None
+
+
+def _thick_router_main(listen_fd, worker_dispatch_fds, writer_dispatch_fd):
+    '''Entry point for the thick router child process.'''
+    import synapse.lib.thickrouter as s_thickrouter
+
+    async def _run():
+        import threading
+        import synapse.glob as s_glob
+        s_glob._glob_loop = asyncio.get_running_loop()
+        s_glob._glob_thrd = threading.current_thread()
+
+        print(f'[thick-router pid={os.getpid()}] Starting...', flush=True)
+        router = s_thickrouter.ThickRouter(
+            cell=None,
+            worker_fds=worker_dispatch_fds,
+            writer_fd=writer_dispatch_fd,
+        )
+        await router.start()
+        print(f'[thick-router pid={os.getpid()}] Daemon started', flush=True)
+
+        import socket as _socket
+        sock = _socket.socket(fileno=listen_fd)
+        sock.setblocking(False)
+        await router.listen(f'tcp://0.0.0.0', ssl=None, sock=sock)
+        print(f'[thick-router pid={os.getpid()}] Listening', flush=True)
+
+        stop_event = asyncio.Event()
+
+        def _on_term():
+            stop_event.set()
+
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGTERM, _on_term)
+        loop.add_signal_handler(signal.SIGINT, _on_term)
+
+        await stop_event.wait()
+        await router.stop()
+
+    asyncio.run(_run())
+
+
+def _reopen_writer_slabs():
+    '''Re-open LMDB environments in the writer process after fork.'''
+    import lmdb as _lmdb
+    for slab in list(s_lmdbslab.Slab.allslabs.values()):
+        path = slab.path
+        opts = {
+            'map_size': slab.mapsize,
+            'max_dbs': 128,
+            'max_readers': 256,
+            'writemap': True,
+            'readonly': slab.readonly,
+            'readahead': slab.readahead,
+            'map_async': True,
+        }
+        try:
+            slab.lenv = _lmdb.open(str(path), **opts)
+            slab.isfini = False
+            slab.lockdoneevent = asyncio.Event()
+            slab.lockdoneevent.set()
+
+            if not slab.readonly:
+                slab._initCoXact()
+
+            old_dbnames = dict(slab.dbnames)
+            slab.dbnames = {None: (None, False)}
+            for name, (db, dupsort) in old_dbnames.items():
+                if name is None:
+                    continue
+                try:
+                    if slab.readonly:
+                        newdb = slab.lenv.open_db(name.encode('utf8'), create=False, dupsort=dupsort)
+                    else:
+                        newdb = slab.lenv.open_db(name.encode('utf8'), txn=slab.xact, dupsort=dupsort)
+                    slab.dbnames[name] = (newdb, dupsort)
+                except Exception:
+                    logger.warning('Failed to re-open db %s in slab %s', name, path)
+
+            if not slab.readonly:
+                slab.dirty = True
+                slab.forcecommit()
+
+            logger.debug('Re-opened slab %s for writer (%d dbs)', path, len(slab.dbnames) - 1)
+        except Exception:
+            logger.exception('Failed to re-open slab %s for writer', path)

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -156,6 +156,8 @@ class Auth(s_nexus.Pusher):
 
         self.allrole = await self.getRoleByName('all')
         if self.allrole is None:
+            if slab.readonly:
+                raise s_exc.NeedConfValu(mesg='Auth not initialized. Boot in write mode first.')
             # initialize the role of which all users are a member
             guid = s_common.guid((seed, 'auth', 'role', 'all'))
             await self._addRole(guid, 'all')
@@ -164,12 +166,15 @@ class Auth(s_nexus.Pusher):
         # initialize an admin user named root
         self.rootuser = await self.getUserByName('root')
         if self.rootuser is None:
+            if slab.readonly:
+                raise s_exc.NeedConfValu(mesg='Auth not initialized. Boot in write mode first.')
             guid = s_common.guid((seed, 'auth', 'user', 'root'))
             await self._addUser(guid, 'root')
             self.rootuser = self.user(guid)
 
-        await self.rootuser.setAdmin(True, logged=False)
-        await self.rootuser.setLocked(False, logged=False)
+        if not slab.readonly:
+            await self.rootuser.setAdmin(True, logged=False)
+            await self.rootuser.setLocked(False, logged=False)
 
     def users(self):
         for useriden in self.useridenbyname.values():

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1220,6 +1220,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             'issuewait': 1
         }
 
+        self.readonly = readonly
+
         self.safemode = self.conf.req('safemode')
         if self.safemode:
             mesg = f'Booting {self.getCellType()} in safe-mode. Some functionality may be disabled.'
@@ -1337,7 +1339,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         self.optimizeddb = self.slab.initdb('cell:optimized')  # time -> optimization record
 
-        if self._save_optimized:
+        if self._save_optimized and not self.readonly:
             lkey = s_common.int64en(self._last_optimized['init']['time'])
             self.slab.put(lkey, s_msgpack.en(self._last_optimized), db=self.optimizeddb)
             self._save_optimized = False
@@ -1370,7 +1372,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             logger.error(mesg)
             raise s_exc.BadVersion(mesg=mesg, currver=self.VERSION, lastver=lastver)
 
-        self.cellinfo.set('cell:version', self.VERSION)
+        if not self.readonly:
+            self.cellinfo.set('cell:version', self.VERSION)
 
         # Check the synapse version didn't regress
         if (lastver := self.cellinfo.get('synapse:version')) is not None and s_version.version < lastver:
@@ -1378,7 +1381,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             logger.error(mesg)
             raise s_exc.BadVersion(mesg=mesg, currver=s_version.version, lastver=lastver)
 
-        self.cellinfo.set('synapse:version', s_version.version)
+        if not self.readonly:
+            self.cellinfo.set('synapse:version', s_version.version)
 
         self.nexsvers = self.cellinfo.get('nexus:version', (0, 0))
         self.nexspatches = ()
@@ -1390,7 +1394,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         self.auth = await self._initCellAuth()
 
         auth_passwd = self.conf.get('auth:passwd')
-        if auth_passwd is not None:
+        if auth_passwd is not None and not self.readonly:
             user = await self.auth.getUserByName('root')
 
             if not await user.tryPasswd(auth_passwd, nexs=False, enforce_policy=False):
@@ -1665,6 +1669,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         self._cellguidfd.close()
 
     def _getCellLock(self):
+        if self.readonly:
+            return
         cmd = fcntl.LOCK_EX | fcntl.LOCK_NB
         try:
             fcntl.lockf(self._cellguidfd, cmd)
@@ -1845,6 +1851,14 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
     async def _bumpCellVers(self, name, updates, nexs=True):
 
+        if self.readonly:
+            curv = self.cellvers.get(name, 0)
+            reqv = updates[-1][0]
+            if curv < reqv:
+                mesg = f'Storage requires migration ({name} v{curv} -> v{reqv}). Boot in write mode first.'
+                raise s_exc.NeedConfValu(mesg=mesg)
+            return
+
         if self.inaugural:
             await self.setCellVers(name, updates[-1][0], nexs=nexs)
             return
@@ -1993,10 +2007,16 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             (2, self._driveCellMigration),
         ), nexs=False)
 
-        path = s_common.gendir(self.dirn, 'slabs', 'drive.lmdb')
+        if self.readonly:
+            path = s_common.genpath(self.dirn, 'slabs', 'drive.lmdb')
+        else:
+            path = s_common.gendir(self.dirn, 'slabs', 'drive.lmdb')
         sockpath = s_common.genpath(self.sockdirn, 'drive')
 
-        if s_common.envbool('SYNDEV_CELL_DRIVE_NOSPAWN'):
+        if self.readonly:
+            self.drive_slab = await self._initSlabFile(path, readonly=True)
+            self.drive = await s_drive.Drive.anit(self.drive_slab, s_drive.CELLDRIVE)
+        elif s_common.envbool('SYNDEV_CELL_DRIVE_NOSPAWN'):
             self.drive_slab = await self._initSlabFile(path)
             self.drive = await s_drive.Drive.anit(self.drive_slab, s_drive.CELLDRIVE)
         else:
@@ -3726,7 +3746,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             _slab.initdb('hive')
             await _slab.fini()
 
-        self.slab = await self._initSlabFile(path)
+        self.slab = await self._initSlabFile(path, readonly=readonly)
 
     async def _initCellAuth(self):
 
@@ -4120,6 +4140,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                           help=f'The (optional) additional name to share the {name} as. This defaults to '
                                f'{telendef}, and may be also be overridden by the {telenvar} environment'
                                f' variable.')
+        pars.add_argument('--readonly', default=False, action='store_true',
+                          help='Start the cell in read-only mode.')
 
         if conf is not None:
             args = conf.getArgParseArgs()
@@ -4564,7 +4586,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         s_processpool._setPoolLogging(logconf)
 
         try:
-            cell = await cls.anit(opts.dirn, conf=conf)
+            cell = await cls.anit(opts.dirn, conf=conf, readonly=opts.readonly)
         except:
             logger.exception(f'Error starting cell at {opts.dirn}')
             raise
@@ -4620,6 +4642,374 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         cell = await cls.initFromArgv(argv, outp=outp)
 
         await cell.main()
+
+    @classmethod
+    def startmain(cls, argv, outp=None):
+        '''Sync entry point that supports the init → fork → serve lifecycle.
+
+        If the cell has fork mode enabled (getForkInfo() returns non-None),
+        the lifecycle is:
+
+        1. asyncio.run(init) — initialize the cell, event loop closes on return
+        2. os.fork() × N — fork read workers (no event loop running, safe to fork)
+        3. Writer: asyncio.run(serve) — new event loop for the writer process
+        4. Workers: each creates its own event loop via worker_main()
+
+        If fork mode is not enabled, falls back to the normal asyncio.run(execmain) path.
+        '''
+        # Fast path: check if fork mode could be active before doing the
+        # two-phase init.  Only Cortex with multi:process:readers > 0 uses it.
+        # For all other cells, use the original single-phase path.
+        #
+        # We probe the config to decide without initializing the cell twice.
+        # If the probe is inconclusive, we use the two-phase path and fall
+        # back to normal mode if prepareFork() returns None.
+        if not cls._mayFork(argv):
+            asyncio.run(cls.execmain(argv, outp=outp))
+            return
+
+        import synapse.lib.arbiter as s_arbiter
+        import synapse.lib.worker as s_worker
+
+        if outp is None:
+            outp = s_output.stdout
+
+        # Phase 1: Initialize the cell (event loop created and destroyed by asyncio.run)
+        cell_info = asyncio.run(cls._initForFork(argv, outp=outp))
+
+        cell = cell_info['cell']
+        fork_info = cell_info.get('fork_info')
+
+        if fork_info is None:
+            # prepareFork() returned None — fall back to normal serve.
+            # The cell is already initialized; just need to serve.
+            # Re-create listeners and active coros in a new event loop.
+            async def _fallback_serve():
+                # Same fixes as _writer_serve: rebind to new loop
+                cell.loop = asyncio.get_running_loop()
+                cell.isfini = False
+                cell.finievt = asyncio.Event()
+                cell.dmon.isfini = False
+                cell.dmon.finievt = asyncio.Event()
+                await cell._restoreAfterInitLoop()
+                await cell.main()
+            asyncio.run(_fallback_serve())
+            return
+
+        # Phase 2: Fork workers (no event loop running — safe to fork)
+        listen_fd = fork_info['listen_fd']
+        uds_path = fork_info['uds_path']
+        datadir = fork_info['datadir']
+        count = fork_info['count']
+
+        # E-1 fix: The init event loop is dead. Null out the stale loop
+        # reference so nothing accidentally uses it between phases.
+        cell.loop = None
+
+        def _worker_entry(control_fd, uds_path_arg, worker_id, write_fd=None, dispatch_fd=None):
+            s_worker.worker_main(control_fd, uds_path_arg, datadir, cell=cell,
+                                 write_fd=write_fd, dispatch_fd=dispatch_fd)
+
+        arbiter = s_arbiter.Arbiter()
+        arbiter.fork_workers(count, listen_fd, uds_path, _worker_entry)
+
+        # Fork thick router on separate port
+        thick_listen_fd = fork_info['thick_listen_fd']
+        arbiter.fork_thick_router(thick_listen_fd)
+
+        # Phase 3: Writer process creates a new event loop and serves
+        async def _writer_serve():
+
+            # E-1 fix: Rebind ALL Base objects to the new event loop.
+            # The init loop is dead; every Base created during init has a
+            # stale loop reference.
+            import gc
+            import threading
+            import synapse.glob as s_glob
+            new_loop = asyncio.get_running_loop()
+
+            # Reset the global loop reference so s_glob.iAmLoop() and
+            # s_glob.initloop() return the correct (new) loop.
+            s_glob._glob_loop = new_loop
+            s_glob._glob_thrd = threading.current_thread()
+
+            fini_count = 0
+            evt_count = 0
+            
+            for obj in gc.get_objects():
+                if isinstance(obj, s_base.Base) and obj.anitted:
+                    if obj.isfini:
+                        fini_count += 1
+                    obj.loop = new_loop
+                    obj.isfini = False
+                    obj.finievt = asyncio.Event()
+                    # E-6 fix: Recreate asyncio.Event attributes bound to the
+                    # dead init loop.  s_coro.Event subclasses asyncio.Event so
+                    # isinstance catches both.
+                    for attr in list(vars(obj)):
+                        if attr == 'finievt':
+                            continue
+                        val = getattr(obj, attr, None)
+                        if isinstance(val, asyncio.Event):
+                            if isinstance(val, s_coro.Event):
+                                setattr(obj, attr, s_coro.Event())
+                            else:
+                                setattr(obj, attr, asyncio.Event())
+                            evt_count += 1
+            cell.loop = new_loop
+            if fini_count:
+                logger.warning('E-1 fix: Reset isfini on %d Base objects', fini_count)
+            if evt_count:
+                logger.info('E-6 fix: Recreated %d asyncio.Event objects on new loop', evt_count)
+
+            # E-2 fix: Decrement the extra ref we added in _initForFork
+            # to prevent fini during asyncio.run() teardown.
+            cell._syn_refs -= 1
+
+            # Verify nexsroot state
+            if hasattr(cell, 'nexsroot') and cell.nexsroot is not None:
+                logger.info('Writer: nexsroot.isfini=%s nexsroot.readonly=%s',
+                           cell.nexsroot.isfini, cell.nexsroot.readonly)
+
+            # E-3 fix: Re-open LMDB slabs closed before fork.
+            s_arbiter._reopen_writer_slabs()
+
+            # E-4 fix: Re-open nexus log tail slab if it was fini'd during
+            # init loop teardown. The MultiSlabSeqn's tail slab may have been
+            # removed from allslabs if asyncio.run() teardown cancelled tasks
+            # that triggered its fini.
+            if hasattr(cell, 'nexsroot') and cell.nexsroot is not None:
+                nexslog = cell.nexsroot.nexslog
+                if nexslog is not None and nexslog.tailslab is not None:
+                    tailslab = nexslog.tailslab
+                    if tailslab.isfini or str(tailslab.path) not in s_lmdbslab.Slab.allslabs:
+                        import lmdb as _lmdb
+                        path = tailslab.path
+                        tailslab.isfini = False
+                        tailslab.lenv = _lmdb.open(str(path),
+                            map_size=tailslab.mapsize, max_dbs=128, max_readers=256,
+                            writemap=True, readonly=False, readahead=tailslab.readahead,
+                            map_async=True)
+                        tailslab._initCoXact()
+                        old_dbnames = dict(tailslab.dbnames)
+                        tailslab.dbnames = {None: (None, False)}
+                        for name, (db, dupsort) in old_dbnames.items():
+                            if name is None:
+                                continue
+                            try:
+                                newdb = tailslab.lenv.open_db(name.encode('utf8'), txn=tailslab.xact, dupsort=dupsort)
+                                tailslab.dbnames[name] = (newdb, dupsort)
+                            except Exception:
+                                pass
+                        tailslab.dirty = True
+                        tailslab.forcecommit()
+                        s_lmdbslab.Slab.allslabs[str(path)] = tailslab
+                        logger.info('E-4: Re-opened nexus log tail slab: %s', path)
+
+            # Verify all writable slabs have valid transactions
+            for slab in list(s_lmdbslab.Slab.allslabs.values()):
+                if not slab.readonly and slab.xact is None:
+                    logger.warning('Slab %s had xact=None after reopen, re-initializing', slab.path)
+                    slab._initCoXact()
+
+            # S-1 fix: Replace the raw signal.signal SIGCHLD handler with
+            # a loop-based handler so restarts happen from the event loop,
+            # not inside a signal handler (which is undefined behavior).
+            arbiter.install_loop_signal_handler(cell.loop)
+
+            # Clear stale server refs and UDS files from the init loop
+            cell.dmon.listenservers.clear()
+            for spath in (os.path.join(cell.dirn, 'sock'), uds_path):
+                try:
+                    os.unlink(spath)
+                except FileNotFoundError:
+                    pass
+
+            # Re-create the local unix socket
+            try:
+                await cell.dmon.listen(f'unix://{os.path.join(cell.dirn, "sock")}')
+            except OSError:
+                logger.warning('Failed to re-create local unix socket')
+
+            # F-1 fix: The router owns the listen socket now. Close our copy
+            # so the writer does NOT accept TCP connections directly.
+            os.close(listen_fd)
+
+            # Re-create the UDS listener for write forwarding
+            await cell.dmon.listen(f'unix://{uds_path}')
+
+            # Start the write channel listener for direct worker→writer RPC
+            writer_fds = arbiter.get_writer_fds()
+            thick_writer_fd = arbiter.get_thick_writer_fd()
+            if thick_writer_fd is not None:
+                writer_fds.append(thick_writer_fd)
+            if writer_fds:
+                import synapse.lib.writechannel as s_writechannel
+                wc_listener = s_writechannel.WriteChannelListener(cell, writer_fds)
+                await wc_listener.start()
+
+            # Re-fire active coros that were cancelled when the init loop closed
+            cell._fireActiveCoros()
+
+            # E-5 fix: Restart the Slab sync loop. The class-level synctask
+            # died with the init event loop; without it the writer never
+            # commits dirty transactions and workers cannot see new data.
+            s_lmdbslab.Slab.synctask = None
+            for slab in s_lmdbslab.Slab.allslabs.values():
+                if not slab.readonly:
+                    await s_lmdbslab.Slab.initSyncLoop(slab)
+                    break
+
+            await cell.main()
+
+        try:
+            asyncio.run(_writer_serve())
+        finally:
+            arbiter.shutdown()
+
+    @classmethod
+    def _mayFork(cls, argv):
+        '''Quick check whether this cell class might use fork mode.
+
+        Returns True only if the cell config has multi:process:readers > 0.
+        This avoids the two-phase init (which breaks the forkserver pool)
+        when fork mode isn't actually needed.
+        '''
+        if not hasattr(cls, 'prepareFork'):
+            return False
+
+        # Probe the cell.yaml in the data directory (first positional arg)
+        # to check if multi:process:readers is configured.
+        import yaml
+        dirn = None
+        for arg in argv:
+            if not arg.startswith('-'):
+                dirn = arg
+                break
+        if dirn is None:
+            return False
+
+        cellpath = os.path.join(dirn, 'cell.yaml')
+        try:
+            with open(cellpath) as f:
+                conf = yaml.safe_load(f) or {}
+            return conf.get('multi:process:core_pct', 0) > 0
+        except (OSError, yaml.YAMLError):
+            return False
+
+    @classmethod
+    async def _initForFork(cls, argv, outp=None):
+        '''Initialize the cell and return it with fork info.
+
+        The cell is fully initialized (storage, runtime, network) but
+        main() has not been called — no signal handlers, no waitfini.
+        '''
+        if outp is None:
+            outp = s_output.stdout
+
+        cell = await cls.initFromArgv(argv, outp=outp)
+
+        # prepareFork() finalizes fork setup (UDS listener, socket fd lookup)
+        # after all init phases (including network) have completed.
+        fork_info = None
+        if hasattr(cell, 'prepareFork'):
+            fork_info = await cell.prepareFork()
+
+        if fork_info is not None:
+            # Dup the listen fd so it survives event loop teardown.
+            fork_info['listen_fd'] = os.dup(fork_info['listen_fd'])
+
+        # Prevent the cell (and its children) from being fini'd during
+        # asyncio.run() teardown.
+        cell._syn_refs += 1
+
+        return {'cell': cell, 'fork_info': fork_info}
+
+    async def _restoreDmonListener(self, listen_fd):
+        '''Re-create the dmon TCP listener using an inherited socket fd.
+
+        Used after fork to re-attach the shared listening socket to the
+        writer's new event loop.
+        '''
+        sock = socket.socket(fileno=listen_fd)
+        sock.setblocking(False)
+
+        # Determine if SSL is needed from the dmon:listen config
+        turl = self._getDmonListen()
+        sslctx = None
+        if turl is not None:
+            info = s_telepath.chopurl(turl)
+            if info.get('scheme') == 'ssl':
+                caname = info.get('ca')
+                hostname = info.get('hostname', info.get('host'))
+                sslctx = self.dmon.certdir.getServerSSLContext(hostname=hostname, caname=caname)
+
+        is_tls = sslctx is not None
+
+        async def onconn(reader, writer):
+            info = {'tls': is_tls}
+            link = await s_link.Link.anit(reader, writer, info=info)
+            link.schedCoro(self.dmon._onLinkInit(link))
+
+        server = await asyncio.start_server(onconn, sock=sock, ssl=sslctx)
+        self.dmon.listenservers.append(server)
+
+    async def _restoreAfterInitLoop(self):
+        '''Restore cell state after the init event loop has been closed.
+
+        Re-creates dmon listeners and re-fires active coros in the new
+        event loop.  Called by startmain() when the two-phase lifecycle
+        is used (init loop → fork → serve loop).
+        '''
+        # Clear stale asyncio server refs from the init loop
+        self.dmon.listenservers.clear()
+
+        # Remove stale UDS files before re-binding
+        sockpath = os.path.join(self.dirn, 'sock')
+        try:
+            os.unlink(sockpath)
+        except FileNotFoundError:
+            pass
+
+        # Re-create the local unix socket listener
+        try:
+            await self.dmon.listen(f'unix://{sockpath}')
+        except OSError:
+            logger.warning('Failed to re-create local unix socket at %s', sockpath)
+
+        # Re-create the TCP/SSL listener from config
+        turl = self._getDmonListen()
+        if turl is not None:
+            self.sockaddr = await self.dmon.listen(turl)
+
+        # E-6 fix: Recreate asyncio.Event attributes on Base objects that are
+        # still bound to the dead init loop.
+        import gc
+        evt_count = 0
+        for obj in gc.get_objects():
+            if isinstance(obj, s_base.Base) and obj.anitted:
+                for attr in list(vars(obj)):
+                    if attr == 'finievt':
+                        continue
+                    val = getattr(obj, attr, None)
+                    if isinstance(val, asyncio.Event):
+                        if isinstance(val, s_coro.Event):
+                            setattr(obj, attr, s_coro.Event())
+                        else:
+                            setattr(obj, attr, asyncio.Event())
+                        evt_count += 1
+        if evt_count:
+            logger.info('E-6 fix: Recreated %d asyncio.Event objects on new loop', evt_count)
+
+        # Re-fire active coros that were cancelled when the init loop closed
+        self._fireActiveCoros()
+
+    def getForkInfo(self):
+        '''Return fork config if fork mode is active, else None.
+
+        Subclasses (e.g. Cortex) override this to return fork configuration.
+        '''
+        return None
 
     async def _getCellUser(self, link, mesg):
 

--- a/synapse/lib/layer.py
+++ b/synapse/lib/layer.py
@@ -1525,7 +1525,7 @@ class Layer(s_nexus.Pusher):
         self.activetasks = []
 
         # this must be last!
-        self.readonly = layrinfo.get('readonly')
+        self.readonly = layrinfo.get('readonly') or self.core.readonly
 
     def _getBuidCacheSize(self):
         '''
@@ -2756,6 +2756,9 @@ class Layer(s_nexus.Pusher):
 
         if self.growsize is not None:
             slabopts['growsize'] = self.growsize
+
+        if self.core.readonly:
+            slabopts['readonly'] = True
 
         await self._initSlabs(slabopts)
 

--- a/synapse/lib/link.py
+++ b/synapse/lib/link.py
@@ -368,9 +368,11 @@ async def connect(host, port, ssl=None, hostname=None, linkinfo=None, linkcls=Li
     reader, writer = await asyncio.open_connection(host, port, ssl=ssl, server_hostname=hostname)
     return await linkcls.anit(reader, writer, info=info)
 
-async def listen(host, port, onlink, ssl=None, linkcls=Link):
+async def listen(host, port, onlink, ssl=None, linkcls=Link, sock=None):
     '''
     Listen on the given host/port and fire onlink(<linkcls>).
+
+    If sock is provided, use it directly instead of binding host/port.
 
     Returns a server object that contains the listening sockets
     '''
@@ -381,5 +383,8 @@ async def listen(host, port, onlink, ssl=None, linkcls=Link):
         link = await linkcls.anit(reader, writer, info=info)
         link.schedCoro(onlink(link))
 
-    server = await asyncio.start_server(onconn, host=host, port=port, ssl=ssl)
+    if sock is not None:
+        server = await asyncio.start_server(onconn, sock=sock, ssl=ssl)
+    else:
+        server = await asyncio.start_server(onconn, host=host, port=port, ssl=ssl)
     return server

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -780,6 +780,9 @@ class Slab(s_base.Base):
     # warn if commit takes too long
     WARN_COMMIT_TIME_MS = int(float(os.environ.get('SYN_SLAB_COMMIT_WARN', '1.0')) * 1000)
 
+    # how often to refresh the read-only transaction to release the MVCC snapshot
+    READONLY_REFRESH_PERIOD = float(os.environ.get('SYN_SLAB_READONLY_REFRESH', '5.0'))
+
     DEFAULT_MAPSIZE = s_const.gibibyte
     DEFAULT_GROWSIZE = None
 
@@ -887,6 +890,7 @@ class Slab(s_base.Base):
         self.recovering = False
 
         opts.setdefault('max_dbs', 128)
+        opts.setdefault('max_readers', 256)
         opts.setdefault('writemap', True)
 
         self.maxsize = opts.pop('maxsize', None)
@@ -1026,6 +1030,23 @@ class Slab(s_base.Base):
         self.txnrefcount -= 1
         if not self.txnrefcount:
             self._finiCoXact()
+
+    def _refresh_ro_xact(self):
+        '''Cycle the read-only transaction to release the MVCC snapshot.'''
+        if self.xact is None:
+            return
+
+        [scan.bump() for scan in self.scans]
+
+        self.xact.abort()
+        del self.xact
+        self.xact = None
+
+        try:
+            self._initCoXact()
+        except Exception:
+            logger.exception("Failed to refresh readonly transaction, shutting down slab")
+            self.schedCallSafe(self.fini)
 
     def _saveOptsFile(self):
         if self.readonly:
@@ -1265,6 +1286,10 @@ class Slab(s_base.Base):
                 # This can only happen if readonly and another process added data (e.g. cortex spawn)
                 # _initCoXact knows the magic to resolve this
                 self._initCoXact()
+            except lmdb.NotFoundError:
+                if self.readonly:
+                    return None
+                raise
 
     def dropdb(self, name):
         '''

--- a/synapse/lib/multislabseqn.py
+++ b/synapse/lib/multislabseqn.py
@@ -33,12 +33,14 @@ class MultiSlabSeqn(s_base.Base):
                        dirn: str,
                        opts: Optional[Dict] = None,
                        slabopts: Optional[Dict] = None,
-                       cell=None):
+                       cell=None,
+                       readonly: bool = False):
         '''
         Args:
             dirn (str):  directory where to store the slabs
             opts (Optional[Dict]):  options for this multislab
             slabopts (Optional[Dict]):  options to pass through to the slab creation
+            readonly (bool):  open all slabs in readonly mode
 
         '''
 
@@ -47,12 +49,15 @@ class MultiSlabSeqn(s_base.Base):
         if opts is None:
             opts = {}
 
+        self.readonly = readonly
+
         self.offsevents: List[Tuple[int, int, asyncio.Event]] = []  # as a heap
         self._waitcounter = 0
 
         self.cell = cell
         self.dirn: str = dirn
-        s_common.gendir(self.dirn)
+        if not readonly:
+            s_common.gendir(self.dirn)
         self.slabopts: Dict[str, Any] = {} if slabopts is None else slabopts
 
         # The last/current slab
@@ -135,7 +140,7 @@ class MultiSlabSeqn(s_base.Base):
                 if fnstartidx != lastidx + 1:
                     logger.debug(f'Multislab:  gap in indices at {fn}.  Previous last index is {lastidx}.')
 
-            async with await s_lmdbslab.Slab.anit(fn, **self.slabopts) as slab:
+            async with await s_lmdbslab.Slab.anit(fn, readonly=self.readonly, **self.slabopts) as slab:
                 self.firstindx = self._getFirstIndx(slab)
                 # We use the old name of the sequence to ease migration from the old system
                 seqn = slab.getSeqn('nexuslog')
@@ -176,9 +181,13 @@ class MultiSlabSeqn(s_base.Base):
         self.tailslab, self.tailseqn = await self._makeSlab(indx)
 
         if not self.tailslab.dbexists('info'):
-            self._setFirstIndx(self.tailslab, self.firstindx)
-            self.tailseqn.indx = indx
-            self._ranges.append(indx)
+            if self.readonly:
+                self.tailseqn.indx = indx
+                self._ranges.append(indx)
+            else:
+                self._setFirstIndx(self.tailslab, self.firstindx)
+                self.tailseqn.indx = indx
+                self._ranges.append(indx)
 
         return indx
 
@@ -282,7 +291,7 @@ class MultiSlabSeqn(s_base.Base):
 
             fn = self.slabFilename(self.dirn, startidx)
 
-            slab = await s_lmdbslab.Slab.anit(fn, **self.slabopts)
+            slab = await s_lmdbslab.Slab.anit(fn, readonly=self.readonly, **self.slabopts)
             if self.cell is not None:
                 slab.addResizeCallback(self.cell.checkFreeSpace)
 

--- a/synapse/lib/nexus.py
+++ b/synapse/lib/nexus.py
@@ -122,7 +122,7 @@ class NexsRoot(s_base.Base):
 
         logpath = s_common.genpath(self.dirn, 'slabs', 'nexuslog')
 
-        self.nexsslab = await cell._initSlabFile(path)
+        self.nexsslab = await cell._initSlabFile(path, readonly=cell.readonly)
 
         self.nexshot = await self.nexsslab.getHotCount('nexs:indx')
 
@@ -136,14 +136,15 @@ class NexsRoot(s_base.Base):
         elif vers != 2:
             raise s_exc.BadStorageVersion(mesg=f'Got nexus log version {vers}.  Expected 2.  Accidental downgrade?')
 
-        self.nexslog = await s_multislabseqn.MultiSlabSeqn.anit(logpath, cell=cell)
+        self.nexslog = await s_multislabseqn.MultiSlabSeqn.anit(logpath, cell=cell, readonly=cell.readonly)
 
         # just in case were previously configured differently
         logindx = self.nexslog.index()
         hotindx = self.nexshot.get('nexs:indx')
         maxindx = max(logindx, hotindx)
 
-        self.nexshot.set('nexs:indx', maxindx)
+        if not cell.readonly:
+            self.nexshot.set('nexs:indx', maxindx)
         self.nexslog.setIndex(maxindx)
 
         async def fini():
@@ -281,6 +282,9 @@ class NexsRoot(s_base.Base):
             replaying the last action that (might have) already happened is harmless.
         '''
         if not self.donexslog:  # pragma: no cover
+            return
+
+        if self.cell.readonly:
             return
 
         indxitem = await self.nexslog.last()

--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -633,6 +633,10 @@ class Node:
 
         '''
 
+        if self.snap.readonly:
+            mesg = 'The snapshot is in read-only mode.'
+            raise s_exc.IsReadOnly(mesg=mesg)
+
         formname, formvalu = self.ndef
 
         if self.form.isrunt:

--- a/synapse/lib/queryrouter.py
+++ b/synapse/lib/queryrouter.py
@@ -1,0 +1,80 @@
+'''
+Storm query classifier for read/write routing.
+
+The regex-based classification approach is used because Storm's grammar makes
+static analysis expensive. Rather than parsing the full AST for every query,
+we use targeted regexes that match the known write patterns:
+
+1. Edit bracket syntax ``[ form=valu ]`` — the primary node-creation syntax.
+   The negative lookbehind avoids false positives from variable indexing ($x[0]).
+2. Pipe-to-command syntax ``| delnode``, ``| merge``, etc. — all known mutating
+   Storm commands are enumerated in _write_commands.
+3. Method call patterns — ``$node.data.set()``, edge-add syntax ``->>`` etc.
+
+This is intentionally conservative: unknown patterns default to 'read', and
+the worker will fall back to write-forwarding if an IsReadOnly error surfaces.
+'''
+import re
+
+_write_commands = frozenset((
+    'auth.user.add', 'auth.user.del', 'auth.role.add', 'auth.role.del',
+    'auth.user.grant', 'auth.user.revoke', 'auth.user.addrule', 'auth.user.delrule',
+    'auth.role.addrule', 'auth.role.delrule',
+    'cron.add', 'cron.del', 'cron.mod', 'cron.move', 'cron.enable', 'cron.disable',
+    'cron.cleanup',
+    'delnode',
+    'dmon.add', 'dmon.del',
+    'feed.ingest',
+    'graph.add', 'graph.del',
+    'layer.add', 'layer.del', 'layer.set', 'layer.pull.add', 'layer.push.add',
+    'macro.set', 'macro.del',
+    'merge',
+    'model.edge.set', 'model.edge.del',
+    'model.depr.lock', 'model.depr.unlock',
+    'movetag',
+    'pkg.load', 'pkg.del',
+    'queue.add', 'queue.del',
+    'service.add', 'service.del',
+    'trigger.add', 'trigger.del', 'trigger.mod', 'trigger.enable', 'trigger.disable',
+    'view.add', 'view.del', 'view.set', 'view.merge',
+))
+
+# Must not match variable indexing like $x[0] or $lib.list()[0]
+_re_edit_bracket = re.compile(r'(?<![a-zA-Z0-9_\)\]])\[')
+
+_re_write_cmd = re.compile(
+    r'\|\s*(' + '|'.join(re.escape(c) for c in sorted(_write_commands, key=len, reverse=True)) + r')\b'
+)
+
+_re_write_patterns = re.compile(
+    r'\$node\.data\.set\b'
+    r'|\$node\.data\.pop\b'
+    r'|\$lib\.queue\.\w+\.put\b'
+    r'|->>\s*\w+'
+)
+
+
+def classify(text):
+    '''
+    Classify a Storm query as 'read' or 'write'.
+
+    Returns:
+        str: 'read' or 'write'
+    '''
+    stripped = _strip_comments(text)
+
+    if _re_edit_bracket.search(stripped):
+        return 'write'
+
+    if _re_write_cmd.search(stripped):
+        return 'write'
+
+    if _re_write_patterns.search(stripped):
+        return 'write'
+
+    return 'read'
+
+
+def _strip_comments(text):
+    '''Remove // line comments from Storm text.'''
+    return re.sub(r'//[^\n]*', '', text)

--- a/synapse/lib/thickrouter.py
+++ b/synapse/lib/thickrouter.py
@@ -1,0 +1,460 @@
+'''
+Thick router process — owns all client telepath connections, classifies
+queries, and dispatches reads to workers / writes to the writer via
+socketpair RPC.
+
+Workers are pure readers: they receive ('storm', req_id, text, opts) and
+stream back ('msg', req_id, mesg) / ('done', req_id) / ('err', req_id, info).
+'''
+import os
+import asyncio
+import logging
+
+import msgpack
+
+import synapse.exc as s_exc
+import synapse.common as s_common
+import synapse.daemon as s_daemon
+import synapse.lib.link as s_link
+import synapse.lib.scope as s_scope
+import synapse.lib.msgpack as s_msgpack
+import synapse.lib.worker as s_worker
+
+logger = logging.getLogger(__name__)
+
+_RECV_BUF = 65536
+_REQ_COUNTER = 0
+
+
+class _HandshakeProxy:
+    '''Minimal proxy for telepath handshake when cell is None.
+
+    Exposes storm as an async generator so getShareInfo marks it genr=True,
+    which tells the client proxy to use GenrMethod (t2:genr protocol).
+    '''
+    async def storm(self, text, opts=None):
+        yield  # pragma: no cover
+
+    async def callStorm(self, text, opts=None):
+        return None  # pragma: no cover
+
+    async def getCellInfo(self):
+        return None  # pragma: no cover
+
+
+def _next_req_id():
+    global _REQ_COUNTER
+    _REQ_COUNTER += 1
+    return _REQ_COUNTER
+
+
+class ThickRouter:
+    '''Thick router: owns Daemon, classifies queries, dispatches via socketpair RPC.
+
+    Args:
+        cell: The Cortex cell object (for Daemon sharing).
+        worker_fds: dict {worker_id: fd} — socketpair endpoints to workers.
+        writer_fd: int — socketpair endpoint to the writer process.
+    '''
+
+    def __init__(self, cell, worker_fds, writer_fd):
+        self._cell = cell
+        self._worker_fds = dict(worker_fds)  # {wid: fd}
+        self._writer_fd = writer_fd
+        self._dmon = None
+        self._running = False
+
+        # Per-fd msgpack unpackers (SOCK_STREAM framing)
+        self._unpackers = {}
+        # Per-fd asyncio.Queue for demuxed responses: {fd: {req_id: Queue}}
+        self._pending = {}
+        # Reader tasks per fd
+        self._reader_tasks = {}
+        # Outstanding query count per worker for least-outstanding selection
+        self._outstanding = {}
+
+        for wid, fd in self._worker_fds.items():
+            self._unpackers[fd] = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+            self._pending[fd] = {}
+            self._outstanding[wid] = 0
+
+        self._unpackers[writer_fd] = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+        self._pending[writer_fd] = {}
+
+    async def start(self):
+        '''Initialize the Daemon and start reader tasks for all socketpairs.'''
+        self._running = True
+        loop = asyncio.get_running_loop()
+
+        # Start demux reader tasks for each worker fd
+        for wid, fd in self._worker_fds.items():
+            self._reader_tasks[fd] = loop.create_task(self._demux_reader(fd))
+
+        # Start demux reader for writer fd
+        self._reader_tasks[self._writer_fd] = loop.create_task(
+            self._demux_reader(self._writer_fd))
+
+        # Initialize Daemon and share a proxy placeholder.
+        # The thick router intercepts all t2:init messages via _onTaskV2Init,
+        # so the shared object is only needed for the tele:syn handshake.
+        self._dmon = await s_daemon.Daemon.anit()
+        proxy = self._cell if self._cell is not None else _HandshakeProxy()
+        self._dmon.share('*', proxy)
+
+        # When cell is None, override _getSharedItem so any share name
+        # resolves to the proxy (clients connect with e.g. /cortex).
+        if self._cell is None:
+            async def _getAnyShare(name):
+                return proxy
+            self._dmon._getSharedItem = _getAnyShare
+
+        # Override _onTaskV2Init with our dispatch logic
+        self._dmon.mesgfuncs['t2:init'] = self._onTaskV2Init
+
+        logger.info('ThickRouter started with %d workers', len(self._worker_fds))
+
+    async def listen(self, url, **opts):
+        '''Bind the Daemon to listen on the given URL.'''
+        return await self._dmon.listen(url, **opts)
+
+    async def stop(self):
+        '''Stop the thick router, cancel reader tasks, close fds.'''
+        self._running = False
+
+        for task in self._reader_tasks.values():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        if self._dmon is not None:
+            await self._dmon.fini()
+
+        for fd in self._worker_fds.values():
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            os.close(self._writer_fd)
+        except OSError:
+            pass
+
+        logger.info('ThickRouter stopped')
+
+    # ------------------------------------------------------------------
+    # Demux reader: reads from a socketpair fd and dispatches to queues
+    # ------------------------------------------------------------------
+
+    async def _demux_reader(self, fd):
+        '''Read msgpack messages from fd and route to per-request queues.'''
+        loop = asyncio.get_running_loop()
+        unpacker = self._unpackers[fd]
+
+        try:
+            while self._running:
+                try:
+                    data = await loop.run_in_executor(None, os.read, fd, _RECV_BUF)
+                except OSError:
+                    break
+                if not data:
+                    break
+                unpacker.feed(data)
+                for msg in unpacker:
+                    # Skip non-tuple messages (e.g. ready byte from PureWorker)
+                    if not isinstance(msg, (list, tuple)) or len(msg) < 2:
+                        continue
+                    req_id = msg[1]
+                    q = self._pending[fd].get(req_id)
+                    if q is not None:
+                        q.put_nowait(msg)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            # Signal all waiters on this fd
+            for q in self._pending[fd].values():
+                q.put_nowait(None)
+
+    # ------------------------------------------------------------------
+    # Worker selection: least outstanding queries
+    # ------------------------------------------------------------------
+
+    def _select_worker(self):
+        '''Select the worker with the fewest outstanding queries.'''
+        if not self._worker_fds:
+            return None
+        wid = min(self._outstanding, key=self._outstanding.get)
+        return wid
+
+    # ------------------------------------------------------------------
+    # Dispatch helpers
+    # ------------------------------------------------------------------
+
+    def _send(self, fd, msg):
+        '''Send a msgpack-encoded message on fd (blocking, full write).'''
+        data = s_msgpack.en(msg)
+        mv = memoryview(data)
+        while mv:
+            try:
+                sent = os.write(fd, mv)
+            except OSError as e:
+                logger.warning('ThickRouter: send failed on fd %d: %s', fd, e)
+                return False
+            mv = mv[sent:]
+        return True
+
+    async def _dispatch_storm(self, fd, text, opts):
+        '''Dispatch a storm query to fd and yield response messages.
+
+        Yields:
+            Each ('msg', req_id, mesg) payload as mesg.
+
+        Returns when ('done', req_id) is received.
+
+        Raises:
+            s_exc.SynErr on ('err', req_id, excinfo) or channel death.
+        '''
+        req_id = _next_req_id()
+        q = asyncio.Queue()
+        self._pending[fd][req_id] = q
+
+        try:
+            loop = asyncio.get_running_loop()
+            ok = await loop.run_in_executor(
+                None, self._send, fd, ('storm', req_id, text, opts))
+            if not ok:
+                raise s_exc.SynErr(mesg='Failed to dispatch to worker/writer')
+
+            while True:
+                resp = await q.get()
+                if resp is None:
+                    raise s_exc.SynErr(mesg='Worker/writer channel died')
+                kind = resp[0]
+                if kind == 'msg':
+                    yield resp[2]
+                elif kind == 'done':
+                    return
+                elif kind == 'err':
+                    excinfo = resp[2]
+                    raise _ExcInfo(excinfo)
+        finally:
+            self._pending[fd].pop(req_id, None)
+
+    # ------------------------------------------------------------------
+    # t2:init override — the core dispatch logic
+    # ------------------------------------------------------------------
+
+    async def _onTaskV2Init(self, link: s_link.Link, mesg):
+        '''Handle t2:init: classify, dispatch, relay results to client.'''
+        name = mesg[1].get('name')
+        sidn = mesg[1].get('sess')
+        todo = mesg[1].get('todo')
+
+        try:
+            if sidn is None or todo is None:
+                raise s_exc.NoSuchObj(name=name)
+
+            # Resolve session (same logic as Daemon._onTaskV2Init)
+            sess = self._dmon.sessions.get(sidn)
+            if sess is None:
+                sess = link.get('sess')
+                if sess is not None:
+                    item = sess.getSessItem(name)
+                    if item is None:
+                        raise s_exc.NoSuchObj(name=name)
+                else:
+                    item = await self._dmon._getSharedItem(name or '*')
+                    if item is None:
+                        raise s_exc.NoSuchObj(name=name)
+
+                    sess = await s_daemon.Sess.anit()
+
+                    async def sessfini():
+                        self._dmon.sessions.pop(sess.iden, None)
+
+                    sess.onfini(sessfini)
+                    link.onfini(sess.fini)
+                    self._dmon.sessions[sess.iden] = sess
+                    link.set('sess', sess)
+                    sess.setSessItem(name, item)
+            else:
+                item = sess.getSessItem(name)
+                if item is None:
+                    raise s_exc.NoSuchObj(name=name)
+
+            s_scope.set('sess', sess)
+            s_scope.set('link', link)
+
+            methname, args, kwargs = todo
+
+            # Intercept storm() and callStorm() for dispatch
+            if methname not in ('storm', 'callStorm'):
+                # Route non-storm methods to the writer (which has full telepath)
+                await self._dispatch_method_to_writer(link, methname, args, kwargs)
+                return
+
+            # Extract storm args: storm(text, opts=None)
+            text = args[0] if args else kwargs.get('text', '')
+            opts = kwargs.get('opts') or (args[1] if len(args) > 1 else None) or {}
+
+            # Propagate user/view context from session into opts
+            if 'user' not in opts:
+                user = getattr(sess, 'user', None)
+                if user is not None:
+                    opts = dict(opts)
+                    opts['user'] = user
+
+            await self._dispatch_and_relay(link, methname, text, opts)
+
+        except (asyncio.CancelledError, Exception) as e:
+            if not isinstance(e, asyncio.CancelledError):
+                logger.exception('ThickRouter: error on t2:init: %s',
+                                 s_common.trimText(repr(mesg), n=80))
+            if not link.isfini:
+                retn = s_common.retnexc(e)
+                await link.tx(('t2:fini', {'retn': retn}))
+
+    async def _dispatch_and_relay(self, link, methname, text, opts):
+        '''Classify, dispatch to worker or writer, relay streaming results.'''
+        classification = s_worker.classify(text)
+
+        if methname == 'callStorm':
+            # callStorm always goes to writer (it's a write operation)
+            await self._relay_callstorm_to_writer(link, text, opts)
+        elif classification == 'write':
+            await self._relay_to_writer(link, text, opts)
+        else:
+            await self._relay_to_worker(link, text, opts)
+
+    async def _relay_to_worker(self, link, text, opts):
+        '''Dispatch read query to a worker, relay results. Re-dispatch on IsReadOnly.'''
+        wid = self._select_worker()
+        if wid is None:
+            raise s_exc.SynErr(mesg='No workers available')
+
+        fd = self._worker_fds[wid]
+        self._outstanding[wid] += 1
+
+        try:
+            await link.tx(('t2:genr', {}))
+
+            async for mesg in self._dispatch_storm(fd, text, opts):
+                await link.tx(('t2:yield', {'retn': (True, mesg)}))
+
+            await link.tx(('t2:yield', {'retn': None}))
+
+        except _ExcInfo as e:
+            if e.excinfo.get('err') == 'IsReadOnly':
+                # Re-dispatch to writer (client never sees the failed attempt)
+                await self._relay_to_writer_continued(link, text, opts)
+            else:
+                # Forward error to client
+                retn = (False, (e.excinfo.get('err', 'SynErr'),
+                                {'mesg': e.excinfo.get('mesg', 'Worker error')}))
+                await link.tx(('t2:yield', {'retn': retn}))
+                await link.tx(('t2:yield', {'retn': None}))
+        finally:
+            self._outstanding[wid] -= 1
+
+    async def _relay_to_writer(self, link, text, opts):
+        '''Dispatch write query to the writer, relay results.'''
+        await link.tx(('t2:genr', {}))
+
+        try:
+            async for mesg in self._dispatch_storm(self._writer_fd, text, opts):
+                await link.tx(('t2:yield', {'retn': (True, mesg)}))
+
+            await link.tx(('t2:yield', {'retn': None}))
+
+        except _ExcInfo as e:
+            retn = (False, (e.excinfo.get('err', 'SynErr'),
+                            {'mesg': e.excinfo.get('mesg', 'Writer error')}))
+            await link.tx(('t2:yield', {'retn': retn}))
+            await link.tx(('t2:yield', {'retn': None}))
+
+    async def _relay_to_writer_continued(self, link, text, opts):
+        '''Re-dispatch to writer after IsReadOnly, continuing an already-started stream.'''
+        try:
+            async for mesg in self._dispatch_storm(self._writer_fd, text, opts):
+                await link.tx(('t2:yield', {'retn': (True, mesg)}))
+
+            await link.tx(('t2:yield', {'retn': None}))
+
+        except _ExcInfo as e:
+            retn = (False, (e.excinfo.get('err', 'SynErr'),
+                            {'mesg': e.excinfo.get('mesg', 'Writer error')}))
+            await link.tx(('t2:yield', {'retn': retn}))
+            await link.tx(('t2:yield', {'retn': None}))
+
+    async def _relay_callstorm_to_writer(self, link, text, opts):
+        '''Dispatch callStorm to the writer and return the result.'''
+        req_id = _next_req_id()
+        q = asyncio.Queue()
+        self._pending[self._writer_fd][req_id] = q
+
+        try:
+            loop = asyncio.get_running_loop()
+            ok = await loop.run_in_executor(
+                None, self._send, self._writer_fd,
+                ('callStorm', req_id, text, opts))
+            if not ok:
+                raise s_exc.SynErr(mesg='Failed to dispatch callStorm to writer')
+
+            resp = await q.get()
+            if resp is None:
+                raise s_exc.SynErr(mesg='Writer channel died during callStorm')
+
+            kind = resp[0]
+            if kind == 'result':
+                await link.tx(('t2:fini', {'retn': (True, resp[2])}))
+            elif kind == 'err':
+                excinfo = resp[2]
+                retn = (False, (excinfo.get('err', 'SynErr'),
+                                {'mesg': excinfo.get('mesg', 'Writer error')}))
+                await link.tx(('t2:fini', {'retn': retn}))
+            else:
+                raise s_exc.SynErr(mesg=f'Unexpected callStorm response: {kind}')
+
+        finally:
+            self._pending[self._writer_fd].pop(req_id, None)
+
+
+    async def _dispatch_method_to_writer(self, link, methname, args, kwargs):
+        '''Dispatch a non-storm method call to the writer and return the result.'''
+        req_id = _next_req_id()
+        q = asyncio.Queue()
+        self._pending[self._writer_fd][req_id] = q
+
+        try:
+            loop = asyncio.get_running_loop()
+            ok = await loop.run_in_executor(
+                None, self._send, self._writer_fd,
+                ('method', req_id, methname, args, kwargs))
+            if not ok:
+                raise s_exc.SynErr(mesg='Failed to dispatch method to writer')
+
+            resp = await q.get()
+            if resp is None:
+                raise s_exc.SynErr(mesg='Writer channel died during method call')
+
+            kind = resp[0]
+            if kind == 'result':
+                await link.tx(('t2:fini', {'retn': (True, resp[2])}))
+            elif kind == 'err':
+                excinfo = resp[2]
+                retn = (False, (excinfo.get('err', 'SynErr'),
+                                {'mesg': excinfo.get('mesg', 'Writer error')}))
+                await link.tx(('t2:fini', {'retn': retn}))
+            else:
+                raise s_exc.SynErr(mesg=f'Unexpected method response: {kind}')
+
+        finally:
+            self._pending[self._writer_fd].pop(req_id, None)
+
+
+class _ExcInfo(Exception):
+    '''Internal exception wrapping an error response from a worker/writer.'''
+    def __init__(self, excinfo):
+        self.excinfo = excinfo
+        super().__init__(excinfo.get('mesg', ''))

--- a/synapse/lib/view.py
+++ b/synapse/lib/view.py
@@ -96,7 +96,7 @@ class View(s_nexus.Pusher):  # type: ignore
         self.dirn = s_common.gendir(core.dirn, 'views', self.iden)
 
         slabpath = s_common.genpath(self.dirn, 'viewstate.lmdb')
-        self.viewslab = await s_lmdbslab.Slab.anit(slabpath)
+        self.viewslab = await s_lmdbslab.Slab.anit(slabpath, readonly=core.readonly)
         self.viewslab.addResizeCallback(core.checkFreeSpace)
 
         self.trigqueue = self.viewslab.getSeqn('trigqueue')

--- a/synapse/lib/worker.py
+++ b/synapse/lib/worker.py
@@ -1,0 +1,601 @@
+'''
+ReadOnlyWorker — forked read worker for the prefork Cortex architecture.
+
+After the parent Cortex initializes fully, it forks N workers that inherit
+the listening socket. Each worker re-opens LMDB in readonly mode, accepts
+client connections with EPOLLEXCLUSIVE, serves reads locally, and forwards
+writes to the writer process via msgpack RPC over a pre-connected socketpair.
+'''
+import os
+import re
+import time
+import select
+import socket
+import asyncio
+import logging
+
+import lmdb
+import msgpack
+
+import synapse.exc as s_exc
+import synapse.daemon as s_daemon
+import synapse.lib.link as s_link
+import synapse.lib.lmdbslab as s_lmdbslab
+import synapse.lib.msgpack as s_msgpack
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Query classification
+# ---------------------------------------------------------------------------
+
+_write_commands = frozenset((
+    'auth.user.add', 'auth.user.del', 'auth.role.add', 'auth.role.del',
+    'auth.user.grant', 'auth.user.revoke', 'auth.user.addrule', 'auth.user.delrule',
+    'auth.role.addrule', 'auth.role.delrule',
+    'cron.add', 'cron.del', 'cron.mod', 'cron.move', 'cron.enable', 'cron.disable',
+    'cron.cleanup',
+    'delnode',
+    'dmon.add', 'dmon.del',
+    'feed.ingest',
+    'graph.add', 'graph.del',
+    'layer.add', 'layer.del', 'layer.set', 'layer.pull.add', 'layer.push.add',
+    'macro.set', 'macro.del',
+    'merge',
+    'model.edge.set', 'model.edge.del',
+    'model.depr.lock', 'model.depr.unlock',
+    'movetag',
+    'pkg.load', 'pkg.del',
+    'queue.add', 'queue.del',
+    'service.add', 'service.del',
+    'trigger.add', 'trigger.del', 'trigger.mod', 'trigger.enable', 'trigger.disable',
+    'view.add', 'view.del', 'view.set', 'view.merge',
+))
+
+_re_edit_bracket = re.compile(r'(?<![a-zA-Z0-9_\)\]])\[')
+_re_write_cmd = re.compile(
+    r'\|\s*(' + '|'.join(re.escape(c) for c in sorted(_write_commands, key=len, reverse=True)) + r')\b'
+)
+_re_write_patterns = re.compile(
+    r'\$node\.data\.set\b'
+    r'|\$node\.data\.pop\b'
+    r'|\$lib\.queue\.\w+\.put\b'
+    r'|->>\s*\w+'
+)
+
+_re_comment = re.compile(r'//[^\n]*')
+
+
+def classify(text):
+    '''Classify a Storm query as 'read' or 'write'.'''
+    stripped = _re_comment.sub('', text)
+    if _re_edit_bracket.search(stripped):
+        return 'write'
+    if _re_write_cmd.search(stripped):
+        return 'write'
+    if _re_write_patterns.search(stripped):
+        return 'write'
+    return 'read'
+
+
+# ---------------------------------------------------------------------------
+# Worker entry point (called after fork)
+# ---------------------------------------------------------------------------
+
+def worker_main(control_fd, uds_path, datadir, cell=None, write_fd=None, dispatch_fd=None):
+    '''
+    Entry point for a forked read worker process.
+
+    Args:
+        control_fd: File descriptor of the UDS control channel from the router.
+        uds_path: Path to the writer's UDS endpoint (legacy, unused with write_fd).
+        datadir: Cortex data directory (for LMDB slab re-open).
+        cell: The inherited Cortex cell object (shared via dmon for telepath).
+        write_fd: File descriptor of the write channel socketpair to the writer.
+        dispatch_fd: File descriptor of the dispatch channel from the thick router.
+    '''
+    # Neutralize the inherited forkpool (stale threads/pipes after fork)
+    import synapse.lib.processpool as s_processpool
+    if getattr(s_processpool, 'forkpool', None) is not None:
+        s_processpool.forkpool.shutdown(wait=False)
+        s_processpool.forkpool = None
+
+    _reopen_lmdb_readonly(datadir)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    # Rebind all inherited Base objects to the worker's new event loop.
+    if cell is not None:
+        import gc
+        import synapse.lib.base as s_base
+        for obj in gc.get_objects():
+            if isinstance(obj, s_base.Base) and obj.anitted:
+                obj.loop = loop
+                obj.finievt = asyncio.Event()
+        cell.loop = loop
+
+    if dispatch_fd is not None:
+        # Thick router mode — run as pure worker (socketpair task receiver)
+        # pure_worker_main handles its own LMDB reopen and event loop
+        # so we skip the ReadOnlyWorker path entirely. But worker_main
+        # already reopened LMDB and created a loop above, so just use
+        # PureWorker directly on the existing loop.
+        worker = PureWorker(dispatch_fd, cell)
+        try:
+            loop.run_until_complete(worker.serve())
+        except KeyboardInterrupt:
+            pass
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+        return
+
+    worker = ReadOnlyWorker(control_fd, uds_path, cell=cell, write_fd=write_fd)
+    try:
+        loop.run_until_complete(worker.serve())
+    except KeyboardInterrupt:
+        pass
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+
+
+def _reopen_lmdb_readonly(datadir):
+    '''Re-open inherited LMDB slabs in readonly mode.'''
+    for slab in list(s_lmdbslab.Slab.allslabs.values()):
+        path = slab.path
+        try:
+            slab.lenv = lmdb.open(
+                str(path),
+                map_size=0,
+                max_dbs=128,
+                max_readers=256,
+                readonly=True,
+                create=False,
+                readahead=False,
+            )
+            slab.isfini = False
+            slab.readonly = True
+            slab.xact = None
+            slab.txnrefcount = 0
+
+            old_dbnames = dict(slab.dbnames)
+            slab.dbnames = {None: (None, False)}
+            for name, (db, dupsort) in old_dbnames.items():
+                if name is None:
+                    continue
+                try:
+                    newdb = slab.lenv.open_db(name.encode('utf8'), create=False, dupsort=dupsort)
+                    slab.dbnames[name] = (newdb, dupsort)
+                except Exception:
+                    logger.warning('Worker: failed to re-open db %s in slab %s', name, path)
+
+            logger.debug('Worker: re-opened slab %s readonly (%d dbs)', path, len(slab.dbnames) - 1)
+        except Exception:
+            logger.exception('Worker: failed to re-open slab %s', path)
+
+
+# ---------------------------------------------------------------------------
+# ReadOnlyWorker
+# ---------------------------------------------------------------------------
+
+_RECV_BUF = 65536
+_REQ_COUNTER = 0
+
+
+class ReadOnlyWorker:
+    '''
+    Forked read worker. Receives connection fds from the router via a UDS
+    control channel, serves Storm reads locally, and forwards writes to
+    the writer via msgpack RPC over a pre-connected socketpair.
+    '''
+
+    def __init__(self, control_fd, uds_path, cell=None, write_fd=None):
+        self._control_fd = control_fd
+        self._uds_path = uds_path
+        self._cell = cell
+        self._write_fd = write_fd
+        self._write_alive = write_fd is not None
+        self._dmon = None
+        self._stopping = False
+        self._pid = os.getpid()
+        # Demux state: single reader task dispatches to per-request queues
+        self._write_lock = None       # asyncio.Lock for serializing sends
+        self._write_ready = None      # asyncio.Event set when writer is ready
+        self._pending_reqs = {}       # {req_id: asyncio.Queue}
+        self._reader_task = None
+
+    async def serve(self):
+        '''Main worker loop. Receives fds from router via recvmsg on control channel.'''
+        loop = asyncio.get_running_loop()
+
+        if self._cell is not None:
+            self._install_write_forwarding()
+
+        if self._cell is not None:
+            self._dmon = await s_daemon.Daemon.anit()
+            parent_dmon = getattr(self._cell, 'dmon', None)
+            if parent_dmon is not None:
+                for name, item in parent_dmon.shared.items():
+                    self._dmon.share(name, self._cell)
+            else:
+                self._dmon.share('*', self._cell)
+
+        control_sock = socket.socket(fileno=self._control_fd)
+        control_sock.setblocking(False)
+
+        try:
+            control_sock.send(b'\x52')
+        except OSError:
+            logger.error('Worker %d: failed to send READY', self._pid)
+
+        logger.info('Worker %d: receiving connections via control channel', self._pid)
+
+        try:
+            while not self._stopping:
+                readable = await loop.run_in_executor(None, self._poll_control, control_sock)
+                if not readable:
+                    continue
+
+                fd = await loop.run_in_executor(None, self._recv_fd, control_sock)
+                if fd is None:
+                    if self._stopping:
+                        break
+                    logger.warning('Worker %d: control channel closed', self._pid)
+                    break
+
+                conn = socket.socket(fileno=fd)
+                conn.setblocking(False)
+                loop.create_task(self._handle_connection(conn, conn.getpeername()))
+        finally:
+            control_sock.detach()
+            if self._dmon is not None:
+                await self._dmon.fini()
+            if self._write_fd is not None:
+                try:
+                    os.close(self._write_fd)
+                except OSError:
+                    pass
+            logger.info('Worker %d: stopped', self._pid)
+
+    def _poll_control(self, control_sock):
+        '''Poll the control socket for readability (blocking, run in executor).'''
+        try:
+            r, _, _ = select.select([control_sock], [], [], 1.0)
+            return bool(r)
+        except (OSError, ValueError):
+            return False
+
+    def _recv_fd(self, control_sock):
+        '''Receive a file descriptor from the control channel.'''
+        import array
+        try:
+            msg, ancdata, flags, addr = control_sock.recvmsg(1, socket.CMSG_SPACE(4))
+        except (OSError, ConnectionError):
+            return None
+        for cmsg_level, cmsg_type, cmsg_data in ancdata:
+            if cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS:
+                fds = array.array('i')
+                fds.frombytes(cmsg_data[:4])
+                return fds[0]
+        return None
+
+    async def _handle_connection(self, conn, addr):
+        '''Handle a single client connection via the telepath dmon protocol.'''
+        if self._dmon is None:
+            conn.close()
+            return
+
+        reader, writer = await asyncio.open_connection(sock=conn)
+        link = await s_link.Link.anit(reader, writer)
+        link.schedCoro(self._dmon._onLinkInit(link))
+
+    # ------------------------------------------------------------------
+    # Write forwarding via socketpair RPC
+    # ------------------------------------------------------------------
+
+    def _install_write_forwarding(self):
+        '''Monkey-patch cell.storm() and cell.callStorm() to forward writes.
+
+        Strategy: execute all queries with readonly=True. If IsReadOnly
+        surfaces, forward to the writer via the write channel socketpair.
+        Regex classify() provides a fast-path for obvious writes.
+        '''
+        cell = self._cell
+        _orig_storm = cell.storm
+        _orig_callStorm = cell.callStorm
+        worker = self
+
+        # Start the demux reader and init the send lock
+        self._write_lock = asyncio.Lock()
+        self._write_ready = asyncio.Event()
+        if self._write_fd is not None:
+            self._reader_task = asyncio.get_running_loop().create_task(self._demux_reader())
+
+        def _refresh_all_ro_slabs():
+            for slab in s_lmdbslab.Slab.allslabs.values():
+                if slab.readonly:
+                    slab._refresh_ro_xact()
+
+        async def _patched_storm(text, opts=None):
+            _refresh_all_ro_slabs()
+            if classify(text) == 'write':
+                async for mesg in worker._forward_write_stream(text, opts):
+                    yield mesg
+                return
+
+            ropts = dict(opts) if opts else {}
+            ropts['readonly'] = True
+
+            async for mesg in _orig_storm(text, opts=ropts):
+                if mesg[0] == 'err' and mesg[1][0] == 'IsReadOnly':
+                    async for fmesg in worker._forward_write_stream(text, opts):
+                        yield fmesg
+                    return
+                yield mesg
+
+        async def _patched_callStorm(text, opts=None):
+            _refresh_all_ro_slabs()
+            if classify(text) == 'write':
+                return await worker._forward_callStorm(text, opts)
+
+            ropts = dict(opts) if opts else {}
+            ropts['readonly'] = True
+
+            try:
+                return await _orig_callStorm(text, opts=ropts)
+            except s_exc.IsReadOnly:
+                return await worker._forward_callStorm(text, opts)
+
+        cell.storm = _patched_storm
+        cell.callStorm = _patched_callStorm
+
+    async def _demux_reader(self):
+        '''Background task: read from write_fd and dispatch to per-request queues.'''
+        loop = asyncio.get_running_loop()
+
+        # Wait for the writer's ready byte before processing responses.
+        # The WriteChannelListener sends 0x01 on each writer-end fd once
+        # its epoll loop is registered and ready to receive requests.
+        try:
+            ready_byte = await asyncio.wait_for(
+                loop.run_in_executor(None, os.read, self._write_fd, 1),
+                timeout=60.0)
+            if not ready_byte:
+                logger.error('Worker %d: write channel closed before ready', self._pid)
+                self._write_alive = False
+                return
+            logger.info('Worker %d: write channel ready', self._pid)
+        except (OSError, asyncio.TimeoutError) as e:
+            logger.error('Worker %d: write channel ready wait failed: %s', self._pid, e)
+            self._write_alive = False
+            return
+
+        # Signal that writes can now be forwarded
+        self._write_ready.set()
+
+        unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+        while self._write_alive:
+            try:
+                data = await loop.run_in_executor(None, os.read, self._write_fd, _RECV_BUF)
+            except OSError:
+                break
+            if not data:
+                break
+            unpacker.feed(data)
+            for resp in unpacker:
+                req_id = resp[1]
+                q = self._pending_reqs.get(req_id)
+                if q is not None:
+                    q.put_nowait(resp)
+        # Channel dead — signal all waiters
+        self._write_alive = False
+        for q in self._pending_reqs.values():
+            q.put_nowait(None)
+
+    async def _send_write_rpc(self, req):
+        '''Send a write RPC request, serialized via lock.'''
+        # Wait for the writer to signal readiness (ready byte received)
+        if self._write_ready is not None and not self._write_ready.is_set():
+            try:
+                await asyncio.wait_for(self._write_ready.wait(), timeout=60.0)
+            except asyncio.TimeoutError:
+                raise s_exc.SynErr(mesg='Writer unavailable (write channel not ready)')
+
+        if not self._write_alive:
+            raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+
+        data = s_msgpack.en(req)
+        loop = asyncio.get_running_loop()
+        async with self._write_lock:
+            try:
+                await asyncio.wait_for(
+                    loop.run_in_executor(None, self._sendall, data),
+                    timeout=30.0)
+            except (OSError, BrokenPipeError, asyncio.TimeoutError):
+                self._write_alive = False
+                raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+
+    def _sendall(self, data):
+        '''Write all bytes to the write channel fd, handling partial writes.'''
+        mv = memoryview(data)
+        while mv:
+            sent = os.write(self._write_fd, mv)
+            mv = mv[sent:]
+
+    async def _forward_write_stream(self, text, opts):
+        '''Forward a storm query to the writer via socketpair, yielding messages.'''
+        global _REQ_COUNTER
+        _REQ_COUNTER += 1
+        req_id = _REQ_COUNTER
+
+        q = asyncio.Queue()
+        self._pending_reqs[req_id] = q
+        try:
+            await self._send_write_rpc(('storm', req_id, text, opts))
+            while True:
+                resp = await asyncio.wait_for(q.get(), timeout=30.0)
+                if resp is None:
+                    raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+                if resp[0] == 'msg':
+                    yield resp[2]
+                elif resp[0] == 'done':
+                    return
+                elif resp[0] == 'err':
+                    raise s_exc.SynErr(mesg=resp[2].get('mesg', 'Write forwarding error'))
+        except asyncio.TimeoutError:
+            raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+        finally:
+            self._pending_reqs.pop(req_id, None)
+
+    async def _forward_callStorm(self, text, opts):
+        '''Forward a callStorm to the writer, returning the result value.'''
+        global _REQ_COUNTER
+        _REQ_COUNTER += 1
+        req_id = _REQ_COUNTER
+
+        q = asyncio.Queue()
+        self._pending_reqs[req_id] = q
+        try:
+            await self._send_write_rpc(('callStorm', req_id, text, opts))
+            while True:
+                resp = await asyncio.wait_for(q.get(), timeout=30.0)
+                if resp is None:
+                    raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+                if resp[0] == 'result':
+                    return resp[2]
+                elif resp[0] == 'err':
+                    raise s_exc.SynErr(mesg=resp[2].get('mesg', 'Write forwarding error'))
+        except asyncio.TimeoutError:
+            raise s_exc.SynErr(mesg='Writer unavailable (write channel dead)')
+        finally:
+            self._pending_reqs.pop(req_id, None)
+
+    def shutdown(self):
+        '''Signal the worker to stop accepting new connections.'''
+        self._stopping = True
+        logger.info('Worker %d: shutdown requested', self._pid)
+
+
+# ---------------------------------------------------------------------------
+# Pure Worker — socketpair task receiver for thick router
+# ---------------------------------------------------------------------------
+
+_CANCEL_CHECK_INTERVAL = 64  # Check cancellation every N yielded messages
+_LARGE_MSG_THRESHOLD = 65536  # Use run_in_executor for messages > 64KB
+
+
+class PureWorker:
+    '''
+    Pure read worker for the thick router. Receives query tasks via
+    socketpair, executes cell.storm() directly, streams results back.
+    No Daemon, no connection handling, no write forwarding.
+    '''
+
+    def __init__(self, task_fd, cell):
+        self._task_fd = task_fd
+        self._cell = cell
+        self._pid = os.getpid()
+        self._cancelled = set()  # Set of cancelled req_ids
+
+    async def serve(self):
+        '''Main loop: read tasks from socketpair, execute, stream results.'''
+        loop = asyncio.get_running_loop()
+        unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+
+        # Signal ready to router
+        try:
+            os.write(self._task_fd, b'\x52')
+        except OSError:
+            logger.error('PureWorker %d: failed to send READY', self._pid)
+            return
+
+        logger.info('PureWorker %d: ready', self._pid)
+
+        while True:
+            try:
+                data = await loop.run_in_executor(None, os.read, self._task_fd, _RECV_BUF)
+            except OSError:
+                break
+            if not data:
+                break
+
+            unpacker.feed(data)
+            for msg in unpacker:
+                kind = msg[0]
+                if kind == 'storm':
+                    _, req_id, text, opts = msg
+                    loop.create_task(self._exec_storm(req_id, text, opts))
+                elif kind == 'cancel':
+                    _, req_id = msg
+                    self._cancelled.add(req_id)
+
+        logger.info('PureWorker %d: stopped', self._pid)
+
+    async def _exec_storm(self, req_id, text, opts):
+        '''Execute a storm query and stream results back to the router.'''
+        self._refresh_slabs()
+
+        ropts = dict(opts) if opts else {}
+        ropts['readonly'] = True
+
+        try:
+            count = 0
+            async for mesg in self._cell.storm(text, opts=ropts):
+                if req_id in self._cancelled:
+                    break
+                await self._send_async(('msg', req_id, mesg))
+                count += 1
+                if count % _CANCEL_CHECK_INTERVAL == 0:
+                    await asyncio.sleep(0)
+
+            if req_id in self._cancelled:
+                self._cancelled.discard(req_id)
+                self._send(('done', req_id))
+            else:
+                self._send(('done', req_id))
+
+        except s_exc.IsReadOnly:
+            self._send(('err', req_id, {'err': 'IsReadOnly'}))
+        except Exception as e:
+            logger.exception('PureWorker %d: storm error req=%s', self._pid, req_id)
+            self._send(('err', req_id, {'err': type(e).__name__, 'mesg': str(e)}))
+        finally:
+            self._cancelled.discard(req_id)
+
+    def _refresh_slabs(self):
+        '''Refresh all readonly LMDB transactions before each query.'''
+        for slab in s_lmdbslab.Slab.allslabs.values():
+            if slab.readonly:
+                slab._refresh_ro_xact()
+
+    def _send(self, msg):
+        '''Send a msgpack-encoded message to the router via socketpair.'''
+        data = s_msgpack.en(msg)
+        mv = memoryview(data)
+        while mv:
+            try:
+                sent = os.write(self._task_fd, mv)
+                mv = mv[sent:]
+            except OSError:
+                return
+
+    async def _send_async(self, msg):
+        '''Send a msgpack-encoded message, using executor for large payloads.'''
+        data = s_msgpack.en(msg)
+        if len(data) > _LARGE_MSG_THRESHOLD:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._write_all, data)
+        else:
+            self._write_all(data)
+
+    def _write_all(self, data):
+        '''Write all bytes to the task fd.'''
+        mv = memoryview(data)
+        while mv:
+            try:
+                sent = os.write(self._task_fd, mv)
+                mv = mv[sent:]
+            except OSError:
+                return

--- a/synapse/lib/writechannel.py
+++ b/synapse/lib/writechannel.py
@@ -1,0 +1,248 @@
+'''
+Write channel listener for the writer process.
+
+The writer process listens on per-worker write channel socketpairs via epoll.
+Workers send write requests (storm/callStorm) as msgpack-encoded tuples;
+the writer executes them against the cell and streams results back.
+
+Protocol (all messages are msgpack-encoded, self-delimiting on SOCK_STREAM):
+
+  Request:  ('storm', req_id, text, opts)
+  Response: ('msg', req_id, mesg) ...  (one per storm yield)
+            ('done', req_id)           (stream complete)
+            ('err', req_id, excinfo)   (on error)
+'''
+import os
+import select
+import asyncio
+import logging
+
+import msgpack
+
+import synapse.exc as s_exc
+import synapse.lib.msgpack as s_msgpack
+
+logger = logging.getLogger(__name__)
+
+# Read buffer size for recv() calls on the write channel socketpairs.
+_RECV_BUF = 65536
+
+
+class WriteChannelListener:
+    '''Epoll-based listener that receives write RPCs from worker socketpairs.
+
+    Args:
+        cell: The Cortex cell object (provides storm/callStorm methods).
+        writer_fds: List of writer-end file descriptors from the arbiter.
+    '''
+
+    def __init__(self, cell, writer_fds, send_ready=True):
+        self._cell = cell
+        self._writer_fds = list(writer_fds)
+        self._running = False
+        self._task = None
+        self._send_ready = send_ready
+
+    async def start(self):
+        '''Start the write channel listener as a background task.'''
+        self._running = True
+        self._task = asyncio.get_running_loop().create_task(self._listen())
+        logger.info('Write channel listener started with %d worker fds', len(self._writer_fds))
+
+    async def stop(self):
+        '''Stop the listener and close all writer-end fds.'''
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        for fd in self._writer_fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        logger.info('Write channel listener stopped')
+
+    async def _listen(self):
+        '''Main listener loop: epoll on all writer fds, dispatch requests.'''
+        loop = asyncio.get_running_loop()
+        ep = select.epoll()
+
+        # Per-fd msgpack unpacker for SOCK_STREAM framing
+        unpackers = {}
+        for fd in self._writer_fds:
+            ep.register(fd, select.EPOLLIN)
+            unpackers[fd] = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+
+        # Signal readiness to workers: send a single byte on each writer-end
+        # fd so the worker's _demux_reader knows the channel is ready.
+        if self._send_ready:
+            for fd in self._writer_fds:
+                try:
+                    os.write(fd, b'\x01')
+                except OSError as e:
+                    logger.warning('Failed to send ready byte on fd %d: %s', fd, e)
+
+        try:
+            while self._running:
+                # Poll in executor to avoid blocking the event loop
+                events = await loop.run_in_executor(None, ep.poll, 1.0)
+                for fd, event in events:
+                    if event & (select.EPOLLHUP | select.EPOLLERR):
+                        logger.warning('Write channel fd %d closed (worker died)', fd)
+                        ep.unregister(fd)
+                        unpackers.pop(fd, None)
+                        try:
+                            os.close(fd)
+                        except OSError:
+                            pass
+                        continue
+
+                    if event & select.EPOLLIN:
+                        try:
+                            data = os.read(fd, _RECV_BUF)
+                        except OSError:
+                            continue
+                        if not data:
+                            # EOF — worker closed its end
+                            logger.warning('Write channel fd %d EOF', fd)
+                            ep.unregister(fd)
+                            unpackers.pop(fd, None)
+                            try:
+                                os.close(fd)
+                            except OSError:
+                                pass
+                            continue
+
+                        unpacker = unpackers[fd]
+                        unpacker.feed(data)
+                        for msg in unpacker:
+                            # Dispatch each request as a concurrent task
+                            loop.create_task(self._handle_request(fd, msg))
+        except asyncio.CancelledError:
+            pass
+        finally:
+            ep.close()
+
+    async def _handle_request(self, fd, msg):
+        '''Handle a single write request and stream results back.
+
+        Args:
+            fd: The writer-end fd to send responses on.
+            msg: Decoded msgpack tuple: ('storm', req_id, text, opts)
+        '''
+        try:
+            kind = msg[0]
+            req_id = msg[1]
+        except (IndexError, TypeError):
+            logger.error('Malformed write request on fd %d: %r', fd, msg)
+            return
+
+        if kind == 'storm':
+            await self._handle_storm(fd, req_id, msg)
+        elif kind == 'callStorm':
+            await self._handle_callStorm(fd, req_id, msg)
+        elif kind == 'method':
+            await self._handle_method(fd, req_id, msg)
+        else:
+            logger.error('Unknown write request kind %r on fd %d', kind, fd)
+            await self._send(fd, ('err', req_id, {'mesg': f'Unknown request kind: {kind}'}))
+
+    async def _handle_storm(self, fd, req_id, msg):
+        '''Execute cell.storm() and stream results back to the worker.'''
+        try:
+            text = msg[2]
+            opts = msg[3] if len(msg) > 3 else None
+        except (IndexError, TypeError):
+            await self._send(fd, ('err', req_id, {'mesg': 'Malformed storm request'}))
+            return
+
+        try:
+            async for mesg in self._cell.storm(text, opts=opts):
+                await self._send(fd, ('msg', req_id, mesg))
+            await self._send(fd, ('done', req_id))
+        except Exception as e:
+            excinfo = {
+                'mesg': str(e),
+                'err': e.__class__.__name__,
+            }
+            await self._send(fd, ('err', req_id, excinfo))
+
+    async def _handle_callStorm(self, fd, req_id, msg):
+        '''Execute cell.callStorm() and return the result to the worker.'''
+        try:
+            text = msg[2]
+            opts = msg[3] if len(msg) > 3 else None
+        except (IndexError, TypeError):
+            await self._send(fd, ('err', req_id, {'mesg': 'Malformed callStorm request'}))
+            return
+
+        try:
+            result = await self._cell.callStorm(text, opts=opts)
+            await self._send(fd, ('result', req_id, result))
+        except Exception as e:
+            excinfo = {
+                'mesg': str(e),
+                'err': e.__class__.__name__,
+            }
+            await self._send(fd, ('err', req_id, excinfo))
+
+    async def _handle_method(self, fd, req_id, msg):
+        '''Execute an arbitrary method on the cell and return the result.'''
+        try:
+            methname = msg[2]
+            args = msg[3] if len(msg) > 3 else ()
+            kwargs = msg[4] if len(msg) > 4 else {}
+        except (IndexError, TypeError):
+            await self._send(fd, ('err', req_id, {'mesg': 'Malformed method request'}))
+            return
+
+        try:
+            meth = getattr(self._cell, methname)
+            result = meth(*args, **kwargs)
+            if asyncio.iscoroutine(result):
+                result = await result
+            # Verify the result is msgpack-serializable (Share objects are not)
+            s_msgpack.en(('result', req_id, result))
+            await self._send(fd, ('result', req_id, result))
+        except (TypeError, OverflowError, s_exc.NotMsgpackSafe) as e:
+            # Non-serializable result (e.g., Share object) — explicit error
+            excinfo = {
+                'mesg': f'Method {methname!r} returned a non-serializable result (Share object). Use storm instead.',
+                'err': 'NoSuchMeth',
+            }
+            await self._send(fd, ('err', req_id, excinfo))
+        except Exception as e:
+            excinfo = {
+                'mesg': str(e),
+                'err': e.__class__.__name__,
+            }
+            await self._send(fd, ('err', req_id, excinfo))
+
+    async def _send(self, fd, msg):
+        '''Send a msgpack-encoded message on the given fd.
+
+        For messages under 64KB, writes directly (socketpair writes are
+        atomic on Linux for sizes under PIPE_BUF/64KB). Falls back to
+        executor for larger messages to avoid blocking the event loop.
+        '''
+        data = s_msgpack.en(msg)
+        try:
+            if len(data) < 65536:
+                os.write(fd, data)
+            else:
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, _sendall, fd, data)
+        except OSError as e:
+            logger.warning('Write channel send failed on fd %d: %s', fd, e)
+
+
+def _sendall(fd, data):
+    '''Write all bytes to fd, handling partial writes (blocking, thread-safe).'''
+    mv = memoryview(data)
+    while mv:
+        sent = os.write(fd, mv)
+        mv = mv[sent:]

--- a/synapse/servers/cortex.py
+++ b/synapse/servers/cortex.py
@@ -5,4 +5,4 @@ import asyncio
 import synapse.cortex as s_cortex
 
 if __name__ == '__main__':  # pragma: no cover
-    asyncio.run(s_cortex.Cortex.execmain(sys.argv[1:]))
+    s_cortex.Cortex.startmain(sys.argv[1:])

--- a/synapse/tests/test_lib_thickrouter.py
+++ b/synapse/tests/test_lib_thickrouter.py
@@ -1,0 +1,210 @@
+'''
+Unit tests for synapse.lib.thickrouter.ThickRouter.
+
+Tests the thick router dispatch logic using socketpairs and mock workers,
+without requiring a full Cortex instance.
+'''
+import os
+import socket
+import asyncio
+import unittest
+
+import msgpack
+
+import synapse.lib.msgpack as s_msgpack
+from synapse.lib.thickrouter import ThickRouter
+
+
+class MockCell:
+    '''Minimal mock cell for Daemon sharing.'''
+    pass
+
+
+def _pack(obj):
+    return s_msgpack.en(obj)
+
+
+def _sendall(fd, data):
+    mv = memoryview(data)
+    while mv:
+        sent = os.write(fd, mv)
+        mv = mv[sent:]
+
+
+class MockWorkerResponder:
+    '''Simulates a worker process responding on a socketpair.
+
+    Reads ('storm', req_id, text, opts) and responds with messages.
+    '''
+
+    def __init__(self, fd, responses=None, error=None):
+        self._fd = fd
+        self._responses = responses or []
+        self._error = error
+        self._task = None
+
+    async def start(self):
+        self._task = asyncio.get_running_loop().create_task(self._run())
+
+    async def stop(self):
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def _run(self):
+        loop = asyncio.get_running_loop()
+        unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+        try:
+            while True:
+                data = await loop.run_in_executor(None, os.read, self._fd, 65536)
+                if not data:
+                    break
+                unpacker.feed(data)
+                for msg in unpacker:
+                    await self._handle(msg)
+        except (asyncio.CancelledError, OSError):
+            pass
+
+    async def _handle(self, msg):
+        req_id = msg[1]
+        if self._error:
+            _sendall(self._fd, _pack(('err', req_id, self._error)))
+            return
+        for resp in self._responses:
+            _sendall(self._fd, _pack(('msg', req_id, resp)))
+        _sendall(self._fd, _pack(('done', req_id)))
+
+
+class TestThickRouterDispatch(unittest.TestCase):
+    '''Test the dispatch and relay logic of ThickRouter.'''
+
+    def test_select_worker_least_outstanding(self):
+        '''Verify least-outstanding-queries selection.'''
+        # Create dummy fds (won't actually be used for I/O here)
+        router = ThickRouter(MockCell(), {0: 999, 1: 998}, 997)
+        router._outstanding[0] = 5
+        router._outstanding[1] = 2
+        self.assertEqual(router._select_worker(), 1)
+
+    def test_select_worker_empty(self):
+        '''No workers returns None.'''
+        router = ThickRouter(MockCell(), {}, 997)
+        self.assertIsNone(router._select_worker())
+
+
+class TestThickRouterIntegration(unittest.IsolatedAsyncioTestCase):
+    '''Integration tests using real socketpairs.'''
+
+    async def test_dispatch_read_to_worker(self):
+        '''A read query dispatches to a worker and relays results.'''
+        # Create socketpairs: router_end <-> worker_end
+        r_sock, w_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        router_fd = r_sock.fileno()
+        worker_fd = w_sock.fileno()
+        r_sock.detach()
+        w_sock.detach()
+
+        # Writer socketpair (unused for this test but required)
+        wr_sock, ww_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        writer_router_fd = wr_sock.fileno()
+        writer_fd = ww_sock.fileno()
+        wr_sock.detach()
+        ww_sock.detach()
+
+        # Set up mock worker responder
+        responder = MockWorkerResponder(worker_fd, responses=[
+            ('node', {'iden': 'abc123'}),
+            ('node', {'iden': 'def456'}),
+        ])
+        await responder.start()
+
+        # Create ThickRouter (don't call start() — we test _dispatch_storm directly)
+        router = ThickRouter(MockCell(), {0: router_fd}, writer_router_fd)
+        router._running = True
+        # Start the demux reader for the worker fd
+        loop = asyncio.get_running_loop()
+        router._reader_tasks[router_fd] = loop.create_task(
+            router._demux_reader(router_fd))
+
+        # Give the reader task a moment to start
+        await asyncio.sleep(0.05)
+
+        # Dispatch and collect results
+        results = []
+        async for mesg in router._dispatch_storm(router_fd, 'inet:ipv4', {}):
+            results.append(mesg)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0], ('node', {'iden': 'abc123'}))
+        self.assertEqual(results[1], ('node', {'iden': 'def456'}))
+
+        # Cleanup
+        await responder.stop()
+        router._running = False
+        for task in router._reader_tasks.values():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        for fd in (router_fd, worker_fd, writer_router_fd, writer_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    async def test_dispatch_error_from_worker(self):
+        '''An error response from worker raises _ExcInfo.'''
+        r_sock, w_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        router_fd = r_sock.fileno()
+        worker_fd = w_sock.fileno()
+        r_sock.detach()
+        w_sock.detach()
+
+        wr_sock, ww_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        writer_router_fd = wr_sock.fileno()
+        writer_fd = ww_sock.fileno()
+        wr_sock.detach()
+        ww_sock.detach()
+
+        responder = MockWorkerResponder(worker_fd, error={
+            'err': 'IsReadOnly',
+            'mesg': 'Cannot write in readonly mode',
+        })
+        await responder.start()
+
+        router = ThickRouter(MockCell(), {0: router_fd}, writer_router_fd)
+        router._running = True
+        loop = asyncio.get_running_loop()
+        router._reader_tasks[router_fd] = loop.create_task(
+            router._demux_reader(router_fd))
+
+        await asyncio.sleep(0.05)
+
+        from synapse.lib.thickrouter import _ExcInfo
+        with self.assertRaises(_ExcInfo) as ctx:
+            async for _ in router._dispatch_storm(router_fd, '[inet:ipv4=1.2.3.4]', {}):
+                pass
+
+        self.assertEqual(ctx.exception.excinfo['err'], 'IsReadOnly')
+
+        await responder.stop()
+        router._running = False
+        for task in router._reader_tasks.values():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        for fd in (router_fd, worker_fd, writer_router_fd, writer_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/synapse/tests/test_lib_worker_forwarding.py
+++ b/synapse/tests/test_lib_worker_forwarding.py
@@ -1,0 +1,231 @@
+'''
+Unit tests for the worker's write forwarding via socketpair RPC.
+
+Tests the worker-side forwarding methods (_forward_write_stream,
+_forward_callStorm) using socketpairs and a mock writer, without
+requiring a full Cortex or fork.
+'''
+import os
+import socket
+import asyncio
+import unittest
+import threading
+
+import msgpack
+
+import synapse.exc as s_exc
+import synapse.lib.msgpack as s_msgpack
+from synapse.lib.worker import ReadOnlyWorker
+
+
+def _mock_writer_thread(writer_fd, responses):
+    '''Simulate the writer process: read requests, send canned responses.'''
+    unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+    try:
+        while True:
+            data = os.read(writer_fd, 65536)
+            if not data:
+                break
+            unpacker.feed(data)
+            for msg in unpacker:
+                req_id = msg[1]
+                kind = msg[0]
+                for resp in responses.get(kind, []):
+                    out = (resp[0], req_id) + resp[2:]
+                    buf = s_msgpack.en(out)
+                    mv = memoryview(buf)
+                    while mv:
+                        sent = os.write(writer_fd, mv)
+                        mv = mv[sent:]
+    except OSError:
+        pass
+
+
+def _make_worker_with_reader(loop, worker_fd):
+    '''Create a ReadOnlyWorker with write forwarding and a demux reader task.'''
+    worker = ReadOnlyWorker(0, '/tmp/unused', write_fd=worker_fd)
+    worker._write_lock = asyncio.Lock()
+    worker._write_ready = asyncio.Event()
+    worker._write_ready.set()
+
+    async def _reader():
+        unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+        while worker._write_alive:
+            try:
+                data = await loop.run_in_executor(None, os.read, worker_fd, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            unpacker.feed(data)
+            for resp in unpacker:
+                req_id = resp[1]
+                q = worker._pending_reqs.get(req_id)
+                if q is not None:
+                    q.put_nowait(resp)
+        worker._write_alive = False
+        for q in worker._pending_reqs.values():
+            q.put_nowait(None)
+
+    worker._reader_task = loop.create_task(_reader())
+    return worker
+
+
+class TestWorkerWriteForwarding(unittest.TestCase):
+
+    def _run(self, coro):
+        return self.loop.run_until_complete(coro)
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_forward_write_stream(self):
+        '''Worker streams storm messages from writer via socketpair.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        responses = {
+            'storm': [
+                ('msg', None, ('node', ({'ndef': ('inet:fqdn', 'test.com')},))),
+                ('msg', None, ('init', {'tick': 123})),
+                ('done', None),
+            ]
+        }
+
+        t = threading.Thread(target=_mock_writer_thread, args=(writer_fd, responses))
+        t.daemon = True
+        t.start()
+
+        worker = _make_worker_with_reader(self.loop, worker_fd)
+
+        async def _test():
+            msgs = []
+            async for mesg in worker._forward_write_stream('[ inet:fqdn=test.com ]', None):
+                msgs.append(mesg)
+            return msgs
+
+        msgs = self._run(_test())
+        os.close(worker_fd)
+        os.close(writer_fd)
+
+        self.assertEqual(len(msgs), 2)
+        self.assertEqual(msgs[0][0], 'node')
+        self.assertEqual(msgs[1][0], 'init')
+
+    def test_forward_callStorm(self):
+        '''Worker receives callStorm result from writer via socketpair.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        responses = {
+            'callStorm': [
+                ('result', None, 'test.com'),
+            ]
+        }
+
+        t = threading.Thread(target=_mock_writer_thread, args=(writer_fd, responses))
+        t.daemon = True
+        t.start()
+
+        worker = _make_worker_with_reader(self.loop, worker_fd)
+
+        async def _test():
+            return await worker._forward_callStorm('[ inet:fqdn=test.com ] return($node.repr())', None)
+
+        result = self._run(_test())
+        os.close(worker_fd)
+        os.close(writer_fd)
+
+        self.assertEqual(result, 'test.com')
+
+    def test_forward_write_error(self):
+        '''Worker raises SynErr when writer returns error.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        responses = {
+            'storm': [
+                ('err', None, {'mesg': 'IsReadOnly', 'err': 'IsReadOnly'}),
+            ]
+        }
+
+        t = threading.Thread(target=_mock_writer_thread, args=(writer_fd, responses))
+        t.daemon = True
+        t.start()
+
+        worker = _make_worker_with_reader(self.loop, worker_fd)
+
+        async def _test():
+            msgs = []
+            async for mesg in worker._forward_write_stream('bad query', None):
+                msgs.append(mesg)
+
+        with self.assertRaises(s_exc.SynErr):
+            self._run(_test())
+
+        os.close(worker_fd)
+        os.close(writer_fd)
+
+    def test_dead_write_channel(self):
+        '''Worker raises SynErr when write channel is dead.'''
+        worker = ReadOnlyWorker(0, '/tmp/unused', write_fd=None)
+        worker._write_lock = asyncio.Lock()
+        worker._write_ready = asyncio.Event()
+        worker._write_ready.set()
+
+        async def _test_stream():
+            async for _ in worker._forward_write_stream('query', None):
+                pass
+
+        async def _test_call():
+            await worker._forward_callStorm('query', None)
+
+        with self.assertRaises(s_exc.SynErr):
+            self._run(_test_stream())
+
+        with self.assertRaises(s_exc.SynErr):
+            self._run(_test_call())
+
+    def test_broken_pipe_marks_dead(self):
+        '''Worker marks write channel dead on BrokenPipeError.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        # Close writer end immediately to cause BrokenPipeError on write
+        os.close(writer_fd)
+
+        worker = ReadOnlyWorker(0, '/tmp/unused', write_fd=worker_fd)
+        worker._write_lock = asyncio.Lock()
+        worker._write_ready = asyncio.Event()
+        worker._write_ready.set()
+        self.assertTrue(worker._write_alive)
+
+        async def _test():
+            async for _ in worker._forward_write_stream('query', None):
+                pass
+
+        with self.assertRaises(s_exc.SynErr):
+            self._run(_test())
+
+        self.assertFalse(worker._write_alive)
+        os.close(worker_fd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/synapse/tests/test_lib_worker_pure.py
+++ b/synapse/tests/test_lib_worker_pure.py
@@ -1,0 +1,212 @@
+'''
+Unit tests for PureWorker — the socketpair task receiver for thick router mode.
+'''
+import os
+import socket
+import asyncio
+import unittest
+
+import msgpack
+
+import synapse.exc as s_exc
+import synapse.lib.msgpack as s_msgpack
+from synapse.lib.worker import PureWorker
+
+
+class MockCell:
+    '''Mock cell that yields canned storm results.'''
+
+    def __init__(self, results=None, raise_exc=None):
+        self._results = results or []
+        self._raise_exc = raise_exc
+
+    async def storm(self, text, opts=None):
+        if self._raise_exc:
+            raise self._raise_exc
+        for mesg in self._results:
+            yield mesg
+
+
+class TestPureWorker(unittest.TestCase):
+
+    def _run(self, coro):
+        return self.loop.run_until_complete(coro)
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def _make_worker(self, cell):
+        '''Create a PureWorker with a socketpair, return (worker, router_fd).'''
+        worker_sock, router_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_sock.fileno()
+        router_fd = router_sock.fileno()
+        worker_sock.detach()
+        router_sock.detach()
+        worker = PureWorker(worker_fd, cell)
+        return worker, worker_fd, router_fd
+
+    def _read_responses(self, router_fd, timeout=2.0):
+        '''Read all msgpack responses from the router fd.'''
+        import time
+        import select
+        responses = []
+        unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            r, _, _ = select.select([router_fd], [], [], min(remaining, 0.1))
+            if not r:
+                if responses and responses[-1][0] in ('done', 'err'):
+                    break
+                continue
+            data = os.read(router_fd, 65536)
+            if not data:
+                break
+            unpacker.feed(data)
+            for msg in unpacker:
+                responses.append(msg)
+                if msg[0] in ('done', 'err'):
+                    return responses
+        return responses
+
+    def test_storm_streams_results(self):
+        '''PureWorker streams storm messages and sends done.'''
+        results = [
+            ('init', {'tick': 100}),
+            ('node', ({'ndef': ('inet:fqdn', 'test.com')},)),
+            ('fini', {'tock': 200}),
+        ]
+        cell = MockCell(results=results)
+        worker, worker_fd, router_fd = self._make_worker(cell)
+
+        async def _test():
+            # Start serve in background
+            serve_task = asyncio.get_running_loop().create_task(worker.serve())
+            # Wait for ready byte
+            ready = await asyncio.get_running_loop().run_in_executor(None, os.read, router_fd, 1)
+            self.assertEqual(ready, b'\x52')
+
+            # Send a storm task
+            req = ('storm', 1, 'inet:fqdn=test.com', {})
+            os.write(router_fd, s_msgpack.en(req))
+
+            # Read responses
+            responses = await asyncio.get_running_loop().run_in_executor(
+                None, self._read_responses, router_fd)
+
+            # Close to stop serve
+            os.close(router_fd)
+            await asyncio.wait_for(serve_task, timeout=2.0)
+            os.close(worker_fd)
+            return responses
+
+        responses = self._run(_test())
+
+        # Should have 3 msg + 1 done
+        msgs = [r for r in responses if r[0] == 'msg']
+        dones = [r for r in responses if r[0] == 'done']
+        self.assertEqual(len(msgs), 3)
+        self.assertEqual(len(dones), 1)
+        self.assertEqual(msgs[0], ('msg', 1, ('init', {'tick': 100})))
+        self.assertEqual(msgs[1], ('msg', 1, ('node', ({'ndef': ('inet:fqdn', 'test.com')},))))
+        self.assertEqual(dones[0], ('done', 1))
+
+    def test_isreadonly_error(self):
+        '''PureWorker returns IsReadOnly error for write queries.'''
+        cell = MockCell(raise_exc=s_exc.IsReadOnly(mesg='readonly'))
+        worker, worker_fd, router_fd = self._make_worker(cell)
+
+        async def _test():
+            serve_task = asyncio.get_running_loop().create_task(worker.serve())
+            ready = await asyncio.get_running_loop().run_in_executor(None, os.read, router_fd, 1)
+            self.assertEqual(ready, b'\x52')
+
+            req = ('storm', 42, '[ inet:fqdn=evil.com ]', {})
+            os.write(router_fd, s_msgpack.en(req))
+
+            responses = await asyncio.get_running_loop().run_in_executor(
+                None, self._read_responses, router_fd)
+
+            os.close(router_fd)
+            await asyncio.wait_for(serve_task, timeout=2.0)
+            os.close(worker_fd)
+            return responses
+
+        responses = self._run(_test())
+
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0][0], 'err')
+        self.assertEqual(responses[0][1], 42)
+        self.assertEqual(responses[0][2]['err'], 'IsReadOnly')
+
+    def test_cancellation(self):
+        '''PureWorker stops streaming on cancel.'''
+        # Generate many results so cancellation can interrupt
+        results = [('node', {'i': i}) for i in range(200)]
+        cell = MockCell(results=results)
+        worker, worker_fd, router_fd = self._make_worker(cell)
+
+        async def _test():
+            serve_task = asyncio.get_running_loop().create_task(worker.serve())
+            ready = await asyncio.get_running_loop().run_in_executor(None, os.read, router_fd, 1)
+            self.assertEqual(ready, b'\x52')
+
+            # Send storm then immediately cancel
+            req = ('storm', 7, 'inet:fqdn', {})
+            cancel = ('cancel', 7)
+            os.write(router_fd, s_msgpack.en(req) + s_msgpack.en(cancel))
+
+            responses = await asyncio.get_running_loop().run_in_executor(
+                None, self._read_responses, router_fd)
+
+            os.close(router_fd)
+            await asyncio.wait_for(serve_task, timeout=2.0)
+            os.close(worker_fd)
+            return responses
+
+        responses = self._run(_test())
+
+        # Should have fewer than 200 messages (cancelled early) and end with done
+        msgs = [r for r in responses if r[0] == 'msg']
+        dones = [r for r in responses if r[0] == 'done']
+        self.assertLess(len(msgs), 200)
+        self.assertEqual(len(dones), 1)
+
+    def test_generic_exception(self):
+        '''PureWorker returns err on unexpected exceptions.'''
+        cell = MockCell(raise_exc=ValueError('something broke'))
+        worker, worker_fd, router_fd = self._make_worker(cell)
+
+        async def _test():
+            serve_task = asyncio.get_running_loop().create_task(worker.serve())
+            ready = await asyncio.get_running_loop().run_in_executor(None, os.read, router_fd, 1)
+            self.assertEqual(ready, b'\x52')
+
+            req = ('storm', 99, 'broken', {})
+            os.write(router_fd, s_msgpack.en(req))
+
+            responses = await asyncio.get_running_loop().run_in_executor(
+                None, self._read_responses, router_fd)
+
+            os.close(router_fd)
+            await asyncio.wait_for(serve_task, timeout=2.0)
+            os.close(worker_fd)
+            return responses
+
+        responses = self._run(_test())
+
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0][0], 'err')
+        self.assertEqual(responses[0][1], 99)
+        self.assertEqual(responses[0][2]['err'], 'ValueError')
+        self.assertIn('something broke', responses[0][2]['mesg'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/synapse/tests/test_lib_writechannel.py
+++ b/synapse/tests/test_lib_writechannel.py
@@ -1,0 +1,415 @@
+'''
+Unit tests for synapse.lib.writechannel.WriteChannelListener.
+
+Tests the writer-side write channel listener using socketpairs and a mock
+cell, without requiring a full Cortex instance.
+'''
+import os
+import socket
+import asyncio
+import unittest
+
+import msgpack
+
+import synapse.lib.msgpack as s_msgpack
+from synapse.lib.writechannel import WriteChannelListener
+
+# Tests use send_ready=False since they read directly from the fd
+# without a _demux_reader that expects the ready byte.
+_TEST_SEND_READY = False
+
+
+class MockCell:
+    '''Minimal mock cell that provides storm() and callStorm().'''
+
+    def __init__(self, messages=None, error=None, call_result=None):
+        self._messages = messages or []
+        self._error = error
+        self._call_result = call_result
+
+    async def storm(self, text, opts=None):
+        if self._error:
+            raise self._error
+        for msg in self._messages:
+            yield msg
+
+    async def callStorm(self, text, opts=None):
+        if self._error:
+            raise self._error
+        return self._call_result
+
+
+def _pack(obj):
+    return s_msgpack.en(obj)
+
+
+def _recv_all(fd, unpacker, timeout=5.0):
+    '''Read all available msgpack messages from fd within timeout.'''
+    msgs = []
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            break
+        try:
+            data = os.read(fd, 65536)
+        except BlockingIOError:
+            break
+        if not data:
+            break
+        unpacker.feed(data)
+        for msg in unpacker:
+            msgs.append(msg)
+            # Stop after receiving a 'done' or 'err' message
+            if msg[0] in ('done', 'err'):
+                return msgs
+    return msgs
+
+
+class TestWriteChannelListener(unittest.TestCase):
+
+    def _run(self, coro):
+        return self.loop.run_until_complete(coro)
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_storm_streaming(self):
+        '''Writer streams storm messages back with correct req_id framing.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        storm_msgs = [
+            ('node', ({'ndef': ('inet:ipv4', 0x01020304)},)),
+            ('node', ({'ndef': ('inet:ipv4', 0x05060708)},)),
+        ]
+        cell = MockCell(messages=storm_msgs)
+        listener = WriteChannelListener(cell, [writer_fd], send_ready=_TEST_SEND_READY)
+
+        async def _test():
+            await listener.start()
+            # Send a storm request
+            req = ('storm', 'req-1', 'inet:ipv4', None)
+            os.write(worker_fd, _pack(req))
+
+            # Read responses
+            unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+            msgs = []
+            for _ in range(20):  # poll up to 20 times
+                await asyncio.sleep(0.05)
+                try:
+                    data = os.read(worker_fd, 65536)
+                except BlockingIOError:
+                    continue
+                if data:
+                    unpacker.feed(data)
+                    for m in unpacker:
+                        msgs.append(m)
+                    # Check if we got the 'done' message
+                    if any(m[0] == 'done' for m in msgs):
+                        break
+
+            await listener.stop()
+            return msgs
+
+        # Set worker_fd non-blocking for async reads
+        import fcntl
+        flags = fcntl.fcntl(worker_fd, fcntl.F_GETFL)
+        fcntl.fcntl(worker_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+        msgs = self._run(_test())
+        os.close(worker_fd)
+
+        # Verify: 2 msg responses + 1 done
+        self.assertEqual(len(msgs), 3)
+        self.assertEqual(msgs[0][0], 'msg')
+        self.assertEqual(msgs[0][1], 'req-1')
+        self.assertEqual(msgs[0][2], storm_msgs[0])
+        self.assertEqual(msgs[1][0], 'msg')
+        self.assertEqual(msgs[1][1], 'req-1')
+        self.assertEqual(msgs[1][2], storm_msgs[1])
+        self.assertEqual(msgs[2][0], 'done')
+        self.assertEqual(msgs[2][1], 'req-1')
+
+    def test_storm_error(self):
+        '''Writer sends err response when storm() raises.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        cell = MockCell(error=RuntimeError('test error'))
+        listener = WriteChannelListener(cell, [writer_fd], send_ready=_TEST_SEND_READY)
+
+        async def _test():
+            await listener.start()
+            req = ('storm', 'req-err', 'bad query', None)
+            os.write(worker_fd, _pack(req))
+
+            unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+            msgs = []
+            import fcntl
+            flags = fcntl.fcntl(worker_fd, fcntl.F_GETFL)
+            fcntl.fcntl(worker_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+            for _ in range(20):
+                await asyncio.sleep(0.05)
+                try:
+                    data = os.read(worker_fd, 65536)
+                except BlockingIOError:
+                    continue
+                if data:
+                    unpacker.feed(data)
+                    for m in unpacker:
+                        msgs.append(m)
+                    if any(m[0] == 'err' for m in msgs):
+                        break
+
+            await listener.stop()
+            return msgs
+
+        msgs = self._run(_test())
+        os.close(worker_fd)
+
+        self.assertEqual(len(msgs), 1)
+        self.assertEqual(msgs[0][0], 'err')
+        self.assertEqual(msgs[0][1], 'req-err')
+        self.assertIn('mesg', msgs[0][2])
+
+    def test_concurrent_requests(self):
+        '''Writer handles concurrent requests with different req_ids.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        storm_msgs = [('node', ({'ndef': ('test:str', 'hello')},))]
+        cell = MockCell(messages=storm_msgs)
+        listener = WriteChannelListener(cell, [writer_fd], send_ready=_TEST_SEND_READY)
+
+        async def _test():
+            await listener.start()
+
+            import fcntl
+            flags = fcntl.fcntl(worker_fd, fcntl.F_GETFL)
+            fcntl.fcntl(worker_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+            # Send two requests back-to-back
+            os.write(worker_fd, _pack(('storm', 'r1', 'query1', None)))
+            os.write(worker_fd, _pack(('storm', 'r2', 'query2', None)))
+
+            unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+            msgs = []
+            for _ in range(40):
+                await asyncio.sleep(0.05)
+                try:
+                    data = os.read(worker_fd, 65536)
+                except BlockingIOError:
+                    continue
+                if data:
+                    unpacker.feed(data)
+                    for m in unpacker:
+                        msgs.append(m)
+                    done_count = sum(1 for m in msgs if m[0] == 'done')
+                    if done_count >= 2:
+                        break
+
+            await listener.stop()
+            return msgs
+
+        msgs = self._run(_test())
+        os.close(worker_fd)
+
+        # Should have responses for both req_ids
+        r1_msgs = [m for m in msgs if m[1] == 'r1']
+        r2_msgs = [m for m in msgs if m[1] == 'r2']
+        self.assertEqual(len(r1_msgs), 2)  # 1 msg + 1 done
+        self.assertEqual(len(r2_msgs), 2)  # 1 msg + 1 done
+        self.assertEqual(r1_msgs[-1][0], 'done')
+        self.assertEqual(r2_msgs[-1][0], 'done')
+
+    def test_callStorm(self):
+        '''Writer returns result for callStorm requests.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        cell = MockCell(call_result='test-result-value')
+        listener = WriteChannelListener(cell, [writer_fd], send_ready=_TEST_SEND_READY)
+
+        async def _test():
+            await listener.start()
+
+            import fcntl
+            flags = fcntl.fcntl(worker_fd, fcntl.F_GETFL)
+            fcntl.fcntl(worker_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+            req = ('callStorm', 'req-cs', '[ inet:fqdn=x.com ] return($node.repr())', None)
+            os.write(worker_fd, _pack(req))
+
+            unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+            msgs = []
+            for _ in range(20):
+                await asyncio.sleep(0.05)
+                try:
+                    data = os.read(worker_fd, 65536)
+                except BlockingIOError:
+                    continue
+                if data:
+                    unpacker.feed(data)
+                    for m in unpacker:
+                        msgs.append(m)
+                    if any(m[0] in ('result', 'err') for m in msgs):
+                        break
+
+            await listener.stop()
+            return msgs
+
+        msgs = self._run(_test())
+        os.close(worker_fd)
+
+        self.assertEqual(len(msgs), 1)
+        self.assertEqual(msgs[0][0], 'result')
+        self.assertEqual(msgs[0][1], 'req-cs')
+        self.assertEqual(msgs[0][2], 'test-result-value')
+
+    def test_callStorm_error(self):
+        '''Writer sends err response when callStorm() raises.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        cell = MockCell(error=RuntimeError('callStorm failed'))
+        listener = WriteChannelListener(cell, [writer_fd], send_ready=_TEST_SEND_READY)
+
+        async def _test():
+            await listener.start()
+
+            import fcntl
+            flags = fcntl.fcntl(worker_fd, fcntl.F_GETFL)
+            fcntl.fcntl(worker_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+            req = ('callStorm', 'req-cse', 'bad query', None)
+            os.write(worker_fd, _pack(req))
+
+            unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+            msgs = []
+            for _ in range(20):
+                await asyncio.sleep(0.05)
+                try:
+                    data = os.read(worker_fd, 65536)
+                except BlockingIOError:
+                    continue
+                if data:
+                    unpacker.feed(data)
+                    for m in unpacker:
+                        msgs.append(m)
+                    if any(m[0] == 'err' for m in msgs):
+                        break
+
+            await listener.stop()
+            return msgs
+
+        msgs = self._run(_test())
+        os.close(worker_fd)
+
+        self.assertEqual(len(msgs), 1)
+        self.assertEqual(msgs[0][0], 'err')
+        self.assertEqual(msgs[0][1], 'req-cse')
+        self.assertIn('callStorm failed', msgs[0][2]['mesg'])
+
+    def test_worker_disconnect(self):
+        '''Listener handles worker disconnect gracefully.'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        cell = MockCell()
+        listener = WriteChannelListener(cell, [writer_fd], send_ready=_TEST_SEND_READY)
+
+        async def _test():
+            await listener.start()
+            # Close worker end — should trigger EPOLLHUP on writer end
+            os.close(worker_fd)
+            await asyncio.sleep(1.5)  # Let epoll detect it
+            await listener.stop()
+
+        # Should not raise
+        self._run(_test())
+
+    def test_burst_writes_no_data_loss(self):
+        '''Burst of rapid writes completes without data loss (partial write regression).'''
+        worker_end, writer_end = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        worker_fd = worker_end.fileno()
+        writer_fd = writer_end.fileno()
+        worker_end.detach()
+        writer_end.detach()
+
+        storm_msgs = [('node', ({'ndef': ('inet:ipv4', i)},)) for i in range(3)]
+        cell = MockCell(messages=storm_msgs)
+        listener = WriteChannelListener(cell, [writer_fd], send_ready=_TEST_SEND_READY)
+
+        num_requests = 20
+
+        async def _test():
+            await listener.start()
+
+            import fcntl
+            flags = fcntl.fcntl(worker_fd, fcntl.F_GETFL)
+            fcntl.fcntl(worker_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+            # Send many requests as fast as possible
+            for i in range(num_requests):
+                req = ('storm', f'burst-{i}', f'query-{i}', None)
+                data = _pack(req)
+                mv = memoryview(data)
+                while mv:
+                    try:
+                        sent = os.write(worker_fd, mv)
+                        mv = mv[sent:]
+                    except BlockingIOError:
+                        await asyncio.sleep(0.01)
+
+            unpacker = msgpack.Unpacker(**s_msgpack.unpacker_kwargs)
+            done_ids = set()
+            for _ in range(200):
+                await asyncio.sleep(0.05)
+                try:
+                    data = os.read(worker_fd, 65536)
+                except BlockingIOError:
+                    continue
+                if data:
+                    unpacker.feed(data)
+                    for m in unpacker:
+                        if m[0] == 'done':
+                            done_ids.add(m[1])
+                if len(done_ids) >= num_requests:
+                    break
+
+            await listener.stop()
+            return done_ids
+
+        done_ids = self._run(_test())
+        os.close(worker_fd)
+
+        self.assertEqual(len(done_ids), num_requests,
+                         f'Expected {num_requests} done responses, got {len(done_ids)}')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add multi-process architecture to the Synapse Cortex for horizontal read scaling. A thick router process owns all client telepath connections, classifies each query, and dispatches reads to forked worker processes / writes to the writer via socketpair RPC.

Architecture:
- Fork-based worker pool: workers inherit LMDB maps (zero-copy shared memory), execute read queries in parallel across CPU cores
- Thick router (synapse/lib/thickrouter.py): per-query dispatch via socketpair, streaming relay, IsReadOnly re-dispatch, non-storm method routing to writer
- Write channel (synapse/lib/writechannel.py): dedicated socketpair RPC for write serialization to single writer process
- Arbiter (synapse/lib/arbiter.py): process lifecycle, SIGCHLD respawn
- Query classification: regex-based read/write split with false-negative recovery via IsReadOnly re-dispatch
- Read-after-write consistency: per-query LMDB transaction refresh

Performance (EC2 c5.4xlarge, 16 vCPU, 8 workers):
- 5x read throughput vs single-process (288 -> 1,699 QPS)
- 7.7x read latency improvement (204ms -> 24ms p50)
- 7x write latency improvement (1,146ms -> 151ms p50)
- 600s soak: 0 errors, read p99=2.7ms
- 25ms router respawn after crash
- 100% read-after-write consistency