### PR TITLE
SYN-11164 add inet:http:request:fetch property

### DIFF
--- a/changes/5f83bd8e7f92d6da23bf9b6d3bf862ba.yaml
+++ b/changes/5f83bd8e7f92d6da23bf9b6d3bf862ba.yaml
@@ -1,0 +1,7 @@
+---
+desc: Added the ``inet:http:request:fetch`` property to record the ``it:exec:url``
+  event which caused the HTTP request.
+desc:literal: false
+prs: []
+type: model
+...

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -2428,6 +2428,9 @@ class InetModule(s_module.CoreModule):
                         ('response:body', ('file:bytes', {}), {}),
                         ('session', ('inet:http:session', {}), {
                             'doc': 'The HTTP session this request was part of.'}),
+
+                        ('fetch', ('it:exec:url', {}), {
+                            'doc': 'The fetch or page load event which caused the HTTP request.'}),
                     )),
 
                     ('inet:http:session', {}, (

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -865,11 +865,13 @@ class InetModelTest(s_t_utils.SynTest):
             server = s_common.guid()
             flow = s_common.guid()
             iden = s_common.guid()
+            fetch = s_common.guid()
 
             props = {
                 'body': 64 * 'b',
                 'flow': flow,
                 'sess': sess,
+                'fetch': fetch,
                 'client:host': client,
                 'server:host': server,
                 'sandbox:file': 64 * 'c'
@@ -893,6 +895,7 @@ class InetModelTest(s_t_utils.SynTest):
                 :server="5.5.5.5:443"
                 :server:host=$p."server:host"
                 :session=$p.sess
+                :fetch=$p.fetch
                 :sandbox:file=$p."sandbox:file"
                 ]'''
             nodes = await core.nodes(q, opts={'vars': {'valu': iden, 'p': props}})
@@ -912,6 +915,7 @@ class InetModelTest(s_t_utils.SynTest):
             self.eq(node.get('response:headers'), (('baz', 'faz'),))
             self.eq(node.get('response:body'), 'sha256:' + 64 * 'b')
             self.eq(node.get('session'), sess)
+            self.eq(node.get('fetch'), fetch)
             self.eq(node.get('sandbox:file'), 'sha256:' + 64 * 'c')
             self.eq(node.get('client'), 'tcp://1.2.3.4')
             self.eq(node.get('client:ipv4'), 0x01020304)


### PR DESCRIPTION
## Summary

Adds an additive `:fetch` property to the `inet:http:request` form, linking an HTTP request to the fetch / page load event which caused it. Needed for Power-Ups.

- `inet:http:request:fetch = <it:exec:url>`

This is the **v2** side of SYN-11164 (the v3 counterpart in synapse-enterprise uses `it:exec:fetch`).

## Changes

- Model: added `:fetch` to `inet:http:request` in `synapse/models/inet.py`.
- Tests: `test_http_request` sets and asserts `:fetch`.
- Changelog entry (`type: model`).

Jira: SYN-11164