### PR TITLE
SYN-10713: add --percent option to stats.countby

### DIFF
--- a/changes/b6963550d557f13088b5f2c5d8bbe1a2.yaml
+++ b/changes/b6963550d557f13088b5f2c5d8bbe1a2.yaml
@@ -1,0 +1,7 @@
+---
+desc: Added the ``--percent`` option to the ``stats.countby`` Storm command to include
+  a percent column in the output.
+desc:literal: false
+prs: []
+type: feat
+...

--- a/synapse/lib/stormlib/stats.py
+++ b/synapse/lib/stormlib/stats.py
@@ -116,7 +116,10 @@ class StatsCountByCmd(s_storm.Cmd):
             if size:
                 values = values[len(values) - size:]
 
-        totalcount = sum(counts.values())
+        pctstrs = {}
+        if percent:
+            totalcount = sum(counts.values())
+            pctstrs = {name: f'{(count / totalcount) * 100.0:.2f}%' for (name, count) in values}
 
         namewidth = 0
         countwidth = 0
@@ -128,10 +131,8 @@ class StatsCountByCmd(s_storm.Cmd):
             if (countlen := len(str(count))) > countwidth:
                 countwidth = countlen
 
-            if percent:
-                pct = (count / totalcount) * 100.0
-                if (pctlen := len(f'{pct:.2f}%')) > pctwidth:
-                    pctwidth = pctlen
+            if percent and (pctlen := len(pctstrs[name])) > pctwidth:
+                pctwidth = pctlen
 
         if labelwidth is not None:
             namewidth = min(labelwidth, namewidth)
@@ -141,8 +142,7 @@ class StatsCountByCmd(s_storm.Cmd):
             barsize = int((count / maxv) * barwidth)
             bar = ''.ljust(barsize, char)
             if percent:
-                pctstr = f'{(count / totalcount) * 100.0:.2f}%'
-                line = f'{name[0:namewidth].rjust(namewidth)} | {count:>{countwidth}} | {pctstr:>{pctwidth}} | {bar}'
+                line = f'{name[0:namewidth].rjust(namewidth)} | {count:>{countwidth}} | {pctstrs[name]:>{pctwidth}} | {bar}'
             else:
                 line = f'{name[0:namewidth].rjust(namewidth)} | {count:>{countwidth}} | {bar}'
 

--- a/synapse/lib/stormlib/stats.py
+++ b/synapse/lib/stormlib/stats.py
@@ -43,6 +43,8 @@ class StatsCountByCmd(s_storm.Cmd):
                           dest='yieldnodes', help='Yield inbound nodes.')
         pars.add_argument('--by-name', default=False, action='store_true',
                           help='Print stats sorted by name instead of count.')
+        pars.add_argument('--percent', default=False, action='store_true',
+                          help='Include a percent column after the count column.')
         return pars
 
     async def execStormCmd(self, runt, genr):
@@ -58,6 +60,7 @@ class StatsCountByCmd(s_storm.Cmd):
             raise s_exc.BadArg(mesg=mesg)
 
         byname = await s_stormtypes.tobool(self.opts.by_name)
+        percent = await s_stormtypes.tobool(self.opts.percent)
 
         counts = collections.defaultdict(int)
 
@@ -113,14 +116,22 @@ class StatsCountByCmd(s_storm.Cmd):
             if size:
                 values = values[len(values) - size:]
 
+        totalcount = sum(counts.values())
+
         namewidth = 0
         countwidth = 0
+        pctwidth = 0
         for (name, count) in values:
             if (namelen := len(str(name))) > namewidth:
                 namewidth = namelen
 
             if (countlen := len(str(count))) > countwidth:
                 countwidth = countlen
+
+            if percent:
+                pct = (count / totalcount) * 100.0
+                if (pctlen := len(f'{pct:.2f}%')) > pctwidth:
+                    pctwidth = pctlen
 
         if labelwidth is not None:
             namewidth = min(labelwidth, namewidth)
@@ -129,7 +140,11 @@ class StatsCountByCmd(s_storm.Cmd):
 
             barsize = int((count / maxv) * barwidth)
             bar = ''.ljust(barsize, char)
-            line = f'{name[0:namewidth].rjust(namewidth)} | {count:>{countwidth}} | {bar}'
+            if percent:
+                pctstr = f'{(count / totalcount) * 100.0:.2f}%'
+                line = f'{name[0:namewidth].rjust(namewidth)} | {count:>{countwidth}} | {pctstr:>{pctwidth}} | {bar}'
+            else:
+                line = f'{name[0:namewidth].rjust(namewidth)} | {count:>{countwidth}} | {bar}'
 
             await runt.printf(line)
 

--- a/synapse/tests/test_lib_stormlib_stats.py
+++ b/synapse/tests/test_lib_stormlib_stats.py
@@ -114,6 +114,20 @@ chartipv4_byname = '''
  0.0.0.1 | 1 | ##################################################
 '''.strip()
 
+chartpercent = '''
+ 6 | 5 | 33.33% | ##################################################
+13 | 4 | 26.67% | ########################################
+ 3 | 3 | 20.00% | ##############################
+10 | 2 | 13.33% | ####################
+ 0 | 1 |  6.67% | ##########
+'''.strip()
+
+chartpercent_size = '''
+ 6 | 5 | 33.33% | ##################################################
+13 | 4 | 26.67% | ########################################
+ 3 | 3 | 20.00% | ##############################
+'''.strip()
+
 
 class StatsTest(s_test.SynTest):
 
@@ -183,6 +197,12 @@ class StatsTest(s_test.SynTest):
             msgs = await core.stormlist(
                 'inet:ipv4=0.0.0.1 inet:ipv4=0.0.0.2 inet:ipv4=0.0.0.6 inet:ipv4=0.0.0.10 | stats.countby --by-name')
             self.stormIsInPrint(chartipv4_byname, msgs)
+
+            msgs = await core.stormlist('inet:ipv4 | stats.countby :asn --percent')
+            self.stormIsInPrint(chartpercent, msgs)
+
+            msgs = await core.stormlist('inet:ipv4 | stats.countby :asn --percent --size 3')
+            self.stormIsInPrint(chartpercent_size, msgs)
 
             msgs = await core.stormlist('stats.countby foo')
             self.stormIsInPrint('No values to display!', msgs)

--- a/synapse/tests/test_lib_stormlib_stats.py
+++ b/synapse/tests/test_lib_stormlib_stats.py
@@ -128,6 +128,14 @@ chartpercent_size = '''
  3 | 3 | 20.00% | ##############################
 '''.strip()
 
+chartpercent_rev_byname = '''
+ 0 | 1 |  6.67% | ##########
+ 3 | 3 | 20.00% | ##############################
+ 6 | 5 | 33.33% | ##################################################
+10 | 2 | 13.33% | ####################
+13 | 4 | 26.67% | ########################################
+'''.strip()
+
 
 class StatsTest(s_test.SynTest):
 
@@ -203,6 +211,9 @@ class StatsTest(s_test.SynTest):
 
             msgs = await core.stormlist('inet:ipv4 | stats.countby :asn --percent --size 3')
             self.stormIsInPrint(chartpercent_size, msgs)
+
+            msgs = await core.stormlist('inet:ipv4 | stats.countby :asn --percent --reverse --by-name')
+            self.stormIsInPrint(chartpercent_rev_byname, msgs)
 
             msgs = await core.stormlist('stats.countby foo')
             self.stormIsInPrint('No values to display!', msgs)


### PR DESCRIPTION
## Summary
- Adds ``--percent`` flag to the ``stats.countby`` Storm command which inserts a percent column after the count column.
- Percentages are computed against the total of all tallied counts, so ``--size`` still reflects dataset proportions.

Jira: [SYN-10713](https://vertexproject.atlassian.net/browse/SYN-10713)

## Test plan
- [x] ``python -m pytest synapse/tests/test_lib_stormlib_stats.py``

[SYN-10713]: https://vertexproject.atlassian.net/browse/SYN-10713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ