### PR TITLE
auth: keep AuthGate in-memory cache in sync on gated edits

### DIFF
--- a/changes/8f8c44c5a798a7e46c83c66b9c0cc9a6.yaml
+++ b/changes/8f8c44c5a798a7e46c83c66b9c0cc9a6.yaml
@@ -1,0 +1,11 @@
+---
+desc: Fixed a bug where changes to the permissions a user or role had on a specific
+  object (such as a Layer or View) were not reflected when those permissions were
+  listed (for example via ``$lib.auth.gates.get()`` or the Beholder stream), even
+  though the changes took effect immediately. Restarting the Cortex would show the
+  updated permissions. Permission enforcement was never affected; only the reported
+  values could be out of date.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/synapse/lib/auth.py
+++ b/synapse/lib/auth.py
@@ -539,6 +539,7 @@ class Auth(s_nexus.Pusher):
                 info = user.genGateInfo(gateiden)
                 info[name] = s_msgpack.deepcopy(valu)
                 gate.users.set(iden, info)
+                gate.gateusers[iden] = info
                 user.info['authgates'][gateiden] = info
 
             self.userdefs.set(iden, user.info)
@@ -600,6 +601,7 @@ class Auth(s_nexus.Pusher):
                 info = role.genGateInfo(gateiden)
                 info[name] = s_msgpack.deepcopy(valu)
                 gate.roles.set(iden, info)
+                gate.gateroles[iden] = info
                 role.info['authgates'][gateiden] = info
 
             self.roledefs.set(iden, role.info)

--- a/synapse/tests/test_lib_auth.py
+++ b/synapse/tests/test_lib_auth.py
@@ -477,6 +477,52 @@ class AuthTest(s_test.SynTest):
                 self.none(await core.auth.getUserByName('fred'))
                 self.none(await core.auth.getRoleByName('friends'))
 
+    async def test_authgate_pack_after_restart(self):
+        # Regression: after a restart, gate.gateusers / gate.gateroles (read by
+        # AuthGate.pack(), i.e. $lib.auth.gates.get() and the beholder feed) are
+        # loaded from a separate slab than user.authgates / role.authgates. A
+        # subsequent gated rule/admin edit must keep the in-memory gate cache in
+        # sync, or pack() returns stale rules while user.allowed() (which reads
+        # the user/role copy) reports the change. That divergence only resets on
+        # a backend restart, not a client reload.
+        with self.getTestDir() as dirn:
+
+            async with self.getTestCore(dirn=dirn) as core:
+                user = await core.auth.addUser('bob')
+                role = await core.auth.addRole('staff')
+                gateiden = core.getLayer().iden
+                await user.addRule((True, ('layer', 'read')), gateiden=gateiden)
+                await role.addRule((True, ('layer', 'read')), gateiden=gateiden)
+                useriden = user.iden
+                roleiden = role.iden
+
+            # restart: gateusers/gateroles now load as objects distinct from the
+            # user/role authgate copies.
+            async with self.getTestCore(dirn=dirn) as core:
+                user = core.auth.user(useriden)
+                role = core.auth.role(roleiden)
+                gate = core.auth.getAuthGate(gateiden)
+
+                await user.addRule((True, ('node',)), gateiden=gateiden)
+                await role.addRule((True, ('node',)), gateiden=gateiden)
+
+                packed = gate.pack()
+                packuser = [u for u in packed['users'] if u['iden'] == useriden][0]
+                packrole = [r for r in packed['roles'] if r['iden'] == roleiden][0]
+
+                # pack() (gates.get / beholder) must reflect the just-added rule.
+                self.isin((True, ('node',)), packuser['rules'])
+                self.isin((True, ('node',)), packrole['rules'])
+
+                # admin toggling must likewise reflect in pack().
+                await user.setAdmin(True, gateiden=gateiden)
+                self.true([u for u in gate.pack()['users'] if u['iden'] == useriden][0]['admin'])
+
+                # removing the rule must also reflect (no stale leftover).
+                await user.delRule((True, ('node',)), gateiden=gateiden)
+                packuser = [u for u in gate.pack()['users'] if u['iden'] == useriden][0]
+                self.notin((True, ('node',)), packuser['rules'])
+
     async def test_auth_invalid(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
## Problem

After a Cortex restart, `gate.gateusers` / `gate.gateroles` (read by `AuthGate.pack()`, i.e. `$lib.auth.gates.get()` and the Beholder feed) load from a separate slab than `user.authgates` / `role.authgates` (read by `allowed()`). A subsequent gated rule or admin edit updated the user/role copy and the slab but left the in-memory gate cache stale, so `gates.get` and the Beholder feed returned old rules until the next backend restart (a client reload did not help).

Permission enforcement was **unaffected** — only the reported gate information could be stale.

## Fix

Sync `gate.gateusers` / `gate.gateroles` to the live info object on every gated write in `_setUserInfo` / `setRoleInfo` (`synapse/lib/auth.py`).

## Test

Adds `test_authgate_pack_after_restart`, which edits a gate entry after a restart and asserts `pack()` reflects added rules, admin toggles, and rule removals. Verified the test fails without the fix and passes with it.