### PR TITLE
require admin for $lib.aha.callPeerApi and callPeerGenr (SYN-10548)

### DIFF
--- a/changes/9e81c279756e0bf25ec2fb40b6ccbd83.yaml
+++ b/changes/9e81c279756e0bf25ec2fb40b6ccbd83.yaml
@@ -1,0 +1,6 @@
+---
+desc: Added a missing admin check to ``$lib.aha.callPeerApi()`` and ``$lib.aha.callPeerGenr()``.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/synapse/lib/stormlib/aha.py
+++ b/synapse/lib/stormlib/aha.py
@@ -174,6 +174,7 @@ class AhaLib(s_stormtypes.Lib):
             timeout (int): Optional timeout in seconds.
             skiprun (str): Optional run ID argument allows skipping self-enumeration.
         '''
+        self.runt.reqAdmin()
         svcname = await s_stormtypes.tostr(svcname)
         todo = await s_stormtypes.toprim(todo)
         timeout = await s_stormtypes.toint(timeout, noneok=True)
@@ -202,6 +203,7 @@ class AhaLib(s_stormtypes.Lib):
             timeout (int): Optional timeout in seconds.
             skiprun (str): Optional run ID argument allows skipping self-enumeration.
         '''
+        self.runt.reqAdmin()
         svcname = await s_stormtypes.tostr(svcname)
         todo = await s_stormtypes.toprim(todo)
         timeout = await s_stormtypes.toint(timeout, noneok=True)

--- a/synapse/tests/test_lib_stormlib_aha.py
+++ b/synapse/tests/test_lib_stormlib_aha.py
@@ -328,6 +328,21 @@ Connection information:
                     $lib.aha.callPeerApi(noiden.cell..., $todo)
                 '''))
 
+                lowuser = await core00.auth.addUser('lowuser')
+                await lowuser.addRule((True, ('storm',)))
+                lowopts = {'user': lowuser.iden}
+                with self.raises(s_exc.AuthDeny):
+                    await core00.callStorm('''
+                        $todo = $lib.utils.todo('getCellInfo')
+                        for ($name, $info) in $lib.aha.callPeerApi(cell..., $todo) {}
+                    ''', opts=lowopts)
+
+                with self.raises(s_exc.AuthDeny):
+                    await core00.callStorm('''
+                        $todo = $lib.utils.todo('getNexusChanges', (0), wait=(false))
+                        for ($name, $info) in $lib.aha.callPeerGenr(cell..., $todo) {}
+                    ''', opts=lowopts)
+
                 msgs = await core00.stormlist('aha.svc.mirror')
                 self.stormIsInPrint('Service Mirror Groups:', msgs)
                 self.stormIsInPrint('cell.synapse', msgs)


### PR DESCRIPTION
## Summary
- Add `self.runt.reqAdmin()` to `_methCallPeerApi` and `_methCallPeerGenr` in `synapse/lib/stormlib/aha.py`. Every other `$lib.aha.*` method already enforces this check; these two were missing it, allowing a non-admin Storm user to invoke arbitrary Telepath methods on AHA service peers via the Cortex's admin AHA proxy.
- Add a regression test in `test_lib_stormlib_aha.py` that verifies a non-admin user gets `AuthDeny` on both `callPeerApi` and `callPeerGenr`.
- Add a bug-class changelog entry.

Jira: [SYN-10548](https://vertexproject.atlassian.net/browse/SYN-10548)

## Test plan
- [x] `python -m pytest synapse/tests/test_lib_stormlib_aha.py::AhaLibTest::test_stormlib_aha_mirror -v`

[SYN-10548]: https://vertexproject.atlassian.net/browse/SYN-10548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ