### PR TITLE
Fast service shutdown (SYN-10746, SYN-10758)

### DIFF
--- a/changes/5df6c0f247b1ec50ac71d8f42e91b192.yaml
+++ b/changes/5df6c0f247b1ec50ac71d8f42e91b192.yaml
@@ -1,5 +1,5 @@
 ---
-desc: Fix a bug in the ``Cell.shutdown()`` API where the ``timeout`` argument was not bounding
+desc: Fixed a bug in the ``Cell.shutdown()`` API where the ``timeout`` argument was not bounding
   the total runtime of the API. That timeout argument is now applied across the entire function.
 desc:literal: false
 prs: []

--- a/changes/5df6c0f247b1ec50ac71d8f42e91b192.yaml
+++ b/changes/5df6c0f247b1ec50ac71d8f42e91b192.yaml
@@ -1,0 +1,7 @@
+---
+desc: Fix a bug in the ``Cell.shutdown()`` API where the ``timeout`` argument was not bounding
+  the total runtime of the API. That timeout argument is now applied across the entire function.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/changes/84d831ce9b8546eac1ba231e3586209c.yaml
+++ b/changes/84d831ce9b8546eac1ba231e3586209c.yaml
@@ -1,8 +1,11 @@
 ---
-desc: Added a ``--drain`` argument to the ``synapse.tools.service.shutdown`` tool.
+desc: Added a ``--no-drain`` argument to the ``synapse.tools.service.shutdown`` tool.
   This argument causes running tasks to be cancelled when the service is shutdown, instead
-  of waiting for them to finish. The tool now has an exit code of ``2`` for unexpected
-  errors, distinguishing them from a graceful shutdown aborted due to timeout (exit code ``1``).
+  of waiting for them to finish. ``Cell.shutdown()`` / ``CellApi.shutdown()`` /
+  ``Boss.shutdown()`` accept a corresponding ``drain`` keyword (default ``True``); pass
+  ``drain=False`` to opt into the fast cancel path. The tool now has an exit code of
+  ``2`` for unexpected errors, distinguishing them from a graceful shutdown aborted due
+  to timeout (exit code ``1``).
 desc:literal: false
 prs: []
 type: feat

--- a/changes/84d831ce9b8546eac1ba231e3586209c.yaml
+++ b/changes/84d831ce9b8546eac1ba231e3586209c.yaml
@@ -1,7 +1,7 @@
 ---
 desc: Added a ``--no-drain`` argument to the ``synapse.tools.service.shutdown`` tool.
   This argument causes running tasks to be cancelled when the service is shutdown, instead
-  of waiting for them to finish. The tool now has an exit code of  ``2`` for unexpected
+  of waiting for them to finish. The tool now has an exit code of ``2`` for unexpected
   errors, distinguishing them from a graceful shutdown aborted due to timeout
   (exit code ``1``).
 desc:literal: false

--- a/changes/84d831ce9b8546eac1ba231e3586209c.yaml
+++ b/changes/84d831ce9b8546eac1ba231e3586209c.yaml
@@ -1,5 +1,5 @@
 ---
-desc: Added a ``--cancel-tasks`` argument to the ``synapse.tools.service.shutdown`` tool.
+desc: Added a ``--drain`` argument to the ``synapse.tools.service.shutdown`` tool.
   This argument causes running tasks to be cancelled when the service is shutdown, instead
   of waiting for them to finish. The tool now has an exit code of ``2`` for unexpected
   errors, distinguishing them from a graceful shutdown aborted due to timeout (exit code ``1``).

--- a/changes/84d831ce9b8546eac1ba231e3586209c.yaml
+++ b/changes/84d831ce9b8546eac1ba231e3586209c.yaml
@@ -1,0 +1,9 @@
+---
+desc: Added a ``--cancel-tasks`` argument to the ``synapse.tools.service.shutdown`` tool.
+  This argument causes running tasks to be cancelled when the service is shutdown, instead
+  of waiting for them to finish. The tool now has a exit code of ``2`` when a graceful
+  shutdown is aborted due to timeout, distinguishing it from unexpected errors (exiting with ``1``).
+desc:literal: false
+prs: []
+type: feat
+...

--- a/changes/84d831ce9b8546eac1ba231e3586209c.yaml
+++ b/changes/84d831ce9b8546eac1ba231e3586209c.yaml
@@ -1,8 +1,8 @@
 ---
 desc: Added a ``--cancel-tasks`` argument to the ``synapse.tools.service.shutdown`` tool.
   This argument causes running tasks to be cancelled when the service is shutdown, instead
-  of waiting for them to finish. The tool now has a exit code of ``2`` when a graceful
-  shutdown is aborted due to timeout, distinguishing it from unexpected errors (exiting with ``1``).
+  of waiting for them to finish. The tool now has an exit code of ``2`` for unexpected
+  errors, distinguishing them from a graceful shutdown aborted due to timeout (exit code ``1``).
 desc:literal: false
 prs: []
 type: feat

--- a/changes/84d831ce9b8546eac1ba231e3586209c.yaml
+++ b/changes/84d831ce9b8546eac1ba231e3586209c.yaml
@@ -1,11 +1,9 @@
 ---
 desc: Added a ``--no-drain`` argument to the ``synapse.tools.service.shutdown`` tool.
   This argument causes running tasks to be cancelled when the service is shutdown, instead
-  of waiting for them to finish. ``Cell.shutdown()`` / ``CellApi.shutdown()`` /
-  ``Boss.shutdown()`` accept a corresponding ``drain`` keyword (default ``True``); pass
-  ``drain=False`` to opt into the fast cancel path. The tool now has an exit code of
-  ``2`` for unexpected errors, distinguishing them from a graceful shutdown aborted due
-  to timeout (exit code ``1``).
+  of waiting for them to finish. The tool now has an exit code of  ``2`` for unexpected
+  errors, distinguishing them from a graceful shutdown aborted due to timeout
+  (exit code ``1``).
 desc:literal: false
 prs: []
 type: feat

--- a/synapse/lib/boss.py
+++ b/synapse/lib/boss.py
@@ -33,16 +33,16 @@ class Boss(s_base.Base):
         Background tasks and child tasks are not awaited or cancelled.
 
         Args:
-            timeout: Optional total time budget in seconds for reaping tasks.
-                The budget is shared across all tasks; if it is exhausted
+            timeout: Optional total timeout in seconds for reaping tasks.
+                The timeout is shared across all tasks; if it is reached
                 before every task is reaped the shutdown is aborted. ``None``
                 blocks indefinitely.
             cancel_tasks: If True, cancel top-level tasks before awaiting them.
                 If False, top-level tasks are only awaited.
 
         Returns:
-            bool: True if all eligible tasks were reaped before the budget
-            was exhausted; False otherwise.
+            bool: True if all eligible tasks were reaped before the timeout
+            was reached; False otherwise.
         '''
         self.reqNotShut()
 

--- a/synapse/lib/boss.py
+++ b/synapse/lib/boss.py
@@ -25,7 +25,7 @@ class Boss(s_base.Base):
         self.shutdown_lock = asyncio.Lock()
         self.onfini(self._onBossFini)
 
-    async def shutdown(self, timeout=None, cancel_tasks=False):
+    async def shutdown(self, timeout=None, drain=True):
         '''
         Initiate a shutdown of the Boss by stopping promotion of any new tasks
         and either awaiting or cancelling top-level promoted tasks.
@@ -37,8 +37,9 @@ class Boss(s_base.Base):
                 The timeout is shared across all tasks; if it is reached
                 before every task is reaped the shutdown is aborted. ``None``
                 blocks indefinitely.
-            cancel_tasks: If True, cancel top-level tasks before awaiting them.
-                If False, top-level tasks are only awaited.
+            drain: If True (the default), top-level tasks are awaited until
+                they complete on their own. If False, top-level tasks are
+                cancelled before being awaited.
 
         Returns:
             bool: True if all eligible tasks were reaped before the timeout
@@ -51,7 +52,7 @@ class Boss(s_base.Base):
             toplevel = [task for task in self.tasks.values()
                         if task.root is None and not task.background]
 
-            if cancel_tasks:
+            if not drain:
                 for task in toplevel:
                     task.task.cancel()
 

--- a/synapse/lib/boss.py
+++ b/synapse/lib/boss.py
@@ -26,9 +26,24 @@ class Boss(s_base.Base):
         self.onfini(self._onBossFini)
 
     async def shutdown(self, timeout=None, cancel_tasks=False):
-        # when a boss is "shutting down" it should not promote any new tasks,
-        # but await the completion of any which are already underway...
+        '''
+        Initiate a shutdown of the Boss by stopping promotion of any new tasks
+        and either awaiting or cancelling top-level promoted tasks.
 
+        Background tasks and child tasks are not awaited or cancelled.
+
+        Args:
+            timeout: Optional total time budget in seconds for reaping tasks.
+                The budget is shared across all tasks; if it is exhausted
+                before every task is reaped the shutdown is aborted. ``None``
+                blocks indefinitely.
+            cancel_tasks: If True, cancel top-level tasks before awaiting them.
+                If False, top-level tasks are only awaited.
+
+        Returns:
+            bool: True if all eligible tasks were reaped before the budget
+            was exhausted; False otherwise.
+        '''
         self.reqNotShut()
 
         async with self.shutdown_lock:

--- a/synapse/lib/boss.py
+++ b/synapse/lib/boss.py
@@ -25,7 +25,7 @@ class Boss(s_base.Base):
         self.shutdown_lock = asyncio.Lock()
         self.onfini(self._onBossFini)
 
-    async def shutdown(self, timeout=None):
+    async def shutdown(self, timeout=None, cancel_tasks=False):
         # when a boss is "shutting down" it should not promote any new tasks,
         # but await the completion of any which are already underway...
 
@@ -33,17 +33,18 @@ class Boss(s_base.Base):
 
         async with self.shutdown_lock:
 
-            for task in list(self.tasks.values()):
+            toplevel = [task for task in self.tasks.values()
+                        if task.root is None and not task.background]
 
-                # do not wait on child tasks
-                if task.root is not None:
-                    continue
+            if cancel_tasks:
+                for task in toplevel:
+                    task.task.cancel()
 
-                # do not wait on background tasks
-                if task.background:
-                    continue
+            remaining = s_coro.deadline(timeout)
 
-                if not await s_coro.waittask(task.task, timeout=timeout):
+            for task in toplevel:
+
+                if not await s_coro.waittask(task.task, timeout=remaining()):
                     return False
 
             self.is_shutdown = True

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1717,10 +1717,6 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         # if we're the leader, lets see if we can handoff...
         if self.isactive and self.ahaclient is not None:
 
-            if timeout is not None and remaining() == 0.0:
-                logger.warning('...timeout reached before demote phase. Aborting shutdown.', extra=extra)
-                return False
-
             try:
                 peers = await self._getDemotePeers(timeout=remaining())
             except TimeoutError:

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -210,7 +210,7 @@ class CellApi(s_base.Base):
         pass
 
     @adminapi(log=True)
-    async def shutdown(self, timeout=None, drain=False):
+    async def shutdown(self, timeout=None, drain=True):
         return await self.cell.shutdown(timeout=timeout, drain=drain)
 
     @adminapi(log=True)
@@ -1693,13 +1693,13 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             self._onFiniCellGuid()
         return retn
 
-    async def shutdown(self, timeout=None, drain=False):
+    async def shutdown(self, timeout=None, drain=True):
         '''
         Execute a graceful shutdown.
 
-        When ``drain`` is False, promoted boss tasks are awaited until they
-        complete. When ``drain`` is True, promoted boss tasks are cancelled
-        and then awaited.
+        When ``drain`` is True (the default), promoted boss tasks are awaited
+        until they complete. When ``drain`` is False, promoted boss tasks are
+        cancelled and then awaited.
 
         The ``timeout`` argument bounds the entire operation. Demote and task
         reaping share the single timeout value; no sub-phase may exceed the
@@ -1732,7 +1732,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             logger.warning('...timeout reached before tasks phase. Aborting shutdown.', extra=extra)
             return False
 
-        if not await self.boss.shutdown(timeout=remaining(), cancel_tasks=drain):
+        if not await self.boss.shutdown(timeout=remaining(), drain=drain):
             logger.warning('...tasks did not complete within timeout. Aborting shutdown.', extra=extra)
             return False
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -210,8 +210,8 @@ class CellApi(s_base.Base):
         pass
 
     @adminapi(log=True)
-    async def shutdown(self, timeout=None):
-        return await self.cell.shutdown(timeout=timeout)
+    async def shutdown(self, timeout=None, cancel_tasks=False):
+        return await self.cell.shutdown(timeout=timeout, cancel_tasks=cancel_tasks)
 
     @adminapi(log=True)
     async def freeze(self, timeout=30):
@@ -1217,7 +1217,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             'tellready': 1,
             'dynmirror': 1,
             'tasks': 1,
-            'issuewait': 1
+            'issuewait': 1,
+            'shutdowncancel': 1,
         }
 
         self.safemode = self.conf.req('safemode')
@@ -1692,23 +1693,50 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             self._onFiniCellGuid()
         return retn
 
-    async def shutdown(self, timeout=None):
+    async def shutdown(self, timeout=None, cancel_tasks=False):
         '''
-        Execute a graceful shutdown by allowing any promoted boss tasks to complete
-        and prevents the boss from accepting additional tasks.
+        Execute a graceful shutdown.
+
+        When ``cancel_tasks`` is False, promoted boss tasks are awaited until they
+        complete. When ``cancel_tasks`` is True, promoted boss tasks are cancelled
+        and then awaited.
+
+        The ``timeout`` argument bounds the entire operation. Demote and task
+        reaping share a single budget; no sub-phase may exceed the time
+        remaining when it starts.
+
+        Returns:
+            bool: True if the shutdown was initiated, False if the timeout was
+            exhausted before completion.
         '''
         extra = self.getLogExtra()
         logger.warning('Graceful shutdown initiated...', extra=extra)
 
+        remaining = s_coro.deadline(timeout)
+
         # if we're the leader, lets see if we can handoff...
         if self.isactive and self.ahaclient is not None:
-            peers = await self._getDemotePeers(timeout=timeout)
+
+            if timeout is not None and remaining() == 0.0:
+                logger.warning('...budget exhausted before demote phase. Aborting shutdown.', extra=extra)
+                return False
+
+            try:
+                peers = await self._getDemotePeers(timeout=remaining())
+            except TimeoutError:
+                logger.warning('...budget exhausted finding demote peers. Aborting shutdown.', extra=extra)
+                return False
+
             if peers:
-                if not await self.demote(peers=peers, timeout=timeout): # pragma: no cover
+                if not await self.demote(peers=peers, timeout=remaining()): # pragma: no cover
                     logger.warning('...we are the leader and failed to demote. Aborting shutdown.', extra=extra)
                     return False
 
-        if not await self.boss.shutdown(timeout=timeout):
+        if timeout is not None and remaining() == 0.0:
+            logger.warning('...budget exhausted before tasks phase. Aborting shutdown.', extra=extra)
+            return False
+
+        if not await self.boss.shutdown(timeout=remaining(), cancel_tasks=cancel_tasks):
             logger.warning('...tasks did not complete within timeout. Aborting shutdown.', extra=extra)
             return False
 

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -1702,8 +1702,8 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         and then awaited.
 
         The ``timeout`` argument bounds the entire operation. Demote and task
-        reaping share a single budget; no sub-phase may exceed the time
-        remaining when it starts.
+        reaping share the single timeout value; no sub-phase may exceed the
+        time remaining when it starts.
 
         Returns:
             bool: True if the shutdown was initiated, False if the timeout was
@@ -1718,13 +1718,13 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
         if self.isactive and self.ahaclient is not None:
 
             if timeout is not None and remaining() == 0.0:
-                logger.warning('...budget exhausted before demote phase. Aborting shutdown.', extra=extra)
+                logger.warning('...timeout reached before demote phase. Aborting shutdown.', extra=extra)
                 return False
 
             try:
                 peers = await self._getDemotePeers(timeout=remaining())
             except TimeoutError:
-                logger.warning('...budget exhausted finding demote peers. Aborting shutdown.', extra=extra)
+                logger.warning('...timeout reached while finding demote peers. Aborting shutdown.', extra=extra)
                 return False
 
             if peers:
@@ -1733,7 +1733,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
                     return False
 
         if timeout is not None and remaining() == 0.0:
-            logger.warning('...budget exhausted before tasks phase. Aborting shutdown.', extra=extra)
+            logger.warning('...timeout reached before tasks phase. Aborting shutdown.', extra=extra)
             return False
 
         if not await self.boss.shutdown(timeout=remaining(), cancel_tasks=cancel_tasks):

--- a/synapse/lib/cell.py
+++ b/synapse/lib/cell.py
@@ -210,8 +210,8 @@ class CellApi(s_base.Base):
         pass
 
     @adminapi(log=True)
-    async def shutdown(self, timeout=None, cancel_tasks=False):
-        return await self.cell.shutdown(timeout=timeout, cancel_tasks=cancel_tasks)
+    async def shutdown(self, timeout=None, drain=False):
+        return await self.cell.shutdown(timeout=timeout, drain=drain)
 
     @adminapi(log=True)
     async def freeze(self, timeout=30):
@@ -1218,7 +1218,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             'dynmirror': 1,
             'tasks': 1,
             'issuewait': 1,
-            'shutdowncancel': 1,
+            'shutdowndrain': 1,
         }
 
         self.safemode = self.conf.req('safemode')
@@ -1693,12 +1693,12 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             self._onFiniCellGuid()
         return retn
 
-    async def shutdown(self, timeout=None, cancel_tasks=False):
+    async def shutdown(self, timeout=None, drain=False):
         '''
         Execute a graceful shutdown.
 
-        When ``cancel_tasks`` is False, promoted boss tasks are awaited until they
-        complete. When ``cancel_tasks`` is True, promoted boss tasks are cancelled
+        When ``drain`` is False, promoted boss tasks are awaited until they
+        complete. When ``drain`` is True, promoted boss tasks are cancelled
         and then awaited.
 
         The ``timeout`` argument bounds the entire operation. Demote and task
@@ -1732,7 +1732,7 @@ class Cell(s_nexus.Pusher, s_telepath.Aware):
             logger.warning('...timeout reached before tasks phase. Aborting shutdown.', extra=extra)
             return False
 
-        if not await self.boss.shutdown(timeout=remaining(), cancel_tasks=cancel_tasks):
+        if not await self.boss.shutdown(timeout=remaining(), cancel_tasks=drain):
             logger.warning('...tasks did not complete within timeout. Aborting shutdown.', extra=extra)
             return False
 

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -146,12 +146,12 @@ def deadline(timeout):
     The returned callable yields ``None`` if ``timeout`` is ``None``
     (unbounded), otherwise ``max(0.0, <seconds until deadline>)``.
 
-    This is useful for sharing a single timeout budget across multiple
-    awaited operations.
+    This is useful for sharing a single timeout across multiple awaited
+    operations.
 
     Examples:
 
-        Compute a shared budget across multiple operations::
+        Share a single timeout across multiple operations::
 
             remaining = s_coro.deadline(timeout)
 

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -9,6 +9,7 @@ import contextlib
 
 logger = logging.getLogger(__name__)
 
+import synapse.exc as s_exc
 import synapse.glob as s_glob
 import synapse.common as s_common
 
@@ -162,6 +163,10 @@ def deadline(timeout):
     '''
     if timeout is None:
         return lambda: None
+
+    if timeout < 0:
+        mesg = f'timeout must be non-negative, got {timeout}.'
+        raise s_exc.BadArg(mesg=mesg)
 
     loop = asyncio.get_running_loop()
     end = loop.time() + timeout

--- a/synapse/lib/coro.py
+++ b/synapse/lib/coro.py
@@ -137,6 +137,40 @@ async def waittask(task, timeout=None):
     finally:
         task.remove_done_callback(futu.set_result)
 
+def deadline(timeout):
+    '''
+    Return a callable that yields the seconds remaining until ``timeout``
+    seconds from now have elapsed.
+
+    The returned callable yields ``None`` if ``timeout`` is ``None``
+    (unbounded), otherwise ``max(0.0, <seconds until deadline>)``.
+
+    This is useful for sharing a single timeout budget across multiple
+    awaited operations.
+
+    Examples:
+
+        Compute a shared budget across multiple operations::
+
+            remaining = s_coro.deadline(timeout)
+
+            await opOne(timeout=remaining())
+            await opTwo(timeout=remaining())
+
+    Notes:
+        Must be called from within a running event loop.
+    '''
+    if timeout is None:
+        return lambda: None
+
+    loop = asyncio.get_running_loop()
+    end = loop.time() + timeout
+
+    def remaining():
+        return max(0.0, end - loop.time())
+
+    return remaining
+
 async def ornot(func, *args, **kwargs):
     '''
     Calls func and awaits it if a returns a coroutine.

--- a/synapse/tests/test_lib_boss.py
+++ b/synapse/tests/test_lib_boss.py
@@ -70,7 +70,7 @@ class BossTest(s_test.SynTest):
             with self.raises(s_exc.ShuttingDown):
                 boss.reqNotShut()
 
-    async def test_boss_shutdown_cancel_tasks(self):
+    async def test_boss_shutdown_no_drain(self):
 
         async with self.getTestCell(BossCell) as bcell:
             boss = bcell.cboss
@@ -88,10 +88,10 @@ class BossTest(s_test.SynTest):
 
             self.len(1, boss.ps())
 
-            self.true(await boss.shutdown(timeout=2, cancel_tasks=True))
+            self.true(await boss.shutdown(timeout=2, drain=False))
             self.true(boss.is_shutdown)
 
-    async def test_boss_shutdown_cancel_slowexit(self):
+    async def test_boss_shutdown_no_drain_slowexit(self):
 
         async with self.getTestCell(BossCell) as bcell:
             boss = bcell.cboss
@@ -104,14 +104,14 @@ class BossTest(s_test.SynTest):
                 try:
                     await asyncio.sleep(60)
                 except asyncio.CancelledError:
-                    # simulate a slow cleanup that blows the budget
+                    # simulate a slow cleanup that blows the timeout
                     await asyncio.sleep(0.5)
                     raise
 
             await boss.execute(slowexit(), 'slowexit', root)
             await evnt.wait()
 
-            self.false(await boss.shutdown(timeout=0.05, cancel_tasks=True))
+            self.false(await boss.shutdown(timeout=0.05, drain=False))
             self.false(boss.is_shutdown)
 
     async def test_boss_shutdown_shared_budget(self):

--- a/synapse/tests/test_lib_boss.py
+++ b/synapse/tests/test_lib_boss.py
@@ -69,3 +69,73 @@ class BossTest(s_test.SynTest):
             boss.is_shutdown = True
             with self.raises(s_exc.ShuttingDown):
                 boss.reqNotShut()
+
+    async def test_boss_shutdown_cancel_tasks(self):
+
+        async with self.getTestCell(BossCell) as bcell:
+            boss = bcell.cboss
+            root = await bcell.auth.getUserByName('root')
+
+            evnt = asyncio.Event()
+
+            async def stuck():
+                evnt.set()
+                while True:
+                    await asyncio.sleep(10)
+
+            await boss.execute(stuck(), 'stuck', root)
+            await evnt.wait()
+
+            self.len(1, boss.ps())
+
+            self.true(await boss.shutdown(timeout=2, cancel_tasks=True))
+            self.true(boss.is_shutdown)
+
+    async def test_boss_shutdown_cancel_slowexit(self):
+
+        async with self.getTestCell(BossCell) as bcell:
+            boss = bcell.cboss
+            root = await bcell.auth.getUserByName('root')
+
+            evnt = asyncio.Event()
+
+            async def slowexit():
+                evnt.set()
+                try:
+                    await asyncio.sleep(60)
+                except asyncio.CancelledError:
+                    # simulate a slow cleanup that blows the budget
+                    await asyncio.sleep(0.5)
+                    raise
+
+            await boss.execute(slowexit(), 'slowexit', root)
+            await evnt.wait()
+
+            self.false(await boss.shutdown(timeout=0.05, cancel_tasks=True))
+            self.false(boss.is_shutdown)
+
+    async def test_boss_shutdown_shared_budget(self):
+
+        async with self.getTestCell(BossCell) as bcell:
+            boss = bcell.cboss
+            root = await bcell.auth.getUserByName('root')
+
+            evnt0 = asyncio.Event()
+            evnt1 = asyncio.Event()
+
+            async def slow(evnt):
+                evnt.set()
+                await asyncio.sleep(10)
+
+            await boss.execute(slow(evnt0), 'slow0', root)
+            await boss.execute(slow(evnt1), 'slow1', root)
+            await evnt0.wait()
+            await evnt1.wait()
+
+            start = asyncio.get_running_loop().time()
+            self.false(await boss.shutdown(timeout=0.2))
+            elapsed = asyncio.get_running_loop().time() - start
+
+            # shared budget: total wall time must respect timeout, not 2*timeout
+            self.lt(elapsed, 0.4)
+            self.false(boss.is_shutdown)

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -3608,7 +3608,7 @@ class CellTest(s_t_utils.SynTest):
                 self.false(await cell.shutdown(timeout=0))
             await stream.expect('timeout reached before tasks phase')
 
-    async def test_cell_shutdown_cancel_tasks_plumbed(self):
+    async def test_cell_shutdown_drain_plumbed(self):
 
         async with self.getTestCell() as cell:
 
@@ -3621,7 +3621,7 @@ class CellTest(s_t_utils.SynTest):
                 return await orig(timeout=timeout, cancel_tasks=cancel_tasks)
 
             with mock.patch.object(cell.boss, 'shutdown', spy):
-                self.true(await cell.shutdown(timeout=5, cancel_tasks=True))
+                self.true(await cell.shutdown(timeout=5, drain=True))
 
             self.true(seen['cancel_tasks'])
             self.lt(seen['timeout'], 5.0)

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -3598,7 +3598,7 @@ class CellTest(s_t_utils.SynTest):
             with mock.patch.object(cell, '_getDemotePeers', boom):
                 with self.getLoggerStream('synapse.lib.cell') as stream:
                     self.false(await cell.shutdown(timeout=5))
-                await stream.expect('budget exhausted finding demote peers')
+                await stream.expect('timeout reached while finding demote peers')
 
     async def test_cell_shutdown_budget_exhausted(self):
 
@@ -3606,7 +3606,7 @@ class CellTest(s_t_utils.SynTest):
 
             with self.getLoggerStream('synapse.lib.cell') as stream:
                 self.false(await cell.shutdown(timeout=0))
-            await stream.expect('budget exhausted before tasks phase')
+            await stream.expect('timeout reached before tasks phase')
 
     async def test_cell_shutdown_cancel_tasks_plumbed(self):
 

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -3584,3 +3584,45 @@ class CellTest(s_t_utils.SynTest):
                         break
 
                 await task
+
+    async def test_cell_shutdown_demote_peers_timeout(self):
+
+        async with self.getTestCell() as cell:
+
+            async def boom(*args, **kwargs):
+                raise TimeoutError()
+
+            cell.isactive = True
+            cell.ahaclient = mock.Mock()
+
+            with mock.patch.object(cell, '_getDemotePeers', boom):
+                with self.getLoggerStream('synapse.lib.cell') as stream:
+                    self.false(await cell.shutdown(timeout=5))
+                await stream.expect('budget exhausted finding demote peers')
+
+    async def test_cell_shutdown_budget_exhausted(self):
+
+        async with self.getTestCell() as cell:
+
+            with self.getLoggerStream('synapse.lib.cell') as stream:
+                self.false(await cell.shutdown(timeout=0))
+            await stream.expect('budget exhausted before tasks phase')
+
+    async def test_cell_shutdown_cancel_tasks_plumbed(self):
+
+        async with self.getTestCell() as cell:
+
+            seen = {}
+            orig = cell.boss.shutdown
+
+            async def spy(timeout=None, cancel_tasks=False):
+                seen['timeout'] = timeout
+                seen['cancel_tasks'] = cancel_tasks
+                return await orig(timeout=timeout, cancel_tasks=cancel_tasks)
+
+            with mock.patch.object(cell.boss, 'shutdown', spy):
+                self.true(await cell.shutdown(timeout=5, cancel_tasks=True))
+
+            self.true(seen['cancel_tasks'])
+            self.lt(seen['timeout'], 5.0)
+            self.gt(seen['timeout'], 0.0)

--- a/synapse/tests/test_lib_cell.py
+++ b/synapse/tests/test_lib_cell.py
@@ -3615,14 +3615,14 @@ class CellTest(s_t_utils.SynTest):
             seen = {}
             orig = cell.boss.shutdown
 
-            async def spy(timeout=None, cancel_tasks=False):
+            async def spy(timeout=None, drain=True):
                 seen['timeout'] = timeout
-                seen['cancel_tasks'] = cancel_tasks
-                return await orig(timeout=timeout, cancel_tasks=cancel_tasks)
+                seen['drain'] = drain
+                return await orig(timeout=timeout, drain=drain)
 
             with mock.patch.object(cell.boss, 'shutdown', spy):
-                self.true(await cell.shutdown(timeout=5, drain=True))
+                self.true(await cell.shutdown(timeout=5, drain=False))
 
-            self.true(seen['cancel_tasks'])
+            self.false(seen['drain'])
             self.lt(seen['timeout'], 5.0)
             self.gt(seen['timeout'], 0.0)

--- a/synapse/tests/test_lib_coro.py
+++ b/synapse/tests/test_lib_coro.py
@@ -80,6 +80,31 @@ class CoroTest(s_t_utils.SynTest):
         # Ensure a generic coroutine is executed on the ioloop thread
         self.eq(s_glob._glob_thrd.ident, await afunc())
 
+    async def test_lib_coro_deadline(self):
+
+        remaining = s_coro.deadline(None)
+        self.none(remaining())
+        self.none(remaining())
+
+        remaining = s_coro.deadline(0.5)
+        first = remaining()
+        self.isinstance(first, float)
+        self.true(0.0 < first <= 0.5)
+
+        await asyncio.sleep(0.1)
+        second = remaining()
+        self.true(second < first)
+
+        remaining = s_coro.deadline(0.01)
+        await asyncio.sleep(0.05)
+        self.eq(0.0, remaining())
+
+        remaining = s_coro.deadline(0)
+        self.eq(0.0, remaining())
+
+        with self.raises(RuntimeError):
+            await s_coro.executor(s_coro.deadline, 1.0)
+
     async def test_lib_coro_create_task(self):
 
         async def sleep(n):

--- a/synapse/tests/test_lib_coro.py
+++ b/synapse/tests/test_lib_coro.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 
+import synapse.exc as s_exc
 import synapse.glob as s_glob
 
 import synapse.lib.coro as s_coro
@@ -101,6 +102,12 @@ class CoroTest(s_t_utils.SynTest):
 
         remaining = s_coro.deadline(0)
         self.eq(0.0, remaining())
+
+        with self.raises(s_exc.BadArg):
+            s_coro.deadline(-1)
+
+        with self.raises(s_exc.BadArg):
+            s_coro.deadline(-0.5)
 
         with self.raises(RuntimeError):
             await s_coro.executor(s_coro.deadline, 1.0)

--- a/synapse/tests/test_tools_service_shutdown.py
+++ b/synapse/tests/test_tools_service_shutdown.py
@@ -70,25 +70,25 @@ class ShutdownToolTest(s_test.SynTest):
                 self.eq(0, await s_t_shutdown.main(argv, outp=outp))
                 self.true(await cell01.waitfini(timeout=12))
 
-    async def test_tool_shutdown_cancel_tasks(self):
+    async def test_tool_shutdown_drain(self):
 
         async with self.getTestCore() as core:
 
-            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--cancel-tasks']
+            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--drain']
             self.eq(0, await s_t_shutdown.main(argv))
 
             self.true(await core.waitfini(timeout=5))
 
-    async def test_tool_shutdown_cancel_tasks_unsupported(self):
+    async def test_tool_shutdown_drain_unsupported(self):
 
         async with self.getTestCore() as core:
 
-            core.features.pop('shutdowncancel')
+            core.features.pop('shutdowndrain')
 
             outp = self.getTestOutp()
-            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--cancel-tasks']
+            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--drain']
             self.eq(2, await s_t_shutdown.main(argv, outp=outp))
-            outp.expect('does not support the --cancel-tasks feature')
+            outp.expect('does not support the --drain feature')
 
     async def test_tool_shutdown_no_features(self):
 

--- a/synapse/tests/test_tools_service_shutdown.py
+++ b/synapse/tests/test_tools_service_shutdown.py
@@ -70,25 +70,25 @@ class ShutdownToolTest(s_test.SynTest):
                 self.eq(0, await s_t_shutdown.main(argv, outp=outp))
                 self.true(await cell01.waitfini(timeout=12))
 
-    async def test_tool_shutdown_drain(self):
+    async def test_tool_shutdown_no_drain(self):
 
         async with self.getTestCore() as core:
 
-            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--drain']
+            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--no-drain']
             self.eq(0, await s_t_shutdown.main(argv))
 
             self.true(await core.waitfini(timeout=5))
 
-    async def test_tool_shutdown_drain_unsupported(self):
+    async def test_tool_shutdown_no_drain_unsupported(self):
 
         async with self.getTestCore() as core:
 
             core.features.pop('shutdowndrain')
 
             outp = self.getTestOutp()
-            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--drain']
+            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--no-drain']
             self.eq(2, await s_t_shutdown.main(argv, outp=outp))
-            outp.expect('does not support the --drain feature')
+            outp.expect('does not support the --no-drain feature')
 
     async def test_tool_shutdown_no_features(self):
 

--- a/synapse/tests/test_tools_service_shutdown.py
+++ b/synapse/tests/test_tools_service_shutdown.py
@@ -24,7 +24,7 @@ class ShutdownToolTest(s_test.SynTest):
 
             argv = ['--url', core.getLocalUrl(), '--timeout', '0']
 
-            self.eq(2, await s_t_shutdown.main(argv))
+            self.eq(1, await s_t_shutdown.main(argv))
 
             for task in core.boss.ps():
                 if task.name == 'storm':
@@ -35,7 +35,7 @@ class ShutdownToolTest(s_test.SynTest):
             self.true(await core.waitfini(timeout=1))
 
         outp = self.getTestOutp()
-        self.eq(1, await s_t_shutdown.main(['--url', 'newp://hehe'], outp=outp))
+        self.eq(2, await s_t_shutdown.main(['--url', 'newp://hehe'], outp=outp))
         outp.expect('Error while attempting graceful shutdown')
 
     async def test_tool_shutdown_leader(self):
@@ -87,7 +87,7 @@ class ShutdownToolTest(s_test.SynTest):
 
             outp = self.getTestOutp()
             argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--cancel-tasks']
-            self.eq(1, await s_t_shutdown.main(argv, outp=outp))
+            self.eq(2, await s_t_shutdown.main(argv, outp=outp))
             outp.expect('does not support the --cancel-tasks feature')
 
     async def test_tool_shutdown_no_features(self):
@@ -112,5 +112,5 @@ class ShutdownToolTest(s_test.SynTest):
                 outp = self.getTestOutp()
                 argv = ['--url', cell00.getLocalUrl(), '--timeout', '12']
                 with self.getLoggerStream('synapse.daemon') as stream:
-                    self.eq(1, await s_t_shutdown.main(argv, outp=outp))
+                    self.eq(2, await s_t_shutdown.main(argv, outp=outp))
                 await stream.expect('AHA server does not support feature: getAhaSvcsByIden >= 1')

--- a/synapse/tests/test_tools_service_shutdown.py
+++ b/synapse/tests/test_tools_service_shutdown.py
@@ -24,7 +24,7 @@ class ShutdownToolTest(s_test.SynTest):
 
             argv = ['--url', core.getLocalUrl(), '--timeout', '0']
 
-            self.eq(1, await s_t_shutdown.main(argv))
+            self.eq(2, await s_t_shutdown.main(argv))
 
             for task in core.boss.ps():
                 if task.name == 'storm':
@@ -69,6 +69,26 @@ class ShutdownToolTest(s_test.SynTest):
                 argv = ['--url', cell01.getLocalUrl(), '--timeout', '12']
                 self.eq(0, await s_t_shutdown.main(argv, outp=outp))
                 self.true(await cell01.waitfini(timeout=12))
+
+    async def test_tool_shutdown_cancel_tasks(self):
+
+        async with self.getTestCore() as core:
+
+            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--cancel-tasks']
+            self.eq(0, await s_t_shutdown.main(argv))
+
+            self.true(await core.waitfini(timeout=5))
+
+    async def test_tool_shutdown_cancel_tasks_unsupported(self):
+
+        async with self.getTestCore() as core:
+
+            core.features.pop('shutdowncancel')
+
+            outp = self.getTestOutp()
+            argv = ['--url', core.getLocalUrl(), '--timeout', '5', '--cancel-tasks']
+            self.eq(1, await s_t_shutdown.main(argv, outp=outp))
+            outp.expect('does not support the --cancel-tasks feature')
 
     async def test_tool_shutdown_no_features(self):
 

--- a/synapse/tools/service/shutdown.py
+++ b/synapse/tools/service/shutdown.py
@@ -54,11 +54,7 @@ async def main(argv, outp=s_output.stdout):
                 kwargs = {'timeout': opts.timeout}
 
                 if opts.cancel_tasks:
-                    try:
-                        supported = proxy._hasTeleFeat('shutdowncancel', vers=1)
-                    except s_exc.NoSuchMeth:
-                        supported = False
-
+                    supported = proxy._hasTeleFeat('shutdowncancel', vers=1)
                     if not supported:
                         outp.printf(f'Service at {opts.url} does not support the --cancel-tasks feature.')
                         return 1

--- a/synapse/tools/service/shutdown.py
+++ b/synapse/tools/service/shutdown.py
@@ -14,17 +14,18 @@ tasks do not exit.
 
 When --cancel-tasks is provided, promoted tasks are cancelled instead of
 awaited, allowing the operator to bound shutdown wall time. Demote is still
-attempted within the timeout budget; only the task-wait phase changes.
+attempted within the timeout; only the task-wait phase changes.
 
 The --timeout value bounds the entire operation. Demote discovery, demote,
-and task reaping share a single budget; no sub-phase may exceed the time
-remaining when it starts.
+and task reaping share the single timeout value; no sub-phase may exceed
+the time remaining when it starts.
 
 Exit codes:
   0 - graceful shutdown was initiated successfully
   1 - an unexpected error occurred
-  2 - the shutdown was aborted because the timeout was exhausted; the
-      service has resumed normal operation
+  2 - the shutdown was aborted because the timeout was reached; the
+      service may be in a partially shutdown state as a result of this
+      timeout.
 
 NOTE: This will also demote the service if run on a leader with mirrors.
 '''

--- a/synapse/tools/service/shutdown.py
+++ b/synapse/tools/service/shutdown.py
@@ -12,8 +12,8 @@ any non-background tasks will be allowed to complete while ensuring
 no new tasks are created. Without a timeout, it can block forever if
 tasks do not exit.
 
-When --drain is provided, the service may drain itself of tasks that it is
-running, allowing the operator to bound shutdown wall time. Demote is still
+When --no-drain is provided, promoted tasks are cancelled instead of
+awaited, allowing the operator to bound shutdown wall time. Demote is still
 attempted within the timeout; only the task-wait phase changes.
 
 The --timeout value bounds the entire operation. Demote discovery, demote,
@@ -40,8 +40,8 @@ async def main(argv, outp=s_output.stdout):
     pars.add_argument('--timeout', default=None, type=int,
                         help='An optional timeout in seconds. If timeout is reached, the shutdown is aborted.')
 
-    pars.add_argument('--drain', default=False, action='store_true',
-                        help='Drain the service of running tasks instead of awaiting them.')
+    pars.add_argument('--no-drain', dest='drain', default=True, action='store_false',
+                        help='Cancel promoted tasks instead of awaiting them.')
 
     opts = pars.parse_args(argv)
 
@@ -53,13 +53,13 @@ async def main(argv, outp=s_output.stdout):
 
                 kwargs = {'timeout': opts.timeout}
 
-                if opts.drain:
+                if not opts.drain:
                     supported = proxy._hasTeleFeat('shutdowndrain', vers=1)
                     if not supported:
-                        outp.printf(f'Service at {opts.url} does not support the --drain feature.')
+                        outp.printf(f'Service at {opts.url} does not support the --no-drain feature.')
                         return 2
 
-                    kwargs['drain'] = True
+                    kwargs['drain'] = False
 
                 if await proxy.shutdown(**kwargs):
                     return 0

--- a/synapse/tools/service/shutdown.py
+++ b/synapse/tools/service/shutdown.py
@@ -22,10 +22,10 @@ the time remaining when it starts.
 
 Exit codes:
   0 - graceful shutdown was initiated successfully
-  1 - an unexpected error occurred
-  2 - the shutdown was aborted because the timeout was reached; the
+  1 - the shutdown was aborted because the timeout was reached; the
       service may be in a partially shutdown state as a result of this
       timeout.
+  2 - an unexpected error occurred
 
 NOTE: This will also demote the service if run on a leader with mirrors.
 '''
@@ -57,19 +57,19 @@ async def main(argv, outp=s_output.stdout):
                     supported = proxy._hasTeleFeat('shutdowncancel', vers=1)
                     if not supported:
                         outp.printf(f'Service at {opts.url} does not support the --cancel-tasks feature.')
-                        return 1
+                        return 2
 
                     kwargs['cancel_tasks'] = True
 
                 if await proxy.shutdown(**kwargs):
                     return 0
 
-                return 2
+                return 1
 
         except Exception as e:
             text = s_exc.reprexc(e)
             outp.printf(f'Error while attempting graceful shutdown: {text}')
-            return 1
+            return 2
 
 if __name__ == '__main__': # pragma: no cover
     s_cmd.exitmain(main)

--- a/synapse/tools/service/shutdown.py
+++ b/synapse/tools/service/shutdown.py
@@ -12,8 +12,8 @@ any non-background tasks will be allowed to complete while ensuring
 no new tasks are created. Without a timeout, it can block forever if
 tasks do not exit.
 
-When --cancel-tasks is provided, promoted tasks are cancelled instead of
-awaited, allowing the operator to bound shutdown wall time. Demote is still
+When --drain is provided, the service may drain itself of tasks that it is
+running, allowing the operator to bound shutdown wall time. Demote is still
 attempted within the timeout; only the task-wait phase changes.
 
 The --timeout value bounds the entire operation. Demote discovery, demote,
@@ -40,8 +40,8 @@ async def main(argv, outp=s_output.stdout):
     pars.add_argument('--timeout', default=None, type=int,
                         help='An optional timeout in seconds. If timeout is reached, the shutdown is aborted.')
 
-    pars.add_argument('--cancel-tasks', default=False, action='store_true',
-                        help='Cancel promoted tasks instead of awaiting them.')
+    pars.add_argument('--drain', default=False, action='store_true',
+                        help='Drain the service of running tasks instead of awaiting them.')
 
     opts = pars.parse_args(argv)
 
@@ -53,13 +53,13 @@ async def main(argv, outp=s_output.stdout):
 
                 kwargs = {'timeout': opts.timeout}
 
-                if opts.cancel_tasks:
-                    supported = proxy._hasTeleFeat('shutdowncancel', vers=1)
+                if opts.drain:
+                    supported = proxy._hasTeleFeat('shutdowndrain', vers=1)
                     if not supported:
-                        outp.printf(f'Service at {opts.url} does not support the --cancel-tasks feature.')
+                        outp.printf(f'Service at {opts.url} does not support the --drain feature.')
                         return 2
 
-                    kwargs['cancel_tasks'] = True
+                    kwargs['drain'] = True
 
                 if await proxy.shutdown(**kwargs):
                     return 0

--- a/synapse/tools/service/shutdown.py
+++ b/synapse/tools/service/shutdown.py
@@ -12,9 +12,19 @@ any non-background tasks will be allowed to complete while ensuring
 no new tasks are created. Without a timeout, it can block forever if
 tasks do not exit.
 
-The command exits with code 0 if the graceful shutdown was successful and
-exit code 1 if a timeout was specified and was hit. Upon hitting the timeout
-the system resumes normal operation.
+When --cancel-tasks is provided, promoted tasks are cancelled instead of
+awaited, allowing the operator to bound shutdown wall time. Demote is still
+attempted within the timeout budget; only the task-wait phase changes.
+
+The --timeout value bounds the entire operation. Demote discovery, demote,
+and task reaping share a single budget; no sub-phase may exceed the time
+remaining when it starts.
+
+Exit codes:
+  0 - graceful shutdown was initiated successfully
+  1 - an unexpected error occurred
+  2 - the shutdown was aborted because the timeout was exhausted; the
+      service has resumed normal operation
 
 NOTE: This will also demote the service if run on a leader with mirrors.
 '''
@@ -29,6 +39,9 @@ async def main(argv, outp=s_output.stdout):
     pars.add_argument('--timeout', default=None, type=int,
                         help='An optional timeout in seconds. If timeout is reached, the shutdown is aborted.')
 
+    pars.add_argument('--cancel-tasks', default=False, action='store_true',
+                        help='Cancel promoted tasks instead of awaiting them.')
+
     opts = pars.parse_args(argv)
 
     async with s_telepath.withTeleEnv():
@@ -37,12 +50,26 @@ async def main(argv, outp=s_output.stdout):
 
             async with await s_telepath.openurl(opts.url) as proxy:
 
-                if await proxy.shutdown(timeout=opts.timeout):
+                kwargs = {'timeout': opts.timeout}
+
+                if opts.cancel_tasks:
+                    try:
+                        supported = proxy._hasTeleFeat('shutdowncancel', vers=1)
+                    except s_exc.NoSuchMeth:
+                        supported = False
+
+                    if not supported:
+                        outp.printf(f'Service at {opts.url} does not support the --cancel-tasks feature.')
+                        return 1
+
+                    kwargs['cancel_tasks'] = True
+
+                if await proxy.shutdown(**kwargs):
                     return 0
 
-                return 1
+                return 2
 
-        except Exception as e: # pragma: no cover
+        except Exception as e:
             text = s_exc.reprexc(e)
             outp.printf(f'Error while attempting graceful shutdown: {text}')
             return 1


### PR DESCRIPTION
## Summary

Three improvements to the graceful shutdown path so operators can reliably bound shutdown wall-time:

- **New `--no-drain` flag** on `synapse.tools.service.shutdown` (and a corresponding `drain` kwarg, defaulting to `True`, on `Cell.shutdown`, `CellApi.shutdown`, and `Boss.shutdown`) that cancels promoted tasks instead of waiting on them, enabling fast bounded shutdowns. Existing API/tool behavior is preserved — only explicit opt-in via `drain=False` / `--no-drain` triggers the new path.
- **Single shared timeout** across `Cell.shutdown`'s sub-phases. Previously the same `timeout` value was passed to `_getDemotePeers`, `demote`, and `boss.shutdown` independently (and within `boss.shutdown`, per-task), so a nominal 30s timeout could stretch to many minutes. Now `Cell.shutdown(timeout=N)` is a hard ceiling and sub-phases share the remaining time.
- **Distinct exit code for timeout** in the shutdown tool: `0` success, `1` shutdown aborted due to timeout (matches the tool's previously documented behavior), `2` unexpected error. Previously `1` conflated both.

Backward compatibility for mixed-version clusters is handled by a new `shutdowndrain` Cell feature flag — the tool calls `proxy._hasTeleFeat('shutdowndrain', vers=1)` before passing `drain=False` and refuses with a clear message against older servers. When the user doesn't pass `--no-drain`, the tool calls `proxy.shutdown(timeout=...)` exactly like before — no new kwarg is sent across the wire.

## Changes

### Code

- `synapse/lib/coro.py` — New reusable `deadline(timeout)` helper returning a `remaining()` callable for sharing a decrementing time value across multiple awaited operations. Rejects negative timeouts with `s_exc.BadArg`.
- `synapse/lib/boss.py` — `Boss.shutdown(timeout=None, drain=True)`: when `drain` is False, top-level non-background tasks are cancelled before being awaited. Uses `s_coro.deadline` so `timeout` is shared across all reaped tasks rather than per-task. Replaced the inline comment with a docstring.
- `synapse/lib/cell.py` — `Cell.shutdown(timeout=None, drain=True)`: uses `s_coro.deadline(timeout)` to compute remaining time for each sub-phase, catches `TimeoutError` raised by `_getDemotePeers`, logs explicit "timeout reached" warnings naming the phase being skipped. `CellApi.shutdown(timeout=None, drain=True)` passes the kwarg through. Added `'shutdowndrain': 1` to `Cell.features`.
- `synapse/tools/service/shutdown.py` — Added `--no-drain` flag (`store_false` on a `drain` arg defaulting to `True`), `_hasTeleFeat('shutdowndrain')` feature gate only when the user opts in (mirroring the pattern in `synapse/tools/aha/mirror.py`), new exit code mapping (0/1/2), and updated `desc` documenting the new behavior.

### Tests

- `synapse/tests/test_lib_coro.py` — Coverage for `s_coro.deadline`: `None` returns a callable that returns `None`; numeric timeout decrements monotonically and clamps at `0.0`; negative values raise `s_exc.BadArg`; requires a running event loop.
- `synapse/tests/test_lib_boss.py` — Three new tests: `drain=False` cancels and reaps a stuck task; `drain=False` with a slow-exiting task and tight timeout returns `False`; shared-timeout semantics keep total wall time within the timeout under the default `drain=True`.
- `synapse/tests/test_lib_cell.py` — Three new tests: `_getDemotePeers` raising `TimeoutError` is caught and logged; `timeout=0` triggers the timeout-reached-before-tasks-phase log; `drain=False` is plumbed all the way through to `Boss.shutdown` and the boss receives a sub-timeout less than the total.
- `synapse/tests/test_tools_service_shutdown.py` — Updated the timeout-hit test to assert exit code `1`; bad-URL test asserts exit code `2`; added `--no-drain` happy-path test and a feature-unsupported fallback test (exit `2`).

### Docs & changelog

- Two changelog entries (`feat`) cover the new `--no-drain` flag + exit code split, and the shared-timeout fix on `Cell.shutdown`.
- The tool's `--help` text (embedded in `docs/synapse/userguides/syn_tools_service_shutdown.rstorm` via `.. shell::`) automatically reflects the new flag and exit codes on doc regeneration.

## Backward compatibility

- `drain=True` is the default everywhere, so existing callers of `Cell.shutdown` / `CellApi.shutdown` / `Boss.shutdown` (and existing invocations of the tool) get the same behavior as before.
- `Boss.shutdown`'s `timeout` is now shared across reaped tasks rather than per-task. This can only shorten worst-case wall time vs. the previous behavior.
- Mixed-version clusters: if the new tool is run with `--no-drain` against a service that doesn't advertise `shutdowndrain`, the feature check refuses early with a clear message (exit `2`) — no `TypeError` traceback. Without `--no-drain`, the tool invokes `proxy.shutdown(timeout=...)` with the same signature it has always used.

## Test plan

- [x] `python -m pytest -n 4 --dist worksteal synapse/tests/test_lib_coro.py synapse/tests/test_lib_boss.py synapse/tests/test_lib_cell.py::CellTest::test_cell_shutdown_demote_peers_timeout synapse/tests/test_lib_cell.py::CellTest::test_cell_shutdown_budget_exhausted synapse/tests/test_lib_cell.py::CellTest::test_cell_shutdown_drain_plumbed synapse/tests/test_tools_service_shutdown.py` — 19 passed
- [x] `python -m pytest -n 4 --dist worksteal synapse/tests/test_tools_service_demote.py` — verifies no regression in callers of `Cell.shutdown`
- [x] `SYNDEV_NEXUS_REPLAY=1 python -m pytest -n 4 synapse/tests/test_tools_service_shutdown.py` — nexus replay passes
