### PR TITLE
SYN-11217: Allow ``hash:ssdeep`` to accept empty hash segments

### DIFF
--- a/changes/1b99bd0362f779db4bf1bba6859dfba6.yaml
+++ b/changes/1b99bd0362f779db4bf1bba6859dfba6.yaml
@@ -1,0 +1,7 @@
+---
+desc: Allow the ``hash:ssdeep`` type to accept empty hash segments, such as the empty-file
+  hash ``3::``.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/synapse/models/crypto.py
+++ b/synapse/models/crypto.py
@@ -147,7 +147,7 @@ class CryptoModule(s_module.CoreModule):
                     'ex': ex_md5
                 }),
                 ('hash:ssdeep', ('str', {'strip': True,
-                                         'regex': r'^([3-9]|[1-9]\d+):[A-Za-z0-9+/]{1,64}:[A-Za-z0-9+/]{1,64}$'}), {
+                                         'regex': r'^([3-9]|[1-9]\d+):[A-Za-z0-9+/]{0,64}:[A-Za-z0-9+/]{0,64}$'}), {
                     'doc': 'A fuzzy hash of a file in ssdeep format.',
                     'ex': '98304:PYZdVAWWlLuKn4messQdqSqkxbpYlXLL:iglLlsHSfxVYVL',
                 }),

--- a/synapse/tests/test_model_crypto.py
+++ b/synapse/tests/test_model_crypto.py
@@ -443,6 +443,10 @@ class CryptoModelTest(s_t_utils.SynTest):
                  '6:' + 'A' * 64 + ':' + 'B' * 32),
                 ('6:' + 'A' * 64 + ':' + 'B' * 64,
                  '6:' + 'A' * 64 + ':' + 'B' * 64),
+                # Empty hash segments are valid (SYN-11217); the empty file's ssdeep is 3::
+                ('3::', '3::'),
+                ('3:A:', '3:A:'),
+                ('3::A', '3::A'),
             ]
 
             for valu, expected in testvectors:
@@ -456,10 +460,6 @@ class CryptoModelTest(s_t_utils.SynTest):
                 '98304:hash1',
                 '0:PYZd:iglL',
                 '2:PYZd:iglL',
-                # Empty hash segments
-                '3::',
-                '3:A:',
-                '3::A',
                 # Invalid characters in hash segments
                 '98304:PYZd!VAlXLL:iglL',
                 # hash1 exceeds SPAMSUM_LENGTH (64)


### PR DESCRIPTION
Relaxed both hash-segment quantifiers from ``{1,64}`` to ``{0,64}`` so that valid ssdeep hashes with empty segments (e.g. ``3::``, the hash of the empty file) are accepted.