### PR TITLE
Fix lift cursor re-yielding nodes on in-transaction deletes (SYN-10972)

### DIFF
--- a/changes/94caa91d4dd4a1f0c575305adb7c682d.yaml
+++ b/changes/94caa91d4dd4a1f0c575305adb7c682d.yaml
@@ -1,0 +1,7 @@
+---
+desc: Fixed a bug where a lift matching multiple nodes could return some of them more
+  than once if the query changed a property on those nodes.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/synapse/lib/lmdbslab.py
+++ b/synapse/lib/lmdbslab.py
@@ -1811,9 +1811,15 @@ class Slab(s_base.Base):
         return True
 
     def pop(self, lkey, db=None):
+        # an in-transaction delete can disrupt the live cursors of active scans
+        # and cause already-yielded rows to be re-emitted, so bump them to force
+        # a safe cursor resume on their next step
+        [scan.bump() for scan in self.scans]
         return self._xact_action(self.pop, lmdb.Transaction.pop, lkey, db=db)
 
     def delete(self, lkey, val=None, db=None):
+        # see pop(): bump active scans so a delete cannot corrupt their cursors
+        [scan.bump() for scan in self.scans]
         return self._xact_action(self.delete, lmdb.Transaction.delete, lkey, val, db=db)
 
     def put(self, lkey, lval, dupdata=False, overwrite=True, append=False, db=None):

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -3054,6 +3054,25 @@ class CortexTest(s_t_utils.SynTest):
         delta = time.time() - before
         self.lt(delta, 1.0)
 
+    async def test_storm_multinode_lift_edit(self):
+
+        # Editing nodes while iterating a lift that yields multiple nodes sharing
+        # the lifted value must not re-emit nodes. Overwriting an
+        # already-set indexed prop deletes that prop's old index entry on the
+        # same db the lift cursor walks; the storage layer must keep the lift
+        # cursor consistent so each node is yielded exactly once.
+        async with self.getTestCore() as core:
+
+            self.len(2, await core.nodes('''
+                [ inet:ipv4=1.2.3.4 :asn=10 :loc=us
+                  inet:ipv4=1.2.3.5 :asn=10 :loc=us ]
+            '''))
+
+            # the two nodes share :loc, so this prop-value lift yields two nodes;
+            # overwriting :asn deletes its old index entry mid-lift
+            self.len(2, await core.nodes('inet:ipv4:loc=us'))
+            self.len(2, await core.nodes('inet:ipv4:loc=us [ :asn=20 ]'))
+
     async def test_storm_pivprop(self):
 
         async with self.getTestCore() as core:

--- a/synapse/tests/test_lib_lmdbslab.py
+++ b/synapse/tests/test_lib_lmdbslab.py
@@ -9,6 +9,7 @@ import synapse.common as s_common
 from unittest.mock import patch
 
 import synapse.lib.base as s_base
+import synapse.lib.coro as s_coro
 import synapse.lib.const as s_const
 import synapse.lib.msgpack as s_msgpack
 import synapse.lib.lmdbslab as s_lmdbslab
@@ -702,6 +703,57 @@ class LmdbSlabTest(s_t_utils.SynTest):
                 slab.delete(b'1', val=b'2', db=dupndb)
                 self.eq((b'1', b'1'), next(it))
                 self.raises(StopIteration, next, it)
+
+    async def test_lmdbslab_scan_delete_noreyield(self):
+
+        # Deleting unrelated entries from a db while a scan iterates it must not
+        # disrupt the live cursor and re-emit rows. The slab bumps
+        # active scans on delete/pop so they resume cleanly on the next step.
+        with self.getTestDir() as dirn:
+
+            path = os.path.join(dirn, 'test.lmdb')
+
+            async with await s_lmdbslab.Slab.anit(path) as slab:
+
+                dupsdb = slab.initdb('dups', dupsort=True)
+
+                async def scan_deleting(genr, decode, *unrelated):
+                    # add unrelated rows (sorting before/after the scanned range)
+                    # and delete one per yielded row to perturb the live cursor
+                    for lkey, lval in unrelated:
+                        slab.put(lkey, lval, dupdata=True, db=dupsdb)
+
+                    todel = list(unrelated)
+                    seen = []
+                    async for lkey, lval in genr:
+                        seen.append(decode(lkey, lval))
+                        if todel:
+                            dkey, dval = todel.pop()
+                            slab.delete(dkey, dval, db=dupsdb)
+
+                    return seen
+
+                # scanByDups: four dups under one key
+                key = b'\x10key'
+                for i in range(4):
+                    slab.put(key, s_common.int64en(i), dupdata=True, db=dupsdb)
+
+                seen = await scan_deleting(
+                    s_coro.agen(slab.scanByDups(key, db=dupsdb)),
+                    lambda lkey, lval: s_common.int64un(lval),
+                    (b'\x00aaa', s_common.int64en(0)), (b'\xffzzz', s_common.int64en(0)))
+                self.eq([0, 1, 2, 3], seen)
+
+                # scanByPref: four keys sharing a prefix
+                pref = b'\x20pref'
+                for i in range(4):
+                    slab.put(pref + s_common.int64en(i), b'v', db=dupsdb)
+
+                seen = await scan_deleting(
+                    s_coro.agen(slab.scanByPref(pref, db=dupsdb)),
+                    lambda lkey, lval: s_common.int64un(lkey[len(pref):]),
+                    (b'\x00bbb', s_common.int64en(0)), (b'\xffyyy', s_common.int64en(0)))
+                self.eq([0, 1, 2, 3], seen)
 
     async def test_lmdbslab_scanback(self):
 


### PR DESCRIPTION
## Summary

Fixes SYN-10972. A Storm lift that matches multiple nodes could return some of them more than once when the query changed a property on those nodes.

## Root cause

Property lifts stream a live dupsort cursor over the `byprop` index. Changing a property deletes that value's old `byprop` entry, and an in-transaction delete disrupts other live scan cursors (LMDB repositions a write-txn cursor when an entry sorting before it is removed), so the cursor re-yields its current row. `lmdbslab.Scan` only reconciles cursors on commit (`_finiCoXact`), never on in-transaction `delete`/`pop`.

This is a long-standing latent bug, not a regression -- the `Scan` bump/resume machinery has only ever been wired to commit.

## Fix

Bump active scans on `delete`/`pop`, mirroring the existing commit-time bump; the existing `resume()` then re-seeks past the already-yielded value.

## Tests

- `test_lmdbslab_scan_delete_noreyield` -- slab-level (`scanByDups`, `scanByPref`): deleting unrelated entries mid-scan must not re-yield rows.
- `test_storm_multinode_lift_edit` -- Storm-level: `inet:ipv4:loc=us [ :asn=20 ]` returns exactly the matched nodes.

Both fail without the fix and pass with it. Affected suites green locally: `test_lib_lmdbslab` (37), `test_lib_layer` (35), `test_cortex` (150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)