### PR TITLE
Add inet:whois registrant:name property and deprecate :registrant

### DIFF
--- a/changes/1aa14e90808146a1a6d2ab51ccd7394a.yaml
+++ b/changes/1aa14e90808146a1a6d2ab51ccd7394a.yaml
@@ -1,0 +1,6 @@
+---
+desc: Deprecate the ``inet:whois:rec:registrant`` property in favor of ``inet:whois:rec:registrant:name``.
+desc:literal: false
+prs: []
+type: deprecation
+...

--- a/changes/290ceb0d3ee873285e1996dd97703d0d.yaml
+++ b/changes/290ceb0d3ee873285e1996dd97703d0d.yaml
@@ -1,0 +1,7 @@
+---
+desc: Add the ``inet:whois:rec:registrant:name`` and ``inet:whois:iprec:registrant:name``
+  properties.
+desc:literal: false
+prs: []
+type: model
+...

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -3440,6 +3440,10 @@ class InetModule(s_module.CoreModule):
                             'doc': 'The registrar name from the whois record.'
                         }),
                         ('registrant', ('inet:whois:reg', {}), {
+                            'deprecated': True,
+                            'doc': 'Deprecated. Please use :registrant:name.'
+                        }),
+                        ('registrant:name', ('ou:name', {}), {
                             'doc': 'The registrant name from the whois record.'
                         }),
                     )),
@@ -3548,7 +3552,10 @@ class InetModule(s_module.CoreModule):
                         }),
                         ('registrant', ('inet:whois:ipcontact', {}), {
                             'deprecated': True,
-                            'doc': 'Deprecated. Add the registrant inet:whois:ipcontact to the :contacts array.'
+                            'doc': 'Deprecated. Please use :registrant:name.'
+                        }),
+                        ('registrant:name', ('ou:name', {}), {
+                            'doc': 'The name assigned to the network by the registrant.'
                         }),
                         ('contacts', ('array', {'type': 'inet:whois:ipcontact', 'uniq': True, 'sorted': True}), {
                             'doc': 'Additional contacts from the record.',

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -2655,8 +2655,10 @@ class InetModelTest(s_t_utils.SynTest):
                 'text': 'YELLING AT pennywise@vertex.link LOUDLY',
                 'registrar': ' cool REGISTRAR ',
                 'registrant': ' cool REGISTRANT ',
+                'registrant:name': ' Cool Registrant Org ',
             }
-            q = '[(inet:whois:rec=$valu :text=$p.text :registrar=$p.registrar :registrant=$p.registrant)]'
+            q = '''[(inet:whois:rec=$valu :text=$p.text :registrar=$p.registrar :registrant=$p.registrant
+                :registrant:name=$p."registrant:name")]'''
             nodes = await core.nodes(q, opts={'vars': {'valu': valu, 'p': props}})
             self.len(1, nodes)
             node = nodes[0]
@@ -2666,6 +2668,7 @@ class InetModelTest(s_t_utils.SynTest):
             self.eq(node.get('text'), 'yelling at pennywise@vertex.link loudly')
             self.eq(node.get('registrar'), ' cool registrar ')
             self.eq(node.get('registrant'), ' cool registrant ')
+            self.eq(node.get('registrant:name'), 'cool registrant org')
 
             nodes = await core.nodes('inet:whois:email')
             self.len(1, nodes)
@@ -2695,6 +2698,7 @@ class InetModelTest(s_t_utils.SynTest):
                 'name': 'vtx',
                 'parentid': 'NET-10-0-0-0-0',
                 'registrant': contact,
+                'registrant:name': ' Vertex Project ',
                 'contacts': (addlcontact, ),
                 'country': 'US',
                 'status': 'validated',
@@ -2703,8 +2707,8 @@ class InetModelTest(s_t_utils.SynTest):
             }
             q = '''[(inet:whois:iprec=$valu :net4=$p.net4 :asof=$p.asof :created=$p.created :updated=$p.updated
                 :text=$p.text :desc=$p.desc :asn=$p.asn :id=$p.id :name=$p.name :parentid=$p.parentid
-                :registrant=$p.registrant :contacts=$p.contacts :country=$p.country :status=$p.status :type=$p.type
-                :links=$p.links)]'''
+                :registrant=$p.registrant :registrant:name=$p."registrant:name" :contacts=$p.contacts
+                :country=$p.country :status=$p.status :type=$p.type :links=$p.links)]'''
             nodes = await core.nodes(q, opts={'vars': {'valu': rec_ipv4, 'p': props}})
             self.len(1, nodes)
             node = nodes[0]
@@ -2722,6 +2726,7 @@ class InetModelTest(s_t_utils.SynTest):
             self.eq(node.get('name'), 'vtx')
             self.eq(node.get('parentid'), 'NET-10-0-0-0-0')
             self.eq(node.get('registrant'), contact)
+            self.eq(node.get('registrant:name'), 'vertex project')
             self.eq(node.get('contacts'), (addlcontact,))
             self.eq(node.get('country'), 'us')
             self.eq(node.get('status'), 'validated')


### PR DESCRIPTION
## Summary
- Add `:registrant:name` (type `ou:name`) to `inet:whois:rec` and `inet:whois:iprec`.
- Deprecate `:registrant` on both forms in favor of `:registrant:name`; doc updated to `Deprecated. Please use :registrant:name.`
- Existing `:registrant` properties are retained (backward compatible).

## Tests
- `test_whois_rec` and `test_whois_iprec` updated to set/assert `:registrant:name`.
- Verified `test_model_inet.py`, `test_datamodel.py`, and `test_model_syn.py` pass.

## Changelog
- `model` entry for the new properties.
- `deprecation` entry for `inet:whois:rec:registrant`.