### PR TITLE
SYN-11163 add it:os:posix:cron form

### DIFF
--- a/changes/40a4518cbfe4aa57e0e9e6213b2aab12.yaml
+++ b/changes/40a4518cbfe4aa57e0e9e6213b2aab12.yaml
@@ -1,0 +1,7 @@
+---
+desc: Added the ``it:os:posix:cron`` form to model cron job entries configured on
+  a host.
+desc:literal: false
+prs: []
+type: model
+...

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -858,6 +858,9 @@ class ItModule(s_module.CoreModule):
                 # ('it:os:windows:task', ('guid', {}), {
                 #     'doc': 'A Microsoft Windows scheduled task configuration.'}),
 
+                ('it:os:posix:cron', ('guid', {}), {
+                    'doc': 'A cron job entry configured on a host.'}),
+
                 # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c92a27b1-c772-4fa7-a432-15df5f1b66a1
                 ('it:os:windows:sid', ('str', {'regex': r'^S-1-(?:\d{1,10}|0x[0-9a-fA-F]{12})(?:-(?:\d+|0x[0-9a-fA-F]{2,}))*$'}), {
                     'doc': 'A Microsoft Windows Security Identifier.',
@@ -2645,6 +2648,34 @@ class ItModule(s_module.CoreModule):
 
                     ('imagepath', ('file:path', {}), {
                         'doc': 'The path to the service binary from the ImagePath registry key.'}),
+                )),
+
+                ('it:os:posix:cron', {}, (
+
+                    ('host', ('it:host', {}), {
+                        'doc': 'The host on which the cron job was configured.'}),
+
+                    ('cmd', ('it:cmd', {}), {
+                        'doc': 'The command which the cron job runs.'}),
+
+                    ('schedule', ('it:dev:str', {}), {
+                        'doc': 'The cron schedule string.'}),
+
+                    ('account', ('it:account', {}), {
+                        'doc': 'The account which the cron job runs as.'}),
+
+                    ('period', ('ival', {}), {
+                        'doc': 'The period when the cron job entry existed.'}),
+
+                    # TODO 3.0 text
+                    ('desc', ('str', {}), {
+                        'doc': 'A description of the cron job entry.'}),
+
+                    ('path', ('file:path', {}), {
+                        'doc': 'The path to the cron file which contained the job.'}),
+
+                    ('file', ('file:bytes', {}), {
+                        'doc': 'The cron file which contains the job definition.'}),
                 )),
 
                 ('it:query', {}, ()),

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -2505,3 +2505,38 @@ class InfotechModelTest(s_t_utils.SynTest):
             self.len(1, await core.nodes('it:os:windows:service -> file:path'))
 
             self.len(1, await core.nodes('[ it:exec:proc=* :windows:service={ it:os:windows:service } ] -> it:os:windows:service'))
+
+    async def test_infotech_posix_cron(self):
+
+        async with self.getTestCore() as core:
+
+            nodes = await core.nodes('''
+                [ it:os:posix:cron=*
+                    :host=*
+                    :cmd="/usr/bin/backup.sh --full"
+                    :schedule="*/5 * * * *"
+                    :account=*
+                    :period=(2020-01-01, 2021-01-01)
+                    :desc="nightly backup"
+                    :path=/etc/cron.d/backup
+                    :file=*
+                ]
+            ''')
+
+            self.len(1, nodes)
+            self.eq(nodes[0].get('cmd'), '/usr/bin/backup.sh --full')
+            self.eq(nodes[0].get('schedule'), '*/5 * * * *')
+            self.eq(nodes[0].get('desc'), 'nightly backup')
+            self.eq(nodes[0].get('path'), '/etc/cron.d/backup')
+            self.eq(nodes[0].get('period'), (1577836800000, 1609459200000))
+            self.nn(nodes[0].get('host'))
+            self.nn(nodes[0].get('account'))
+            self.nn(nodes[0].get('file'))
+
+            self.len(1, await core.nodes('it:os:posix:cron -> it:host'))
+            self.len(1, await core.nodes('it:os:posix:cron -> it:cmd'))
+            self.len(1, await core.nodes('it:os:posix:cron -> it:account'))
+            self.len(1, await core.nodes('it:os:posix:cron -> file:bytes'))
+            self.len(1, await core.nodes('it:os:posix:cron -> file:path'))
+            self.len(1, await core.nodes('it:os:posix:cron:schedule="*/5 * * * *"'))
+            self.len(1, await core.nodes('it:os:posix:cron:period@=2020'))


### PR DESCRIPTION
## Summary

Adds the `it:os:posix:cron` form to model a cron job entry configured on a host (SYN-11163).

Per the ticket, no v3 interfaces are ported to v2. Property type mappings from v3 where the v3 type has no v2 equivalent: `:account` -> `it:account`, `:period` -> `ival`, `:desc` -> `str`.

Props: `:host` (`it:host`), `:cmd` (`it:cmd`), `:schedule` (`it:dev:str`), `:account` (`it:account`), `:period` (`ival`), `:desc` (`str`), `:path` (`file:path`), `:file` (`file:bytes`).

## Testing

- Added `test_infotech_posix_cron` to `synapse/tests/test_model_infotech.py`.
- Added a model changelog entry.

Jira: SYN-11163