### PR TITLE
Add __slots__ to Node and Path

### DIFF
--- a/changes/9451f087e8d1cac2c898cce7e9886d85.yaml
+++ b/changes/9451f087e8d1cac2c898cce7e9886d85.yaml
@@ -1,0 +1,7 @@
+---
+desc: Add ``__slots__`` to ``synapse.lib.node.Node`` and ``synapse.lib.node.Path``
+  to reduce per-instance memory use.
+desc:literal: false
+prs: []
+type: feat
+...

--- a/synapse/lib/node.py
+++ b/synapse/lib/node.py
@@ -20,6 +20,9 @@ class Node:
 
     NOTE: This object is for local Cortex use during a single Xact.
     '''
+    __slots__ = ('snap', 'sode', 'buid', 'bylayer', 'ndef', 'form',
+                 'props', 'tags', 'tagprops', 'nodedata', 'isrunt', '__weakref__')
+
     def __init__(self, snap, sode, bylayer=None):
         self.snap = snap
         self.sode = sode
@@ -731,6 +734,9 @@ class Path:
     '''
     A path context tracked through the storm runtime.
     '''
+    __slots__ = ('node', 'nodes', 'links', 'vars', 'frames', 'ctors',
+                 'builtins', 'display', 'metadata')
+
     def __init__(self, vars, nodes, links=None):
 
         self.node = None

--- a/synapse/tests/test_lib_snap.py
+++ b/synapse/tests/test_lib_snap.py
@@ -1,6 +1,7 @@
 import gc
 import random
 import asyncio
+import weakref
 import contextlib
 import collections
 
@@ -67,10 +68,11 @@ class SnapTest(s_t_utils.SynTest):
         async with self.getTestCore() as core:
             async with await core.snap() as snap:
                 nodebuid = None
+                noderef = None
                 snap.buidcache = collections.deque(maxlen=10)
 
                 async def doit():
-                    nonlocal nodebuid
+                    nonlocal nodebuid, noderef
                     # Reduce the buid cache so we don't have to make 100K nodes
 
                     node0 = await snap.addNode('test:int', 0)
@@ -90,7 +92,10 @@ class SnapTest(s_t_utils.SynTest):
 
                     self.eq(nodes[0].buid, node0.buid)
                     self.eq(id(nodes[0]), id(node0))
-                    node._test = True
+
+                    # Hold a weak reference so we can prove the original node
+                    # object is released once it falls out of the coherency cache.
+                    noderef = weakref.ref(node)
 
                 await doit()  # run in separate function so that objects are gc'd
 
@@ -103,8 +108,9 @@ class SnapTest(s_t_utils.SynTest):
                 self.eq(nodebuid, node.buid)
                 # Ensure that the node is not the same object as we encountered earlier.
                 # We cannot check via id() since it is possible for a pyobject to be
-                # allocated at the same location as the old object.
-                self.false(hasattr(node, '_test'))
+                # allocated at the same location as the old object. Instead, confirm the
+                # original object was released from the coherency cache and collected.
+                self.none(noderef())
 
     async def test_addNodes(self):
         async with self.getTestCore() as core:


### PR DESCRIPTION
## Summary

Add `__slots__` to `synapse.lib.node.Node` and `synapse.lib.node.Path` to remove the per-instance `__dict__` and reduce memory for these high-cardinality runtime objects (a `Node`/`Path` pair is created for every node touched during Storm execution).

## Details

- `Node.__slots__` includes:
  - `__weakref__` -- `Node` instances are held in the snap `livenodes` `WeakValueDictionary` (`synapse/lib/snap.py`), so they must remain weak-referenceable.
  - `isrunt` -- set externally on the instance in `synapse/lib/snap.py`.
- `Path.__slots__` includes `display`, which is set externally in `synapse/lib/storm.py`.
- Rewrote the coherency test in `synapse/tests/test_lib_snap.py`: it previously set a dynamic `node._test` attribute (which `__slots__` forbids) to prove a re-fetched node was a different object. It now holds a `weakref.ref` to the original node and asserts it is collected after GC -- a more direct check that the node was released from the coherency cache.
- Added a `feat` changelog entry.

## Backward compatibility

`__slots__` prevents setting arbitrary attributes on `Node`/`Path` instances. All in-tree assignments are accounted for; out-of-tree code that monkey-patches attributes onto these instances would need updating (noted in the changelog).

## Testing

```
python -m pytest synapse/tests/test_lib_node.py synapse/tests/test_lib_snap.py    # 29 passed
python -m pytest synapse/tests/test_lib_storm.py synapse/tests/test_lib_ast.py     # 120 passed
```