### PR TITLE
WIP: Force init/fini AST nodes to the beginning/end of their siblings

### DIFF
--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -48,13 +48,14 @@ class AstNode:
     '''
     # set to True if recursive runt-safety checks should *not* recurse
     # into children of this node.
+    nodeprio = 0
     runtopaque = False
 
     def __init__(self, astinfo, kids=()):
         self.kids = []
         self.astinfo = astinfo
         self.hasast = {}
-        [self.addKid(k) for k in kids]
+        [self.addKid(k) for k in sorted(kids, key=lambda x: x.nodeprio)]
 
     def getAstText(self):
         return self.astinfo.text[self.astinfo.soff:self.astinfo.eoff]
@@ -880,6 +881,7 @@ class InitBlock(AstNode):
             }
 
     '''
+    nodeprio = -1
 
     async def run(self, runt, genr):
 
@@ -947,6 +949,7 @@ class FiniBlock(AstNode):
         A fini block must be runtsafe.
 
     '''
+    nodeprio = 1
 
     async def run(self, runt, genr):
 

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -2171,7 +2171,7 @@ class AstTest(s_test.SynTest):
 
             nodes = [m[1] for m in msgs if m[0] == 'node']
 
-            self.eq(nodes[0][0], ('test:int', 0))
+            self.eq(nodes[0][0], ('test:int', 2))
             self.eq(nodes[1][0], ('test:int', 2))
 
             nodes = await core.nodes('init { [ test:int=20 ] }')
@@ -2214,8 +2214,8 @@ class AstTest(s_test.SynTest):
             # Runtsafe init works and can yield nodes, this has inbound nodes as well
             q = '''
             test:str^=init
-            $hehe="const"
             init {
+                $hehe="const"
                 [test:str=$hehe]
             }
             '''
@@ -2267,7 +2267,22 @@ class AstTest(s_test.SynTest):
             firs = [m for m in msgs if m[0] == 'storm:fire']
             self.len(1, firs)
             evnt = firs[0]
-            self.eq(evnt[1].get('data'), {'total': 3})
+            self.eq(evnt[1].get('data'), {'total': 2})
+
+            # Init blocks always run first before anything else, but still retain their order
+            nodes = await core.nodes('''
+            for $x in $lib.range($cnt) {
+                [ test:int=$foo ]
+                init { $foo=$x }
+                init { $foo=($foo + 1) }
+            }
+            init { $cnt=(3) }
+            ''')
+
+            self.len(3, nodes)
+            self.eq(nodes[0].ndef, ('test:int', 1))
+            self.eq(nodes[1].ndef, ('test:int', 2))
+            self.eq(nodes[2].ndef, ('test:int', 3))
 
     async def test_ast_emptyblock(self):
 


### PR DESCRIPTION
```
[inet:ipv4=1.1.1.1 inet:ipv4=2.2.2.2] |

init {
    $gronk = "newp"
    $global_count = 0
}

for $x in (["one", "two", "three"]) {
    $gronk = $x
    $global_count = ($global_count + 1)
}
$lib.print($gronk)
$lib.print($global_count)
```

> 1. inet:ipv4=1.1.1.1 is created and its path is initialized, but there are no runtime vars so it gets no path vars
> 2. the init is run, setting $global_count=0, before yielding the 1.1.1.1 node further
> 3. at the start of the loop, the node+path is cloned for each iteration, but at this point the path has no vars set yet
> 4. inside the loop $global_count is pulled from the runtime since each clone of the path does not have it set, this causes it to be incremented from 0 -> 1 -> 2 -> 3 in the 3 iterations
> 5. we reach the bottom of query and print $global_count which has a value of 3
> 6. inet:ipv4=1.1.1.1 is created and its path is initialized, there are now runtime vars set so $global_count is set to 3 on the path from the value on the runtime
> 7. the init has already been run so nothing happens and the 2.2.2.2 continues on
> 8. at the start of the loop, this time we do have path vars, so each clone of the path has $global_count set to 3
> 9. inside the loop, $global_count is now pulled from the path rather than the runtime, so each iteration of the loop only increments the value from 3 -> 4
> 10. we reach the bottom of query and print $global_count which has a value of 4