### PR TITLE
SYN-10728: Add inet:whois:iprec:org and :org:name properties

### DIFF
--- a/changes/e64cbe2adb082d5fb180eebc3e671727.yaml
+++ b/changes/e64cbe2adb082d5fb180eebc3e671727.yaml
@@ -1,0 +1,7 @@
+---
+desc: Added ``inet:whois:iprec:org`` and ``inet:whois:iprec:org:name`` properties to
+  better capture the organization that registered the network.
+desc:literal: false
+prs: []
+type: model
+...

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -3543,6 +3543,12 @@ class InetModule(s_module.CoreModule):
                         ('name', ('str', {}), {
                             'doc': 'The name assigned to the network by the registrant.'
                         }),
+                        ('org', ('ou:org', {}), {
+                            'doc': 'The organization that registered the network.'
+                        }),
+                        ('org:name', ('ou:name', {}), {
+                            'doc': 'The name of the organization that registered the network.'
+                        }),
                         ('parentid', ('inet:whois:regid', {}), {
                             'doc': 'The registry unique identifier of the parent whois record (e.g. NET-74-0-0-0-0).'
                         }),

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -2682,6 +2682,7 @@ class InetModelTest(s_t_utils.SynTest):
         async with self.getTestCore() as core:
             contact = s_common.guid()
             addlcontact = s_common.guid()
+            org = s_common.guid()
             rec_ipv4 = s_common.guid()
             props = {
                 'net4': '10.0.0.0/28',
@@ -2693,6 +2694,8 @@ class InetModelTest(s_t_utils.SynTest):
                 'asn': 12345,
                 'id': 'NET-10-0-0-0-1',
                 'name': 'vtx',
+                'org': org,
+                'org:name': ' VERTEX Project ',
                 'parentid': 'NET-10-0-0-0-0',
                 'registrant': contact,
                 'contacts': (addlcontact, ),
@@ -2702,9 +2705,9 @@ class InetModelTest(s_t_utils.SynTest):
                 'links': ('http://rdap.com/foo', 'http://rdap.net/bar'),
             }
             q = '''[(inet:whois:iprec=$valu :net4=$p.net4 :asof=$p.asof :created=$p.created :updated=$p.updated
-                :text=$p.text :desc=$p.desc :asn=$p.asn :id=$p.id :name=$p.name :parentid=$p.parentid
-                :registrant=$p.registrant :contacts=$p.contacts :country=$p.country :status=$p.status :type=$p.type
-                :links=$p.links)]'''
+                :text=$p.text :desc=$p.desc :asn=$p.asn :id=$p.id :name=$p.name :org=$p.org :org:name=$p."org:name"
+                :parentid=$p.parentid :registrant=$p.registrant :contacts=$p.contacts :country=$p.country
+                :status=$p.status :type=$p.type :links=$p.links)]'''
             nodes = await core.nodes(q, opts={'vars': {'valu': rec_ipv4, 'p': props}})
             self.len(1, nodes)
             node = nodes[0]
@@ -2720,6 +2723,8 @@ class InetModelTest(s_t_utils.SynTest):
             self.eq(node.get('asn'), 12345)
             self.eq(node.get('id'), 'NET-10-0-0-0-1')
             self.eq(node.get('name'), 'vtx')
+            self.eq(node.get('org'), org)
+            self.eq(node.get('org:name'), 'vertex project')
             self.eq(node.get('parentid'), 'NET-10-0-0-0-0')
             self.eq(node.get('registrant'), contact)
             self.eq(node.get('contacts'), (addlcontact,))


### PR DESCRIPTION
## Summary
- Add ``inet:whois:iprec:org`` (``ou:org``) and ``inet:whois:iprec:org:name`` (``ou:name``) to explicitly capture the organization that registered an IP network.
- ``inet:whois:iprec:registrant`` remains deprecated (unchanged).

Ref: [SYN-10728](https://vertexproject.atlassian.net/browse/SYN-10728)

## Test plan
- [x] ``test_whois_iprec`` extended to set/check ``:org`` and ``:org:name``
- [x] Full ``synapse/tests/test_model_inet.py`` passes locally (71/71)

[SYN-10728]: https://vertexproject.atlassian.net/browse/SYN-10728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ