### PR TITLE
SYN-10634: Set service log key for AHA service

### DIFF
--- a/changes/0a10a28753b3425a6596f260eb39a053.yaml
+++ b/changes/0a10a28753b3425a6596f260eb39a053.yaml
@@ -1,0 +1,7 @@
+---
+desc: Updated the ``Aha`` service to set the ``service`` key in its log entries directly
+  since it does not register as an ``Aha`` service.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -565,7 +565,7 @@ class AhaCell(s_cell.Cell):
         # 'aha:name' + 'aha:network' will not produce a value when
         # 'aha:name' is not configured. Fall back to 'dns:name' so
         # the 'service' log key is still populated.
-        name = s_cell.Cell.getSvcName(self)
+        name = super().getSvcName(self)
         if name is not None:
             return name
 

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -559,6 +559,19 @@ class AhaCell(s_cell.Cell):
     def getEnvPrefix(cls):
         return ('SYN_AHA', f'SYN_{cls.__name__.upper()}', )
 
+    def _getAhaSvcName(self):
+        # The AHA service does not register itself with AHA, so the
+        # default cell logic that derives the service log name from
+        # both 'aha:name' and 'aha:network' will not produce a value
+        # when 'aha:name' is not configured. Fall back to 'aha' as
+        # the name so the 'service' log key is always populated.
+        ahanetw = self.conf.get('aha:network')
+        if ahanetw is None:
+            return None
+
+        ahaname = self.conf.get('aha:name', 'aha')
+        return f'{ahaname}.{ahanetw}'
+
     async def _initCellBoot(self):
 
         curl = self.conf.get('clone')

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -559,13 +559,13 @@ class AhaCell(s_cell.Cell):
     def getEnvPrefix(cls):
         return ('SYN_AHA', f'SYN_{cls.__name__.upper()}', )
 
-    def _getAhaSvcName(self):
+    def getSvcName(self):
         # The AHA service does not register itself with AHA, so the
-        # default cell logic that derives the service log name from
-        # both 'aha:name' and 'aha:network' will not produce a value
-        # when 'aha:name' is not configured. Fall back to 'dns:name'
-        # so the 'service' log key is still populated.
-        name = s_cell.Cell._getAhaSvcName(self)
+        # default cell logic that derives the log service name from
+        # 'aha:name' + 'aha:network' will not produce a value when
+        # 'aha:name' is not configured. Fall back to 'dns:name' so
+        # the 'service' log key is still populated.
+        name = s_cell.Cell.getSvcName(self)
         if name is not None:
             return name
 

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -565,7 +565,7 @@ class AhaCell(s_cell.Cell):
         # 'aha:name' + 'aha:network' will not produce a value when
         # 'aha:name' is not configured. Fall back to 'dns:name' so
         # the 'service' log key is still populated.
-        name = super().getSvcName(self)
+        name = super().getSvcName()
         if name is not None:
             return name
 

--- a/synapse/lib/aha.py
+++ b/synapse/lib/aha.py
@@ -563,14 +563,13 @@ class AhaCell(s_cell.Cell):
         # The AHA service does not register itself with AHA, so the
         # default cell logic that derives the service log name from
         # both 'aha:name' and 'aha:network' will not produce a value
-        # when 'aha:name' is not configured. Fall back to 'aha' as
-        # the name so the 'service' log key is always populated.
-        ahanetw = self.conf.get('aha:network')
-        if ahanetw is None:
-            return None
+        # when 'aha:name' is not configured. Fall back to 'dns:name'
+        # so the 'service' log key is still populated.
+        name = s_cell.Cell._getAhaSvcName(self)
+        if name is not None:
+            return name
 
-        ahaname = self.conf.get('aha:name', 'aha')
-        return f'{ahaname}.{ahanetw}'
+        return self.conf.get('dns:name')
 
     async def _initCellBoot(self):
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1244,8 +1244,10 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
         # we need to know this pretty early...
         self.ahasvcname = self._getAhaSvcName()
-        if self.ahasvcname is not None:
-            s_logging.setLogInfo('service', self.ahasvcname)
+
+        svcname = self.getSvcName()
+        if svcname is not None:
+            s_logging.setLogInfo('service', svcname)
 
             # Update the processpool configuration as early as possible; before
             # we go through additional boot steps which may trigger pool workers
@@ -2335,9 +2337,9 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
 
     def _getAhaSvcName(self):
         '''
-        Return the AHA service name used as the ``service`` log key
-        and for the ``ahasvcname`` attribute. Returns None when the
-        cell is not configured as an AHA service.
+        Return the AHA service identifier used for the ``ahasvcname``
+        attribute. Returns None when the cell is not configured as
+        an AHA service.
         '''
         ahaname = self.conf.get('aha:name')
         ahanetw = self.conf.get('aha:network')
@@ -2345,6 +2347,14 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             return f'{ahaname}.{ahanetw}'
 
         return None
+
+    def getSvcName(self):
+        '''
+        Return the name used as the ``service`` key for log entries.
+        Defaults to the AHA service identifier. Returns None when
+        no name is available.
+        '''
+        return self._getAhaSvcName()
 
     async def _initAhaService(self):
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1243,11 +1243,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         await self._initCellBoot()
 
         # we need to know this pretty early...
-        self.ahasvcname = None
-        ahaname = self.conf.get('aha:name')
-        ahanetw = self.conf.get('aha:network')
-        if ahaname is not None and ahanetw is not None:
-            self.ahasvcname = f'{ahaname}.{ahanetw}'
+        self.ahasvcname = self._getAhaSvcName()
+        if self.ahasvcname is not None:
             s_logging.setLogInfo('service', self.ahasvcname)
 
             # Update the processpool configuration as early as possible; before
@@ -2335,6 +2332,19 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         }
 
         return ahainfo
+
+    def _getAhaSvcName(self):
+        '''
+        Return the AHA service name used as the ``service`` log key
+        and for the ``ahasvcname`` attribute. Returns None when the
+        cell is not configured as an AHA service.
+        '''
+        ahaname = self.conf.get('aha:name')
+        ahanetw = self.conf.get('aha:network')
+        if ahaname is not None and ahanetw is not None:
+            return f'{ahaname}.{ahanetw}'
+
+        return None
 
     async def _initAhaService(self):
 

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -13,6 +13,7 @@ import synapse.telepath as s_telepath
 import synapse.lib.aha as s_aha
 import synapse.lib.base as s_base
 import synapse.lib.cell as s_cell
+import synapse.lib.logging as s_logging
 
 import synapse.tools.aha.list as s_a_list
 
@@ -497,6 +498,31 @@ class AhaTest(s_test.SynTest):
 
                     async with await s_telepath.openurl('aha://0.cell...') as proxy:
                         self.nn(await proxy.getCellIden())
+
+    async def test_lib_aha_logging(self):
+
+        s_logging.setup()
+
+        # AHA service does not register as an AHA service so make sure
+        # it sets the 'service' log key directly. The default test AHA
+        # has 'aha:network' set to 'synapse' but not 'aha:name'.
+        async with self.getTestAha() as aha:
+            self.eq(aha.ahasvcname, 'aha.synapse')
+
+            with self.getLoggerStream('synapse.lib.aha') as stream:
+                s_aha.logger.warning('aha test message')
+                mesg = stream.jsonlines()[0]
+                self.eq(mesg['service'], 'aha.synapse')
+
+        # An explicit 'aha:name' overrides the default.
+        conf = {'aha:name': 'aha00'}
+        async with self.getTestAha(conf=conf) as aha:
+            self.eq(aha.ahasvcname, 'aha00.synapse')
+
+            with self.getLoggerStream('synapse.lib.aha') as stream:
+                s_aha.logger.warning('aha test message')
+                mesg = stream.jsonlines()[0]
+                self.eq(mesg['service'], 'aha00.synapse')
 
     async def test_lib_aha_bootstrap(self):
 

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -506,9 +506,11 @@ class AhaTest(s_test.SynTest):
         # AHA service does not register as an AHA service so make sure
         # it sets the 'service' log key directly. The default test AHA
         # has 'aha:network' set to 'synapse' and 'dns:name' set but no
-        # 'aha:name', so the service log key falls back to 'dns:name'.
+        # 'aha:name', so the service log key falls back to 'dns:name'
+        # while 'ahasvcname' stays None.
         async with self.getTestAha() as aha:
-            self.eq(aha.ahasvcname, '00.aha.loop.vertex.link')
+            self.none(aha.ahasvcname)
+            self.eq(aha.getSvcName(), '00.aha.loop.vertex.link')
 
             with self.getLoggerStream('synapse.lib.aha') as stream:
                 s_aha.logger.warning('aha test message')
@@ -519,6 +521,7 @@ class AhaTest(s_test.SynTest):
         conf = {'aha:name': 'aha00'}
         async with self.getTestAha(conf=conf) as aha:
             self.eq(aha.ahasvcname, 'aha00.synapse')
+            self.eq(aha.getSvcName(), 'aha00.synapse')
 
             with self.getLoggerStream('synapse.lib.aha') as stream:
                 s_aha.logger.warning('aha test message')
@@ -529,6 +532,7 @@ class AhaTest(s_test.SynTest):
         conf = {'dns:name': None}
         async with self.getTestAha(conf=conf) as aha:
             self.none(aha.ahasvcname)
+            self.none(aha.getSvcName())
 
     async def test_lib_aha_bootstrap(self):
 

--- a/synapse/tests/test_lib_aha.py
+++ b/synapse/tests/test_lib_aha.py
@@ -505,16 +505,17 @@ class AhaTest(s_test.SynTest):
 
         # AHA service does not register as an AHA service so make sure
         # it sets the 'service' log key directly. The default test AHA
-        # has 'aha:network' set to 'synapse' but not 'aha:name'.
+        # has 'aha:network' set to 'synapse' and 'dns:name' set but no
+        # 'aha:name', so the service log key falls back to 'dns:name'.
         async with self.getTestAha() as aha:
-            self.eq(aha.ahasvcname, 'aha.synapse')
+            self.eq(aha.ahasvcname, '00.aha.loop.vertex.link')
 
             with self.getLoggerStream('synapse.lib.aha') as stream:
                 s_aha.logger.warning('aha test message')
                 mesg = stream.jsonlines()[0]
-                self.eq(mesg['service'], 'aha.synapse')
+                self.eq(mesg['service'], '00.aha.loop.vertex.link')
 
-        # An explicit 'aha:name' overrides the default.
+        # An explicit 'aha:name' uses the standard '{name}.{network}' form.
         conf = {'aha:name': 'aha00'}
         async with self.getTestAha(conf=conf) as aha:
             self.eq(aha.ahasvcname, 'aha00.synapse')
@@ -523,6 +524,11 @@ class AhaTest(s_test.SynTest):
                 s_aha.logger.warning('aha test message')
                 mesg = stream.jsonlines()[0]
                 self.eq(mesg['service'], 'aha00.synapse')
+
+        # When neither 'aha:name' nor 'dns:name' is set the key is unset.
+        conf = {'dns:name': None}
+        async with self.getTestAha(conf=conf) as aha:
+            self.none(aha.ahasvcname)
 
     async def test_lib_aha_bootstrap(self):
 


### PR DESCRIPTION
## Summary
- `AhaCell` did not populate the `service` log key because the typical AHA deployment (per `docs/synapse/kubernetes/aha.yaml`) sets `aha:network` but not `aha:name`, so the `Cell.__anit__` block that derives `service` from both never fires.
- Extracted the derivation into `Cell._getAhaSvcName()`; `AhaCell._getAhaSvcName()` overrides to default `aha:name` to `'aha'` so the key is always set.

## Test plan
- [x] `python -m pytest synapse/tests/test_lib_aha.py` (26 passed, includes new `test_lib_aha_logging`)
- [x] `python -m pytest synapse/tests/test_lib_cell.py` (60 passed, 3 skipped)

Jira: https://vertexproject.atlassian.net/browse/SYN-10634