### PR TITLE
WIP - First pass of updating idna library to account for unicode drift

### DIFF
--- a/changes/3c66d63b7f323c8a27e51f8a20201b67.yaml
+++ b/changes/3c66d63b7f323c8a27e51f8a20201b67.yaml
@@ -1,0 +1,10 @@
+---
+desc: Added a model migration to re-normalize ``inet:fqdn`` values, and the
+  ``inet:email``, ``inet:dns:*``, and ``inet:whois:*`` forms that embed them, which
+  were affected by the updated ``idna`` UTS46 normalization of a small set of rare
+  unicode codepoints. Affected fqdns textually embedded in ``inet:url`` and the
+  ``inet:server``/``inet:client`` primary values are not rewritten.
+desc:literal: false
+prs: []
+type: migration
+...

--- a/changes/a716575f6e4e31381b40c18c24f4369e.yaml
+++ b/changes/a716575f6e4e31381b40c18c24f4369e.yaml
@@ -1,0 +1,7 @@
+---
+desc: Updated the ``idna`` dependency to ``>=3.17,<3.18`` to address CVE-2024-3651
+  and CVE-2026-45409.
+desc:literal: false
+prs: []
+type: note
+...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'cbor2>=5.4.1,<5.10.0',
     'bech32==1.2.0',
     'oauthlib>=3.2.1,<4.0.0',
-    'idna>=3.6,<3.12',
+    'idna>=3.17,<3.18',
     'python-dateutil>=2.8,<3.0',
     'pytz>=2023.3,<2025.3',
     'beautifulsoup4[html5lib]>=4.11.1,<5.0',

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ scalecodec>=1.0.2,<1.3.0  # synapse.vendor.substrateinterface req
 cbor2>=5.4.1,<5.10.0
 bech32==1.2.0
 oauthlib>=3.2.1,<4.0.0
-idna>=3.6,<3.12
+idna>=3.17,<3.18
 python-dateutil>=2.8,<3.0
 pytz>=2023.3,<2025.3
 beautifulsoup4[html5lib]>=4.11.1,<5.0.0

--- a/synapse/lib/modelrev.py
+++ b/synapse/lib/modelrev.py
@@ -2476,6 +2476,16 @@ class ModelMigration_0_2_37(ModelMigrationBase):
 
                     formvalu = formvalu[0]
 
+                    # The affected codepoints are all non-ascii, which the previous idna
+                    # stored as "xn--" punycode a-labels; a value without one can not have
+                    # drifted, so skip the expensive decode/re-encode for plaintext fqdns.
+                    # NOTE: this is an in-scan filter rather than an indexed lift because
+                    # fqdns are indexed reversed (StorTypeFqdn) for suffix/zone scans, and
+                    # an a-label may appear in any label (e.g. foo.xn--bar.com) not just the
+                    # leading one.
+                    if 'xn--' not in str(formvalu):
+                        continue
+
                     try:
                         newvalu, _ = form.type.norm(self._correctValu(form.type, formvalu))
                     except s_exc.BadTypeValu:  # pragma: no cover

--- a/synapse/lib/modelrev.py
+++ b/synapse/lib/modelrev.py
@@ -12,11 +12,12 @@ import synapse.lib.types as s_types
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.spooled as s_spooled
 
+import synapse.models.inet as s_inet
 import synapse.models.infotech as s_infotech
 
 logger = logging.getLogger(__name__)
 
-maxvers = (0, 2, 36)
+maxvers = (0, 2, 37)
 
 class ModelRev:
 
@@ -58,6 +59,7 @@ class ModelRev:
             ((0, 2, 34), self.revModel_0_2_34),
             ((0, 2, 35), self.revModel_0_2_35),
             ((0, 2, 36), self.revModel_0_2_36),
+            ((0, 2, 37), self.revModel_0_2_37),
         )
 
     async def _uniqSortArray(self, todoprops, layers):
@@ -840,6 +842,10 @@ class ModelRev:
 
     async def revModel_0_2_36(self, layers):
         await self._typeToForm(layers, 'econ:pay:pan', 'econ:pay:pan')
+
+    async def revModel_0_2_37(self, layers):
+        migr = await ModelMigration_0_2_37.anit(self.core, layers)
+        await migr.revModel_0_2_37()
 
     async def runStorm(self, text, opts=None):
         '''
@@ -2383,3 +2389,206 @@ class ModelMigration_0_2_35(ModelMigrationBase):
         await self._flushEdits()
 
         logger.info(f'Finished processing bare IPv6 address nodes: {migrated} migrated, {removed} removed')
+
+class ModelMigration_0_2_37(ModelMigrationBase):
+    '''
+    Updating the idna dependency changed UTS46 normalization for a small set of rare
+    unicode codepoints. inet:fqdn stores the normalized value, so re-norming the stored
+    value is a no-op (it is already an a-label) and the standard comp re-norm recursion
+    in moveNode() can not detect the drift either. The change is only visible by decoding
+    the stored value back to its unicode form and re-encoding it with the current idna.
+
+    This migration corrects every form whose primary value embeds an inet:fqdn (the
+    inet:fqdn form itself and the comp forms that nest it, e.g. inet:dns:a, inet:email,
+    inet:url, inet:whois:rec). Forms are processed leaf-first (by fqdn nesting depth) so
+    that moveNode() reference handling never targets an already-migrated node.
+    '''
+
+    queuename = 'model_0_2_37:nodes'
+
+    def _typeFqdnDepth(self, _type):
+        # Return the nesting depth of an inet:fqdn within a type, or None if it has none.
+        # NOTE: inet:url and the inet:addr family (inet:server/inet:client) textually embed
+        # an fqdn in a primary string that can not be safely reconstructed here; their
+        # inet:fqdn sub properties are still corrected via moveNode() reference handling.
+        if isinstance(_type, s_inet.Fqdn):
+            return 0
+
+        if isinstance(_type, s_inet.Email):
+            return 1
+
+        if isinstance(_type, s_types.Comp):
+            depths = []
+            for fname, _ in _type.opts.get('fields', ()):
+                depth = self._typeFqdnDepth(_type.tcache[fname])
+                if depth is not None:
+                    depths.append(depth)
+
+            if depths:
+                return 1 + max(depths)
+
+        return None
+
+    def _correctValu(self, _type, valu):
+        # Decode and re-encode any inet:fqdn embedded in valu, recursing through comps and emails.
+        if isinstance(_type, s_inet.Fqdn):
+            return _type.norm(_type.repr(valu))[0]
+
+        if isinstance(_type, s_inet.Email):
+            user, fqdn = valu.split('@', 1)
+            fqdntype = self.core.model.type('inet:fqdn')
+            return f'{user}@{self._correctValu(fqdntype, fqdn)}'
+
+        if isinstance(_type, s_types.Comp):
+            norm, info = _type.norm(valu)
+            subs = info.get('subs', {})
+            newvalu = []
+            for fname, _ in _type.opts.get('fields', ()):
+                newvalu.append(self._correctValu(_type.tcache[fname], subs.get(fname)))
+
+            return tuple(newvalu)
+
+        return valu
+
+    async def revModel_0_2_37(self):
+
+        # Collect the fqdn-bearing forms ordered leaf-first by fqdn nesting depth.
+        forms = []
+        for form in self.core.model.forms.values():
+            depth = self._typeFqdnDepth(form.type)
+            if depth is not None:
+                forms.append((depth, form.name))
+
+        forms = [name for _, name in sorted(forms)]
+
+        logger.info(f'Collecting {len(forms)} fqdn-bearing forms in {len(self.layers)} layers')
+
+        for formname in forms:
+            form = self.core.model.form(formname)
+
+            for idx, layer in enumerate(self.layers):
+                logger.debug('Scanning %s nodes in layer %s %s', formname, idx, layer.iden)
+
+                async for buid, sode in layer.getStorNodesByForm(formname):
+
+                    if (formvalu := sode.get('valu')) is None:  # pragma: no cover
+                        continue
+
+                    formvalu = formvalu[0]
+
+                    try:
+                        newvalu, _ = form.type.norm(self._correctValu(form.type, formvalu))
+                    except s_exc.BadTypeValu:  # pragma: no cover
+                        logger.error('Encountered un-normable node valu: %s=%s', formname, formvalu)
+                        continue
+
+                    if newvalu == formvalu:
+                        continue
+
+                    node = self.getNode(buid)
+                    node['formvalu'] = formvalu
+                    node['formname'] = formname
+                    layers = list(node['layers'])
+                    layers.append(layer.iden)
+                    node['layers'] = layers
+
+                    await self.nodes.set(buid, node)
+
+        total = len(self.nodes)
+        logger.info(f'Processing {total} fqdn-bearing nodes in {len(self.layers)} layers')
+
+        if total == 0:
+            await self.todos.fini()
+            await self.nodes.fini()
+            return
+
+        # Load full node info
+        for idx, layer in enumerate(self.layers):
+            logger.debug('Loading node info in layer %s %s', idx, layer.iden)
+
+            async for buid, node in s_coro.pause(self.nodes.items()):
+                await self._loadNode(layer, buid, node=node)
+                await self.nodes.set(buid, node)
+
+        # Load node refs
+        for idx, layer in enumerate(self.layers):
+            logger.debug('Loading node refs in layer %s %s', idx, layer.iden)
+
+            async for buid, node in s_coro.pause(self.nodes.items()):
+                formvalu = node.get('formvalu')
+                formname = node.get('formname')
+                formndef = (formname, formvalu)
+
+                refs = node['refs'].get(layer.iden, [])
+
+                for refinfo in self.getRefInfo(formname):
+                    (refform, refprop, reftype, isarray, isro) = refinfo
+
+                    # Read-only fqdn references are the primary-value sub properties of
+                    # the fqdn-bearing forms themselves; those subs are recomputed via the
+                    # node's own moveNode() newsubs. We must not collect them here because
+                    # moveNode() would treat a read-only reference from a non-comp form
+                    # (inet:email, inet:url, inet:addr) as a comp and remove the node.
+                    if isro:
+                        continue
+
+                    if reftype == 'ndef':
+                        propvalu = formndef
+                    else:
+                        propvalu = formvalu
+
+                    async for refbuid, refsode in self.getSodeByPropValuNoNorm(layer, refform, refprop, propvalu):
+                        refs.append((s_common.ehex(refbuid), refinfo))
+
+                        await self.todos.add(('getvalu', (refbuid, True)))
+
+                if refs:
+                    node['refs'][layer.iden] = refs
+
+                await self.nodes.set(buid, node)
+
+        logger.info('Processing fqdn-bearing node references (this may happen multiple times)')
+        await self._collectReferences()
+
+        logger.info(f'Migrating {total} fqdn-bearing nodes')
+
+        formset = set(forms)
+
+        count = 0
+        migrated = 0
+        removed = 0
+        async for buid, node in s_coro.pause(self.nodes.items()):
+
+            formname = node.get('formname')
+            formvalu = node.get('formvalu')
+
+            if formname is None or formvalu is None:  # pragma: no cover
+                continue
+
+            # Only process the fqdn-bearing forms; plain prop and ndef refs are handled by moveNode()
+            if formname not in formset:
+                continue
+
+            form = self.core.model.form(formname)
+
+            try:
+                newvalu, newinfo = form.type.norm(self._correctValu(form.type, formvalu))
+            except Exception:  # pragma: no cover
+                logger.debug('Failed to re-normalize %s=%s, removing', formname, formvalu)
+                await self.removeNode(buid)
+                removed += 1
+                continue
+
+            await self.moveNode(buid, newvalu, newsubs=newinfo.get('subs'))
+            migrated += 1
+
+            count = migrated + removed
+            if count % 1000 == 0:  # pragma: no cover
+                logger.info(f'Processed {count} fqdn-bearing nodes')
+
+        await self._flushEdits()
+
+        logger.info(f'Finished processing fqdn-bearing nodes: {migrated} migrated, {removed} removed')
+
+        await self.todos.fini()
+        await self.nodes.fini()

--- a/synapse/tests/test_lib_modelrev.py
+++ b/synapse/tests/test_lib_modelrev.py
@@ -2115,3 +2115,102 @@ class ModelRevTest(s_tests.SynTest):
             self.len(1, nodes)
             self.eq(4, nodes[0].get('mii'))
             self.eq(402400, nodes[0].get('iin'))
+
+    async def test_modelrev_0_2_37(self):
+
+        # Updating the idna dependency changed UTS46 normalization for a small set of
+        # rare unicode codepoints. The stored value 'xn--aa-g88h.link' decodes back to
+        # the unicode form 'a꟱a.link' which re-encodes to 'asa.link' under the
+        # current idna. Re-norming the stored a-label alone is a no-op, so the migration
+        # decodes then re-encodes the value before moving the node.
+        drift = 'xn--aa-g88h.link'
+        fixed = 'asa.link'
+        drift_user = f'visi@{drift}'
+        fixed_user = f'visi@{fixed}'
+
+        # sanity check the version delta is exercised
+        self.eq((0, 2, 37), s_modelrev.maxvers)
+
+        with self.getTestDir() as dirn:
+
+            async with self.getTestCore(dirn=dirn) as core:
+                layr = core.getLayer()
+
+                # an ascii fqdn that must be left untouched
+                self.len(1, await core.nodes('[ inet:fqdn=vertex.link +#keep ]'))
+
+                # the drifting fqdn with a tag, nodedata, and N1/N2 edges
+                nodes = await core.nodes(f'[ inet:fqdn={drift} +#test.foo ]')
+                self.len(1, nodes)
+                self.eq(nodes[0].get('host'), 'xn--aa-g88h')
+
+                await core.nodes(f'inet:fqdn={drift} $node.data.set(woot, hehe)')
+                await core.nodes(f'inet:fqdn={drift} [ +(refs)> {{[ inet:ipv4=1.2.3.4 ]}} ]')
+                await core.nodes(f'[ inet:ipv4=5.6.7.8 ] [ +(refs)> {{ inet:fqdn={drift} }} ]')
+
+                # a comp form embedding the fqdn, an email (custom composite), a nested
+                # comp embedding both an fqdn and an email, and a plain prop reference
+                self.len(1, await core.nodes(f'[ inet:dns:a=({drift}, 1.2.3.4) ]'))
+                self.len(1, await core.nodes(f'[ inet:email=visi@{drift} ]'))
+                self.len(1, await core.nodes(f'[ inet:whois:email=({drift}, visi@{drift}) ]'))
+                self.len(1, await core.nodes(f'[ inet:download=* :fqdn={drift} ]'))
+
+                self.len(1, await core.nodes(f'inet:dns:a:fqdn={drift}'))
+                self.len(1, await core.nodes(f'inet:email={drift_user}'))
+                self.len(1, await core.nodes(f'inet:download:fqdn={drift}'))
+
+                # roll the model version back so the migration runs on the next startup
+                await layr.setModelVers((0, 2, 36))
+
+            async with self.getTestCore(dirn=dirn) as core:
+
+                await self.waitForActiveMigration(core)
+                self.eq(s_modelrev.maxvers, await core.getLayer().getModelVers())
+
+                # the old node is gone and the re-normalized node exists with fixed subs
+                self.len(0, await core.nodes(f'inet:fqdn={drift}'))
+                nodes = await core.nodes(f'inet:fqdn={fixed}')
+                self.len(1, nodes)
+                self.eq(nodes[0].get('host'), 'asa')
+                self.eq(nodes[0].get('domain'), 'link')
+
+                # tags, nodedata, and edges were carried over
+                self.nn(nodes[0].get('#test.foo'))
+                self.eq('hehe', await nodes[0].getData('woot'))
+                self.len(1, await core.nodes(f'inet:fqdn={fixed} -(refs)> inet:ipv4'))
+                self.len(1, await core.nodes(f'inet:fqdn={fixed} <(refs)- inet:ipv4'))
+
+                # the comp form embedding the fqdn was migrated
+                self.len(0, await core.nodes(f'inet:dns:a:fqdn={drift}'))
+                self.len(1, await core.nodes(f'inet:dns:a:fqdn={fixed}'))
+                self.len(1, await core.nodes(f'inet:dns:a=({fixed}, 1.2.3.4)'))
+
+                # the email (custom composite type) was migrated
+                self.len(0, await core.nodes(f'inet:email={drift_user}'))
+                self.len(1, await core.nodes(f'inet:email={fixed_user}'))
+                nodes = await core.nodes(f'inet:email={fixed_user}')
+                self.eq(nodes[0].get('fqdn'), fixed)
+
+                # the nested comp embedding both fqdn and email was migrated
+                self.len(1, await core.nodes(f'inet:whois:email=({fixed}, {fixed_user})'))
+                self.len(0, await core.nodes(f'inet:whois:email:fqdn={drift}'))
+
+                # the plain (non read-only) prop reference was updated by moveNode
+                self.len(0, await core.nodes(f'inet:download:fqdn={drift}'))
+                self.len(1, await core.nodes(f'inet:download:fqdn={fixed}'))
+
+                # the ascii fqdn was left untouched
+                self.len(1, await core.nodes('inet:fqdn=vertex.link +#keep'))
+
+        # a cortex with no drifting fqdn nodes exercises the empty early-return
+        with self.getTestDir() as dirn:
+
+            async with self.getTestCore(dirn=dirn) as core:
+                layr = core.getLayer()
+                self.len(1, await core.nodes('[ inet:fqdn=vertex.link ]'))
+                await layr.setModelVers((0, 2, 36))
+
+            async with self.getTestCore(dirn=dirn) as core:
+                await self.waitForActiveMigration(core)
+                self.eq(s_modelrev.maxvers, await core.getLayer().getModelVers())
+                self.len(1, await core.nodes('inet:fqdn=vertex.link'))

--- a/synapse/tests/test_lib_modelrev.py
+++ b/synapse/tests/test_lib_modelrev.py
@@ -2139,6 +2139,10 @@ class ModelRevTest(s_tests.SynTest):
                 # an ascii fqdn that must be left untouched
                 self.len(1, await core.nodes('[ inet:fqdn=vertex.link +#keep ]'))
 
+                # a legitimate (non-drifting) IDN a-label: it passes the xn-- prefilter
+                # but re-normalizes to itself, so it must also be left untouched
+                self.len(1, await core.nodes('[ inet:fqdn=xn--tst-6la.link +#keep ]'))
+
                 # the drifting fqdn with a tag, nodedata, and N1/N2 edges
                 nodes = await core.nodes(f'[ inet:fqdn={drift} +#test.foo ]')
                 self.len(1, nodes)
@@ -2199,8 +2203,9 @@ class ModelRevTest(s_tests.SynTest):
                 self.len(0, await core.nodes(f'inet:download:fqdn={drift}'))
                 self.len(1, await core.nodes(f'inet:download:fqdn={fixed}'))
 
-                # the ascii fqdn was left untouched
+                # the ascii fqdn and the non-drifting IDN were left untouched
                 self.len(1, await core.nodes('inet:fqdn=vertex.link +#keep'))
+                self.len(1, await core.nodes('inet:fqdn=xn--tst-6la.link +#keep'))
 
         # a cortex with no drifting fqdn nodes exercises the empty early-return
         with self.getTestDir() as dirn:

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -724,6 +724,138 @@ class InetModelTest(s_t_utils.SynTest):
             self.len(1, nodes)
             self.eq(nodes[0].get('zone'), 'foo.com')
 
+    async def test_fqdn_idna_drift(self):
+        # Demonstrate the inet:fqdn normalization drift introduced by updating the idna
+        # dependency. UTS46 mapping changed for a small set of rare unicode codepoints
+        # (e.g. U+A7F1 LATIN EPIGRAPHIC LETTER SIDEWAYS I), so a value stored as an
+        # a-label under the previous idna is no longer reachable by the unicode form
+        # that originally produced it: the same unicode input now normalizes elsewhere.
+        async with self.getTestCore() as core:
+
+            # The unicode IDN label, written as an escape for the obscure codepoint.
+            unicode_fqdn = 'a\ua7f1a.link'
+
+            # Under the previous idna, encoding the unicode label above failed uts46 and
+            # fell back to the IDNA2003 codec, storing this a-label. The current idna
+            # instead maps the codepoint, normalizing the same input to 'asa.link'.
+            legacy_value = 'xn--aa-g88h.link'
+            current_value = 'asa.link'
+
+            opts = {'vars': {'uni': unicode_fqdn, 'legacy': legacy_value}}
+
+            # A node ingested today from the unicode form normalizes to the new value.
+            nodes = await core.nodes('[ inet:fqdn=$uni ]', opts=opts)
+            self.len(1, nodes)
+            self.eq(nodes[0].ndef, ('inet:fqdn', current_value))
+
+            # A node carried over from a deployment on the previous idna keeps its
+            # a-label primary value (re-norming an a-label is a no-op).
+            nodes = await core.nodes('[ inet:fqdn=$legacy ]', opts=opts)
+            self.len(1, nodes)
+            self.eq(nodes[0].ndef, ('inet:fqdn', legacy_value))
+
+            # The drift: lifting by the unicode form resolves to the new node, not the
+            # legacy-stored one, so the two representations exist as separate nodes.
+            nodes = await core.nodes('inet:fqdn=$uni', opts=opts)
+            self.len(1, nodes)
+            self.eq(nodes[0].ndef, ('inet:fqdn', current_value))
+            self.len(0, await core.nodes('inet:fqdn=$uni +inet:fqdn=$legacy', opts=opts))
+
+            # Both labels now live under the same zone as duplicate hosts.
+            nodes = await core.nodes('inet:fqdn:domain=link')
+            self.len(2, nodes)
+            self.eq({current_value, legacy_value}, {n.ndef[1] for n in nodes})
+
+            # Recall: repr() round-trips the legacy a-label back to the unicode form, but
+            # re-norming that unicode form today points at the new node, not the stored one.
+            nodes = await core.nodes('inet:fqdn=$legacy', opts=opts)
+            self.eq(unicode_fqdn, nodes[0].repr())
+            self.eq(current_value, (await core.nodes('inet:fqdn=$repr', opts={'vars': {'repr': nodes[0].repr()}}))[0].ndef[1])
+
+    async def test_fqdn_idna_drift_codepoints(self):
+        # The full set of unicode codepoints whose inet:fqdn normalization changed when
+        # the idna dependency was updated. Each row is (codepoint, the a-label the
+        # previous idna stored for the label 'a<cp>a.link', the value the current idna
+        # produces). These are the labels the model migration must repair; the drift is
+        # only observable by decoding the stored a-label and re-encoding it.
+        drift = (
+            (0x0115F, 'xn--aa-iuk.link', 'aa.link'),  # HANGUL CHOSEONG FILLER
+            (0x01160, 'xn--aa-luk.link', 'aa.link'),  # HANGUL JUNGSEONG FILLER
+            (0x017B4, 'xn--aa-gto.link', 'aa.link'),  # KHMER VOWEL INHERENT AQ
+            (0x017B5, 'xn--aa-jto.link', 'aa.link'),  # KHMER VOWEL INHERENT AA
+            (0x03164, 'xn--aa-luk.link', 'aa.link'),  # HANGUL FILLER
+            (0x0A7CB, 'xn--aa-648h.link', 'xn--aa-sgb.link'),  # LATIN CAPITAL LETTER RAMS HORN
+            (0x0A7D2, 'xn--aa-s58h.link', 'xn--aa-v58h.link'),  # LATIN CAPITAL LETTER DOUBLE THORN
+            (0x0A7D4, 'xn--aa-y58h.link', 'xn--aa-158h.link'),  # LATIN CAPITAL LETTER DOUBLE WYNN
+            (0x0A7DC, 'xn--aa-n68h.link', 'xn--aa-kya.link'),  # LATIN CAPITAL LETTER LAMBDA WITH STROKE
+            (0x0A7F1, 'xn--aa-g88h.link', 'asa.link'),  # MODIFIER LETTER CAPITAL S
+            (0x0FFA0, 'xn--aa-luk.link', 'aa.link'),  # HALFWIDTH HANGUL FILLER
+            (0x1CCD6, 'xn--aa-ev20a.link', 'aaa.link'),  # OUTLINED LATIN CAPITAL LETTER A
+            (0x1CCD7, 'xn--aa-hv20a.link', 'aba.link'),  # OUTLINED LATIN CAPITAL LETTER B
+            (0x1CCD8, 'xn--aa-kv20a.link', 'aca.link'),  # OUTLINED LATIN CAPITAL LETTER C
+            (0x1CCD9, 'xn--aa-nv20a.link', 'ada.link'),  # OUTLINED LATIN CAPITAL LETTER D
+            (0x1CCDA, 'xn--aa-qv20a.link', 'aea.link'),  # OUTLINED LATIN CAPITAL LETTER E
+            (0x1CCDB, 'xn--aa-tv20a.link', 'afa.link'),  # OUTLINED LATIN CAPITAL LETTER F
+            (0x1CCDC, 'xn--aa-wv20a.link', 'aga.link'),  # OUTLINED LATIN CAPITAL LETTER G
+            (0x1CCDD, 'xn--aa-zv20a.link', 'aha.link'),  # OUTLINED LATIN CAPITAL LETTER H
+            (0x1CCDE, 'xn--aa-2v20a.link', 'aia.link'),  # OUTLINED LATIN CAPITAL LETTER I
+            (0x1CCDF, 'xn--aa-5v20a.link', 'aja.link'),  # OUTLINED LATIN CAPITAL LETTER J
+            (0x1CCE0, 'xn--aa-8v20a.link', 'aka.link'),  # OUTLINED LATIN CAPITAL LETTER K
+            (0x1CCE1, 'xn--aa-cw20a.link', 'ala.link'),  # OUTLINED LATIN CAPITAL LETTER L
+            (0x1CCE2, 'xn--aa-fw20a.link', 'ama.link'),  # OUTLINED LATIN CAPITAL LETTER M
+            (0x1CCE3, 'xn--aa-iw20a.link', 'ana.link'),  # OUTLINED LATIN CAPITAL LETTER N
+            (0x1CCE4, 'xn--aa-lw20a.link', 'aoa.link'),  # OUTLINED LATIN CAPITAL LETTER O
+            (0x1CCE5, 'xn--aa-ow20a.link', 'apa.link'),  # OUTLINED LATIN CAPITAL LETTER P
+            (0x1CCE6, 'xn--aa-rw20a.link', 'aqa.link'),  # OUTLINED LATIN CAPITAL LETTER Q
+            (0x1CCE7, 'xn--aa-uw20a.link', 'ara.link'),  # OUTLINED LATIN CAPITAL LETTER R
+            (0x1CCE8, 'xn--aa-xw20a.link', 'asa.link'),  # OUTLINED LATIN CAPITAL LETTER S
+            (0x1CCE9, 'xn--aa-0w20a.link', 'ata.link'),  # OUTLINED LATIN CAPITAL LETTER T
+            (0x1CCEA, 'xn--aa-3w20a.link', 'aua.link'),  # OUTLINED LATIN CAPITAL LETTER U
+            (0x1CCEB, 'xn--aa-6w20a.link', 'ava.link'),  # OUTLINED LATIN CAPITAL LETTER V
+            (0x1CCEC, 'xn--aa-9w20a.link', 'awa.link'),  # OUTLINED LATIN CAPITAL LETTER W
+            (0x1CCED, 'xn--aa-dx20a.link', 'axa.link'),  # OUTLINED LATIN CAPITAL LETTER X
+            (0x1CCEE, 'xn--aa-gx20a.link', 'aya.link'),  # OUTLINED LATIN CAPITAL LETTER Y
+            (0x1CCEF, 'xn--aa-jx20a.link', 'aza.link'),  # OUTLINED LATIN CAPITAL LETTER Z
+            (0x1CCF0, 'xn--aa-mx20a.link', 'a0a.link'),  # OUTLINED DIGIT ZERO
+            (0x1CCF1, 'xn--aa-px20a.link', 'a1a.link'),  # OUTLINED DIGIT ONE
+            (0x1CCF2, 'xn--aa-sx20a.link', 'a2a.link'),  # OUTLINED DIGIT TWO
+            (0x1CCF3, 'xn--aa-vx20a.link', 'a3a.link'),  # OUTLINED DIGIT THREE
+            (0x1CCF4, 'xn--aa-yx20a.link', 'a4a.link'),  # OUTLINED DIGIT FOUR
+            (0x1CCF5, 'xn--aa-1x20a.link', 'a5a.link'),  # OUTLINED DIGIT FIVE
+            (0x1CCF6, 'xn--aa-4x20a.link', 'a6a.link'),  # OUTLINED DIGIT SIX
+            (0x1CCF7, 'xn--aa-7x20a.link', 'a7a.link'),  # OUTLINED DIGIT SEVEN
+            (0x1CCF8, 'xn--aa-by20a.link', 'a8a.link'),  # OUTLINED DIGIT EIGHT
+            (0x1CCF9, 'xn--aa-ey20a.link', 'a9a.link'),  # OUTLINED DIGIT NINE
+        )
+
+        async with self.getTestCore() as core:
+
+            fqdn = core.model.type('inet:fqdn')
+
+            for cp, legacy, current in drift:
+
+                label = f'a{chr(cp)}a.link'
+                mesg = f'U+{cp:05X}'
+
+                # the unicode form now normalizes to the new value
+                self.eq(current, fqdn.norm(label)[0], mesg)
+
+                # which differs from what the previous idna stored (the drift)
+                self.ne(legacy, current)
+
+                # the legacy a-label is still valid and idempotent under the current idna,
+                # so a plain re-norm migration would not detect the change...
+                self.eq(legacy, fqdn.norm(legacy)[0], mesg)
+
+                # ...but decoding it and re-encoding recovers the new value, which is what
+                # the inet:fqdn model migration relies on.
+                self.eq(current, fqdn.norm(fqdn.repr(legacy))[0], mesg)
+
+                # the unicode label is usable in Storm and creates the new node
+                nodes = await core.nodes('[ inet:fqdn=$valu ]', opts={'vars': {'valu': label}})
+                self.len(1, nodes)
+                self.eq(('inet:fqdn', current), nodes[0].ndef, mesg)
+
     async def test_fqdn_suffix(self):
         # Demonstrate FQDN suffix/zone behavior
 


### PR DESCRIPTION
## Summary

Updates the `idna` dependency to address two denial-of-service CVEs and adds a model
migration to repair `inet:fqdn` values whose normalization changed as a result of the
update.

The previous pin `idna>=3.6,<3.12` allowed the vulnerable `3.6` at the floor and
excluded the `3.14` fix at the ceiling. Bumping to `>=3.17,<3.18` remediates both
CVEs and picks up the `3.17` input-length hardening.

| CVE | Issue | Fixed in |
|-----|-------|----------|
| CVE-2024-3651 | Quadratic-time DoS in `idna.encode()` | 3.7 |
| CVE-2026-45409 | Oversize-input bypass of the CVE-2024-3651 mitigation | 3.14 |

## Why a data migration is needed

`inet:fqdn` stores the **normalized** value (`synapse/models/inet.py` `Fqdn._normPyStr`
/ `Fqdn.repr`). Between idna `3.6` and `3.17` the underlying Unicode data changed
(`3.11` -> Unicode 16.0, `3.12` -> Unicode 17.0, `3.13` -> corrected classification of
`U+A7F1`), which alters UTS46 normalization for **47 rare codepoints** (Hangul/Khmer
fillers, the `OUTLINED` Latin letters/digits block, and a few historic/epigraphic Latin
letters).

A value stored under the old idna (e.g. `xn--aa-g88h.link`) is no longer reachable by
the unicode form that produced it: that input now normalizes to a different node (e.g.
`asa.link`). Because the stored value is an a-label, **re-norming it is a no-op** -- the
drift is only observable by **decoding the stored value and re-encoding it** under the
current idna.

A differential A/B sweep of the entire codepoint space (idna 3.6 / 3.11 / 3.17, all on
Python 3.11) classified the change as **47 output-drift**, **18 newly-accepted** (rare
format/control codepoints that previously errored; additive, no conflict), and
**0 newly-rejected** (nothing stored becomes inaccessible).

## Changes

- **`requirements.txt`, `pyproject.toml`** -- bump `idna` pin to `>=3.17,<3.18`.
- **`synapse/lib/modelrev.py`** -- new `ModelMigration_0_2_37` (model version
  `(0, 2, 37)`). It corrects every form whose primary value embeds an `inet:fqdn`,
  processed **leaf-first** by fqdn-nesting depth so `moveNode()` reference handling never
  targets an already-migrated node:
  - `inet:fqdn` itself,
  - the custom composite `inet:email`,
  - generic comp forms that nest them (`inet:dns:*`, `inet:whois:*`, ...).

  Each value is corrected with a recursive decode-then-re-encode helper and moved with
  recomputed subs. Read-only fqdn sub references are intentionally **not** collected
  during reference resolution: `moveNode()` treats a read-only fqdn reference from a
  non-comp form as a comp and would otherwise delete `inet:email` / `inet:url` /
  `inet:addr` nodes. Each node's own subs are corrected via its own `moveNode(newsubs=...)`.
- **Changelog** -- a `note` entry (CVE bump) and a `migration` entry.

### Performance

The collection scan skips the expensive decode/re-encode for any value that does not
contain an `xn--` label. Every affected codepoint is non-ascii and was stored by the
previous idna as a punycode a-label, so a plaintext fqdn can not have drifted; this
avoids per-node idna work for the (overwhelmingly common) ascii fqdns. It is an in-scan
filter rather than an indexed lift because `inet:fqdn` is indexed reversed
(`StorTypeFqdn`, for suffix/zone scans) and an a-label can appear in any label
(`foo.xn--bar.com`), not just the leading one -- so neither a prefix lift nor the
reversed index can select the candidate set.

### Known limitation

Fqdns textually embedded in the primary strings of `inet:url` and the
`inet:server` / `inet:client` (`inet:addr`) family are **not** rewritten -- those
custom string types have no safe generic reconstruction. Their `inet:fqdn` sub
properties are still corrected via reference handling. This is documented in the
migration docstring and the changelog entry. (Realistically these codepoints do not
appear in legitimate URLs/addresses.)

## Tests

- `synapse/tests/test_lib_modelrev.py::test_modelrev_0_2_37` -- builds a cortex with a
  drifting fqdn plus a comp form (`inet:dns:a`), an email (`inet:email`), a nested comp
  (`inet:whois:email`), a plain-prop reference (`inet:download:fqdn`), tags, nodedata and
  edges; rolls the model version back; and asserts every node migrates correctly while an
  ASCII fqdn is left untouched. Also covers the empty early-return. New migration code is
  fully covered.
- `synapse/tests/test_model_inet.py::test_fqdn_idna_drift` -- isolated Storm-driven
  demonstration of the drift symptom (a legacy a-label and the unicode form resolve to
  separate nodes; `repr()` recall lands on the new node).
- `synapse/tests/test_model_inet.py::test_fqdn_idna_drift_codepoints` -- data-driven test
  over **all 47** drift codepoints (annotated with their Unicode names), asserting the new
  normalization, the drift vs the legacy a-label, a-label idempotency, decode+re-encode
  recovery, and Storm usability of each label.

## Verification

- A/B timing: idna 3.6 spends 25-149ms on oversize input; 3.17 rejects in ~0ms,
  confirming both CVEs are remediated.
- New pin resolves to idna 3.17; `ruff` clean on all changed files.
- `test_lib_modelrev.py`, `test_model_inet.py`, `test_lib_scrape.py`,
  `test_lib_stormlib_scrape.py` pass under idna 3.17. (Regression-core tests requiring the
  separate `synapse-regression` repo are skipped in this environment.)
