### PR TITLE
enforce unique user emails and add $lib.auth.users.byemail()

### DIFF
--- a/changes/d9feeca86270980eacb9a0d365e2a400.yaml
+++ b/changes/d9feeca86270980eacb9a0d365e2a400.yaml
@@ -1,7 +1,7 @@
 ---
-desc: Added a ``cell:storage`` migration that builds a unique user email index. Pre-existing
-  duplicate emails are rewritten to ``<local>+<iden>@<domain>`` form, and invalid or
-  empty values are cleared.
+desc: Added a migration that builds a unique user email index. Pre-existing duplicate
+  emails are rewritten to ``user+<iden>@domain.com`` form, and invalid or empty values
+  are cleared.
 desc:literal: false
 prs: []
 type: migration

--- a/changes/d9feeca86270980eacb9a0d365e2a400.yaml
+++ b/changes/d9feeca86270980eacb9a0d365e2a400.yaml
@@ -1,0 +1,8 @@
+---
+desc: Added a ``cell:storage`` migration that builds a unique user email index. Pre-existing
+  duplicate emails are rewritten to ``<local>+<iden>@<domain>`` form, and invalid or
+  empty values are cleared.
+desc:literal: false
+prs: []
+type: migration
+...

--- a/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
+++ b/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
@@ -1,6 +1,6 @@
 ---
 desc: Added the ``$lib.auth.users.byemail()`` Storm function. User emails are now
-  normalized via the ``inet:email`` type and must be unique within a Cell.
+  normalized via the ``inet:email`` type and must be unique.
 desc:literal: false
 prs: []
 type: feat

--- a/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
+++ b/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
@@ -1,8 +1,9 @@
 ---
 desc: Added the ``$lib.auth.users.byemail()`` Storm function for fast user lookup
-  by email. User emails are now enforced as unique within a Cell; setting a duplicate
-  raises ``DupEmail``. A storage migration builds the email index and rewrites pre-existing
-  duplicates to ``user+<iden>@<domain>`` form.
+  by email. User emails are now normalized via the ``inet:email`` type and enforced
+  as unique within a Cell; setting a duplicate raises ``DupEmail``. A storage migration
+  builds the email index and rewrites pre-existing duplicates to ``user+<iden>@<domain>``
+  form.
 desc:literal: false
 prs: []
 type: feat

--- a/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
+++ b/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
@@ -1,9 +1,6 @@
 ---
-desc: Added the ``$lib.auth.users.byemail()`` Storm function for fast user lookup
-  by email. User emails are now normalized via the ``inet:email`` type and enforced
-  as unique within a Cell; setting a duplicate raises ``DupUserEmail``. A storage migration
-  builds the email index and rewrites pre-existing duplicates to ``user+<iden>@<domain>``
-  form.
+desc: Added the ``$lib.auth.users.byemail()`` Storm function. User emails are now
+  normalized via the ``inet:email`` type and must be unique within a Cell.
 desc:literal: false
 prs: []
 type: feat

--- a/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
+++ b/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
@@ -1,7 +1,7 @@
 ---
 desc: Added the ``$lib.auth.users.byemail()`` Storm function for fast user lookup
   by email. User emails are now normalized via the ``inet:email`` type and enforced
-  as unique within a Cell; setting a duplicate raises ``DupEmail``. A storage migration
+  as unique within a Cell; setting a duplicate raises ``DupUserEmail``. A storage migration
   builds the email index and rewrites pre-existing duplicates to ``user+<iden>@<domain>``
   form.
 desc:literal: false

--- a/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
+++ b/changes/fdbe8b312bd8e128410f2d2e76724f1f.yaml
@@ -1,0 +1,9 @@
+---
+desc: Added the ``$lib.auth.users.byemail()`` Storm function for fast user lookup
+  by email. User emails are now enforced as unique within a Cell; setting a duplicate
+  raises ``DupEmail``. A storage migration builds the email index and rewrites pre-existing
+  duplicates to ``user+<iden>@<domain>`` form.
+desc:literal: false
+prs: []
+type: feat
+...

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -196,6 +196,7 @@ class DupPropName(SynErr): pass
 class DupRoleName(SynErr): pass
 class DupTagPropName(SynErr): pass
 class DupUserName(SynErr): pass
+class DupEmail(SynErr): pass
 class DupStormSvc(SynErr): pass
 
 class DupTypeName(SynErr):

--- a/synapse/exc.py
+++ b/synapse/exc.py
@@ -196,7 +196,7 @@ class DupPropName(SynErr): pass
 class DupRoleName(SynErr): pass
 class DupTagPropName(SynErr): pass
 class DupUserName(SynErr): pass
-class DupEmail(SynErr): pass
+class DupUserEmail(SynErr): pass
 class DupStormSvc(SynErr): pass
 
 class DupTypeName(SynErr):

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -556,9 +556,11 @@ class Auth(s_nexus.Pusher):
                                          email=newnorm)
 
                 self.useridenbyemail.set(newnorm, iden)
+                self.useridenbyemailcache.put(newnorm, iden)
 
             if oldnorm is not None and oldnorm != newnorm:
                 self.useridenbyemail.delete(oldnorm)
+                self.useridenbyemailcache.pop(oldnorm)
 
             user.info['email'] = newnorm
             self.userdefs.set(iden, user.info)

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -543,7 +543,7 @@ class Auth(s_nexus.Pusher):
 
             self.userdefs.set(iden, user.info)
 
-        elif name == 'email':
+        elif name == 'email' and self.nexsroot and self.nexsroot.cell.nexsvers >= (2, 243):
             newnorm = normEmail(valu)
             oldnorm = user.info.get('email')
             if newnorm == oldnorm:

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -497,7 +497,7 @@ class Auth(s_nexus.Pusher):
             if newnorm is not None:
                 existing = self.useridenbyemail.get(newnorm)
                 if existing is not None and existing != iden:
-                    raise s_exc.DupEmail(mesg=f'Duplicate email, email={newnorm!r} already exists.',
+                    raise s_exc.DupUserEmail(mesg=f'Duplicate email, email={newnorm!r} already exists.',
                                          email=newnorm)
 
         await self._push('user:info', iden, name, valu, gateiden=gateiden, logged=logged, mesg=mesg)
@@ -552,7 +552,7 @@ class Auth(s_nexus.Pusher):
             if newnorm is not None:
                 existing = self.useridenbyemail.get(newnorm)
                 if existing is not None and existing != iden:
-                    raise s_exc.DupEmail(mesg=f'Duplicate email, email={newnorm!r} already exists.',
+                    raise s_exc.DupUserEmail(mesg=f'Duplicate email, email={newnorm!r} already exists.',
                                          email=newnorm)
 
                 self.useridenbyemail.set(newnorm, iden)
@@ -729,7 +729,7 @@ class Auth(s_nexus.Pusher):
         if email is not None:
             normnew = normEmail(email)
             if normnew is not None and self.useridenbyemail.get(normnew) is not None:
-                raise s_exc.DupEmail(mesg=f'Duplicate email, email={normnew!r} already exists.',
+                raise s_exc.DupUserEmail(mesg=f'Duplicate email, email={normnew!r} already exists.',
                                      email=normnew)
 
         if iden is None:

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -29,6 +29,29 @@ def textFromRule(rule):
         text = '!' + text
     return text
 
+def normEmail(email):
+    '''
+    Normalize an email address for use as a unique key.
+
+    Returns the normalized form (lowercase, stripped) or None if the input
+    is None or normalizes to an empty string. Raises BadArg if the value is
+    not a string or does not contain an "@" character.
+    '''
+    if email is None:
+        return None
+
+    if not isinstance(email, str):
+        raise s_exc.BadArg(mesg='email must be a string', name='email')
+
+    norm = email.strip().lower()
+    if norm == '':
+        return None
+
+    if '@' not in norm:
+        raise s_exc.BadArg(mesg=f'email must contain "@": {email!r}', name='email')
+
+    return norm
+
 @dataclasses.dataclass(slots=True)
 class _allowedReason:
     value: Union[bool | None]
@@ -143,8 +166,10 @@ class Auth(s_nexus.Pusher):
 
         self.userdefs = self.stor.getSubKeyVal('user:info:')
         self.useridenbyname = self.stor.getSubKeyVal('user:name:')
+        self.useridenbyemail = self.stor.getSubKeyVal('user:email:')
         self.userbyidencache = s_cache.FixedCache(self._getUser, size=1000)
         self.useridenbynamecache = s_cache.FixedCache(self._getUserIden, size=1000)
+        self.useridenbyemailcache = s_cache.FixedCache(self._getUserIdenByEmail, size=1000)
 
         self.roledefs = self.stor.getSubKeyVal('role:info:')
         self.roleidenbyname = self.stor.getSubKeyVal('role:name:')
@@ -263,6 +288,34 @@ class Auth(s_nexus.Pusher):
 
     def _getUserIden(self, name):
         return self.useridenbyname.get(name)
+
+    async def getUserByEmail(self, email):
+        '''
+        Get a user by their email address.
+
+        Args:
+            email (str): Email of the user to get. Normalized before lookup.
+
+        Returns:
+            User: A User. May return None if there is no user with the requested email.
+        '''
+        norm = normEmail(email)
+        if norm is None:
+            return None
+
+        useriden = self.useridenbyemailcache.get(norm)
+        if useriden is not None:
+            return self.user(useriden)
+
+    async def getUserIdenByEmail(self, email):
+        norm = normEmail(email)
+        if norm is None:
+            return None
+
+        return self.useridenbyemailcache.get(norm)
+
+    def _getUserIdenByEmail(self, normemail):
+        return self.useridenbyemail.get(normemail)
 
     async def getRoleByName(self, name):
         roleiden = self.roleidenbynamecache.get(name)
@@ -413,6 +466,17 @@ class Auth(s_nexus.Pusher):
         if name in ('locked', 'archived') and not valu:
             self.checkUserLimit()
 
+        if name == 'email' and gateiden is None:
+            newnorm = normEmail(valu)
+            if newnorm == user.info.get('email'):
+                return
+
+            if newnorm is not None:
+                existing = self.useridenbyemail.get(newnorm)
+                if existing is not None and existing != iden:
+                    raise s_exc.DupEmail(mesg=f'Duplicate email, email={newnorm!r} already exists.',
+                                         email=newnorm)
+
         await self._push('user:info', iden, name, valu, gateiden=gateiden, logged=logged, mesg=mesg)
 
     @s_nexus.Pusher.onPush('user:info')
@@ -455,6 +519,29 @@ class Auth(s_nexus.Pusher):
                 user.info['authgates'][gateiden] = info
 
             self.userdefs.set(iden, user.info)
+
+        elif name == 'email':
+            newnorm = normEmail(valu)
+            oldnorm = user.info.get('email')
+            if newnorm == oldnorm:
+                return
+
+            if newnorm is not None:
+                existing = self.useridenbyemail.get(newnorm)
+                if existing is not None and existing != iden:
+                    raise s_exc.DupEmail(mesg=f'Duplicate email, email={newnorm!r} already exists.',
+                                         email=newnorm)
+
+                self.useridenbyemail.set(newnorm, iden)
+                self.useridenbyemailcache.put(newnorm, iden)
+
+            if oldnorm is not None and oldnorm != newnorm:
+                self.useridenbyemail.delete(oldnorm)
+                self.useridenbyemailcache.pop(oldnorm)
+
+            user.info['email'] = newnorm
+            self.userdefs.set(iden, user.info)
+
         else:
             user.info[name] = s_msgpack.deepcopy(valu)
             self.userdefs.set(iden, user.info)
@@ -616,6 +703,12 @@ class Auth(s_nexus.Pusher):
         if self.useridenbynamecache.get(name) is not None:
             raise s_exc.DupUserName(mesg=f'Duplicate username, {name=} already exists.', name=name)
 
+        if email is not None:
+            normnew = normEmail(email)
+            if normnew is not None and self.useridenbyemail.get(normnew) is not None:
+                raise s_exc.DupEmail(mesg=f'Duplicate email, email={normnew!r} already exists.',
+                                     email=normnew)
+
         if iden is None:
             iden = s_common.guid()
         else:
@@ -745,6 +838,11 @@ class Auth(s_nexus.Pusher):
         self.userbyidencache.pop(user.iden)
         self.useridenbynamecache.pop(user.name)
 
+        email = user.info.get('email')
+        if email is not None:
+            self.useridenbyemail.delete(email)
+            self.useridenbyemailcache.pop(email)
+
         for gateiden in user.authgates.keys():
             gate = self.getAuthGate(gateiden)
             if gate is not None:
@@ -799,6 +897,7 @@ class Auth(s_nexus.Pusher):
         '''
         self.userbyidencache.clear()
         self.useridenbynamecache.clear()
+        self.useridenbyemailcache.clear()
         self.rolebyidencache.clear()
         self.roleidenbynamecache.clear()
         self.authgates.clear()

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -556,11 +556,9 @@ class Auth(s_nexus.Pusher):
                                          email=newnorm)
 
                 self.useridenbyemail.set(newnorm, iden)
-                self.useridenbyemailcache.put(newnorm, iden)
 
             if oldnorm is not None and oldnorm != newnorm:
                 self.useridenbyemail.delete(oldnorm)
-                self.useridenbyemailcache.pop(oldnorm)
 
             user.info['email'] = newnorm
             self.userdefs.set(iden, user.info)

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -29,13 +29,34 @@ def textFromRule(rule):
         text = '!' + text
     return text
 
+_emailtype = None
+
+def _getEmailType():
+    global _emailtype
+    if _emailtype is None:
+        # Lazy load a full data model so non-Cortex cells can reuse the
+        # canonical inet:email normalization.
+        import synapse.datamodel as s_datamodel
+        import synapse.lib.modules as s_modules
+        import synapse.lib.dyndeps as s_dyndeps
+
+        modl = s_datamodel.Model()
+        mdefs = []
+        for ctor in s_modules.coremods:
+            cls = s_dyndeps.reqDynLocal(ctor)
+            mdefs.extend(cls.getModelDefs(None))
+        modl.addDataModels(mdefs)
+        _emailtype = modl.type('inet:email')
+
+    return _emailtype
+
 def normEmail(email):
     '''
-    Normalize an email address for use as a unique key.
+    Normalize an email address for use as a unique key via the inet:email type.
 
-    Returns the normalized form (lowercase, stripped) or None if the input
-    is None or normalizes to an empty string. Raises BadArg if the value is
-    not a string or does not contain an "@" character.
+    Returns the normalized form or None if the input is None or normalizes
+    to an empty string. Raises BadArg if the value is not a string or does
+    not parse as an email address.
     '''
     if email is None:
         return None
@@ -43,12 +64,14 @@ def normEmail(email):
     if not isinstance(email, str):
         raise s_exc.BadArg(mesg='email must be a string', name='email')
 
-    norm = email.strip().lower()
-    if norm == '':
+    valu = email.strip()
+    if valu == '':
         return None
 
-    if '@' not in norm:
-        raise s_exc.BadArg(mesg=f'email must contain "@": {email!r}', name='email')
+    try:
+        norm, _info = _getEmailType().norm(valu)
+    except s_exc.BadTypeValu as e:
+        raise s_exc.BadArg(mesg=e.get('mesg'), name='email') from None
 
     return norm
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -65,7 +65,7 @@ import synapse.tools.service.backup as s_t_backup
 
 logger = logging.getLogger(__name__)
 
-NEXUS_VERSION = (2, 198)
+NEXUS_VERSION = (2, 199)
 
 SLAB_MAP_SIZE = 128 * s_const.mebibyte
 SSLCTX_CACHE_SIZE = 64
@@ -1385,7 +1385,6 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         await self._bumpCellVers('cell:storage', (
             (2, self._storCellAuthMigration),
-            (3, self._storUserEmailIndexMigration),
         ), nexs=False)
 
         self.auth = await self._initCellAuth()
@@ -1871,6 +1870,12 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                     userkv.set(iden, info)
 
             # Clear the auth caches so the changes get picked up by the already running auth subsystem
+            self.auth.clearAuthCache()
+
+        if self.nexsvers < (2, 199) and newvers >= (2, 199) and self.conf.get('auth:ctor') is None:
+            # Build the unique user email index and rewrite any pre-existing duplicates. Driven
+            # through the nexus log so mirrors apply the same writes at the same offset.
+            await self._storUserEmailIndexMigration()
             self.auth.clearAuthCache()
 
     async def configNexsVers(self):

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -65,7 +65,7 @@ import synapse.tools.service.backup as s_t_backup
 
 logger = logging.getLogger(__name__)
 
-NEXUS_VERSION = (2, 199)
+NEXUS_VERSION = (2, 243)
 
 SLAB_MAP_SIZE = 128 * s_const.mebibyte
 SSLCTX_CACHE_SIZE = 64
@@ -1872,7 +1872,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             # Clear the auth caches so the changes get picked up by the already running auth subsystem
             self.auth.clearAuthCache()
 
-        if self.nexsvers < (2, 199) and newvers >= (2, 199) and self.conf.get('auth:ctor') is None:
+        if self.nexsvers < (2, 243) and newvers >= (2, 243) and self.conf.get('auth:ctor') is None:
             # Build the unique user email index and rewrite any pre-existing duplicates. Driven
             # through the nexus log so mirrors apply the same writes at the same offset.
             await self._storUserEmailIndexMigration()

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1385,6 +1385,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         await self._bumpCellVers('cell:storage', (
             (2, self._storCellAuthMigration),
+            (3, self._storUserEmailIndexMigration),
         ), nexs=False)
 
         self.auth = await self._initCellAuth()
@@ -1555,6 +1556,70 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                             rolekv.set(roleiden, role)
 
         logger.warning(f'...Cell ({self.getCellType()}) auth migration complete!')
+
+    async def _storUserEmailIndexMigration(self):
+        if self.conf.get('auth:ctor') is not None:
+            return
+
+        logger.warning(f'Building user email index for Cell ({self.getCellType()})')
+
+        authkv = self.slab.getSafeKeyVal('auth')
+        userkv = authkv.getSubKeyVal('user:info:')
+        emailkv = authkv.getSubKeyVal('user:email:')
+
+        seen = {}
+        collisions = []
+
+        for iden, info in userkv.items():
+            raw = info.get('email')
+            if raw is None or raw == '':
+                continue
+
+            if not isinstance(raw, str):
+                logger.warning(f'User {iden} has non-string email {raw!r}; clearing.')
+                info['email'] = None
+                userkv.set(iden, info)
+                continue
+
+            norm = raw.strip().lower()
+            if '@' not in norm:
+                logger.warning(f'User {iden} has malformed email {raw!r}; clearing.')
+                info['email'] = None
+                userkv.set(iden, info)
+                continue
+
+            if norm in seen:
+                collisions.append((iden, raw, norm))
+                continue
+
+            if info.get('email') != norm:
+                info['email'] = norm
+                userkv.set(iden, info)
+
+            seen[norm] = iden
+
+        for iden, raw, norm in collisions:
+            local, _, domain = norm.partition('@')
+            candidate = f'{local}+{iden}@{domain}'
+            if candidate in seen:
+                logger.warning(f'Could not deduplicate email for user {iden}; clearing.')
+                candidate = None
+            else:
+                logger.warning(f'Duplicate email {raw!r} on user {iden}; rewriting to {candidate}.')
+
+            info = userkv.get(iden)
+            info['email'] = candidate
+            userkv.set(iden, info)
+            if candidate is not None:
+                seen[candidate] = iden
+
+        for iden, info in userkv.items():
+            email = info.get('email')
+            if email is None:
+                continue
+            emailkv.set(email, iden)
+
+        logger.warning(f'...user email index for Cell ({self.getCellType()}) complete!')
 
     async def _drivePermMigration(self):
         async with await s_drive.Drive.anit(self.slab, 'celldrive') as olddrive:
@@ -3321,6 +3386,11 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
     async def getUserIdenByName(self, name):
         user = await self.auth.getUserByName(name)
+        if user is not None:
+            return user.iden
+
+    async def getUserIdenByEmail(self, email):
+        user = await self.auth.getUserByEmail(email)
         if user is not None:
             return user.iden
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1572,20 +1572,19 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         for iden, info in userkv.items():
             raw = info.get('email')
-            if raw is None or raw == '':
-                continue
 
-            if not isinstance(raw, str):
-                logger.warning(f'User {iden} has non-string email {raw!r}; clearing.')
+            try:
+                norm = s_auth.normEmail(raw)
+            except s_exc.BadArg:
+                logger.warning(f'User {iden} has invalid email {raw!r}; clearing.')
                 info['email'] = None
                 userkv.set(iden, info)
                 continue
 
-            norm = raw.strip().lower()
-            if '@' not in norm:
-                logger.warning(f'User {iden} has malformed email {raw!r}; clearing.')
-                info['email'] = None
-                userkv.set(iden, info)
+            if norm is None:
+                if info.get('email') is not None:
+                    info['email'] = None
+                    userkv.set(iden, info)
                 continue
 
             if norm in seen:
@@ -1601,7 +1600,12 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         for iden, raw, norm in collisions:
             local, _, domain = norm.partition('@')
             candidate = f'{local}+{iden}@{domain}'
-            if candidate in seen:
+            try:
+                candidate = s_auth.normEmail(candidate)
+            except s_exc.BadArg:
+                candidate = None
+
+            if candidate is None or candidate in seen:
                 logger.warning(f'Could not deduplicate email for user {iden}; clearing.')
                 candidate = None
             else:

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1571,6 +1571,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         for iden, info in userkv.items():
             raw = info.get('email')
+            if raw is None:
+                continue
 
             try:
                 norm = s_auth.normEmail(raw)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1593,10 +1593,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 candidate = f'{local}+{iden}@{domain}'
                 try:
                     candidate = s_auth.normEmail(candidate)
-                except s_exc.BadArg:
+                except s_exc.BadArg:  # pragma: no cover
                     candidate = None
 
-                if candidate is None or candidate in seen:
+                if candidate is None or candidate in seen:  # pragma: no cover
                     logger.warning(f'Could not deduplicate email for user {iden}; clearing.')
                     info['email'] = None
                     userkv.set(iden, info)

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1568,7 +1568,6 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         emailkv = authkv.getSubKeyVal('user:email:')
 
         seen = {}
-        collisions = []
 
         for iden, info in userkv.items():
             raw = info.get('email')
@@ -1588,40 +1587,31 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                 continue
 
             if norm in seen:
-                collisions.append((iden, raw, norm))
+                local, _, domain = norm.partition('@')
+                candidate = f'{local}+{iden}@{domain}'
+                try:
+                    candidate = s_auth.normEmail(candidate)
+                except s_exc.BadArg:
+                    candidate = None
+
+                if candidate is None or candidate in seen:
+                    logger.warning(f'Could not deduplicate email for user {iden}; clearing.')
+                    info['email'] = None
+                    userkv.set(iden, info)
+                    continue
+
+                logger.warning(f'Duplicate email {raw!r} on user {iden}; rewriting to {candidate}.')
+                info['email'] = candidate
+                userkv.set(iden, info)
+                seen[candidate] = iden
+                emailkv.set(candidate, iden)
                 continue
 
             if info.get('email') != norm:
                 info['email'] = norm
                 userkv.set(iden, info)
-
             seen[norm] = iden
-
-        for iden, raw, norm in collisions:
-            local, _, domain = norm.partition('@')
-            candidate = f'{local}+{iden}@{domain}'
-            try:
-                candidate = s_auth.normEmail(candidate)
-            except s_exc.BadArg:
-                candidate = None
-
-            if candidate is None or candidate in seen:
-                logger.warning(f'Could not deduplicate email for user {iden}; clearing.')
-                candidate = None
-            else:
-                logger.warning(f'Duplicate email {raw!r} on user {iden}; rewriting to {candidate}.')
-
-            info = userkv.get(iden)
-            info['email'] = candidate
-            userkv.set(iden, info)
-            if candidate is not None:
-                seen[candidate] = iden
-
-        for iden, info in userkv.items():
-            email = info.get('email')
-            if email is None:
-                continue
-            emailkv.set(email, iden)
+            emailkv.set(norm, iden)
 
         logger.warning(f'...user email index for Cell ({self.getCellType()}) complete!')
 

--- a/synapse/lib/stormlib/auth.py
+++ b/synapse/lib/stormlib/auth.py
@@ -1904,6 +1904,13 @@ class LibUsers(s_stormtypes.Lib):
                   ),
                   'returns': {'type': ['null', 'auth:user'],
                               'desc': 'The ``auth:user`` object, or null if the user does not exist.', }}},
+        {'name': 'byemail', 'desc': 'Get a specific user by email address.',
+         'type': {'type': 'function', '_funcname': '_methUsersByEmail',
+                  'args': (
+                      {'name': 'email', 'type': 'str', 'desc': 'The email of the user to retrieve.', },
+                  ),
+                  'returns': {'type': ['null', 'auth:user'],
+                              'desc': 'The ``auth:user`` object, or null if the user does not exist.', }}},
     )
     _storm_lib_path = ('auth', 'users')
     _storm_lib_perms = (
@@ -1992,6 +1999,7 @@ class LibUsers(s_stormtypes.Lib):
             'list': self._methUsersList,
             'get': self._methUsersGet,
             'byname': self._methUsersByName,
+            'byemail': self._methUsersByEmail,
         }
 
     @s_stormtypes.stormfunc(readonly=True)
@@ -2010,6 +2018,13 @@ class LibUsers(s_stormtypes.Lib):
     async def _methUsersByName(self, name):
         name = await s_stormtypes.tostr(name)
         useriden = await self.runt.snap.core.getUserIdenByName(name)
+        if useriden is not None:
+            return User(self.runt, useriden)
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _methUsersByEmail(self, email):
+        email = await s_stormtypes.tostr(email)
+        useriden = await self.runt.snap.core.getUserIdenByEmail(email)
         if useriden is not None:
             return User(self.runt, useriden)
 

--- a/synapse/lib/stormlib/auth.py
+++ b/synapse/lib/stormlib/auth.py
@@ -1907,10 +1907,10 @@ class LibUsers(s_stormtypes.Lib):
         {'name': 'byemail', 'desc': 'Get a specific user by email address.',
          'type': {'type': 'function', '_funcname': '_methUsersByEmail',
                   'args': (
-                      {'name': 'email', 'type': 'str', 'desc': 'The email of the user to retrieve.', },
+                      {'name': 'email', 'type': 'str', 'desc': 'The email of the user to retrieve.'},
                   ),
                   'returns': {'type': ['null', 'auth:user'],
-                              'desc': 'The ``auth:user`` object, or null if the user does not exist.', }}},
+                              'desc': 'The ``auth:user`` object, or null if the user does not exist.'}}},
     )
     _storm_lib_path = ('auth', 'users')
     _storm_lib_perms = (

--- a/synapse/tests/test_lib_auth.py
+++ b/synapse/tests/test_lib_auth.py
@@ -172,6 +172,79 @@ class AuthTest(s_test.SynTest):
             with self.raises(s_exc.InconsistentStorage):
                 await auth.addAuthGate(core.view.iden, 'newp')
 
+    async def test_auth_email_unique(self):
+
+        async with self.getTestCore() as core:
+
+            auth = core.auth
+
+            alice = await auth.addUser('alice', email='alice@example.com')
+            bob = await auth.addUser('bob')
+
+            self.eq('alice@example.com', alice.info.get('email'))
+            self.eq(alice, await auth.getUserByEmail('alice@example.com'))
+            self.eq(alice.iden, await auth.getUserIdenByEmail('alice@example.com'))
+
+            self.eq(alice, await auth.getUserByEmail('ALICE@EXAMPLE.COM'))
+            self.eq(alice, await auth.getUserByEmail('  alice@example.com  '))
+
+            self.none(await auth.getUserByEmail(None))
+            self.none(await auth.getUserByEmail(''))
+            self.none(await auth.getUserByEmail('nobody@example.com'))
+
+            with self.raises(s_exc.DupEmail):
+                await auth.addUser('alice2', email='alice@example.com')
+
+            with self.raises(s_exc.DupEmail):
+                await auth.addUser('alice3', email='ALICE@example.com')
+
+            with self.raises(s_exc.DupEmail):
+                await auth.setUserInfo(bob.iden, 'email', 'alice@example.com')
+
+            indx = await core.getNexsIndx()
+            await auth.setUserInfo(alice.iden, 'email', 'alice@example.com')
+            self.eq(indx, await core.getNexsIndx())
+
+            indx = await core.getNexsIndx()
+            await auth.setUserInfo(alice.iden, 'email', 'ALICE@EXAMPLE.COM')
+            self.eq(indx, await core.getNexsIndx())
+            self.eq('alice@example.com', alice.info.get('email'))
+
+            await auth.setUserInfo(alice.iden, 'email', 'Alice@Example.org')
+            self.eq('alice@example.org', alice.info.get('email'))
+            self.none(await auth.getUserByEmail('alice@example.com'))
+            self.eq(alice, await auth.getUserByEmail('alice@example.org'))
+
+            charlie = await auth.addUser('charlie', email='alice@example.com')
+            self.eq(charlie, await auth.getUserByEmail('alice@example.com'))
+
+            await auth.setUserInfo(charlie.iden, 'email', None)
+            self.none(await auth.getUserByEmail('alice@example.com'))
+            self.none(charlie.info.get('email'))
+
+            await auth.setUserInfo(bob.iden, 'email', 'bob@example.com')
+            self.eq(bob, await auth.getUserByEmail('bob@example.com'))
+
+            await auth.setUserInfo(bob.iden, 'email', '')
+            self.none(await auth.getUserByEmail('bob@example.com'))
+            self.none(bob.info.get('email'))
+
+            with self.raises(s_exc.BadArg):
+                await auth.setUserInfo(bob.iden, 'email', 'notanemail')
+
+            with self.raises(s_exc.BadArg):
+                await auth.addUser('dave', email='notanemail')
+
+            with self.raises(s_exc.BadArg):
+                await auth.setUserInfo(bob.iden, 'email', 1234)
+
+            await auth.setUserInfo(alice.iden, 'email', 'alice@example.org')
+            await auth.delUser(alice.iden)
+            self.none(await auth.getUserByEmail('alice@example.org'))
+
+            eve = await auth.addUser('eve', email='alice@example.org')
+            self.eq(eve, await auth.getUserByEmail('alice@example.org'))
+
     async def test_hive_tele_auth(self):
 
         # confirm that the primitives used by higher level APIs

--- a/synapse/tests/test_lib_auth.py
+++ b/synapse/tests/test_lib_auth.py
@@ -245,6 +245,17 @@ class AuthTest(s_test.SynTest):
             eve = await auth.addUser('eve', email='alice@example.org')
             self.eq(eve, await auth.getUserByEmail('alice@example.org'))
 
+            # Exercise the nexus handler email branches directly. The public
+            # setUserInfo pre-check normally catches no-ops and duplicates
+            # before _push, but the handler also guards both for replay safety.
+            frank = await auth.addUser('frank', email='frank@example.com')
+            await auth._push('user:info', frank.iden, 'email', 'frank@example.com')
+            self.eq('frank@example.com', frank.info.get('email'))
+
+            grace = await auth.addUser('grace')
+            with self.raises(s_exc.DupUserEmail):
+                await auth._push('user:info', grace.iden, 'email', 'frank@example.com')
+
     async def test_hive_tele_auth(self):
 
         # confirm that the primitives used by higher level APIs

--- a/synapse/tests/test_lib_auth.py
+++ b/synapse/tests/test_lib_auth.py
@@ -192,13 +192,13 @@ class AuthTest(s_test.SynTest):
             self.none(await auth.getUserByEmail(''))
             self.none(await auth.getUserByEmail('nobody@example.com'))
 
-            with self.raises(s_exc.DupEmail):
+            with self.raises(s_exc.DupUserEmail):
                 await auth.addUser('alice2', email='alice@example.com')
 
-            with self.raises(s_exc.DupEmail):
+            with self.raises(s_exc.DupUserEmail):
                 await auth.addUser('alice3', email='ALICE@example.com')
 
-            with self.raises(s_exc.DupEmail):
+            with self.raises(s_exc.DupUserEmail):
                 await auth.setUserInfo(bob.iden, 'email', 'alice@example.com')
 
             indx = await core.getNexsIndx()

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1437,6 +1437,78 @@ class CellTest(s_t_utils.SynTest):
                 self.eq(eve.iden, await cell.auth.getUserIdenByEmail('unique@example.com'))
                 self.eq(eve.iden, await cell.auth.getUserIdenByEmail('UNIQUE@EXAMPLE.COM'))
 
+    async def test_cell_user_email_migration_mirror(self):
+
+        with self.getTestDir() as dirn:
+            path00 = s_common.gendir(dirn, 'cell00')
+            path01 = s_common.gendir(dirn, 'cell01')
+
+            with mock.patch('synapse.lib.cell.NEXUS_VERSION', (2, 198)):
+
+                conf00 = {'dmon:listen': 'tcp://127.0.0.1:0/',
+                          'nexslog:en': True}
+
+                alice_iden = None
+                bob_iden = None
+
+                async with self.getTestCell(s_cell.Cell, dirn=path00, conf=conf00) as cell00:
+                    alice = await cell00.auth.addUser('alice')
+                    bob = await cell00.auth.addUser('bob')
+                    alice_iden = alice.iden
+                    bob_iden = bob.iden
+
+                # Snapshot the leader for the follower to boot from.
+                s_tools_backup.backup(path00, path01)
+
+                async with self.getTestCell(s_cell.Cell, dirn=path00, conf=conf00) as cell00:
+
+                    conf01 = {'dmon:listen': 'tcp://127.0.0.1:0/',
+                              'mirror': cell00.getLocalUrl(),
+                              'nexslog:en': True}
+
+                    async with self.getTestCell(s_cell.Cell, dirn=path01, conf=conf01) as cell01:
+                        await cell01.sync()
+
+                        self.eq((2, 198), cell00.nexsvers)
+                        self.eq((2, 198), cell01.nexsvers)
+
+                        # Seed an identical duplicate-email state on both slabs to
+                        # simulate legacy data carried from before the uniqueness rule.
+                        # Direct slab writes are not replicated through nexus, so we
+                        # apply the same writes to both cells by hand.
+                        for cell in (cell00, cell01):
+                            userkv = cell.slab.getSafeKeyVal('auth').getSubKeyVal('user:info:')
+                            for iden in (alice_iden, bob_iden):
+                                info = userkv.get(iden)
+                                info['email'] = 'shared@example.com'
+                                userkv.set(iden, info)
+                            cell.auth.clearAuthCache()
+
+                        # Bump the nexus version on the leader; the follower replays.
+                        await cell00.setNexsVers((2, 199))
+                        await cell01.sync()
+
+                        self.eq((2, 199), cell00.nexsvers)
+                        self.eq((2, 199), cell01.nexsvers)
+
+                        # Leader and follower must end up with byte-identical user info
+                        # and email index entries.
+                        for iden in (alice_iden, bob_iden):
+                            i00 = cell00.slab.getSafeKeyVal('auth').getSubKeyVal('user:info:').get(iden)
+                            i01 = cell01.slab.getSafeKeyVal('auth').getSubKeyVal('user:info:').get(iden)
+                            self.eq(i00, i01)
+
+                        e00 = dict(cell00.slab.getSafeKeyVal('auth').getSubKeyVal('user:email:').items())
+                        e01 = dict(cell01.slab.getSafeKeyVal('auth').getSubKeyVal('user:email:').items())
+                        self.eq(e00, e01)
+
+                        # Survivor keeps shared@example.com; the other gets rewritten.
+                        self.isin('shared@example.com', e00)
+                        winner = e00['shared@example.com']
+                        loser = bob_iden if winner == alice_iden else alice_iden
+                        self.isin(f'shared+{loser}@example.com', e00)
+                        self.eq(loser, e00[f'shared+{loser}@example.com'])
+
     async def test_cell_auth_userlimit(self):
         maxusers = 3
         conf = {

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1355,6 +1355,82 @@ class CellTest(s_t_utils.SynTest):
                 self.eq('faz', cell.conf.get('auth:conf')['baz'])
                 await cell.auth.addUser('visi')
                 await cell._storCellAuthMigration()
+                await cell._storUserEmailIndexMigration()
+
+    async def test_cell_user_email_migration(self):
+
+        with self.getTestDir() as dirn:
+
+            async with await s_cell.Cell.anit(dirn) as cell:
+
+                authkv = cell.slab.getSafeKeyVal('auth')
+                userkv = authkv.getSubKeyVal('user:info:')
+                emailkv = authkv.getSubKeyVal('user:email:')
+
+                alice = await cell.auth.addUser('alice')
+                bob = await cell.auth.addUser('bob')
+                charlie = await cell.auth.addUser('charlie')
+                doris = await cell.auth.addUser('doris')
+                eve = await cell.auth.addUser('eve')
+
+                ainfo = userkv.get(alice.iden)
+                ainfo['email'] = 'Shared@Example.com'
+                userkv.set(alice.iden, ainfo)
+
+                binfo = userkv.get(bob.iden)
+                binfo['email'] = 'shared@example.com'
+                userkv.set(bob.iden, binfo)
+
+                cinfo = userkv.get(charlie.iden)
+                cinfo['email'] = 'notanemail'
+                userkv.set(charlie.iden, cinfo)
+
+                dinfo = userkv.get(doris.iden)
+                dinfo['email'] = 12345
+                userkv.set(doris.iden, dinfo)
+
+                einfo = userkv.get(eve.iden)
+                einfo['email'] = ' UNIQUE@Example.com '
+                userkv.set(eve.iden, einfo)
+
+                for norm in ('shared@example.com', 'unique@example.com'):
+                    emailkv.delete(norm)
+
+                with self.getLoggerStream('synapse.lib.cell') as stream:
+                    await cell._storUserEmailIndexMigration()
+
+                logs = stream.getvalue()
+                self.isin('Building user email index', logs)
+                self.isin('user email index for Cell', logs)
+                self.isin('Duplicate email', logs)
+                self.isin('malformed email', logs)
+                self.isin('non-string email', logs)
+
+                cell.auth.clearAuthCache()
+
+                # Iteration order over user idens is not insertion order, so the
+                # "winner" of the shared@example.com collision is whichever iden
+                # the slab yields first; the other gets rewritten.
+                aemail = userkv.get(alice.iden).get('email')
+                bemail = userkv.get(bob.iden).get('email')
+
+                if aemail == 'shared@example.com':
+                    first, second = alice, bob
+                else:
+                    first, second = bob, alice
+
+                self.eq('shared@example.com', userkv.get(first.iden).get('email'))
+                self.eq(f'shared+{second.iden}@example.com', userkv.get(second.iden).get('email'))
+
+                self.none(userkv.get(charlie.iden).get('email'))
+                self.none(userkv.get(doris.iden).get('email'))
+                self.eq('unique@example.com', userkv.get(eve.iden).get('email'))
+
+                self.eq(first.iden, await cell.auth.getUserIdenByEmail('shared@example.com'))
+                self.eq(second.iden,
+                        await cell.auth.getUserIdenByEmail(f'shared+{second.iden}@example.com'))
+                self.eq(eve.iden, await cell.auth.getUserIdenByEmail('unique@example.com'))
+                self.eq(eve.iden, await cell.auth.getUserIdenByEmail('UNIQUE@EXAMPLE.COM'))
 
     async def test_cell_auth_userlimit(self):
         maxusers = 3

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1367,8 +1367,10 @@ class CellTest(s_t_utils.SynTest):
                 userkv = authkv.getSubKeyVal('user:info:')
                 emailkv = authkv.getSubKeyVal('user:email:')
 
-                alice = await cell.auth.addUser('alice')
-                bob = await cell.auth.addUser('bob')
+                # Pin idens for the collision pair so alice's record is yielded
+                # by the slab first (lower lex order) and predictably wins.
+                alice = await cell.auth.addUser('alice', iden='aa' + '0' * 30)
+                bob = await cell.auth.addUser('bob', iden='bb' + '0' * 30)
                 charlie = await cell.auth.addUser('charlie')
                 doris = await cell.auth.addUser('doris')
                 eve = await cell.auth.addUser('eve')
@@ -1412,28 +1414,17 @@ class CellTest(s_t_utils.SynTest):
 
                 cell.auth.clearAuthCache()
 
-                # Iteration order over user idens is not insertion order, so the
-                # "winner" of the shared@example.com collision is whichever iden
-                # the slab yields first; the other gets rewritten.
-                aemail = userkv.get(alice.iden).get('email')
-                bemail = userkv.get(bob.iden).get('email')
-
-                if aemail == 'shared@example.com':
-                    first, second = alice, bob
-                else:
-                    first, second = bob, alice
-
-                self.eq('shared@example.com', userkv.get(first.iden).get('email'))
-                self.eq(f'shared+{second.iden}@example.com', userkv.get(second.iden).get('email'))
+                self.eq('shared@example.com', userkv.get(alice.iden).get('email'))
+                self.eq(f'shared+{bob.iden}@example.com', userkv.get(bob.iden).get('email'))
 
                 self.none(userkv.get(charlie.iden).get('email'))
                 self.none(userkv.get(doris.iden).get('email'))
                 self.eq('unique@example.com', userkv.get(eve.iden).get('email'))
                 self.none(userkv.get(frank.iden).get('email'))
 
-                self.eq(first.iden, await cell.auth.getUserIdenByEmail('shared@example.com'))
-                self.eq(second.iden,
-                        await cell.auth.getUserIdenByEmail(f'shared+{second.iden}@example.com'))
+                self.eq(alice.iden, await cell.auth.getUserIdenByEmail('shared@example.com'))
+                self.eq(bob.iden,
+                        await cell.auth.getUserIdenByEmail(f'shared+{bob.iden}@example.com'))
                 self.eq(eve.iden, await cell.auth.getUserIdenByEmail('unique@example.com'))
                 self.eq(eve.iden, await cell.auth.getUserIdenByEmail('UNIQUE@EXAMPLE.COM'))
 
@@ -1452,8 +1443,10 @@ class CellTest(s_t_utils.SynTest):
                 bob_iden = None
 
                 async with self.getTestCell(s_cell.Cell, dirn=path00, conf=conf00) as cell00:
-                    alice = await cell00.auth.addUser('alice')
-                    bob = await cell00.auth.addUser('bob')
+                    # Pin idens so alice is yielded by the slab first and predictably
+                    # wins the duplicate-email rewrite.
+                    alice = await cell00.auth.addUser('alice', iden='aa' + '0' * 30)
+                    bob = await cell00.auth.addUser('bob', iden='bb' + '0' * 30)
                     alice_iden = alice.iden
                     bob_iden = bob.iden
 
@@ -1502,12 +1495,9 @@ class CellTest(s_t_utils.SynTest):
                         e01 = dict(cell01.slab.getSafeKeyVal('auth').getSubKeyVal('user:email:').items())
                         self.eq(e00, e01)
 
-                        # Survivor keeps shared@example.com; the other gets rewritten.
-                        self.isin('shared@example.com', e00)
-                        winner = e00['shared@example.com']
-                        loser = bob_iden if winner == alice_iden else alice_iden
-                        self.isin(f'shared+{loser}@example.com', e00)
-                        self.eq(loser, e00[f'shared+{loser}@example.com'])
+                        # Alice's pinned iden sorts first so she wins the duplicate.
+                        self.eq(alice_iden, e00['shared@example.com'])
+                        self.eq(bob_iden, e00[f'shared+{bob_iden}@example.com'])
 
     async def test_cell_auth_userlimit(self):
         maxusers = 3

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1485,11 +1485,11 @@ class CellTest(s_t_utils.SynTest):
                             cell.auth.clearAuthCache()
 
                         # Bump the nexus version on the leader; the follower replays.
-                        await cell00.setNexsVers((2, 199))
+                        await cell00.setNexsVers((2, 243))
                         await cell01.sync()
 
-                        self.eq((2, 199), cell00.nexsvers)
-                        self.eq((2, 199), cell01.nexsvers)
+                        self.eq((2, 243), cell00.nexsvers)
+                        self.eq((2, 243), cell01.nexsvers)
 
                         # Leader and follower must end up with byte-identical user info
                         # and email index entries.

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -1372,6 +1372,7 @@ class CellTest(s_t_utils.SynTest):
                 charlie = await cell.auth.addUser('charlie')
                 doris = await cell.auth.addUser('doris')
                 eve = await cell.auth.addUser('eve')
+                frank = await cell.auth.addUser('frank')
 
                 ainfo = userkv.get(alice.iden)
                 ainfo['email'] = 'Shared@Example.com'
@@ -1393,6 +1394,10 @@ class CellTest(s_t_utils.SynTest):
                 einfo['email'] = ' UNIQUE@Example.com '
                 userkv.set(eve.iden, einfo)
 
+                finfo = userkv.get(frank.iden)
+                finfo['email'] = ''
+                userkv.set(frank.iden, finfo)
+
                 for norm in ('shared@example.com', 'unique@example.com'):
                     emailkv.delete(norm)
 
@@ -1403,8 +1408,7 @@ class CellTest(s_t_utils.SynTest):
                 self.isin('Building user email index', logs)
                 self.isin('user email index for Cell', logs)
                 self.isin('Duplicate email', logs)
-                self.isin('malformed email', logs)
-                self.isin('non-string email', logs)
+                self.isin('invalid email', logs)
 
                 cell.auth.clearAuthCache()
 
@@ -1425,6 +1429,7 @@ class CellTest(s_t_utils.SynTest):
                 self.none(userkv.get(charlie.iden).get('email'))
                 self.none(userkv.get(doris.iden).get('email'))
                 self.eq('unique@example.com', userkv.get(eve.iden).get('email'))
+                self.none(userkv.get(frank.iden).get('email'))
 
                 self.eq(first.iden, await cell.auth.getUserIdenByEmail('shared@example.com'))
                 self.eq(second.iden,

--- a/synapse/tests/test_lib_stormlib_auth.py
+++ b/synapse/tests/test_lib_stormlib_auth.py
@@ -368,6 +368,33 @@ class StormLibAuthTest(s_test.SynTest):
             self.stormIsInPrint('Controls the ability to open a telepath URL.', msgs)
             self.stormNotInPrint('node.add.<form>', msgs)
 
+    async def test_stormlib_auth_users_byemail(self):
+
+        async with self.getTestCore() as core:
+
+            visiden = await core.callStorm('return($lib.auth.users.add(visi, email=visi@vertex.link).iden)')
+
+            iden = await core.callStorm('return($lib.auth.users.byemail("visi@vertex.link").iden)')
+            self.eq(iden, visiden)
+
+            iden = await core.callStorm('return($lib.auth.users.byemail("VISI@VERTEX.LINK").iden)')
+            self.eq(iden, visiden)
+
+            self.none(await core.callStorm('return($lib.auth.users.byemail("nobody@vertex.link"))'))
+
+            with self.raises(s_exc.DupEmail):
+                await core.callStorm('$lib.auth.users.add(bob, email=visi@vertex.link)')
+
+            await core.callStorm('$lib.auth.users.add(bob)')
+            with self.raises(s_exc.DupEmail):
+                await core.callStorm('$lib.auth.users.byname(bob).email = "VISI@vertex.link"')
+
+            iden = await core.callStorm(
+                'return($lib.auth.users.byemail("visi@vertex.link").iden)',
+                opts={'readonly': True},
+            )
+            self.eq(iden, visiden)
+
     async def test_stormlib_auth_default_allow(self):
         async with self.getTestCore() as core:
 
@@ -1363,8 +1390,8 @@ class StormLibAuthTest(s_test.SynTest):
             await core.callStorm('$lib.auth.users.byname(new1).name = new2')
             self.none(await core.callStorm('return($lib.auth.users.byname(new1))'))
             self.nn(await core.callStorm('return($lib.auth.users.byname(new2))'))
-            await core.callStorm('$lib.auth.users.byname(new2).email = "visi@vertex.link"')
-            self.eq('visi@vertex.link', await core.callStorm('return($lib.auth.users.byname(new2).email)'))
+            await core.callStorm('$lib.auth.users.byname(new2).email = "new2@vertex.link"')
+            self.eq('new2@vertex.link', await core.callStorm('return($lib.auth.users.byname(new2).email)'))
 
             # test renaming a role
             await core.callStorm('$lib.auth.roles.add(new0)')

--- a/synapse/tests/test_lib_stormlib_auth.py
+++ b/synapse/tests/test_lib_stormlib_auth.py
@@ -382,11 +382,11 @@ class StormLibAuthTest(s_test.SynTest):
 
             self.none(await core.callStorm('return($lib.auth.users.byemail("nobody@vertex.link"))'))
 
-            with self.raises(s_exc.DupEmail):
+            with self.raises(s_exc.DupUserEmail):
                 await core.callStorm('$lib.auth.users.add(bob, email=visi@vertex.link)')
 
             await core.callStorm('$lib.auth.users.add(bob)')
-            with self.raises(s_exc.DupEmail):
+            with self.raises(s_exc.DupUserEmail):
                 await core.callStorm('$lib.auth.users.byname(bob).email = "VISI@vertex.link"')
 
             iden = await core.callStorm(


### PR DESCRIPTION
## Summary
- Adds a normalized `user:email:` slab index in `Auth` so user lookup by email is O(1), exposed in Storm as `$lib.auth.users.byemail()`.
- Enforces uniqueness on user email when one is set; collisions raise the new `s_exc.DupEmail`. Email is now persisted in normalized (lowercase, stripped) form.
- Introduces a `cell:storage` v3 migration that builds the index and rewrites any pre-existing duplicate emails to `user+<iden>@<domain>` form so the unique constraint can be enforced without dropping records. Malformed (no ``@``) or non-string legacy emails are cleared with a warning log.

## Test plan
- [x] `python -m pytest -n 8 --dist worksteal synapse/tests/test_lib_auth.py synapse/tests/test_lib_cell.py synapse/tests/test_lib_stormlib_auth.py` — 82 passed, 4 skipped
- [x] `SYNDEV_NEXUS_REPLAY=1 python -m pytest -n 8 --dist worksteal synapse/tests/test_lib_auth.py` — 9 passed, 1 skipped
- [x] `python -m pytest -n 8 --dist worksteal synapse/tests/test_lib_httpapi.py synapse/tests/test_tools_service_moduser.py` — 24 passed (adjacent regression check)
- [x] Manual smoke: `byemail` finds users case- and whitespace-insensitively; duplicate add/set raises `DupEmail`; migration log + slab state inspected against seeded duplicates.

## Notes
- Persisted form of `user.info['email']` is now the normalized value. `pack()` returns the canonical text. This is a small visible change for callers that previously read back exact case-preserved input.
- The migration is a no-op for cells configured with `auth:ctor` (external auth) and for inaugural cells.
- No new Storm permission is registered: `byemail` mirrors `byname`'s readonly behavior.