### PR TITLE
Repr ival tag timestamps consistently with ival props (SYN-10985)

### DIFF
--- a/changes/e67a81716f9b408c92ace1c35a76be0a.yaml
+++ b/changes/e67a81716f9b408c92ace1c35a76be0a.yaml
@@ -1,0 +1,6 @@
+---
+desc: Fixed a bug where ``ival`` tag timestamps were displayed as raw storage values instead of in the human-friendly repr format used for ``ival`` properties.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/synapse/lib/ast.py
+++ b/synapse/lib/ast.py
@@ -4339,7 +4339,14 @@ class TagValue(Value):
 
     async def compute(self, runt, path):
         name = await self.kids[0].compute(runt, path)
-        return path.node.getTag(name)
+        if (valu := path.node.getTag(name)) is None:
+            return None
+
+        # a tag with no time interval is stored as the all-None sentinel
+        if valu == (None, None, None):
+            return valu
+
+        return await runt.model.type('ival').tostorm(valu)
 
 class TagVirtValue(Value):
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -2673,6 +2673,11 @@ class Ival(Type):
 
     async def _ctorCmprAt(self, valu):
 
+        # unwrap a typed Storm value (e.g. a tag timestamp or ival prop value)
+        # so the comparison works when the @= operand is passed in directly.
+        if isinstance(valu, s_stormtypes.Valu):
+            valu = valu.value()
+
         if valu is None or valu == (None, None, None):
             async def cmpr(item):
                 return False

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -5291,7 +5291,7 @@ class CortexBasicTest(s_t_utils.SynTest):
             self.true(s_node.tagged(pode, '#timetag'))
 
             mesgs = await core.stormlist('test:str=foo $var=$node.value [+#$var=2019] $lib.print(#$var)')
-            self.stormIsInPrint('(1546300800000000, 1546300800000001, 1)', mesgs)
+            self.stormIsInPrint("('2019-01-01T00:00:00Z', '2019-01-01T00:00:00.000001Z')", mesgs)
             podes = [m[1] for m in mesgs if m[0] == 'node']
             self.len(1, podes)
             pode = podes[0]
@@ -5331,7 +5331,7 @@ class CortexBasicTest(s_t_utils.SynTest):
             self.nn(nodes[0].getTag('tag3'))
 
             mesgs = await core.stormlist('test:str=foo $var=$node.value [+?#$var=2019] $lib.print(#$var)')
-            self.stormIsInPrint('(1546300800000000, 1546300800000001, 1)', mesgs)
+            self.stormIsInPrint("('2019-01-01T00:00:00Z', '2019-01-01T00:00:00.000001Z')", mesgs)
             podes = [m[1] for m in mesgs if m[0] == 'node']
             self.len(1, podes)
             pode = podes[0]

--- a/synapse/tests/test_lib_ast.py
+++ b/synapse/tests/test_lib_ast.py
@@ -4393,6 +4393,46 @@ class AstTest(s_test.SynTest):
             with self.raises(s_exc.NoSuchCmpr):
                 await core.nodes('test:arrayprop +test:arrayprop:ints.size*newp=5')
 
+    async def test_ast_tagvalu(self):
+
+        async with self.getTestCore() as core:
+
+            await core.nodes('[inet:fqdn=evil.com +#foo=(2019-09-08, 2021-09-08)]')
+            await core.nodes('[inet:dns:a=(woot.com, 1.2.3.4) :seen=(2019-09-08, 2021-09-08)]')
+
+            # a tag timestamp is repr'd the same way as an equivalent ival prop (SYN-10985)
+            tagrepr = "('2019-09-08T00:00:00Z', '2021-09-08T00:00:00Z')"
+
+            msgs = await core.stormlist('inet:fqdn=evil.com $time=#foo $lib.print($time)')
+            self.stormIsInPrint(tagrepr, msgs)
+
+            msgs = await core.stormlist('inet:dns:a $time=:seen $lib.print($time)')
+            self.stormIsInPrint(tagrepr, msgs)
+
+            # the tag value carries its type and normalized value like a prop value
+            self.eq('ival', await core.callStorm('inet:fqdn=evil.com $time=#foo return($time.type)'))
+            self.eq((1567900800000000, 1631059200000000, 63158400000000),
+                    await core.callStorm('inet:fqdn=evil.com $time=#foo return($time.value)'))
+
+            # the min/max/duration virts are reachable off the tag value
+            self.eq(1567900800000000, await core.callStorm('inet:fqdn=evil.com $time=#foo return($time.min)'))
+            self.eq(1631059200000000, await core.callStorm('inet:fqdn=evil.com $time=#foo return($time.max)'))
+
+            # the wrapped tag value round-trips into an @= comparison against a
+            # tag, tagprop and prop ival - the ival type resolves the operand.
+            await core.addTagProp('_score', ('ival', {}), {})
+            await core.nodes('inet:fqdn=evil.com [ +#foo:_score=(2019-09-08, 2021-09-08) ]')
+            self.len(1, await core.nodes('inet:fqdn=evil.com $time=#foo +#foo@=$time'))
+            self.len(1, await core.nodes('inet:fqdn=evil.com $time=#foo +#foo:_score@=$time'))
+            self.len(1, await core.nodes('inet:dns:a $time=:seen +:seen@=$time'))
+
+            # a tag with no time interval yields the all-None sentinel, not an error
+            await core.nodes('[inet:fqdn=bare.com +#foo]')
+            self.eq((None, None, None), await core.callStorm('inet:fqdn=bare.com $time=#foo return($time)'))
+
+            # a missing tag yields None
+            self.none(await core.callStorm('inet:fqdn=bare.com $time=#newp return($time)'))
+
     async def test_ast_righthand_relprop(self):
         async with self.getTestCore() as core:
             await core.nodes('''[


### PR DESCRIPTION
## Summary

Fixes SYN-10985: `ival` tag timestamps were displayed as raw storage tuples when accessed as Storm values (e.g. `$time=#foo`), while equivalent `ival` property values render in human-friendly repr form.

### Before
```
inet:fqdn=evildomain.com $time=#cno.threat.t20.own $lib.print($time)
(1567900800000000, 1631059200000000, 63158400000000)
```
### After
```
inet:fqdn=evildomain.com $time=#cno.threat.t20.own $lib.print($time)
('2019-09-08T00:00:00Z', '2021-09-08T00:00:00Z')
```

## Changes

- **`synapse/lib/ast.py`** - `TagValue.compute` wraps the tag ival via the `ival` type's `tostorm()`, so tag timestamps repr the same way as props and expose the `min`/`max`/`duration` virts. The all-None sentinel for a tag with no interval is preserved; a missing tag returns `None`.
- **`synapse/lib/types.py`** - `Ival._ctorCmprAt` now unwraps a typed Storm value operand, so `@=` is supported directly on the `ival` type. Wrapping tag values otherwise broke the tag filter comparison paths (`+#foo@=$var`), which pass the operand straight to the comparator rather than through `Poly.getCmprCtor`.

## Tests

- Added `test_ast_tagvalu` covering repr consistency (tag vs prop), the `.type`/`.value`/`.min`/`.max` accessors, `@=` round-trips against tag/tagprop/prop ivals, and bare/missing-tag edge cases.
- Updated `test_storm_tagvar` for the corrected repr output.
- Added a changelog entry.

## Notes

The 4 pre-existing `test_cortex.py` failures (`handoff`, `ext_model`, `query_offload`, `safemode`) fail identically on clean `main` in this environment (SSL/spawner errors) and are unrelated to this change.