### PR TITLE
Add risk:vuln:reporter:url property

### DIFF
--- a/synapse/models/risk.py
+++ b/synapse/models/risk.py
@@ -513,6 +513,9 @@ class RiskModule(s_module.CoreModule):
                     ('reporter:name', ('ou:name', {}), {
                         'doc': 'The name of the organization reporting on the vulnerability.'}),
 
+                    ('reporter:url', ('inet:url', {}), {
+                        'doc': 'The URL for the vulnerability provided by the reporter.'}),
+
                     ('mitigated', ('bool', {}), {
                         'doc': 'Set to true if a mitigation/fix is available for the vulnerability.'}),
 

--- a/synapse/tests/test_model_risk.py
+++ b/synapse/tests/test_model_risk.py
@@ -157,6 +157,7 @@ class RiskModelTest(s_t_utils.SynTest):
 
                     :reporter=*
                     :reporter:name=vertex
+                    :reporter:url=https://vertex.link/advisory/vtx-000-1234
 
                     :timeline:exploited=2020-01-14
                     :timeline:discovered=2020-01-14
@@ -211,6 +212,7 @@ class RiskModelTest(s_t_utils.SynTest):
 
             self.nn(node.get('reporter'))
             self.eq(node.get('reporter:name'), 'vertex')
+            self.eq(node.get('reporter:url'), 'https://vertex.link/advisory/vtx-000-1234')
             self.eq(node.get('timeline:exploited'), 1578960000000)
             self.eq(node.get('timeline:discovered'), 1578960000000)
             self.eq(node.get('timeline:vendor:notified'), 1578960000000)


### PR DESCRIPTION
## Summary

Adds a `:reporter:url` (`inet:url`) property to the `risk:vuln` form to capture the URL for the vulnerability provided by the reporter. This brings the 2.x.x mainline model into alignment with the Synapse 3.x.x model, which already has this property. It sits alongside the existing `:reporter` (`ou:org`) and `:reporter:name` (`ou:name`) properties.

## Changes

- `synapse/models/risk.py` - new `risk:vuln:reporter:url` property
- `synapse/tests/test_model_risk.py` - set and assert the new property in the main `risk:vuln` test

No model version bump, migration, manual changelog, or modelrefs regeneration is required for this additive model property (the model changelog and datamodel docs are auto-generated).

## Testing

- `ruff check` - clean
- `python -m pytest synapse/tests/test_model_risk.py -n auto` - 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)