### PR TITLE
Storm cryptography libraries -- RSA, ECC, and JWT (SYN-3721, SYN-11155)

### DIFF
--- a/changes/3df7af95574d95590ed76be58f99d892.yaml
+++ b/changes/3df7af95574d95590ed76be58f99d892.yaml
@@ -1,0 +1,7 @@
+---
+desc: Added the ``$lib.crypto.ecc`` library to generate and load ECC keys as ``crypto:ecc:key``
+  objects which sign and verify bytes.
+desc:literal: false
+prs: []
+type: feat
+...

--- a/changes/661aed4bddac267f0a5797317af7ab0e.yaml
+++ b/changes/661aed4bddac267f0a5797317af7ab0e.yaml
@@ -1,0 +1,10 @@
+---
+desc: Added the ``$lib.crypto.jwt`` Storm library and ``crypto:jwt`` object for constructing,
+  signing, and verifying JSON Web Tokens (JWTs). Supports the ``HS*``, ``RS*``, ``PS*``,
+  and ``ES*`` algorithms, compact and flattened-JSON serialization, registered-claim
+  validation (``exp`` / ``nbf`` / ``aud`` / ``iss`` / ``sub``), and JWK / JWKS keys
+  including fetching a ``jwks_uri`` over HTTPS.
+desc:literal: false
+prs: []
+type: feat
+...

--- a/changes/9d9da1c51effb747796f57e8168a0285.yaml
+++ b/changes/9d9da1c51effb747796f57e8168a0285.yaml
@@ -1,0 +1,7 @@
+---
+desc: Added the ``$lib.crypto.rsa`` library to generate and load RSA keys as ``crypto:rsa:key``
+  objects which sign and verify bytes (``pkcs1v15`` and ``pss`` padding).
+desc:literal: false
+prs: []
+type: feat
+...

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -58,12 +58,15 @@ import synapse.lib.stormwhois as s_stormwhois  # noqa: F401
 import synapse.lib.stormtypes as s_stormtypes
 
 import synapse.lib.stormlib.aha as s_stormlib_aha  # noqa: F401
+import synapse.lib.stormlib.ecc as s_stormlib_ecc  # noqa: F401
 import synapse.lib.stormlib.env as s_stormlib_env  # noqa: F401
 import synapse.lib.stormlib.gen as s_stormlib_gen  # noqa: F401
 import synapse.lib.stormlib.gis as s_stormlib_gis  # noqa: F401
 import synapse.lib.stormlib.hex as s_stormlib_hex  # noqa: F401
+import synapse.lib.stormlib.jwt as s_stormlib_jwt  # noqa: F401
 import synapse.lib.stormlib.log as s_stormlib_log  # noqa: F401
 import synapse.lib.stormlib.pkg as s_stormlib_pkg  # noqa: F401
+import synapse.lib.stormlib.rsa as s_stormlib_rsa  # noqa: F401
 import synapse.lib.stormlib.xml as s_stormlib_xml  # noqa: F401
 import synapse.lib.stormlib.auth as s_stormlib_auth  # noqa: F401
 import synapse.lib.stormlib.cell as s_stormlib_cell  # noqa: F401
@@ -977,6 +980,11 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
         self.tagprune = s_cache.FixedCache(self._getTagPrune, size=1000)
 
         self.querycache = s_cache.FixedCache(self._getStormQuery, size=10000)
+
+        # $lib.crypto.jwt JWKS caches: jwks_uri -> (expiry_epoch_seconds, jwkset) and
+        # jwks_uri -> asyncio.Lock for per-uri single-flight fetching.
+        self.jwkscache = {}
+        self.jwkslocks = {}
 
         self.stormpool = None
         self.stormpoolurl = None

--- a/synapse/lib/crypto/ecc.py
+++ b/synapse/lib/crypto/ecc.py
@@ -1,6 +1,5 @@
 
 import hashlib
-import logging
 
 import cryptography.hazmat.primitives.hashes as c_hashes
 import cryptography.hazmat.primitives.kdf.hkdf as c_hkdf
@@ -11,8 +10,7 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 
 import synapse.exc as s_exc
-
-logger = logging.getLogger(__name__)
+import synapse.lib.crypto.utils as s_crypto
 
 
 class PriKey:
@@ -32,17 +30,18 @@ class PriKey:
         '''
         return self.publ.iden()
 
-    def sign(self, byts):
+    def sign(self, byts, hashalgo='sha256'):
         '''
         Compute the ECC signature for the given bytestream.
 
         Args:
             byts (bytes): The bytes to sign.
+            hashalgo (str): The hash algorithm to use (sha256, sha384, or sha512).
 
         Returns:
-            bytes: The RSA Signature bytes.
+            bytes: The DER encoded ECDSA signature bytes.
         '''
-        chosen_hash = c_hashes.SHA256()
+        chosen_hash = s_crypto.getHashByName(hashalgo)
         hasher = c_hashes.Hash(chosen_hash, default_backend())
         hasher.update(byts)
         digest = hasher.finalize()
@@ -76,45 +75,57 @@ class PriKey:
         return PubKey(self.priv.public_key())
 
     @staticmethod
-    def generate():
+    def generate(curve='SECP384R1'):
         '''
         Generate a new ECC PriKey instance.
+
+        Args:
+            curve (str): The named curve to use. Defaults to SECP384R1.
 
         Returns:
             PriKey: A new PriKey instance.
         '''
+        curveobj = s_crypto.getCurveByName(curve)
+
         return PriKey(c_ec.generate_private_key(
-            c_ec.SECP384R1(),
+            curveobj,
             default_backend()
         ))
 
-    def dump(self):
+    def dump(self, fmt='der'):
         '''
-        Get the private key bytes in DER/PKCS8 format.
+        Get the private key bytes in PKCS8 format.
+
+        Args:
+            fmt (str): The encoding format, "der" (default) or "pem".
 
         Returns:
-            bytes: The DER/PKCS8 encoded private key.
+            bytes: The encoded PKCS8 private key.
         '''
         return self.priv.private_bytes(
-            encoding=c_ser.Encoding.DER,
+            encoding=s_crypto.getEncodingByName(fmt),
             format=c_ser.PrivateFormat.PKCS8,
             encryption_algorithm=c_ser.NoEncryption())
 
     @staticmethod
-    def load(byts):
+    def load(byts, fmt='der'):
         '''
-        Create a PriKey instance from DER/PKCS8 encoded bytes.
+        Create a PriKey instance from PKCS8 encoded bytes.
 
         Args:
-            byts (bytes): Bytes to load
+            byts (bytes): Bytes to load.
+            fmt (str): The encoding format, "der" (default) or "pem".
 
         Returns:
-            PriKey: A new PubKey instance.
+            PriKey: A new PriKey instance.
         '''
-        return PriKey(c_ser.load_der_private_key(
-                byts,
-                password=None,
-                backend=default_backend()))
+        s_crypto.getEncodingByName(fmt)
+        if fmt.lower() == 'pem':
+            priv = c_ser.load_pem_private_key(byts, password=None, backend=default_backend())
+        else:
+            priv = c_ser.load_der_private_key(byts, password=None, backend=default_backend())
+
+        return PriKey(priv)
 
 class PubKey:
     '''
@@ -124,31 +135,35 @@ class PubKey:
     def __init__(self, publ):
         self.publ = publ  # type: c_ec.EllipticCurvePublicKey
 
-    def dump(self):
+    def dump(self, fmt='der'):
         '''
-        Get the public key bytes in DER/SubjectPublicKeyInfo format.
+        Get the public key bytes in SubjectPublicKeyInfo format.
+
+        Args:
+            fmt (str): The encoding format, "der" (default) or "pem".
 
         Returns:
-            bytes: The DER/SubjectPublicKeyInfo encoded public key.
+            bytes: The encoded SubjectPublicKeyInfo public key.
         '''
         return self.publ.public_bytes(
-            encoding=c_ser.Encoding.DER,
+            encoding=s_crypto.getEncodingByName(fmt),
             format=c_ser.PublicFormat.SubjectPublicKeyInfo)
 
-    def verify(self, byts, sign):
+    def verify(self, byts, sign, hashalgo='sha256'):
         '''
         Verify the signature for the given bytes using the ECC
         public key.
 
         Args:
             byts (bytes): The data bytes.
-            sign (bytes): The signature bytes.
+            sign (bytes): The DER encoded signature bytes.
+            hashalgo (str): The hash algorithm to use (sha256, sha384, or sha512).
 
         Returns:
             bool: True if the data was verified, False otherwise.
         '''
         try:
-            chosen_hash = c_hashes.SHA256()
+            chosen_hash = s_crypto.getHashByName(hashalgo)
             hasher = c_hashes.Hash(chosen_hash, default_backend())
             hasher.update(byts)
             digest = hasher.finalize()
@@ -158,7 +173,6 @@ class PubKey:
                              )
             return True
         except InvalidSignature:
-            logger.exception('Error in publ.verify')
             return False
 
     def iden(self):
@@ -171,19 +185,47 @@ class PubKey:
         return hashlib.sha256(self.dump()).hexdigest()
 
     @staticmethod
-    def load(byts):
+    def load(byts, fmt='der'):
         '''
-        Create a PubKey instance from DER/PKCS8 encoded bytes.
+        Create a PubKey instance from SubjectPublicKeyInfo encoded bytes.
 
         Args:
-            byts (bytes): Bytes to load
+            byts (bytes): Bytes to load.
+            fmt (str): The encoding format, "der" (default) or "pem".
 
         Returns:
             PubKey: A new PubKey instance.
         '''
-        return PubKey(c_ser.load_der_public_key(
-                byts,
-                backend=default_backend()))
+        s_crypto.getEncodingByName(fmt)
+        if fmt.lower() == 'pem':
+            publ = c_ser.load_pem_public_key(byts, backend=default_backend())
+        else:
+            publ = c_ser.load_der_public_key(byts, backend=default_backend())
+
+        return PubKey(publ)
+
+def loadKey(byts):
+    '''
+    Load a single ECC public or private key, auto-detecting the PEM vs DER
+    encoding and whether the key is public or private.
+
+    Args:
+        byts (bytes): The DER or PEM encoded ECC key bytes.
+
+    Returns:
+        PriKey or PubKey: The loaded key wrapper.
+    '''
+    isprivate, key = s_crypto.loadKey(byts)
+    if isprivate:
+        if not isinstance(key, c_ec.EllipticCurvePrivateKey):
+            raise s_exc.BadArg(mesg='Key is not an ECC private key.')
+
+        return PriKey(key)
+
+    if not isinstance(key, c_ec.EllipticCurvePublicKey):
+        raise s_exc.BadArg(mesg='Key is not an ECC public key.')
+
+    return PubKey(key)
 
 def doECDHE(statprv_u, statpub_v, ephmprv_u, ephmpub_v,
             length=64,

--- a/synapse/lib/crypto/jwk.py
+++ b/synapse/lib/crypto/jwk.py
@@ -1,0 +1,82 @@
+import json
+import hashlib
+
+import cryptography.hazmat.primitives.asymmetric.ec as c_ec
+import cryptography.hazmat.primitives.asymmetric.rsa as c_rsa
+
+import synapse.exc as s_exc
+
+import synapse.lib.crypto.ecc as s_ecc
+import synapse.lib.crypto.rsa as s_rsa
+import synapse.lib.crypto.utils as s_crypto
+
+def _b64uint(text):
+    # decode a JWK Base64urlUInt (RFC 7518 2) into a big-endian unsigned integer
+    return int.from_bytes(s_crypto.debase64url(text), 'big')
+
+def jwkToKey(jwk):
+    '''
+    Convert a JWK (RFC 7517) into a Synapse backend key wrapper.
+
+    Args:
+        jwk (dict): The JWK members.
+
+    Returns:
+        An s_rsa.PriKey/PubKey or s_ecc.PriKey/PubKey for an RSA or EC key. Raises s_exc.BadArg
+        for an unsupported key type, a malformed member, or an off-curve EC point.
+    '''
+    if not isinstance(jwk, dict):
+        raise s_exc.BadArg(mesg='JWK must be a mapping.')
+
+    kty = jwk.get('kty')
+
+    try:
+        if kty == 'RSA':
+            pubnums = c_rsa.RSAPublicNumbers(_b64uint(jwk['e']), _b64uint(jwk['n']))
+            if 'd' in jwk:
+                privnums = c_rsa.RSAPrivateNumbers(_b64uint(jwk['p']), _b64uint(jwk['q']),
+                                                   _b64uint(jwk['d']), _b64uint(jwk['dp']),
+                                                   _b64uint(jwk['dq']), _b64uint(jwk['qi']), pubnums)
+                return s_rsa.PriKey(privnums.private_key())
+
+            return s_rsa.PubKey(pubnums.public_key())
+
+        if kty == 'EC':
+            crv = jwk.get('crv')
+            curvector = s_crypto.curves.get(crv.lower()) if isinstance(crv, str) else None
+            if curvector is None:
+                raise s_exc.BadArg(mesg=f'Unsupported JWK EC curve: {crv}', crv=crv)
+
+            pubnums = c_ec.EllipticCurvePublicNumbers(_b64uint(jwk['x']), _b64uint(jwk['y']), curvector())
+            if 'd' in jwk:
+                privnums = c_ec.EllipticCurvePrivateNumbers(_b64uint(jwk['d']), pubnums)
+                return s_ecc.PriKey(privnums.private_key())
+
+            # public_key() validates that the point lies on the named curve (RFC 8725 3.4).
+            return s_ecc.PubKey(pubnums.public_key())
+
+    except (KeyError, TypeError, ValueError) as e:
+        raise s_exc.BadArg(mesg=f'Malformed JWK: {e}') from None
+
+    raise s_exc.BadArg(mesg=f'Unsupported JWK kty: {kty}', kty=kty)
+
+def jwkThumbprint(jwk):
+    '''
+    Compute the RFC 7638 JWK SHA-256 thumbprint and return it as a base64url string.
+    '''
+    kty = jwk.get('kty')
+
+    try:
+        if kty == 'RSA':
+            members = {'e': jwk['e'], 'kty': 'RSA', 'n': jwk['n']}
+        elif kty == 'EC':
+            members = {'crv': jwk['crv'], 'kty': 'EC', 'x': jwk['x'], 'y': jwk['y']}
+        elif kty == 'oct':
+            members = {'k': jwk['k'], 'kty': 'oct'}
+        else:
+            raise s_exc.BadArg(mesg=f'Unsupported JWK kty: {kty}', kty=kty)
+    except KeyError as e:
+        raise s_exc.BadArg(mesg=f'Malformed JWK: missing {e}') from None
+
+    canon = json.dumps(members, separators=(',', ':'), sort_keys=True).encode('utf-8')
+    return s_crypto.enbase64url(hashlib.sha256(canon).digest())

--- a/synapse/lib/crypto/rsa.py
+++ b/synapse/lib/crypto/rsa.py
@@ -1,12 +1,12 @@
 import hashlib
 
-import cryptography.hazmat.primitives.hashes as c_hashes
 import cryptography.hazmat.primitives.serialization as c_ser
-import cryptography.hazmat.primitives.asymmetric.rsa as c_rsa  # noqa: F401
-import cryptography.hazmat.primitives.asymmetric.padding as c_padding
+import cryptography.hazmat.primitives.asymmetric.rsa as c_rsa
 
+import synapse.exc as s_exc
 import synapse.common as s_common
 import synapse.lib.msgpack as s_msgpack
+import synapse.lib.crypto.utils as s_crypto
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
@@ -30,19 +30,22 @@ class PriKey:
         '''
         return self.publ.iden()
 
-    def sign(self, byts: bytes) -> bytes:
+    def sign(self, byts, padding='pss', hashalgo='sha256', saltlen=None):
         '''
         Compute the RSA signature for the given bytestream.
 
         Args:
             byts (bytes): The bytes to sign.
+            padding (str): The padding scheme, "pss" (default) or "pkcs1v15".
+            hashalgo (str): The hash algorithm name (sha256, sha384, or sha512).
+            saltlen: The PSS salt length in bytes, or None for the maximum length.
 
         Returns:
-            bytes: The RSA Signature bytes.
+            bytes: The RSA signature bytes.
         '''
-        sha256 = c_hashes.SHA256()
-        pad = c_padding.PSS(c_padding.MGF1(sha256), c_padding.PSS.MAX_LENGTH)
-        return self.priv.sign(byts, pad, sha256)
+        hashobj = s_crypto.getHashByName(hashalgo)
+        pad = s_crypto.getPaddingByName(padding, hashobj, saltlen=saltlen)
+        return self.priv.sign(byts, pad, hashobj)
 
     def signitem(self, item) -> bytes:
         '''
@@ -66,6 +69,80 @@ class PriKey:
         '''
         return PubKey(self.priv.public_key())
 
+    @staticmethod
+    def generate(bits=2048):
+        '''
+        Generate a new RSA PriKey instance.
+
+        Args:
+            bits (int): The size of the RSA key in bits.
+
+        Returns:
+            PriKey: A new PriKey instance.
+        '''
+        return PriKey(c_rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=bits,
+            backend=default_backend()))
+
+    def dump(self, fmt='der'):
+        '''
+        Get the private key bytes in PKCS8 format.
+
+        Args:
+            fmt (str): The encoding format, "der" (default) or "pem".
+
+        Returns:
+            bytes: The encoded PKCS8 private key.
+        '''
+        return self.priv.private_bytes(
+            encoding=s_crypto.getEncodingByName(fmt),
+            format=c_ser.PrivateFormat.PKCS8,
+            encryption_algorithm=c_ser.NoEncryption())
+
+    @staticmethod
+    def load(byts, fmt='der'):
+        '''
+        Create a PriKey instance from PKCS8 encoded bytes.
+
+        Args:
+            byts (bytes): Bytes to load.
+            fmt (str): The encoding format, "der" (default) or "pem".
+
+        Returns:
+            PriKey: A new PriKey instance.
+        '''
+        s_crypto.getEncodingByName(fmt)
+        if fmt.lower() == 'pem':
+            priv = c_ser.load_pem_private_key(byts, password=None, backend=default_backend())
+        else:
+            priv = c_ser.load_der_private_key(byts, password=None, backend=default_backend())
+
+        return PriKey(priv)
+
+def loadKey(byts):
+    '''
+    Load a single RSA public or private key, auto-detecting the PEM vs DER
+    encoding and whether the key is public or private.
+
+    Args:
+        byts (bytes): The DER or PEM encoded RSA key bytes.
+
+    Returns:
+        PriKey or PubKey: The loaded key wrapper.
+    '''
+    isprivate, key = s_crypto.loadKey(byts)
+    if isprivate:
+        if not isinstance(key, c_rsa.RSAPrivateKey):
+            raise s_exc.BadArg(mesg='Key is not an RSA private key.')
+
+        return PriKey(key)
+
+    if not isinstance(key, c_rsa.RSAPublicKey):
+        raise s_exc.BadArg(mesg='Key is not an RSA public key.')
+
+    return PubKey(key)
+
 class PubKey:
     '''
     A helper class for using RSA public keys.
@@ -74,33 +151,38 @@ class PubKey:
     def __init__(self, publ):
         self.publ = publ  # type: c_rsa.RSAPublicKey
 
-    def dump(self):
+    def dump(self, fmt='der'):
         '''
-        Get the public key bytes in DER/SubjectPublicKeyInfo format.
+        Get the public key bytes in SubjectPublicKeyInfo format.
+
+        Args:
+            fmt (str): The encoding format, "der" (default) or "pem".
 
         Returns:
-            bytes: The DER/SubjectPublicKeyInfo encoded public key.
+            bytes: The encoded SubjectPublicKeyInfo public key.
         '''
         return self.publ.public_bytes(
-            encoding=c_ser.Encoding.DER,
+            encoding=s_crypto.getEncodingByName(fmt),
             format=c_ser.PublicFormat.SubjectPublicKeyInfo)
 
-    def verify(self, byts, sign):
+    def verify(self, byts, sign, padding='pss', hashalgo='sha256', saltlen=None):
         '''
-        Verify the signature for the given bytes using the RSA
-        public key.
+        Verify the signature for the given bytes using the RSA public key.
 
         Args:
             byts (bytes): The data bytes.
             sign (bytes): The signature bytes.
+            padding (str): The padding scheme, "pss" (default) or "pkcs1v15".
+            hashalgo (str): The hash algorithm name (sha256, sha384, or sha512).
+            saltlen: The PSS salt length in bytes, or None for the maximum length.
 
         Returns:
             bool: True if the data was verified, False otherwise.
         '''
-        sha256 = c_hashes.SHA256()
-        pad = c_padding.PSS(c_padding.MGF1(sha256), c_padding.PSS.MAX_LENGTH)
+        hashobj = s_crypto.getHashByName(hashalgo)
+        pad = s_crypto.getPaddingByName(padding, hashobj, saltlen=saltlen)
         try:
-            self.publ.verify(sign, byts, pad, sha256)
+            self.publ.verify(sign, byts, pad, hashobj)
             return True
         except InvalidSignature:
             return False
@@ -129,14 +211,21 @@ class PubKey:
         return hashlib.sha256(self.dump()).hexdigest()
 
     @staticmethod
-    def load(byts):
+    def load(byts, fmt='der'):
         '''
-        Create a PubKey instance from DER/PKCS8 encoded bytes.
+        Create a PubKey instance from SubjectPublicKeyInfo encoded bytes.
 
         Args:
-            byts (bytes): Bytes to load
+            byts (bytes): Bytes to load.
+            fmt (str): The encoding format, "der" (default) or "pem".
 
         Returns:
             PubKey: A new PubKey instance.
         '''
-        return PubKey(c_ser.load_der_public_key(byts, backend=default_backend()))
+        s_crypto.getEncodingByName(fmt)
+        if fmt.lower() == 'pem':
+            publ = c_ser.load_pem_public_key(byts, backend=default_backend())
+        else:
+            publ = c_ser.load_der_public_key(byts, backend=default_backend())
+
+        return PubKey(publ)

--- a/synapse/lib/crypto/utils.py
+++ b/synapse/lib/crypto/utils.py
@@ -1,0 +1,142 @@
+import base64
+
+import cryptography.hazmat.primitives.hashes as c_hashes
+import cryptography.hazmat.primitives.asymmetric.ec as c_ec
+import cryptography.hazmat.primitives.serialization as c_ser
+import cryptography.hazmat.primitives.asymmetric.padding as c_padding
+from cryptography.hazmat.backends import default_backend
+
+import synapse.exc as s_exc
+
+hashes = {
+    'sha256': c_hashes.SHA256,
+    'sha384': c_hashes.SHA384,
+    'sha512': c_hashes.SHA512,
+}
+
+encodings = {
+    'der': c_ser.Encoding.DER,
+    'pem': c_ser.Encoding.PEM,
+}
+
+curves = {
+    'p-256': c_ec.SECP256R1,
+    'secp256r1': c_ec.SECP256R1,
+    'p-384': c_ec.SECP384R1,
+    'secp384r1': c_ec.SECP384R1,
+    'p-521': c_ec.SECP521R1,
+    'secp521r1': c_ec.SECP521R1,
+}
+
+def enbase64url(byts):
+    # base64url-encode bytes without padding (the JOSE convention, RFC 7515 2).
+    return base64.urlsafe_b64encode(byts).rstrip(b'=').decode('ascii')
+
+def debase64url(text):
+    # strict base64url decode: reject any non-urlsafe character (whitespace, '+', '/') rather
+    # than silently discarding it, so every JOSE segment is exactly its canonical base64url
+    # form. This closes a token-malleability gap where whitespace in the signature segment,
+    # which is not part of the signing input, was ignored and the token still verified.
+    if isinstance(text, str):
+        text = text.encode('ascii')
+
+    return base64.b64decode(text + b'=' * (-len(text) % 4), altchars=b'-_', validate=True)
+
+def getHashByName(hashalgo):
+    '''
+    Get an instantiated cryptography hash for the given algorithm name.
+
+    Args:
+        hashalgo (str): The hash algorithm name (sha256, sha384, or sha512).
+
+    Returns:
+        The instantiated hash algorithm.
+    '''
+    ctor = hashes.get(hashalgo.lower())
+    if ctor is None:
+        raise s_exc.BadArg(mesg=f'Invalid hash algorithm: {hashalgo}', hashalgo=hashalgo)
+
+    return ctor()
+
+def getEncodingByName(fmt):
+    '''
+    Get the cryptography serialization Encoding for the given format name.
+
+    Args:
+        fmt (str): The encoding format, "der" or "pem".
+
+    Returns:
+        The cryptography Encoding.
+    '''
+    enc = encodings.get(fmt.lower())
+    if enc is None:
+        raise s_exc.BadArg(mesg=f'Invalid key encoding format: {fmt}', fmt=fmt)
+
+    return enc
+
+def getCurveByName(name):
+    '''
+    Get an instantiated cryptography elliptic curve for the given curve name.
+
+    Args:
+        name (str): The named curve (P-256, P-384, or P-521).
+
+    Returns:
+        The instantiated elliptic curve.
+    '''
+    ctor = curves.get(name.lower())
+    if ctor is None:
+        raise s_exc.BadArg(mesg=f'Invalid ECC curve: {name}', curve=name)
+
+    return ctor()
+
+def loadKey(byts):
+    '''
+    Load a single public or private key, auto-detecting the PEM vs DER encoding
+    and whether the key is a public or private key.
+
+    Args:
+        byts (bytes): The DER or PEM encoded key bytes.
+
+    Returns:
+        A ``(isprivate, key)`` tuple where ``key`` is the loaded cryptography key object.
+    '''
+    if b'-----BEGIN' in byts:
+        if byts.count(b'-----BEGIN') != 1:
+            raise s_exc.BadArg(mesg='Expected a single PEM encoded key.')
+
+        try:
+            return (True, c_ser.load_pem_private_key(byts, password=None, backend=default_backend()))
+        except ValueError:
+            return (False, c_ser.load_pem_public_key(byts, backend=default_backend()))
+
+    try:
+        return (True, c_ser.load_der_private_key(byts, password=None, backend=default_backend()))
+    except ValueError:
+        return (False, c_ser.load_der_public_key(byts, backend=default_backend()))
+
+def getPaddingByName(padding, hashobj, saltlen=None):
+    '''
+    Get the cryptography asymmetric padding for the given scheme name.
+
+    Args:
+        padding (str): The padding scheme, "pss" or "pkcs1v15".
+        hashobj: The instantiated hash used to construct MGF1 for PSS padding.
+        saltlen: The PSS salt length in bytes. Defaults to the maximum length; callers
+                 that require a specific salt length (e.g. the JWS PS* algorithms, which
+                 mandate salt length equal to the digest length) may pass an integer.
+
+    Returns:
+        The cryptography padding object.
+    '''
+    padding = padding.lower()
+    if padding == 'pkcs1v15':
+        return c_padding.PKCS1v15()
+
+    if padding == 'pss':
+        if saltlen is None:
+            saltlen = c_padding.PSS.MAX_LENGTH
+
+        return c_padding.PSS(c_padding.MGF1(hashobj), saltlen)
+
+    raise s_exc.BadArg(mesg=f'Invalid padding scheme: {padding}', padding=padding)

--- a/synapse/lib/schemas.py
+++ b/synapse/lib/schemas.py
@@ -1219,3 +1219,31 @@ _httpLoginV1Schema = {
     'required': ['user', 'passwd'],
 }
 reqValidHttpLoginV1 = s_config.getJsValidator(_httpLoginV1Schema)
+
+# RFC 7519 2 StringOrURI: an arbitrary string, but any value containing a ':' MUST be an
+# RFC 3986 URI (a valid scheme followed by URI-legal characters). An empty string has no ':'
+# and stays valid. '$' is a legal sub-delim but is omitted from the class because
+# fastjsonschema rewrites a literal '$' in a pattern to '\Z' (it can be percent-encoded as %24).
+_jwtStringOrUri = r"^(?:[^:]*|[A-Za-z][A-Za-z0-9+.\-]*:[A-Za-z0-9\-._~:/?#\[\]@!&'()*+,;=%]*)$"
+
+# JSON Schema for the RFC 7519 4.1 registered claims. additionalProperties is True so
+# callers may set custom claims; there is no "required" list because every registered
+# claim is optional. iss/sub/aud are StringOrURI (see above); jti is a plain string
+# (RFC 7519 4.1.7). exp/nbf/iat are NumericDate values (epoch seconds), so they
+# are numbers rather than strings.
+_jwtclaimschema = {
+    'type': 'object',
+    'additionalProperties': True,
+    'properties': {
+        'iss': {'type': 'string', 'pattern': _jwtStringOrUri},
+        'sub': {'type': 'string', 'pattern': _jwtStringOrUri},
+        'aud': {'oneOf': [{'type': 'string', 'pattern': _jwtStringOrUri},
+                          {'type': 'array', 'items': {'type': 'string', 'pattern': _jwtStringOrUri}}]},
+        'exp': {'type': 'number', 'minimum': 0},
+        'nbf': {'type': 'number', 'minimum': 0},
+        'iat': {'type': 'number', 'minimum': 0},
+        'jti': {'type': 'string'},
+    },
+}
+reqValidJwtClaims = s_config.getJsValidator(_jwtclaimschema)
+jwtRegisteredClaims = frozenset(_jwtclaimschema['properties'])

--- a/synapse/lib/stormlib/cryptoutils.py
+++ b/synapse/lib/stormlib/cryptoutils.py
@@ -1,0 +1,86 @@
+import cryptography.exceptions as c_exc
+
+import synapse.exc as s_exc
+
+import synapse.lib.crypto.rsa as s_rsa
+import synapse.lib.stormtypes as s_stormtypes
+
+# cryptography key-loading can raise any of these; the Storm boundary treats them all as bad
+# input so no raw cryptography/Python exception escapes into the runtime.
+_loaderrors = (ValueError, TypeError, c_exc.UnsupportedAlgorithm, c_exc.InvalidKey)
+
+class CryptoKey(s_stormtypes.Prim):
+    '''
+    Base class for the ``crypto:rsa:key`` and ``crypto:ecc:key`` Storm objects.
+
+    The object wraps a backend ``PriKey`` or ``PubKey`` and, when converted to a
+    primitive, yields the PEM encoded key as a string.
+    '''
+    def __init__(self, runt, key, isprivate):
+        s_stormtypes.Prim.__init__(self, None)
+        self.runt = runt
+        self.key = key
+        self.isprivate = isprivate
+
+        self.locls.update({
+            'isPrivate': isprivate,
+            'pubkey': self._methPubkey,
+            'encode': self._methEncode,
+            'sign': self._methSign,
+            'verify': self._methVerify,
+        })
+
+    def value(self):
+        return self.key.dump(fmt='pem').decode()
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _methPubkey(self):
+        if not self.isprivate:
+            raise s_exc.BadArg(mesg=f'The {self._storm_typename} is already public-only.')
+
+        return type(self)(self.runt, self.key.public(), False)
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _methEncode(self, fmt='pem'):
+        fmt = await s_stormtypes.tostr(fmt)
+        byts = self.key.dump(fmt=fmt)
+        if fmt.lower() == 'pem':
+            return byts.decode()
+
+        return byts
+
+def reqPadding(padding):
+    padding = padding.lower()
+    if padding not in ('pkcs1v15', 'pss'):
+        raise s_exc.BadArg(mesg=f'Invalid padding scheme: {padding}', padding=padding)
+
+    return padding
+
+async def reqBytes(valu, name):
+    valu = await s_stormtypes.toprim(valu)
+    if not isinstance(valu, bytes):
+        raise s_exc.BadArg(mesg=f'{name} must be bytes.', name=name)
+
+    return valu
+
+async def reqKey(valu, name):
+    valu = await s_stormtypes.toprim(valu)
+    if isinstance(valu, str):
+        valu = valu.encode()
+
+    if not isinstance(valu, bytes):
+        raise s_exc.BadArg(mesg=f'{name} must be bytes or str.', name=name)
+
+    return valu
+
+def loadRsaPriv(byts):
+    try:
+        return s_rsa.PriKey.load(byts, fmt='pem')
+    except _loaderrors as e:
+        raise s_exc.BadArg(mesg=f'Invalid RSA private key: {e}') from None
+
+def loadRsaPub(byts):
+    try:
+        return s_rsa.PubKey.load(byts, fmt='pem')
+    except _loaderrors as e:
+        raise s_exc.BadArg(mesg=f'Invalid RSA public key: {e}') from None

--- a/synapse/lib/stormlib/ecc.py
+++ b/synapse/lib/stormlib/ecc.py
@@ -1,0 +1,164 @@
+import synapse.exc as s_exc
+
+import synapse.lib.coro as s_coro
+import synapse.lib.crypto.ecc as s_ecc
+import synapse.lib.stormtypes as s_stormtypes
+import synapse.lib.stormlib.cryptoutils as s_cryptoutils
+
+@s_stormtypes.registry.registerLib
+class LibEcc(s_stormtypes.Lib):
+    '''
+    A Storm library for generating and loading ECC keys.
+    '''
+    _storm_locals = (
+        {'name': 'generate', 'desc': '''
+        Generate a new ECC private key.
+
+        Examples:
+            Generate a key and sign a message::
+
+                $key = $lib.crypto.ecc.generate()
+                $sig = $key.sign($mesg.encode())
+        ''',
+         'type': {'type': 'function', '_funcname': '_generate',
+                  'args': (
+                      {'name': 'curve', 'type': 'str', 'default': 'P-256',
+                       'desc': 'The named curve to use (P-256, P-384, or P-521).'},
+                  ),
+                  'returns': {'type': 'crypto:ecc:key',
+                              'desc': 'A new ``crypto:ecc:key`` containing the generated private key.'}}},
+        {'name': 'load', 'desc': '''
+        Load an ECC public or private key.
+
+        The encoding (DER or PEM) and whether the key is a public or private key are
+        detected automatically. The key must contain a single key.
+
+        Examples:
+            Load a PEM encoded private key::
+
+                $key = $lib.crypto.ecc.load($pem)
+        ''',
+         'type': {'type': 'function', '_funcname': '_load',
+                  'args': (
+                      {'name': 'key', 'type': ['str', 'bytes'],
+                       'desc': 'A DER or PEM encoded ECC public or private key. May be a str (PEM) or bytes.'},
+                  ),
+                  'returns': {'type': 'crypto:ecc:key',
+                              'desc': 'A new ``crypto:ecc:key`` containing the loaded key.'}}},
+    )
+    _storm_lib_path = ('crypto', 'ecc')
+
+    def getObjLocals(self):
+        return {
+            'load': self._load,
+            'generate': self._generate,
+        }
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _generate(self, curve='P-256'):
+        curve = await s_stormtypes.tostr(curve)
+
+        def generate():
+            return s_ecc.PriKey.generate(curve=curve)
+
+        prikey = await s_coro.executor(generate)
+        return CryptoEccKey(self.runt, prikey, True)
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _load(self, key):
+        byts = await s_cryptoutils.reqKey(key, 'key')
+        try:
+            keyobj = s_ecc.loadKey(byts)
+        except s_cryptoutils._loaderrors as e:
+            raise s_exc.BadArg(mesg=f'Invalid ECC key: {e}') from None
+
+        return CryptoEccKey(self.runt, keyobj, isinstance(keyobj, s_ecc.PriKey))
+
+@s_stormtypes.registry.registerType
+class CryptoEccKey(s_cryptoutils.CryptoKey):
+    '''
+    A Storm object representing an ECC public or private key.
+    '''
+    _storm_typename = 'crypto:ecc:key'
+
+    _storm_locals = (
+        {'name': 'isPrivate', 'type': 'boolean',
+         'desc': 'True if the object contains a private key and can sign, otherwise False.'},
+
+        {'name': 'pubkey', 'desc': '''
+        Return a new ``crypto:ecc:key`` containing only the public key.
+
+        This raises if the key is already a public-only key.
+        ''',
+         'type': {'type': 'function', '_funcname': '_methPubkey',
+                  'args': (),
+                  'returns': {'type': 'crypto:ecc:key',
+                              'desc': 'A new ``crypto:ecc:key`` containing only the public key.'}}},
+
+        {'name': 'sign', 'desc': '''
+        Compute the ECDSA signature for the given bytes.
+
+        This raises if the key does not contain a private key.
+        ''',
+         'type': {'type': 'function', '_funcname': '_methSign',
+                  'args': (
+                      {'name': 'byts', 'type': 'bytes', 'desc': 'The bytes to sign.'},
+                      {'name': 'hashalgo', 'type': 'str', 'default': 'sha256',
+                       'desc': 'The hash algorithm to use (sha256, sha384, or sha512).'},
+                  ),
+                  'returns': {'type': 'bytes', 'desc': 'The DER encoded ECDSA signature bytes.'}}},
+
+        {'name': 'verify', 'desc': 'Verify the ECDSA signature for the given bytes.',
+         'type': {'type': 'function', '_funcname': '_methVerify',
+                  'args': (
+                      {'name': 'byts', 'type': 'bytes', 'desc': 'The bytes to verify.'},
+                      {'name': 'signature', 'type': 'bytes', 'desc': 'The DER encoded signature bytes to verify.'},
+                      {'name': 'hashalgo', 'type': 'str', 'default': 'sha256',
+                       'desc': 'The hash algorithm to use (sha256, sha384, or sha512).'},
+                  ),
+                  'returns': {'type': 'boolean', 'desc': 'True if the signature is valid, otherwise False.'}}},
+
+        {'name': 'encode', 'desc': 'Encode the key as PEM or DER.',
+         'type': {'type': 'function', '_funcname': '_methEncode',
+                  'args': (
+                      {'name': 'fmt', 'type': 'str', 'default': 'pem',
+                       'desc': 'The encoding format: "pem" (returns a str) or "der" (returns bytes).'},
+                  ),
+                  'returns': {'type': ['str', 'bytes'],
+                              'desc': 'The PEM encoded string or the DER encoded bytes.'}}},
+    )
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _methSign(self, byts, hashalgo='sha256'):
+        if not self.isprivate:
+            raise s_exc.BadArg(mesg='Cannot sign with a public key.')
+
+        byts = await s_cryptoutils.reqBytes(byts, 'byts')
+        hashalgo = await s_stormtypes.tostr(hashalgo)
+
+        def sign():
+            return self.key.sign(byts, hashalgo=hashalgo)
+
+        # ECDSA over the fixed NIST curves and the sha256/384/512 set has no reachable failure
+        # here; the wrapper is a defensive net so that no raw error can ever reach the Storm
+        # runtime if that changes.
+        try:
+            return await s_coro.executor(sign)
+        except (ValueError, TypeError) as e:  # pragma: no cover
+            raise s_exc.CryptoErr(mesg=f'ECC signing failed: {e}') from None
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _methVerify(self, byts, signature, hashalgo='sha256'):
+        byts = await s_cryptoutils.reqBytes(byts, 'byts')
+        signature = await s_cryptoutils.reqBytes(signature, 'signature')
+        hashalgo = await s_stormtypes.tostr(hashalgo)
+
+        def verify():
+            publ = self.key.public() if self.isprivate else self.key
+            return publ.verify(byts, signature, hashalgo=hashalgo)
+
+        try:
+            return await s_coro.executor(verify)
+        except (ValueError, TypeError) as e:  # pragma: no cover
+            # defensive, as with sign() above: no reachable raw error given the curve/hash sets.
+            raise s_exc.CryptoErr(mesg=f'ECC verification failed: {e}') from None

--- a/synapse/lib/stormlib/jwt.py
+++ b/synapse/lib/stormlib/jwt.py
@@ -1,0 +1,1000 @@
+import hmac
+import socket
+import asyncio
+import ipaddress
+import urllib.parse
+
+import aiohttp
+import aiohttp_socks
+
+import cryptography.hazmat.primitives.asymmetric.utils as c_utils
+
+import synapse.exc as s_exc
+import synapse.common as s_common
+
+import synapse.lib.coro as s_coro
+import synapse.lib.json as s_json
+import synapse.lib.crypto.ecc as s_ecc
+import synapse.lib.crypto.jwk as s_jwk
+import synapse.lib.crypto.rsa as s_rsa
+import synapse.lib.crypto.utils as s_crypto
+import synapse.lib.schemas as s_schemas
+import synapse.lib.stormtypes as s_stormtypes
+import synapse.lib.stormlib.cryptoutils as s_cryptoutils
+
+# JWKS fetch/cache tuning.
+JWKS_TTL = 300              # seconds a fetched JWKS is served from cache
+JWKS_TIMEOUT = 10           # seconds for the JWKS HTTPS fetch
+JWKS_MAX_BYTES = 256 * 1024  # maximum JWKS response body size
+JWKS_CACHE_MAX = 128        # maximum distinct jwks_uri entries cached per Cortex
+
+# Minimum RSA modulus size (bits) accepted for RS*/PS* signing and verification.
+RSA_MIN_BITS = 2048
+
+# Supported JWS algorithms and their crypto parameters. The "none" algorithm is
+# intentionally absent and unsupported. JWE decryption is not supported. The HMAC
+# "minkey" is the RFC 7518 3.2 minimum secret length (equal to the hash output size).
+jwtalgs = {
+    'HS256': {'kind': 'hmac', 'hash': 'sha256', 'minkey': 32},
+    'HS384': {'kind': 'hmac', 'hash': 'sha384', 'minkey': 48},
+    'HS512': {'kind': 'hmac', 'hash': 'sha512', 'minkey': 64},
+    'RS256': {'kind': 'rsa', 'hash': 'sha256'},
+    'RS384': {'kind': 'rsa', 'hash': 'sha384'},
+    'RS512': {'kind': 'rsa', 'hash': 'sha512'},
+    # RSASSA-PSS: RFC 7518 3.5 mandates a salt length equal to the digest length.
+    'PS256': {'kind': 'rsa-pss', 'hash': 'sha256', 'saltlen': 32},
+    'PS384': {'kind': 'rsa-pss', 'hash': 'sha384', 'saltlen': 48},
+    'PS512': {'kind': 'rsa-pss', 'hash': 'sha512', 'saltlen': 64},
+    'ES256': {'kind': 'ecc', 'hash': 'sha256', 'curve': 'secp256r1', 'coordlen': 32},
+    'ES384': {'kind': 'ecc', 'hash': 'sha384', 'curve': 'secp384r1', 'coordlen': 48},
+    'ES512': {'kind': 'ecc', 'hash': 'sha512', 'curve': 'secp521r1', 'coordlen': 66},
+}
+
+# defensive upper bound on a base64url header segment before we decode/parse it
+MAX_HEADER_B64 = 65536
+
+def _reqAlg(alg):
+    info = jwtalgs.get(alg)
+    if info is None:
+        raise s_exc.BadArg(mesg=f'Invalid or unsupported JWT algorithm: {alg}', alg=alg)
+
+    return info
+
+def _reqAlgs(algorithms):
+    if not isinstance(algorithms, (list, tuple)):
+        raise s_exc.BadArg(mesg='algorithms must be a list of strings.')
+
+    algs = set()
+    for alg in algorithms:
+        if not isinstance(alg, str):
+            raise s_exc.BadArg(mesg='algorithms must be a list of strings.')
+
+        _reqAlg(alg)
+        algs.add(alg)
+
+    if not algs:
+        raise s_exc.BadArg(mesg='At least one algorithm must be provided.')
+
+    return algs
+
+def _reqEccCurve(keyname, info, alg):
+    if keyname != info['curve']:
+        mesg = f'ECC key curve {keyname} does not match the curve required for JWT algorithm {alg}.'
+        raise s_exc.BadArg(mesg=mesg, alg=alg)
+
+def _reqHmacKey(key, info):
+    # positive key-type binding: an asymmetric key (a PEM, or a crypto:*:key which toprims
+    # to a PEM) must never be accepted as an HMAC secret. This closes the RS256->HS256
+    # confusion footgun even when a caller misconfigures the algorithm allowlist.
+    if b'-----BEGIN' in key:
+        raise s_exc.BadArg(mesg='An asymmetric key may not be used with an HMAC (HS*) algorithm.')
+
+    if len(key) < info['minkey']:
+        raise s_exc.BadArg(mesg=f'The HMAC secret must be at least {info["minkey"]} bytes for this algorithm.')
+
+def _reqRsaBits(bits):
+    if bits < RSA_MIN_BITS:
+        raise s_exc.BadArg(mesg=f'RSA keys must be at least {RSA_MIN_BITS} bits, got {bits}.', bits=bits)
+
+def _reqValidClaims(payload):
+    # validate the registered claims of a full payload; custom claims are unconstrained
+    # (additionalProperties is True) and non-JSON-safe values are caught at serialization.
+    try:
+        s_schemas.reqValidJwtClaims(payload)
+    except s_exc.SchemaViolation as e:
+        raise s_exc.BadArg(mesg=f'Invalid JWT payload: {e}') from None
+
+def _makeSig(alg, info, key, signin):
+    kind = info['kind']
+    hashalg = info['hash']
+
+    if kind == 'hmac':
+        _reqHmacKey(key, info)
+        return hmac.new(key, signin, digestmod=hashalg).digest()
+
+    if kind == 'rsa':
+        prikey = s_cryptoutils.loadRsaPriv(key)
+        _reqRsaBits(prikey.priv.key_size)
+        return prikey.sign(signin, padding='pkcs1v15', hashalgo=hashalg)
+
+    if kind == 'rsa-pss':
+        prikey = s_cryptoutils.loadRsaPriv(key)
+        _reqRsaBits(prikey.priv.key_size)
+        return prikey.sign(signin, padding='pss', hashalgo=hashalg, saltlen=info['saltlen'])
+
+    try:
+        prikey = s_ecc.PriKey.load(key, fmt='pem')
+    except s_cryptoutils._loaderrors as e:
+        raise s_exc.BadArg(mesg=f'Invalid ECC private key: {e}') from None
+
+    _reqEccCurve(prikey.priv.curve.name, info, alg)
+    der = prikey.sign(signin, hashalgo=hashalg)
+    r, s = c_utils.decode_dss_signature(der)
+    coordlen = info['coordlen']
+    return r.to_bytes(coordlen, 'big') + s.to_bytes(coordlen, 'big')
+
+def _checkSig(alg, info, key, signin, signature):
+    kind = info['kind']
+    hashalg = info['hash']
+
+    if kind == 'hmac':
+        _reqHmacKey(key, info)
+        expected = hmac.new(key, signin, digestmod=hashalg).digest()
+        return hmac.compare_digest(expected, signature)
+
+    if kind == 'rsa':
+        pubkey = s_cryptoutils.loadRsaPub(key)
+        _reqRsaBits(pubkey.publ.key_size)
+        return pubkey.verify(signin, signature, padding='pkcs1v15', hashalgo=hashalg)
+
+    if kind == 'rsa-pss':
+        pubkey = s_cryptoutils.loadRsaPub(key)
+        _reqRsaBits(pubkey.publ.key_size)
+        return pubkey.verify(signin, signature, padding='pss', hashalgo=hashalg, saltlen=info['saltlen'])
+
+    try:
+        pubkey = s_ecc.PubKey.load(key, fmt='pem')
+    except s_cryptoutils._loaderrors as e:
+        raise s_exc.BadArg(mesg=f'Invalid ECC public key: {e}') from None
+
+    _reqEccCurve(pubkey.publ.curve.name, info, alg)
+
+    coordlen = info['coordlen']
+    if len(signature) != coordlen * 2:
+        return False
+
+    r = int.from_bytes(signature[:coordlen], 'big')
+    s = int.from_bytes(signature[coordlen:], 'big')
+    der = c_utils.encode_dss_signature(r, s)
+    return pubkey.verify(signin, der, hashalgo=hashalg)
+
+def _splitToken(text):
+    '''
+    Split a JWS into its (protected, payload, signature) base64url segments, accepting
+    either the compact serialization or the flattened JWS JSON serialization. Raises
+    BadArg on a JWE (5-segment compact or a JSON object carrying ``ciphertext``) and on
+    the general (multi-signature) JSON serialization.
+    '''
+    stripped = text.lstrip()
+    if stripped[:1] in ('{', '['):
+        try:
+            obj = s_json.loads(stripped.encode())
+        except (ValueError, TypeError, s_exc.BadJsonText) as e:
+            raise s_exc.BadArg(mesg=f'Unable to decode JWS JSON: {e}') from None
+
+        if not isinstance(obj, dict):
+            raise s_exc.BadArg(mesg='JWS JSON serialization must be an object.')
+
+        if 'ciphertext' in obj:
+            raise s_exc.BadArg(mesg='input is a JWE; JWE decryption is not supported.')
+
+        if 'signatures' in obj:
+            raise s_exc.BadArg(mesg='General JWS JSON serialization is not supported; use the flattened form.')
+
+        prot = obj.get('protected')
+        p64 = obj.get('payload')
+        s64 = obj.get('signature')
+        if not (isinstance(prot, str) and isinstance(p64, str) and isinstance(s64, str)):
+            raise s_exc.BadArg(mesg='Flattened JWS JSON must contain string protected, payload, and signature members.')
+
+        return (prot, p64, s64)
+
+    parts = text.split('.')
+    if len(parts) == 5:
+        raise s_exc.BadArg(mesg='input is a JWE; JWE decryption is not supported.')
+
+    if len(parts) != 3 or not all(parts):
+        raise s_exc.BadArg(mesg='JWT must contain three non-empty segments.')
+
+    return (parts[0], parts[1], parts[2])
+
+def _decodeJws(text, algs):
+    '''
+    Decode and validate the structure of a JWS without checking its signature, returning
+    (h64, p64, header, payload, signature, alg, info). Raises BadArg on any failure. The
+    signature is checked separately after the verification key has been resolved.
+    '''
+    h64, p64, s64 = _splitToken(text)
+
+    try:
+        header = s_json.loads(s_crypto.debase64url(h64))
+        payload = s_json.loads(s_crypto.debase64url(p64))
+        signature = s_crypto.debase64url(s64)
+    except (ValueError, TypeError, s_exc.BadJsonText) as e:
+        raise s_exc.BadArg(mesg=f'Unable to decode JWT: {e}') from None
+
+    if not isinstance(header, dict):
+        raise s_exc.BadArg(mesg='JWT header must be a JSON object.')
+
+    if not isinstance(payload, dict):
+        raise s_exc.BadArg(mesg='JWT payload must be a JSON object.')
+
+    # RFC 7515 4.1.11: a crit header lists parameters that MUST be understood. We implement
+    # no extensions, so any non-empty crit is unsupported and the token must be rejected.
+    if header.get('crit'):
+        raise s_exc.BadArg(mesg='JWT contains an unsupported crit header parameter.', crit=header.get('crit'))
+
+    alg = header.get('alg')
+    if not isinstance(alg, str):
+        raise s_exc.BadArg(mesg='JWT header is missing a string alg.')
+
+    if alg not in algs:
+        raise s_exc.BadArg(mesg=f'JWT alg {alg} is not in the list of allowed algorithms.', alg=alg)
+
+    info = _reqAlg(alg)
+
+    return (h64, p64, header, payload, signature, alg, info)
+
+def _reqNumericDate(valu, name):
+    # NumericDate (RFC 7519 2) is a JSON number of epoch seconds. A bool is a JSON number
+    # in Python's eyes but is never a valid date, so exclude it explicitly.
+    if isinstance(valu, bool) or not isinstance(valu, (int, float)):
+        raise s_exc.BadArg(mesg=f'JWT {name} claim must be a number.', claim=name)
+
+def _checkAudience(aud, audience):
+    # RFC 7519 4.1.3: the principal must identify itself with a value in aud. A falsy aud
+    # (absent, empty string, or empty list) carries no value to match, so the token is rejected
+    # when audience validation is requested.
+    if not aud:
+        raise s_exc.BadArg(mesg='JWT has no aud claim value to match the expected audience.')
+
+    tokauds = set(aud) if isinstance(aud, (list, tuple)) else {aud}
+    wants = set(audience) if isinstance(audience, (list, tuple)) else {audience}
+    if not (tokauds & wants):
+        raise s_exc.BadArg(mesg='JWT aud does not match the expected audience.')
+
+def _checkMatch(valu, expected, name):
+    # a str expected value is an exact match; a list/tuple is a membership test. Never a
+    # substring test (RFC 8725 / CVE-2024-53861).
+    if isinstance(expected, (list, tuple)):
+        if valu not in expected:
+            raise s_exc.BadArg(mesg=f'JWT {name} does not match any expected value.', claim=name)
+    elif valu != expected:
+        raise s_exc.BadArg(mesg=f'JWT {name} does not match the expected value.', claim=name)
+
+def _checkClaims(payload, header, nowsecs, audience, issuer, subject, leeway, typ, requiredclaims, options):
+    '''
+    Apply the RFC 7519 claim checks. Raises BadArg on any failure. exp/nbf/iat are validated
+    automatically whenever present (secure-by-default); aud/iss/sub are validated only when
+    the caller supplies an expected value. Each check may be disabled via the options dict.
+    '''
+    for name in requiredclaims:
+        if name not in payload:
+            raise s_exc.BadArg(mesg=f'JWT is missing required claim: {name}', claim=name)
+
+    if typ is not None and header.get('typ') != typ:
+        raise s_exc.BadArg(mesg=f'JWT typ {header.get("typ")} does not match the expected typ {typ}.')
+
+    if options.get('verify_exp', True) and 'exp' in payload:
+        exp = payload['exp']
+        _reqNumericDate(exp, 'exp')
+        if nowsecs - leeway >= exp:
+            raise s_exc.BadArg(mesg='JWT has expired.')
+
+    if options.get('verify_nbf', True) and 'nbf' in payload:
+        nbf = payload['nbf']
+        _reqNumericDate(nbf, 'nbf')
+        if nowsecs + leeway < nbf:
+            raise s_exc.BadArg(mesg='JWT is not yet valid (nbf).')
+
+    if options.get('verify_iat', True) and 'iat' in payload:
+        _reqNumericDate(payload['iat'], 'iat')
+
+    if options.get('verify_aud', True) and audience is not None:
+        _checkAudience(payload.get('aud'), audience)
+
+    if options.get('verify_iss', True) and issuer is not None:
+        _checkMatch(payload.get('iss'), issuer, 'iss')
+
+    if options.get('verify_sub', True) and subject is not None:
+        _checkMatch(payload.get('sub'), subject, 'sub')
+
+def _reqSafeUrl(url):
+    '''
+    Require the https scheme for a jwks_uri and return its (host, port). Raises BadArg on a
+    non-https URL or a URL with no host. This is a cheap, synchronous check with no DNS.
+    '''
+    info = urllib.parse.urlparse(url)
+    if info.scheme != 'https':
+        raise s_exc.BadArg(mesg='jwks_uri must be an https URL.', url=url)
+
+    if not info.hostname:
+        raise s_exc.BadArg(mesg='jwks_uri is missing a host.', url=url)
+
+    return info.hostname, info.port or 443
+
+async def _resolveJwksHost(host, port):
+    '''
+    Resolve a jwks_uri host asynchronously (so the ioloop is never blocked on DNS) and return the
+    getaddrinfo records so the caller can dial exactly the resolved addresses and avoid a
+    DNS-rebinding TOCTOU. A resolution failure is transient, so the caller may serve a stale cache
+    entry rather than hard-fail.
+    '''
+    loop = asyncio.get_running_loop()
+    try:
+        return await loop.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except OSError as e:
+        raise s_exc.BadArg(mesg=f'Unable to resolve jwks_uri host: {e}', url=host) from None
+
+def _reqGlobalAddrs(host, sockaddrs, allowinternal):
+    '''
+    Unless allowinternal is set, reject any non-global address (loopback, link-local, private, or a
+    cloud metadata endpoint). This is a policy rejection rather than a transient failure, so it
+    always hard-fails and never falls back to a stale cache entry.
+    '''
+    if allowinternal:
+        return
+
+    # sockaddrs are getaddrinfo (family, socktype, proto, canonname, sockaddr) tuples; element 0
+    # of each trailing sockaddr is the resolved IP string (IPv4 and IPv6 alike).
+    for *_, sockaddr in sockaddrs:
+        ipaddr = ipaddress.ip_address(sockaddr[0])
+        if not ipaddr.is_global:
+            mesg = f'jwks_uri resolves to the non-global address {ipaddr}; set allowinternal to override.'
+            raise s_exc.BadArg(mesg=mesg, host=host)
+
+class _PinnedResolver(aiohttp.abc.AbstractResolver):
+    '''
+    An aiohttp resolver that returns only the addresses already resolved and vetted, so the
+    connection dials exactly the checked IPs rather than re-resolving (which a DNS-rebinding
+    host could answer differently).
+    '''
+    def __init__(self, addrs):
+        self.addrs = addrs
+
+    async def resolve(self, host, port=0, family=socket.AF_UNSPEC):
+        results = []
+        for fam, _, _, _, sockaddr in self.addrs:
+            if family in (socket.AF_UNSPEC, fam):
+                results.append({'hostname': host, 'host': sockaddr[0], 'port': port,
+                                'family': fam, 'proto': socket.IPPROTO_TCP, 'flags': socket.AI_NUMERICHOST})
+
+        return results
+
+    async def close(self):
+        pass
+
+def _kidInSet(jwkset, kid):
+    # whether a JWKS (already validated to carry a keys list) contains a key with this kid
+    return any(isinstance(k, dict) and k.get('kid') == kid for k in jwkset.get('keys', ()))
+
+def _pickJwk(jwkobj, header):
+    # select a single JWK from a JWK or a JWKS (by the token kid) for verification
+    if 'keys' not in jwkobj:
+        return jwkobj
+
+    keys = jwkobj.get('keys')
+    if not isinstance(keys, (list, tuple)):
+        raise s_exc.BadArg(mesg='JWKS keys must be a list.')
+
+    cands = [k for k in keys if isinstance(k, dict)]
+
+    kid = header.get('kid')
+    if kid is not None:
+        matched = [k for k in cands if k.get('kid') == kid]
+        if len(matched) != 1:
+            raise s_exc.BadArg(mesg=f'JWKS does not contain exactly one key with kid {kid}.', kid=kid)
+
+        return matched[0]
+
+    if len(cands) != 1:
+        raise s_exc.BadArg(mesg='JWKS contains multiple keys but the token has no kid to select one.')
+
+    return cands[0]
+
+def _selectJwk(jwkobj, header, alg):
+    '''
+    Resolve the verification key bytes from a JWK or JWKS for the given algorithm. Returns
+    PEM bytes for RS*/PS*/ES* and the raw secret bytes for HS*. Raises BadArg on a key that
+    does not match the algorithm family.
+    '''
+    kind = jwtalgs[alg]['kind']
+    jwk = _pickJwk(jwkobj, header)
+    kty = jwk.get('kty')
+
+    if kind == 'hmac':
+        if kty != 'oct' or not isinstance(jwk.get('k'), str):
+            raise s_exc.BadArg(mesg=f'JWK kty {kty} does not match the HMAC algorithm {alg}.')
+
+        try:
+            return s_crypto.debase64url(jwk['k'])
+        except (ValueError, TypeError) as e:
+            raise s_exc.BadArg(mesg=f'Invalid HMAC JWK k value: {e}') from None
+
+    keyobj = s_jwk.jwkToKey(jwk)
+
+    if kind in ('rsa', 'rsa-pss'):
+        if not isinstance(keyobj, (s_rsa.PriKey, s_rsa.PubKey)):
+            raise s_exc.BadArg(mesg=f'JWK is not an RSA key for algorithm {alg}.')
+
+        pubkey = keyobj.public() if isinstance(keyobj, s_rsa.PriKey) else keyobj
+        return pubkey.dump(fmt='pem')
+
+    if not isinstance(keyobj, (s_ecc.PriKey, s_ecc.PubKey)):
+        raise s_exc.BadArg(mesg=f'JWK is not an EC key for algorithm {alg}.')
+
+    pubkey = keyobj.public() if isinstance(keyobj, s_ecc.PriKey) else keyobj
+    return pubkey.dump(fmt='pem')
+
+def _decodeHeader(h64):
+    if len(h64) > MAX_HEADER_B64:
+        raise s_exc.BadArg(mesg='JWT header segment is too large.')
+
+    try:
+        header = s_json.loads(s_crypto.debase64url(h64))
+    except (ValueError, TypeError, s_exc.BadJsonText) as e:
+        raise s_exc.BadArg(mesg=f'Unable to decode JWT header: {e}') from None
+
+    if not isinstance(header, dict):
+        raise s_exc.BadArg(mesg='JWT header must be a JSON object.')
+
+    return header
+
+def _parseToken(text):
+    '''
+    Key-free structural parse: report whether a token is a JWS or a JWE and decode only
+    its protected header. Does no signature check and no decryption.
+    '''
+    stripped = text.lstrip()
+    if stripped[:1] in ('{', '['):
+        try:
+            obj = s_json.loads(stripped.encode())
+        except (ValueError, TypeError, s_exc.BadJsonText) as e:
+            raise s_exc.BadArg(mesg=f'Unable to decode JOSE JSON: {e}') from None
+
+        if not isinstance(obj, dict):
+            raise s_exc.BadArg(mesg='JOSE JSON serialization must be an object.')
+
+        if 'ciphertext' in obj:
+            typ = 'JWE'
+            prot = obj.get('protected')
+        elif 'signatures' in obj:
+            typ = 'JWS'
+            sigs = obj.get('signatures')
+            prot = sigs[0].get('protected') if isinstance(sigs, list) and sigs and isinstance(sigs[0], dict) else None
+        elif 'signature' in obj:
+            typ = 'JWS'
+            prot = obj.get('protected')
+        else:
+            raise s_exc.BadArg(mesg='Unrecognized JOSE JSON serialization.')
+
+        header = _decodeHeader(prot) if isinstance(prot, str) and prot else {}
+        return {'typ': typ, 'header': header}
+
+    parts = text.split('.')
+    if len(parts) == 3:
+        typ = 'JWS'
+    elif len(parts) == 5:
+        typ = 'JWE'
+    else:
+        raise s_exc.BadArg(mesg='Unrecognized compact JOSE serialization.')
+
+    return {'typ': typ, 'header': _decodeHeader(parts[0])}
+
+@s_stormtypes.registry.registerLib
+class LibJwt(s_stormtypes.Lib):
+    '''
+    A Storm library for constructing, signing, and verifying JSON Web Tokens (JWTs).
+    '''
+    _storm_locals = (
+        {'name': 'generate', 'desc': '''
+        Construct a new unsigned ``crypto:jwt`` object.
+
+        Examples:
+            Construct a token, set a claim, and sign it::
+
+                $key = $lib.crypto.rsa.generate()
+                $token = $lib.crypto.jwt.generate()
+                $token.payload.sub = "1234567890"
+                $jwtstr = $token.sign($key, "RS256")
+        ''',
+         'type': {'type': 'function', '_funcname': '_generate',
+                  'args': (
+                      {'name': 'payload', 'type': 'dict', 'default': None,
+                       'desc': 'An optional dictionary to use as the initial claims payload.'},
+                  ),
+                  'returns': {'type': 'crypto:jwt', 'desc': 'The newly constructed crypto:jwt object.'}}},
+
+        {'name': 'verify', 'desc': '''
+        Verify a JWT and return a ``crypto:jwt`` object.
+
+        The ``algorithms`` list is a required allowlist. The algorithm named in the token header must be
+        present in the allowlist or verification fails. This is the primary mitigation against JWT algorithm
+        confusion attacks. The ``none`` algorithm is never supported. Both the compact and the flattened
+        JWS JSON serializations are accepted.
+
+        The ``exp``, ``nbf``, and ``iat`` claims are validated automatically whenever they are present. The
+        ``audience``, ``issuer``, and ``subject`` claims are validated when a corresponding expected value
+        is provided. Each of these checks may be disabled via the ``options`` dictionary.
+
+        The ``key`` may be a PEM key, an HMAC secret, a crypto:rsa:key / crypto:ecc:key object, or a JWK /
+        JWKS dictionary (a JWKS is selected by the token ``kid``). If ``key`` is null and a ``jwks_uri`` is
+        provided, the key set is fetched over HTTPS (respecting ``ssl_verify``, ``ssl_opts``, and ``proxy``) and cached. The
+        token header ``jku`` / ``x5u`` / ``jwk`` are never followed.
+
+        Examples:
+            Verify a token and use the returned object::
+
+                ($ok, $valu) = $lib.crypto.jwt.verify($jwtstr, $key.pubkey(), ("RS256",), audience="myapp")
+                if $ok { $lib.print($valu.payload.sub) }
+        ''',
+         'type': {'type': 'function', '_funcname': '_verify',
+                  'args': (
+                      {'name': 'token', 'type': 'str', 'desc': 'The JWT string to verify.'},
+                      {'name': 'key', 'type': ['str', 'bytes', 'dict', 'crypto:rsa:key', 'crypto:ecc:key'],
+                       'desc': 'The verification key: a PEM public key (or crypto:rsa:key / crypto:ecc:key) '
+                               'for RS* / PS* / ES*, an HMAC secret for HS*, a JWK / JWKS dictionary, or '
+                               'null to resolve the key via jwks_uri.'},
+                      {'name': 'algorithms', 'type': 'list',
+                       'desc': 'The required allowlist of acceptable JWS algorithms.'},
+                      {'name': 'audience', 'type': ['str', 'list'], 'default': None,
+                       'desc': 'The expected audience. The token aud claim must contain at least one match.'},
+                      {'name': 'issuer', 'type': ['str', 'list'], 'default': None,
+                       'desc': 'The expected issuer. A str is an exact match; a list is a membership test.'},
+                      {'name': 'subject', 'type': 'str', 'default': None,
+                       'desc': 'The expected subject, compared for exact equality with the sub claim.'},
+                      {'name': 'leeway', 'type': 'int', 'default': 0,
+                       'desc': 'Seconds of clock-skew leeway applied to the exp and nbf checks.'},
+                      {'name': 'typ', 'type': 'str', 'default': None,
+                       'desc': 'An expected header typ value to require (e.g. "JWT" or "at+jwt").'},
+                      {'name': 'requiredclaims', 'type': 'list', 'default': None,
+                       'desc': 'Claim names that must be present in the payload (presence only, not value).'},
+                      {'name': 'options', 'type': 'dict', 'default': None,
+                       'desc': 'Toggles for verify_exp, verify_nbf, verify_iat, verify_aud, verify_iss, '
+                               'and verify_sub. Each defaults to true.'},
+                      {'name': 'jwks_uri', 'type': 'str', 'default': None,
+                       'desc': 'An https URL to fetch the JWKS from when key is null. The result is cached.'},
+                      {'name': 'ssl_verify', 'type': 'boolean', 'default': True,
+                       'desc': 'Perform SSL/TLS verification.'},
+                      {'name': 'ssl_opts', 'type': 'dict', 'default': None,
+                       'desc': 'Optional SSL/TLS options. See $lib.inet.http help for additional details.'},
+                      {'name': 'proxy', 'type': ['boolean', 'str'], 'default': True,
+                       'desc': 'Proxy configuration for the jwks_uri fetch (same as $lib.inet.http).'},
+                      {'name': 'allowinternal', 'type': 'boolean', 'default': False,
+                       'desc': 'Allow a jwks_uri that resolves to a loopback / private / link-local address.'},
+                  ),
+                  'returns': {'type': 'list',
+                              'desc': 'An ($ok, $valu) tuple. On success $valu is a verified crypto:jwt '
+                                      'object; on failure $valu is a dictionary of error information.'}}},
+
+        {'name': 'parse', 'desc': '''
+        Structurally parse a token without a key, reporting whether it is a JWS or a JWE and decoding only
+        its protected header. This performs no signature verification and no decryption.
+        ''',
+         'type': {'type': 'function', '_funcname': '_parse',
+                  'args': (
+                      {'name': 'token', 'type': 'str', 'desc': 'The compact or JSON serialized token.'},
+                  ),
+                  'returns': {'type': 'dict',
+                              'desc': 'A dictionary with ``typ`` ("JWS" or "JWE") and the decoded ``header``.'}}},
+
+        {'name': 'algorithms', 'desc': 'The list of JWS algorithms supported by the JWT functionality.',
+         'type': {'type': 'gtor', '_gtorfunc': '_gtorAlgorithms',
+                  'returns': {'type': 'list', 'desc': 'A list of the supported JWS algorithm names.'}}},
+    )
+    _storm_lib_path = ('crypto', 'jwt')
+
+    def __init__(self, runt, name=()):
+        s_stormtypes.Lib.__init__(self, runt, name=name)
+        self.gtors['algorithms'] = self._gtorAlgorithms
+
+    def getObjLocals(self):
+        return {
+            'parse': self._parse,
+            'verify': self._verify,
+            'generate': self._generate,
+        }
+
+    async def _gtorAlgorithms(self):
+        return list(jwtalgs)
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _generate(self, payload=None):
+        payload = await s_stormtypes.toprim(payload)
+        if payload is None:
+            payload = {}
+
+        if not isinstance(payload, dict):
+            raise s_exc.BadArg(mesg='The JWT payload must be a dictionary.')
+
+        if not all(isinstance(k, str) for k in payload):
+            raise s_exc.BadArg(mesg='JWT claim names must be strings.')
+
+        _reqValidClaims(payload)
+
+        return Jwt(self.runt, payload=payload)
+
+    async def _fetchJwks(self, url, host, addrs, ssl_verify, ssl_opts, proxy):
+        # HTTPS GET of a JWKS document from the pre-vetted addresses; returns the parsed set.
+        sslctx = self.runt.snap.core.getCachedSslCtx(opts=ssl_opts, verify=ssl_verify)
+
+        proxyurl = await s_stormtypes.resolveCoreProxyUrl(proxy)
+        if proxyurl is not None:
+            # the proxy performs the connect; the local address vetting still ran.
+            connector = aiohttp_socks.ProxyConnector.from_url(proxyurl)
+        else:
+            # dial only the resolved and vetted addresses (defeats DNS-rebinding).
+            connector = aiohttp.TCPConnector(resolver=_PinnedResolver(addrs))
+
+        timeout = aiohttp.ClientTimeout(total=JWKS_TIMEOUT)
+
+        async with aiohttp.ClientSession(connector=connector, timeout=timeout) as sess:
+            async with sess.get(url, ssl=sslctx, allow_redirects=False) as resp:
+
+                if resp.status != 200:
+                    raise s_exc.BadArg(mesg=f'JWKS endpoint returned HTTP {resp.status}.', status=resp.status)
+
+                total = 0
+                chunks = []
+                async for chunk in resp.content.iter_chunked(65536):
+                    total += len(chunk)
+                    if total > JWKS_MAX_BYTES:
+                        raise s_exc.BadArg(mesg='JWKS response exceeds the maximum allowed size.')
+
+                    chunks.append(chunk)
+
+                byts = b''.join(chunks)
+
+        try:
+            data = s_json.loads(byts)
+        except (ValueError, TypeError, s_exc.BadJsonText) as e:
+            raise s_exc.BadArg(mesg=f'Unable to decode JWKS JSON: {e}') from None
+
+        if not isinstance(data, dict) or not isinstance(data.get('keys'), list):
+            raise s_exc.BadArg(mesg='A JWKS must be an object with a keys array.')
+
+        return data
+
+    async def _getJwks(self, url, ssl_verify, ssl_opts, proxy, allowinternal, refresh):
+        # fetch a JWKS with a per-Cortex TTL cache, per-uri single-flight, and serve-stale on
+        # a failed refresh so a transient JWKS outage does not break verification outright.
+        core = self.runt.snap.core
+        cache = core.jwkscache
+        locks = core.jwkslocks
+
+        if not refresh:
+            entry = cache.get(url)
+            if entry is not None and s_common.now() / 1000 < entry[0]:
+                return entry[1]
+
+        # Validate and resolve the URL BEFORE taking a lock, so a rejected or unresolvable URL
+        # leaves no permanent lock residue. Resolution is async so the ioloop is never blocked.
+        host, port = _reqSafeUrl(url)
+        try:
+            addrs = await _resolveJwksHost(host, port)
+        except s_exc.BadArg:
+            # a transient resolution failure serves a present (stale) cache entry, matching the
+            # failed-refresh path below, so a DNS blip does not break verification outright.
+            entry = cache.get(url)
+            if entry is not None:
+                return entry[1]
+
+            raise
+
+        # a non-global address is a policy rejection, not a transient failure: it always hard-fails
+        # and never serves stale.
+        _reqGlobalAddrs(host, addrs, allowinternal)
+
+        # Bound the per-Cortex maps: drop unlocked locks whose URL is no longer cached before
+        # adding a new one, so failed/rotating URLs cannot accrete unbounded lock objects.
+        if len(locks) >= JWKS_CACHE_MAX:
+            for stale in [u for u in locks if u not in cache and not locks[u].locked()]:
+                locks.pop(stale, None)
+
+        lock = locks.setdefault(url, asyncio.Lock())
+        async with lock:
+
+            if not refresh:
+                entry = cache.get(url)
+                if entry is not None and s_common.now() / 1000 < entry[0]:
+                    return entry[1]
+
+            try:
+                jwkset = await self._fetchJwks(url, host, addrs, ssl_verify, ssl_opts, proxy)
+            except Exception:
+                entry = cache.get(url)
+                if entry is not None:
+                    return entry[1]
+
+                raise
+
+            cache[url] = (s_common.now() / 1000 + JWKS_TTL, jwkset)
+
+            # cap the cache by evicting the soonest-to-expire other entries (and their locks).
+            while len(cache) > JWKS_CACHE_MAX:
+                victim = min((u for u in cache if u != url), key=lambda u: cache[u][0], default=None)
+                if victim is None:
+                    break
+
+                cache.pop(victim, None)
+                if victim in locks and not locks[victim].locked():
+                    locks.pop(victim, None)
+
+            return jwkset
+
+    async def _resolveKey(self, key, header, alg, jwks_uri, ssl_verify, ssl_opts, proxy, allowinternal):
+        keyprim = await s_stormtypes.toprim(key)
+
+        if keyprim is not None and keyprim != '' and keyprim != b'':
+            if isinstance(keyprim, dict):
+                return _selectJwk(keyprim, header, alg)
+
+            return await s_cryptoutils.reqKey(key, 'key')
+
+        if jwks_uri is None:
+            raise s_exc.BadArg(mesg='verify requires a key or a jwks_uri.')
+
+        jwks_uri = await s_stormtypes.tostr(jwks_uri)
+        jwkset = await self._getJwks(jwks_uri, ssl_verify, ssl_opts, proxy, allowinternal, refresh=False)
+        try:
+            return _selectJwk(jwkset, header, alg)
+        except s_exc.BadArg:
+            # Only a genuine unknown-kid miss (a plausible key rotation) triggers a refresh; a
+            # structural / type-mismatch failure must not let a bad token defeat the cache TTL.
+            kid = header.get('kid')
+            if kid is None or _kidInSet(jwkset, kid):
+                raise
+
+            jwkset = await self._getJwks(jwks_uri, ssl_verify, ssl_opts, proxy, allowinternal, refresh=True)
+            return _selectJwk(jwkset, header, alg)
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _verify(self, token, key, algorithms, audience=None, issuer=None, subject=None,
+                      leeway=0, typ=None, requiredclaims=None, options=None,
+                      jwks_uri=None, ssl_verify=True, ssl_opts=None, proxy=True, allowinternal=False):
+        # verify() never raises: any failure (including invalid input) is returned as the
+        # ($ok, $info) tuple so callers can branch on $ok without a try/except in Storm.
+        try:
+            token = await s_stormtypes.tostr(token)
+            algorithms = await s_stormtypes.toprim(algorithms)
+            algs = _reqAlgs(algorithms)
+
+            audience = await s_stormtypes.toprim(audience)
+            issuer = await s_stormtypes.toprim(issuer)
+            subject = await s_stormtypes.toprim(subject)
+            typ = await s_stormtypes.toprim(typ)
+            requiredclaims = await s_stormtypes.toprim(requiredclaims)
+            if requiredclaims is None:
+                requiredclaims = ()
+
+            if isinstance(requiredclaims, str):
+                requiredclaims = (requiredclaims,)
+
+            options = await s_stormtypes.toprim(options)
+            if options is None:
+                options = {}
+
+            if not isinstance(options, dict):
+                raise s_exc.BadArg(mesg='options must be a dictionary.')
+
+            leeway = await s_stormtypes.toint(leeway)
+            if leeway < 0:
+                raise s_exc.BadArg(mesg='leeway must not be negative.', leeway=leeway)
+
+            ssl_verify = await s_stormtypes.tobool(ssl_verify, noneok=True)
+            ssl_opts = await s_stormtypes.toprim(ssl_opts)
+            proxy = await s_stormtypes.toprim(proxy)
+            jwks_uri = await s_stormtypes.toprim(jwks_uri)
+            allowinternal = await s_stormtypes.tobool(allowinternal)
+
+            # Offload the structural decode to the executor pool to avoid blocking the ioloop
+            # on large payloads.
+            h64, p64, header, payload, signature, alg, info = \
+                await s_coro.executor(lambda: _decodeJws(token, algs))
+
+            keybyts = await self._resolveKey(key, header, alg, jwks_uri, ssl_verify, ssl_opts, proxy, allowinternal)
+
+            def checksig():
+                # reconstruct the signing input from the received base64url segments verbatim.
+                signin = f'{h64}.{p64}'.encode('ascii')
+                if not _checkSig(alg, info, keybyts, signin, signature):
+                    raise s_exc.BadArg(mesg='JWT signature verification failed.')
+
+            await s_coro.executor(checksig)
+
+            # s_common.now() is milliseconds; convert to epoch seconds for NumericDate math.
+            nowsecs = s_common.now() / 1000
+            _checkClaims(payload, header, nowsecs, audience, issuer, subject, leeway,
+                         typ, requiredclaims, options)
+
+        except Exception as e:
+            return s_common.retnexc(e)
+
+        jwt = Jwt(self.runt, payload=payload)
+        jwt.header = header
+        jwt.locls['signature'] = signature
+        jwt.locked = True
+
+        return (True, jwt)
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _parse(self, token):
+        token = await s_stormtypes.tostr(token)
+
+        def parse():
+            return _parseToken(token)
+
+        return await s_coro.executor(parse)
+
+@s_stormtypes.registry.registerType
+class Jwt(s_stormtypes.StormType):
+    '''
+    A JSON Web Token (JWT) to construct, sign, and verify.
+    '''
+    _storm_typename = 'crypto:jwt'
+
+    _storm_locals = (
+
+        {'name': 'payload',
+         'desc': '''
+         The claims payload of the JWT.
+
+         While the token is being constructed, individual claims may be set (e.g. ``$token.payload.sub = "foo"``).
+         Once the token has been signed or loaded via ``$lib.crypto.jwt.verify()``, the payload becomes immutable.
+         ''',
+         'type': {'type': 'gtor', '_gtorfunc': '_gtorPayload',
+                  'returns': {'type': 'crypto:jwt:dict', 'desc': 'The JWT claims payload.'}}},
+
+        {'name': 'header',
+         'desc': '''
+         The JOSE header of the JWT.
+
+         Header parameters (e.g. ``kid``, ``cty``) may be set while the token is being constructed. The
+         ``alg`` and ``typ`` parameters are set by ``sign()``; a caller-set ``alg`` is always overridden by
+         the ``sign()`` algorithm argument. Once the token has been signed or loaded the header becomes
+         immutable.
+         ''',
+         'type': {'type': 'gtor', '_gtorfunc': '_gtorHeader',
+                  'returns': {'type': 'crypto:jwt:dict', 'desc': 'The JWT JOSE header.'}}},
+
+        {'name': 'signature', 'type': 'bytes',
+         'desc': 'The raw signature bytes of the token, or ``$lib.null`` if it has not been signed or verified.'},
+
+        {'name': 'sign',
+         'desc': '''
+         Sign the current payload and return a JWT string.
+
+         The JOSE header is populated with the algorithm and type and the signature bytes are set. The
+         payload becomes immutable once the token is signed.
+         ''',
+         'type': {'type': 'function', '_funcname': 'sign',
+                  'args': (
+                      {'name': 'key', 'type': ['str', 'bytes', 'crypto:rsa:key', 'crypto:ecc:key'],
+                       'desc': 'The signing key. A PEM encoded private key (or a crypto:rsa:key / '
+                               'crypto:ecc:key object) for RS* / PS* / ES* algorithms, or the secret for '
+                               'HS* algorithms. May be a str or bytes.'},
+                      {'name': 'alg', 'type': 'str',
+                       'desc': 'The JWS algorithm (HS256/384/512, RS256/384/512, PS256/384/512, or ES256/384/512).'},
+                      {'name': 'fmt', 'type': 'str', 'default': 'compact',
+                       'desc': 'The serialization: "compact" (default) or "json" (flattened JWS JSON serialization).'},
+                  ),
+                  'returns': {'type': 'str', 'desc': 'The signed JWT string.'}}},
+    )
+
+    def __init__(self, runt, payload=None):
+        s_stormtypes.StormType.__init__(self, None)
+        self.runt = runt
+
+        self.payload = payload if payload is not None else {}
+        self.header = {}
+        self.locked = False
+
+        self.locls.update({
+            'sign': self.sign,
+            'signature': None,
+        })
+
+        self.gtors.update({
+            'payload': self._gtorPayload,
+            'header': self._gtorHeader,
+        })
+
+    async def _gtorPayload(self):
+        return JwtDict(self.payload, self, validate=True)
+
+    async def _gtorHeader(self):
+        return JwtDict(self.header, self)
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def sign(self, key, alg, fmt='compact'):
+        if self.locked:
+            raise s_exc.BadArg(mesg='This JWT has already been signed or loaded.')
+
+        key = await s_cryptoutils.reqKey(key, 'key')
+        alg = await s_stormtypes.tostr(alg)
+        fmt = (await s_stormtypes.tostr(fmt)).lower()
+        if fmt not in ('compact', 'json'):
+            raise s_exc.BadArg(mesg=f'Invalid JWT serialization format: {fmt}', fmt=fmt)
+
+        info = _reqAlg(alg)
+
+        payload = await s_stormtypes.toprim(self.payload)
+        userhdr = await s_stormtypes.toprim(self.header)
+
+        # re-validate the full payload at sign time: a nested claim (e.g. an aud list) can be
+        # mutated in place after generate()/setitem, so this remains the last gate.
+        _reqValidClaims(payload)
+
+        def sign():
+            header = dict(userhdr)
+            # the sign() algorithm is authoritative; a caller-set alg never overrides it.
+            header['alg'] = alg
+            header.setdefault('typ', 'JWT')
+
+            try:
+                h64 = s_crypto.enbase64url(s_json.dumps(header))
+                p64 = s_crypto.enbase64url(s_json.dumps(payload))
+            except s_exc.MustBeJsonSafe as e:
+                raise s_exc.BadArg(mesg=f'Unable to encode JWT payload: {e}') from None
+
+            signin = f'{h64}.{p64}'.encode('ascii')
+            signature = _makeSig(alg, info, key, signin)
+            s64 = s_crypto.enbase64url(signature)
+
+            if fmt == 'compact':
+                token = f'{h64}.{p64}.{s64}'
+            else:
+                token = s_json.dumps({'payload': p64, 'protected': h64, 'signature': s64}).decode()
+
+            return (token, header, signature)
+
+        # Offload the serialization and signing to the executor pool to avoid blocking
+        # the ioloop, which matters for large payloads and expensive keys.
+        token, header, signature = await s_coro.executor(sign)
+
+        self.header = header
+        self.locls['signature'] = signature
+        self.locked = True
+
+        return token
+
+@s_stormtypes.registry.registerType
+class JwtDict(s_stormtypes.Dict):
+    '''
+    A dictionary view of JWT payload or header data which becomes immutable once the token is signed or loaded.
+    '''
+    _storm_typename = 'crypto:jwt:dict'
+
+    def __init__(self, valu, jwt, validate=False):
+        s_stormtypes.Dict.__init__(self, valu)
+        self.jwt = jwt
+        self.validate = validate
+
+    async def setitem(self, name, valu):
+        if self.jwt.locked:
+            raise s_exc.IsReadOnly(mesg='The JWT is read only and may not be modified.')
+
+        pname = await s_stormtypes.toprim(name)
+        if not isinstance(pname, str):
+            raise s_exc.BadArg(mesg='JWT claim and header names must be strings.', name=pname)
+
+        # validate a set registered claim against the schema (payload dict only); custom
+        # claims and JOSE header params are unconstrained beyond the string-key requirement.
+        if self.validate and valu is not s_stormtypes.undef and pname in s_schemas.jwtRegisteredClaims:
+            pvalu = await s_stormtypes.toprim(valu)
+            try:
+                s_schemas.reqValidJwtClaims({pname: pvalu})
+            except s_exc.SchemaViolation as e:
+                raise s_exc.BadArg(mesg=f'Invalid JWT claim {pname}: {e}') from None
+
+        return await s_stormtypes.Dict.setitem(self, name, valu)

--- a/synapse/lib/stormlib/rsa.py
+++ b/synapse/lib/stormlib/rsa.py
@@ -1,0 +1,172 @@
+import synapse.exc as s_exc
+
+import synapse.lib.coro as s_coro
+import synapse.lib.crypto.rsa as s_rsa
+import synapse.lib.stormtypes as s_stormtypes
+import synapse.lib.stormlib.cryptoutils as s_cryptoutils
+
+@s_stormtypes.registry.registerLib
+class LibRsa(s_stormtypes.Lib):
+    '''
+    A Storm library for generating and loading RSA keys.
+    '''
+    _storm_locals = (
+        {'name': 'generate', 'desc': '''
+        Generate a new RSA private key.
+
+        Examples:
+            Generate a key and sign a message::
+
+                $key = $lib.crypto.rsa.generate()
+                $sig = $key.sign($mesg.encode())
+        ''',
+         'type': {'type': 'function', '_funcname': '_generate',
+                  'args': (
+                      {'name': 'bits', 'type': 'int', 'default': 2048,
+                       'desc': 'The size of the RSA key to generate in bits (1024 to 8192).'},
+                  ),
+                  'returns': {'type': 'crypto:rsa:key',
+                              'desc': 'A new ``crypto:rsa:key`` containing the generated private key.'}}},
+        {'name': 'load', 'desc': '''
+        Load an RSA public or private key.
+
+        The encoding (DER or PEM) and whether the key is a public or private key are
+        detected automatically. The key must contain a single key.
+
+        Examples:
+            Load a PEM encoded private key::
+
+                $key = $lib.crypto.rsa.load($pem)
+        ''',
+         'type': {'type': 'function', '_funcname': '_load',
+                  'args': (
+                      {'name': 'key', 'type': ['str', 'bytes'],
+                       'desc': 'A DER or PEM encoded RSA public or private key. May be a str (PEM) or bytes.'},
+                  ),
+                  'returns': {'type': 'crypto:rsa:key',
+                              'desc': 'A new ``crypto:rsa:key`` containing the loaded key.'}}},
+    )
+    _storm_lib_path = ('crypto', 'rsa')
+
+    def getObjLocals(self):
+        return {
+            'load': self._load,
+            'generate': self._generate,
+        }
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _generate(self, bits=2048):
+        bits = await s_stormtypes.toint(bits)
+        if bits < 1024 or bits > 8192:
+            raise s_exc.BadArg(mesg=f'RSA key size must be between 1024 and 8192 bits, got {bits}.', bits=bits)
+
+        def generate():
+            return s_rsa.PriKey.generate(bits=bits)
+
+        prikey = await s_coro.executor(generate)
+        return CryptoRsaKey(self.runt, prikey, True)
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _load(self, key):
+        byts = await s_cryptoutils.reqKey(key, 'key')
+        try:
+            keyobj = s_rsa.loadKey(byts)
+        except s_cryptoutils._loaderrors as e:
+            raise s_exc.BadArg(mesg=f'Invalid RSA key: {e}') from None
+
+        return CryptoRsaKey(self.runt, keyobj, isinstance(keyobj, s_rsa.PriKey))
+
+@s_stormtypes.registry.registerType
+class CryptoRsaKey(s_cryptoutils.CryptoKey):
+    '''
+    A Storm object representing an RSA public or private key.
+    '''
+    _storm_typename = 'crypto:rsa:key'
+
+    _storm_locals = (
+        {'name': 'isPrivate', 'type': 'boolean',
+         'desc': 'True if the object contains a private key and can sign, otherwise False.'},
+
+        {'name': 'pubkey', 'desc': '''
+        Return a new ``crypto:rsa:key`` containing only the public key.
+
+        This raises if the key is already a public-only key.
+        ''',
+         'type': {'type': 'function', '_funcname': '_methPubkey',
+                  'args': (),
+                  'returns': {'type': 'crypto:rsa:key',
+                              'desc': 'A new ``crypto:rsa:key`` containing only the public key.'}}},
+
+        {'name': 'sign', 'desc': '''
+        Compute the RSA signature for the given bytes.
+
+        This raises if the key does not contain a private key.
+        ''',
+         'type': {'type': 'function', '_funcname': '_methSign',
+                  'args': (
+                      {'name': 'byts', 'type': 'bytes', 'desc': 'The bytes to sign.'},
+                      {'name': 'padding', 'type': 'str', 'default': 'pss',
+                       'desc': 'The padding scheme to use (pss or pkcs1v15).'},
+                      {'name': 'hashalgo', 'type': 'str', 'default': 'sha256',
+                       'desc': 'The hash algorithm to use (sha256, sha384, or sha512).'},
+                  ),
+                  'returns': {'type': 'bytes', 'desc': 'The RSA signature bytes.'}}},
+
+        {'name': 'verify', 'desc': 'Verify the RSA signature for the given bytes.',
+         'type': {'type': 'function', '_funcname': '_methVerify',
+                  'args': (
+                      {'name': 'byts', 'type': 'bytes', 'desc': 'The bytes to verify.'},
+                      {'name': 'signature', 'type': 'bytes', 'desc': 'The signature bytes to verify.'},
+                      {'name': 'padding', 'type': 'str', 'default': 'pss',
+                       'desc': 'The padding scheme to use (pss or pkcs1v15).'},
+                      {'name': 'hashalgo', 'type': 'str', 'default': 'sha256',
+                       'desc': 'The hash algorithm to use (sha256, sha384, or sha512).'},
+                  ),
+                  'returns': {'type': 'boolean', 'desc': 'True if the signature is valid, otherwise False.'}}},
+
+        {'name': 'encode', 'desc': 'Encode the key as PEM or DER.',
+         'type': {'type': 'function', '_funcname': '_methEncode',
+                  'args': (
+                      {'name': 'fmt', 'type': 'str', 'default': 'pem',
+                       'desc': 'The encoding format: "pem" (returns a str) or "der" (returns bytes).'},
+                  ),
+                  'returns': {'type': ['str', 'bytes'],
+                              'desc': 'The PEM encoded string or the DER encoded bytes.'}}},
+    )
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _methSign(self, byts, padding='pss', hashalgo='sha256'):
+        if not self.isprivate:
+            raise s_exc.BadArg(mesg='Cannot sign with a public key.')
+
+        byts = await s_cryptoutils.reqBytes(byts, 'byts')
+        padding = s_cryptoutils.reqPadding(await s_stormtypes.tostr(padding))
+        hashalgo = await s_stormtypes.tostr(hashalgo)
+
+        def sign():
+            return self.key.sign(byts, padding=padding, hashalgo=hashalgo)
+
+        # the >= 1024 bit key floor and the fixed sha256/384/512 set mean cryptography cannot
+        # actually raise on a sign here; the wrapper is a defensive net so that no raw error can
+        # ever reach the Storm runtime if that changes.
+        try:
+            return await s_coro.executor(sign)
+        except (ValueError, TypeError) as e:  # pragma: no cover
+            raise s_exc.CryptoErr(mesg=f'RSA signing failed: {e}') from None
+
+    @s_stormtypes.stormfunc(readonly=True)
+    async def _methVerify(self, byts, signature, padding='pss', hashalgo='sha256'):
+        byts = await s_cryptoutils.reqBytes(byts, 'byts')
+        signature = await s_cryptoutils.reqBytes(signature, 'signature')
+        padding = s_cryptoutils.reqPadding(await s_stormtypes.tostr(padding))
+        hashalgo = await s_stormtypes.tostr(hashalgo)
+
+        def verify():
+            publ = self.key.public() if self.isprivate else self.key
+            return publ.verify(byts, signature, padding=padding, hashalgo=hashalgo)
+
+        try:
+            return await s_coro.executor(verify)
+        except (ValueError, TypeError) as e:  # pragma: no cover
+            # defensive, as with sign() above: no reachable raw error given the key/hash floors.
+            raise s_exc.CryptoErr(mesg=f'RSA verification failed: {e}') from None

--- a/synapse/tests/test_lib_crypto_ecc.py
+++ b/synapse/tests/test_lib_crypto_ecc.py
@@ -11,6 +11,7 @@ import synapse.exc as s_exc
 import synapse.lib.const as s_const
 import synapse.tests.utils as s_t_utils
 import synapse.lib.crypto.ecc as s_ecc
+import synapse.lib.crypto.utils as s_crypto
 
 class EccTest(s_t_utils.SynTest):
 
@@ -48,6 +49,50 @@ class EccTest(s_t_utils.SynTest):
         sign = prikey.sign(byts)
         self.true(pubkey.verify(byts, sign))
 
+    def test_lib_crypto_ecc_curves_algs_pem(self):
+
+        # default curve is SECP384R1 (backward compatible)
+        prikey = s_ecc.PriKey.generate()
+        self.eq(prikey.priv.curve.name, 'secp384r1')
+
+        for curve, name, hashalgo in (('P-256', 'secp256r1', 'sha256'),
+                                 ('secp256r1', 'secp256r1', 'sha256'),
+                                 ('P-384', 'secp384r1', 'sha384'),
+                                 ('P-521', 'secp521r1', 'sha512')):
+
+            prikey = s_ecc.PriKey.generate(curve=curve)
+            self.eq(prikey.priv.curve.name, name)
+
+            pubkey = prikey.public()
+
+            # sign / verify round trip with a selectable hash
+            sign = prikey.sign(b'haha', hashalgo=hashalgo)
+            self.true(pubkey.verify(b'haha', sign, hashalgo=hashalgo))
+            self.false(pubkey.verify(b'nope', sign, hashalgo=hashalgo))
+
+            # PEM round trip
+            pemprv = prikey.dump(fmt='pem')
+            pempub = pubkey.dump(fmt='pem')
+            self.true(pemprv.startswith(b'-----BEGIN'))
+            self.true(pempub.startswith(b'-----BEGIN'))
+
+            newpri = s_ecc.PriKey.load(pemprv, fmt='pem')
+            newpub = s_ecc.PubKey.load(pempub, fmt='pem')
+            self.eq(newpri.priv.curve.name, name)
+            self.true(newpub.verify(b'haha', sign, hashalgo=hashalgo))
+
+        # unknown curve / hash / encoding format raise BadArg
+        self.raises(s_exc.BadArg, s_ecc.PriKey.generate, curve='newp')
+        self.raises(s_exc.BadArg, s_crypto.getCurveByName, 'newp')
+        self.raises(s_exc.BadArg, s_crypto.getHashByName, 'newp')
+        self.raises(s_exc.BadArg, s_crypto.getEncodingByName, 'newp')
+        self.raises(s_exc.BadArg, prikey.dump, fmt='newp')
+        self.raises(s_exc.BadArg, s_ecc.PriKey.load, pemprv, fmt='newp')
+
+        # the fmt argument is case insensitive
+        self.eq(prikey.dump(fmt='pem'), prikey.dump(fmt='PEM'))
+        self.nn(s_ecc.PriKey.load(prikey.dump(fmt='PEM'), fmt='Pem'))
+
     def test_lib_crypto_ecc_break(self):
         pvk1 = s_ecc.PriKey.generate()
         pbk1 = pvk1.public()
@@ -64,6 +109,35 @@ class EccTest(s_t_utils.SynTest):
         # Tampered messages fail to validate
         self.false(pbk1.verify(mesg, sig1[:-10] + os.urandom(10)))
         self.false(pbk1.verify(mesg, os.urandom(10) + sig1[:10]))
+
+    def test_lib_crypto_ecc_loadkey(self):
+
+        import synapse.lib.crypto.rsa as s_rsa
+
+        prikey = s_ecc.PriKey.generate(curve='P-256')
+        pubkey = prikey.public()
+
+        # PEM/DER and public/private are auto-detected
+        self.isinstance(s_ecc.loadKey(prikey.dump(fmt='pem')), s_ecc.PriKey)
+        self.isinstance(s_ecc.loadKey(pubkey.dump(fmt='pem')), s_ecc.PubKey)
+        self.isinstance(s_ecc.loadKey(prikey.dump(fmt='der')), s_ecc.PriKey)
+        self.isinstance(s_ecc.loadKey(pubkey.dump(fmt='der')), s_ecc.PubKey)
+
+        # a blob containing more than one key is rejected
+        with self.raises(s_exc.BadArg):
+            s_ecc.loadKey(prikey.dump(fmt='pem') + pubkey.dump(fmt='pem'))
+
+        # an RSA key (public or private) is not an ECC key
+        rsak = s_rsa.PriKey.generate(bits=1024)
+        with self.raises(s_exc.BadArg):
+            s_ecc.loadKey(rsak.dump(fmt='pem'))
+
+        with self.raises(s_exc.BadArg):
+            s_ecc.loadKey(rsak.public().dump(fmt='pem'))
+
+        # garbage bytes are rejected
+        with self.raises(ValueError):
+            s_ecc.loadKey(b'not a key')
 
     def test_lib_crypto_ecc_exchange(self):
         spvk1 = s_ecc.PriKey.generate()

--- a/synapse/tests/test_lib_crypto_jwk.py
+++ b/synapse/tests/test_lib_crypto_jwk.py
@@ -1,0 +1,97 @@
+import synapse.exc as s_exc
+import synapse.tests.utils as s_t_utils
+import synapse.lib.crypto.ecc as s_ecc
+import synapse.lib.crypto.jwk as s_jwk
+import synapse.lib.crypto.rsa as s_rsa
+import synapse.lib.crypto.utils as s_crypto
+
+def i2b64(i):
+    return s_crypto.enbase64url(i.to_bytes((i.bit_length() + 7) // 8 or 1, 'big'))
+
+class JwkTest(s_t_utils.SynTest):
+
+    def test_lib_crypto_jwk_rsa(self):
+
+        prikey = s_rsa.PriKey.generate(bits=2048)
+        pubkey = prikey.public()
+        pn = pubkey.publ.public_numbers()
+
+        pubjwk = {'kty': 'RSA', 'n': i2b64(pn.n), 'e': i2b64(pn.e)}
+        loaded = s_jwk.jwkToKey(pubjwk)
+        self.isinstance(loaded, s_rsa.PubKey)
+        self.true(loaded.verify(b'data', prikey.sign(b'data', padding='pkcs1v15'), padding='pkcs1v15'))
+
+        # a private RSA JWK reconstructs a usable private key
+        prn = prikey.priv.private_numbers()
+        privjwk = {'kty': 'RSA', 'n': i2b64(pn.n), 'e': i2b64(pn.e), 'd': i2b64(prn.d),
+                   'p': i2b64(prn.p), 'q': i2b64(prn.q), 'dp': i2b64(prn.dmp1),
+                   'dq': i2b64(prn.dmq1), 'qi': i2b64(prn.iqmp)}
+        priv = s_jwk.jwkToKey(privjwk)
+        self.isinstance(priv, s_rsa.PriKey)
+        self.true(pubkey.verify(b'data', priv.sign(b'data', padding='pss'), padding='pss'))
+
+        # malformed / non-dict / bad base64 JWKs raise ValueError
+        self.raises(s_exc.BadArg, s_jwk.jwkToKey, {'kty': 'RSA', 'n': i2b64(pn.n)})
+        self.raises(s_exc.BadArg, s_jwk.jwkToKey, 'notadict')
+        self.raises(s_exc.BadArg, s_jwk.jwkToKey, {'kty': 'RSA', 'n': '!!!', 'e': 'AQAB'})
+        self.raises(s_exc.BadArg, s_jwk.jwkToKey, {'kty': 'newp'})
+        # a JWK member is strict base64url: embedded whitespace is rejected, not ignored
+        self.raises(s_exc.BadArg, s_jwk.jwkToKey, {'kty': 'RSA', 'n': i2b64(pn.n) + ' ', 'e': 'AQAB'})
+
+    def test_lib_crypto_jwk_ec(self):
+
+        for curve, clen in (('P-256', 32), ('P-384', 48), ('P-521', 66)):
+
+            prikey = s_ecc.PriKey.generate(curve=curve)
+            pubkey = prikey.public()
+            pn = pubkey.publ.public_numbers()
+
+            def coord(i):
+                return s_crypto.enbase64url(i.to_bytes(clen, 'big'))
+
+            pubjwk = {'kty': 'EC', 'crv': curve, 'x': coord(pn.x), 'y': coord(pn.y)}
+            loaded = s_jwk.jwkToKey(pubjwk)
+            self.isinstance(loaded, s_ecc.PubKey)
+            self.true(loaded.verify(b'data', prikey.sign(b'data')))
+
+            dn = prikey.priv.private_numbers()
+            privjwk = dict(pubjwk, d=coord(dn.private_value))
+            priv = s_jwk.jwkToKey(privjwk)
+            self.isinstance(priv, s_ecc.PriKey)
+            self.true(pubkey.verify(b'data', priv.sign(b'data')))
+
+        # an off-curve point is rejected
+        prikey = s_ecc.PriKey.generate(curve='P-256')
+        pn = prikey.public().publ.public_numbers()
+        offcurve = {'kty': 'EC', 'crv': 'P-256',
+                    'x': s_crypto.enbase64url(pn.x.to_bytes(32, 'big')), 'y': s_crypto.enbase64url((pn.y ^ 1).to_bytes(32, 'big'))}
+        self.raises(s_exc.BadArg, s_jwk.jwkToKey, offcurve)
+
+        # an unknown curve is rejected
+        self.raises(s_exc.BadArg, s_jwk.jwkToKey, {'kty': 'EC', 'crv': 'P-999', 'x': 'AA', 'y': 'AA'})
+
+    def test_lib_crypto_jwk_thumbprint(self):
+
+        # RFC 7638 3.1 canonical example vector
+        rfc = {
+            'kty': 'RSA',
+            'n': '0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4'
+                 'cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n'
+                 '3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ'
+                 '5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHz'
+                 'u6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0f'
+                 'M4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw',
+            'e': 'AQAB',
+        }
+        self.eq(s_jwk.jwkThumbprint(rfc), 'NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs')
+
+        # EC and oct produce thumbprints; missing members and unknown kty raise
+        eck = s_ecc.PriKey.generate(curve='P-256')
+        en = eck.public().publ.public_numbers()
+        ecjwk = {'kty': 'EC', 'crv': 'P-256',
+                 'x': s_crypto.enbase64url(en.x.to_bytes(32, 'big')), 'y': s_crypto.enbase64url(en.y.to_bytes(32, 'big'))}
+        self.isinstance(s_jwk.jwkThumbprint(ecjwk), str)
+        self.isinstance(s_jwk.jwkThumbprint({'kty': 'oct', 'k': 'AAAA'}), str)
+
+        self.raises(s_exc.BadArg, s_jwk.jwkThumbprint, {'kty': 'RSA', 'e': 'AQAB'})
+        self.raises(s_exc.BadArg, s_jwk.jwkThumbprint, {'kty': 'newp'})

--- a/synapse/tests/test_lib_crypto_rsa.py
+++ b/synapse/tests/test_lib_crypto_rsa.py
@@ -1,0 +1,189 @@
+
+import os
+import hashlib
+
+import synapse.exc as s_exc
+import synapse.lib.const as s_const
+import synapse.tests.utils as s_t_utils
+import synapse.lib.crypto.rsa as s_rsa
+import synapse.lib.crypto.utils as s_crypto
+
+class RsaTest(s_t_utils.SynTest):
+
+    def test_lib_crypto_rsa_keys(self):
+
+        prikey = s_rsa.PriKey.generate()
+        pubkey = prikey.public()
+
+        sign = prikey.sign(b'haha')
+        self.true(pubkey.verify(b'haha', sign))
+        self.false(pubkey.verify(b'haha', b'newp'))
+
+        prib = prikey.dump()
+        pubb = pubkey.dump()
+        self.isinstance(prib, bytes)
+        self.isinstance(pubb, bytes)
+
+        # the public key can also be dumped as PEM/SubjectPublicKeyInfo
+        pubpem = pubkey.dump(fmt='pem')
+        self.isinstance(pubpem, bytes)
+        self.true(pubpem.startswith(b'-----BEGIN PUBLIC KEY-----'))
+        self.true(pubpem.rstrip().endswith(b'-----END PUBLIC KEY-----'))
+
+        # Validate iden is as expected
+        self.eq(prikey.iden(), hashlib.sha256(pubb).hexdigest())
+        self.eq(pubkey.iden(), hashlib.sha256(pubb).hexdigest())
+
+        # Test staticmethods
+        newpri = s_rsa.PriKey.load(prib)
+        newpub = s_rsa.PubKey.load(pubb)
+        self.isinstance(newpri, s_rsa.PriKey)
+        self.isinstance(newpub, s_rsa.PubKey)
+        self.eq(newpri.dump(), prib)
+        self.eq(newpub.dump(), pubb)
+
+        nsign = newpri.sign(b'haha')
+        self.true(newpub.verify(b'haha', nsign))
+        self.true(newpub.verify(b'haha', sign))
+        self.false(newpub.verify(b'haha', b'newp'))
+
+        # Sign a huge chunk of data
+        byts = s_const.mebibyte * b'S'
+        sign = prikey.sign(byts)
+        self.true(pubkey.verify(byts, sign))
+
+        # signitem / verifyitem round-trip a python primitive
+        item = ('foo', {'bar': 1})
+        isign = prikey.signitem(item)
+        self.true(pubkey.verifyitem(item, isign))
+        self.false(pubkey.verifyitem(('foo', {'bar': 2}), isign))
+
+        # A larger key size may be requested
+        bigpri = s_rsa.PriKey.generate(bits=3072)
+        self.isinstance(bigpri, s_rsa.PriKey)
+
+    def test_lib_crypto_rsa_signverify_algs(self):
+
+        # getHashByName resolves the supported hashes and rejects anything else
+        for hashalgo in ('sha256', 'sha384', 'sha512'):
+            self.eq(s_crypto.getHashByName(hashalgo).name, hashalgo)
+
+        # hash names are case insensitive (matches the ecc backend)
+        self.eq(s_crypto.getHashByName('SHA256').name, 'sha256')
+        self.eq(s_crypto.getHashByName('Sha512').name, 'sha512')
+
+        with self.raises(s_exc.BadArg):
+            s_crypto.getHashByName('newp')
+
+        prikey = s_rsa.PriKey.generate()
+        pubkey = prikey.public()
+
+        mesg = 'we all float down here'.encode()
+
+        for hashalgo in ('sha256', 'sha384', 'sha512'):
+
+            other = 'sha512' if hashalgo != 'sha512' else 'sha256'
+
+            # pkcs1v15 round-trips, is deterministic, and rejects tampering / wrong hash
+            v15 = prikey.sign(mesg, padding='pkcs1v15', hashalgo=hashalgo)
+            self.isinstance(v15, bytes)
+            self.true(pubkey.verify(mesg, v15, padding='pkcs1v15', hashalgo=hashalgo))
+            self.eq(v15, prikey.sign(mesg, padding='pkcs1v15', hashalgo=hashalgo))
+            self.false(pubkey.verify('tampered'.encode(), v15, padding='pkcs1v15', hashalgo=hashalgo))
+            self.false(pubkey.verify(mesg, v15, padding='pkcs1v15', hashalgo=other))
+
+            # pss round-trips, is probabilistic, and rejects tampering / wrong hash
+            pss = prikey.sign(mesg, padding='pss', hashalgo=hashalgo)
+            self.isinstance(pss, bytes)
+            self.true(pubkey.verify(mesg, pss, padding='pss', hashalgo=hashalgo))
+            self.ne(pss, prikey.sign(mesg, padding='pss', hashalgo=hashalgo))
+            self.false(pubkey.verify('tampered'.encode(), pss, padding='pss', hashalgo=hashalgo))
+            self.false(pubkey.verify(mesg, pss, padding='pss', hashalgo=other))
+
+        # pss is the default padding for verify
+        pss = prikey.sign(mesg, padding='pss')
+        self.true(pubkey.verify(mesg, pss))
+
+        # padding schemes do not cross-validate
+        v15 = prikey.sign(mesg, padding='pkcs1v15')
+        self.false(pubkey.verify(mesg, v15))
+        self.false(pubkey.verify(mesg, pss, padding='pkcs1v15'))
+
+        # an unknown padding scheme raises BadArg on both sign and verify
+        self.raises(s_exc.BadArg, prikey.sign, mesg, padding='newp')
+        self.raises(s_exc.BadArg, pubkey.verify, mesg, pss, padding='newp')
+
+        # padding names are case insensitive
+        self.true(pubkey.verify(mesg, prikey.sign(mesg, padding='PSS'), padding='PSS'))
+        self.true(pubkey.verify(mesg, prikey.sign(mesg, padding='PKCS1V15'), padding='PKCS1V15'))
+
+        # PriKey PEM dump / load round-trips and the reloaded keys interoperate
+        pripem = prikey.dump(fmt='pem')
+        pubpem = pubkey.dump(fmt='pem')
+        self.isinstance(pripem, bytes)
+        self.true(pripem.startswith(b'-----BEGIN PRIVATE KEY-----'))
+
+        newpri = s_rsa.PriKey.load(pripem, fmt='pem')
+        newpub = s_rsa.PubKey.load(pubpem, fmt='pem')
+        self.isinstance(newpri, s_rsa.PriKey)
+        self.isinstance(newpub, s_rsa.PubKey)
+
+        sig = newpri.sign(mesg, padding='pss', hashalgo='sha384')
+        self.true(pubkey.verify(mesg, sig, padding='pss', hashalgo='sha384'))
+        self.true(newpub.verify(mesg, prikey.sign(mesg, padding='pkcs1v15', hashalgo='sha512'),
+                                padding='pkcs1v15', hashalgo='sha512'))
+
+        # an unknown encoding format raises BadArg
+        self.raises(s_exc.BadArg, s_crypto.getEncodingByName, 'newp')
+        self.raises(s_exc.BadArg, prikey.dump, fmt='newp')
+        self.raises(s_exc.BadArg, s_rsa.PriKey.load, pripem, fmt='newp')
+
+        # the fmt argument is case insensitive
+        self.eq(prikey.dump(fmt='pem'), prikey.dump(fmt='PEM'))
+        self.nn(s_rsa.PriKey.load(prikey.dump(fmt='PEM'), fmt='Pem'))
+
+    def test_lib_crypto_rsa_loadkey(self):
+
+        import synapse.lib.crypto.ecc as s_ecc
+
+        prikey = s_rsa.PriKey.generate(bits=1024)
+        pubkey = prikey.public()
+
+        # PEM/DER and public/private are auto-detected
+        self.isinstance(s_rsa.loadKey(prikey.dump(fmt='pem')), s_rsa.PriKey)
+        self.isinstance(s_rsa.loadKey(pubkey.dump(fmt='pem')), s_rsa.PubKey)
+        self.isinstance(s_rsa.loadKey(prikey.dump(fmt='der')), s_rsa.PriKey)
+        self.isinstance(s_rsa.loadKey(pubkey.dump(fmt='der')), s_rsa.PubKey)
+
+        # a blob containing more than one key is rejected
+        with self.raises(s_exc.BadArg):
+            s_rsa.loadKey(prikey.dump(fmt='pem') + pubkey.dump(fmt='pem'))
+
+        # an ECC key (public or private) is not an RSA key
+        eck = s_ecc.PriKey.generate(curve='P-256')
+        with self.raises(s_exc.BadArg):
+            s_rsa.loadKey(eck.dump(fmt='pem'))
+
+        with self.raises(s_exc.BadArg):
+            s_rsa.loadKey(eck.public().dump(fmt='pem'))
+
+        # garbage bytes are rejected
+        with self.raises(ValueError):
+            s_rsa.loadKey(b'not a key')
+
+    def test_lib_crypto_rsa_break(self):
+        pvk1 = s_rsa.PriKey.generate()
+        pbk1 = pvk1.public()
+
+        pvk2 = s_rsa.PriKey.generate()
+        pbk2 = pvk2.public()
+
+        mesg = 'We all float down here'.encode()
+        sig1 = pvk1.sign(mesg)
+
+        # Cannot cross validate messages
+        self.false(pbk2.verify(mesg, sig1))
+
+        # Tampered messages fail to validate
+        self.false(pbk1.verify(mesg, sig1[:-10] + os.urandom(10)))
+        self.false(pbk1.verify(mesg, os.urandom(10) + sig1[:10]))

--- a/synapse/tests/test_lib_stormlib_ecc.py
+++ b/synapse/tests/test_lib_stormlib_ecc.py
@@ -1,0 +1,144 @@
+import cryptography.hazmat.primitives.asymmetric.ec as c_ec
+from cryptography.exceptions import InvalidSignature
+
+import synapse.exc as s_exc
+import synapse.lib.crypto.ecc as s_ecc
+import synapse.lib.crypto.utils as s_crypto
+
+import synapse.tests.utils as s_test
+
+# A crypto:ecc:key primitivizes to a PEM string across a callStorm boundary, so
+# tests carry the PEM forms and reload the object inside each query.
+LOAD = '$key = $lib.crypto.ecc.load($prvpem)\n$pub = $lib.crypto.ecc.load($pubpem)\n'
+
+class StormLibEccTest(s_test.SynTest):
+
+    async def test_stormlib_ecc_object(self):
+
+        async with self.getTestCore() as core:
+
+            # generate() returns a private crypto:ecc:key; toprim yields a PEM key
+            self.true(await core.callStorm('return($lib.crypto.ecc.generate().isPrivate)'))
+            toprimpem = await core.callStorm('return($lib.crypto.ecc.generate())')
+            self.true(toprimpem.startswith('-----BEGIN PRIVATE KEY-----'))
+
+            prvpem, pubpem, prvder, pubder = await core.callStorm('''
+                $key = $lib.crypto.ecc.generate()
+                $pub = $key.pubkey()
+                return(($key.encode(), $pub.encode(), $key.encode(fmt="der"), $pub.encode(fmt="der")))
+            ''')
+
+            opts = {'vars': {'prvpem': prvpem, 'pubpem': pubpem}}
+
+            # encode() defaults to a PEM string, "der" returns bytes, bad fmt raises
+            enc, encder = await core.callStorm(
+                'return(($lib.crypto.ecc.load($prvpem).encode(), $lib.crypto.ecc.load($prvpem).encode(fmt="der")))',
+                opts=opts)
+            self.true(enc.startswith('-----BEGIN'))
+            self.eq(encder, prvder)
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($prvpem).encode(fmt="newp"))', opts=opts)
+
+            # pubkey() yields a public-only key; pubkey()/sign() on public raise
+            self.false(await core.callStorm('return($lib.crypto.ecc.load($prvpem).pubkey().isPrivate)', opts=opts))
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($pubpem).pubkey())', opts=opts)
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($pubpem).sign($lib.hex.decode("ab")))', opts=opts)
+
+    async def test_stormlib_ecc_signverify(self):
+
+        async with self.getTestCore() as core:
+
+            for curve, hashname in (('P-256', 'sha256'), ('P-384', 'sha384'), ('P-521', 'sha512')):
+
+                prvpem, pubpem = await core.callStorm('''
+                    $key = $lib.crypto.ecc.generate(curve=$curve)
+                    return(($key.encode(), $key.pubkey().encode()))
+                ''', opts={'vars': {'curve': curve}})
+
+                mesg = 'hello world'
+                base = {'prvpem': prvpem, 'pubpem': pubpem, 'mesg': mesg, 'hashalgo': hashname}
+
+                # sign / verify round-trips, and verifies on the pubkey too
+                opts = {'vars': base}
+                sig = await core.callStorm(LOAD + 'return($key.sign($mesg.encode(), hashalgo=$hashalgo))', opts=opts)
+                self.isinstance(sig, bytes)
+
+                opts = {'vars': dict(base, sig=sig)}
+                self.true(await core.callStorm(
+                    LOAD + 'return($key.verify($mesg.encode(), $sig, hashalgo=$hashalgo))', opts=opts))
+                self.true(await core.callStorm(
+                    LOAD + 'return($pub.verify($mesg.encode(), $sig, hashalgo=$hashalgo))', opts=opts))
+
+                # tampered message does not verify
+                opts = {'vars': dict(base, sig=sig, mesg='hello there')}
+                self.false(await core.callStorm(
+                    LOAD + 'return($key.verify($mesg.encode(), $sig, hashalgo=$hashalgo))', opts=opts))
+
+                # interop: verify our signature against cryptography directly
+                pubobj = s_ecc.PubKey.load(pubpem.encode(), fmt='pem')
+                chash = s_crypto.hashes[hashname]()
+                pubobj.publ.verify(sig, mesg.encode(), c_ec.ECDSA(chash))
+                with self.raises(InvalidSignature):
+                    pubobj.publ.verify(sig, b'nope', c_ec.ECDSA(chash))
+
+    async def test_stormlib_ecc_load(self):
+
+        async with self.getTestCore() as core:
+
+            prvpem, pubpem, prvder, pubder = await core.callStorm('''
+                $key = $lib.crypto.ecc.generate()
+                $pub = $key.pubkey()
+                return(($key.encode(), $pub.encode(), $key.encode(fmt="der"), $pub.encode(fmt="der")))
+            ''')
+
+            # each encoding/kind auto-detects on load
+            for key, isprivate in ((prvpem, True), (pubpem, False), (prvder, True), (pubder, False)):
+                opts = {'vars': {'key': key}}
+                self.eq(isprivate, await core.callStorm('return($lib.crypto.ecc.load($key).isPrivate)', opts=opts))
+
+            # a PEM key may also be provided as bytes
+            opts = {'vars': {'key': prvpem.encode()}}
+            self.true(await core.callStorm('return($lib.crypto.ecc.load($key).isPrivate)', opts=opts))
+
+            # multiple keys in one blob is rejected
+            opts = {'vars': {'key': prvpem + pubpem}}
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($key))', opts=opts)
+
+            # an RSA key is rejected by the ECC loader
+            rsapem = await core.callStorm('return($lib.crypto.rsa.generate(bits=(1024)).encode())')
+            opts = {'vars': {'key': rsapem}}
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($key))', opts=opts)
+
+            # garbage input is rejected
+            opts = {'vars': {'key': b'not a pem'}}
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($key))', opts=opts)
+
+    async def test_stormlib_ecc_errors(self):
+
+        async with self.getTestCore() as core:
+
+            # unknown curve
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.generate(curve="newp"))')
+
+            prvpem = await core.callStorm('return($lib.crypto.ecc.generate().encode())')
+            opts = {'vars': {'prvpem': prvpem}}
+
+            # non-bytes byts / signature
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($prvpem).sign((1234)))', opts=opts)
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($prvpem).verify($m.encode(), (1234)))',
+                                     opts={'vars': {'prvpem': prvpem, 'm': 'foo'}})
+
+            # invalid hash algorithm
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.ecc.load($prvpem).sign($m.encode(), hashalgo="newp"))',
+                                     opts={'vars': {'prvpem': prvpem, 'm': 'foo'}})

--- a/synapse/tests/test_lib_stormlib_jwt.py
+++ b/synapse/tests/test_lib_stormlib_jwt.py
@@ -1,0 +1,1318 @@
+import time
+import hmac
+import json
+import socket
+import asyncio
+from unittest import mock
+
+import cryptography.hazmat.primitives.asymmetric.utils as c_utils
+
+import synapse.exc as s_exc
+import synapse.lib.json as s_json
+import synapse.lib.httpapi as s_httpapi
+import synapse.lib.crypto.ecc as s_ecc
+import synapse.lib.crypto.rsa as s_rsa
+import synapse.lib.crypto.utils as s_crypto
+import synapse.lib.stormlib.jwt as s_jwt
+
+import synapse.tests.utils as s_test
+
+def rsaJwk(pubpem, kid):
+    pn = s_rsa.PubKey.load(pubpem.encode(), fmt='pem').publ.public_numbers()
+    def i2b(i):
+        return s_crypto.enbase64url(i.to_bytes((i.bit_length() + 7) // 8, 'big'))
+    return {'kty': 'RSA', 'kid': kid, 'n': i2b(pn.n), 'e': i2b(pn.e)}
+
+def eccJwk(pubpem, kid):
+    pn = s_ecc.PubKey.load(pubpem.encode(), fmt='pem').publ.public_numbers()
+    return {'kty': 'EC', 'kid': kid, 'crv': 'P-256',
+            'x': s_crypto.enbase64url(pn.x.to_bytes(32, 'big')), 'y': s_crypto.enbase64url(pn.y.to_bytes(32, 'big'))}
+
+class JwksHandler(s_httpapi.Handler):
+    def initialize(self, cell, state):
+        s_httpapi.Handler.initialize(self, cell)
+        self.state = state
+    async def get(self):
+        self.state['hits'] += 1
+        code = self.state.get('code', 200)
+        if code != 200:
+            self.set_status(code)
+            self.write(b'error')
+            return
+        self.write(self.state['body'])
+
+# HMAC secrets must be at least the hash output length (RFC 7518 3.2), so tests use a
+# 64-byte secret that satisfies HS256/384/512.
+SECRET = b'k' * 64
+SECRET_STR = 'k' * 64
+WRONGSECRET = b'w' * 64
+
+def forgeHmac(header, payload, secret, hashname='sha256'):
+    h = s_crypto.enbase64url(json.dumps(header, separators=(',', ':')).encode())
+    p = s_crypto.enbase64url(json.dumps(payload, separators=(',', ':')).encode())
+    signin = f'{h}.{p}'.encode('ascii')
+    sig = hmac.new(secret, signin, hashname).digest()
+    return f'{h}.{p}.{s_crypto.enbase64url(sig)}'
+
+class StormLibJwtTest(s_test.SynTest):
+
+    async def _rsaPems(self, core):
+        return await core.callStorm('$k = $lib.crypto.rsa.generate() return(($k.encode(), $k.pubkey().encode()))')
+
+    async def _eccPems(self, core, curve):
+        return await core.callStorm(
+            '$k = $lib.crypto.ecc.generate(curve=$c) return(($k.encode(), $k.pubkey().encode()))',
+            opts={'vars': {'c': curve}})
+
+    async def _signHs(self, core, claims):
+        # returns a compact HS256 token whose payload is the given claims dict
+        return await core.callStorm(
+            '$t = $lib.crypto.jwt.generate($claims) return($t.sign($secret, "HS256"))',
+            opts={'vars': {'claims': claims, 'secret': SECRET}})
+
+    async def _verifyHs(self, core, tok, **kwargs):
+        vs = {'tok': tok, 'secret': SECRET}
+        vs.update(kwargs)
+        args = ''.join(f', {k}=${k}' for k in kwargs)
+        return await core.callStorm(
+            f'return($lib.crypto.jwt.verify($tok, $secret, ("HS256",){args}))', opts={'vars': vs})
+
+    async def test_stormlib_jwt_roundtrip(self):
+
+        async with self.getTestCore() as core:
+
+            rsaprv, rsapub = await self._rsaPems(core)
+            eckeys = {}
+            for curve in ('P-256', 'P-384', 'P-521'):
+                eckeys[curve] = await self._eccPems(core, curve)
+
+            cases = (
+                ('HS256', SECRET, SECRET),
+                ('HS384', SECRET, SECRET),
+                ('HS512', SECRET, SECRET),
+                ('RS256', rsaprv, rsapub),
+                ('RS384', rsaprv, rsapub),
+                ('RS512', rsaprv, rsapub),
+                ('PS256', rsaprv, rsapub),
+                ('PS384', rsaprv, rsapub),
+                ('PS512', rsaprv, rsapub),
+                ('ES256', eckeys['P-256'][0], eckeys['P-256'][1]),
+                ('ES384', eckeys['P-384'][0], eckeys['P-384'][1]),
+                ('ES512', eckeys['P-521'][0], eckeys['P-521'][1]),
+            )
+
+            for alg, signkey, verifykey in cases:
+
+                opts = {'vars': {'signkey': signkey, 'verifykey': verifykey, 'alg': alg}}
+                retn = await core.callStorm('''
+                    $token = $lib.crypto.jwt.generate()
+                    $before = $token.signature
+                    $token.payload.sub = "1234567890"
+                    $token.payload.name = "vtx"
+                    $jwtstr = $token.sign($signkey, $alg)
+                    ($ok, $valu) = $lib.crypto.jwt.verify($jwtstr, $verifykey, ($alg,))
+                    return(($before, $jwtstr, $ok, $valu.payload.sub, $valu.payload.name,
+                            $valu.header.alg, $valu.header.typ, $valu.signature, $token.signature))
+                ''', opts=opts)
+
+                before, jwtstr, ok, sub, name, halg, htyp, vsig, tsig = retn
+
+                self.none(before)
+                self.len(3, jwtstr.split('.'))
+                self.true(ok)
+                self.eq(sub, '1234567890')
+                self.eq(name, 'vtx')
+                self.eq(halg, alg)
+                self.eq(htyp, 'JWT')
+                self.isinstance(vsig, bytes)
+                self.isinstance(tsig, bytes)
+
+                parts = jwtstr.split('.')
+                self.eq(json.loads(s_crypto.debase64url(parts[0])).get('alg'), alg)
+                self.eq(json.loads(s_crypto.debase64url(parts[1])).get('sub'), '1234567890')
+
+    async def test_stormlib_jwt_json_serialization(self):
+
+        async with self.getTestCore() as core:
+
+            rsaprv, rsapub = await self._rsaPems(core)
+            opts = {'vars': {'prvpem': rsaprv, 'pubpem': rsapub}}
+
+            jsonstr, compactstr = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.payload.sub = "js"
+                $j = $t.sign($prvpem, "PS256", fmt="json")
+                $t2 = $lib.crypto.jwt.generate()
+                $t2.payload.sub = "js"
+                $c = $t2.sign($prvpem, "PS256")
+                return(($j, $c))
+            ''', opts=opts)
+
+            obj = json.loads(jsonstr)
+            self.sorteq(('payload', 'protected', 'signature'), tuple(obj.keys()))
+            self.len(3, compactstr.split('.'))
+
+            opts2 = {'vars': {'tok': jsonstr, 'pubpem': rsapub}}
+            ok, sub = await core.callStorm('''
+                ($ok, $valu) = $lib.crypto.jwt.verify($tok, $pubpem, ("PS256",))
+                return(($ok, $valu.payload.sub))
+            ''', opts=opts2)
+            self.true(ok)
+            self.eq(sub, 'js')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign($prvpem, "PS256", fmt="newp")', opts=opts)
+
+    async def test_stormlib_jwt_whitespace(self):
+
+        async with self.getTestCore() as core:
+
+            tok = await self._signHs(core, {'sub': 'u'})
+            self.true((await self._verifyHs(core, tok))[0])
+
+            # base64url segments are strict: whitespace anywhere in a compact token fails to
+            # verify (previously a whitespace-only mutation of the signature segment, which is
+            # not part of the signing input, still verified)
+            h, p, s = tok.split('.')
+            for mut in (tok + ' ', tok + '\n', ' ' + tok,
+                        f'{h}.{p}.{s[:4]} {s[4:]}',
+                        f'{h}.{p[:4]} {p[4:]}.{s}',
+                        f'{h[:4]} {h[4:]}.{p}.{s}'):
+                self.false((await self._verifyHs(core, mut))[0])
+
+            # the flattened-JSON form tolerates whitespace around the JSON container, but a
+            # whitespace-corrupted base64url value inside it is still rejected
+            jsontok = await core.callStorm(
+                '$t = $lib.crypto.jwt.generate(({"sub": "u"})) return($t.sign($secret, "HS256", fmt="json"))',
+                opts={'vars': {'secret': SECRET}})
+            self.true((await self._verifyHs(core, f'  {jsontok}  \n'))[0])
+
+            obj = json.loads(jsontok)
+            obj['signature'] = obj['signature'] + ' '
+            self.false((await self._verifyHs(core, json.dumps(obj)))[0])
+
+    async def test_stormlib_jwt_stringoruri(self):
+
+        async with self.getTestCore() as core:
+
+            # iss/sub/aud are RFC 7519 StringOrURI: a value containing a ':' must be a valid URI.
+            # These are enforced on the tokens we construct (generate / setitem / sign).
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate(({"iss": "not a uri: x"}))')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$t = $lib.crypto.jwt.generate() $t.payload.sub = "foo:bar baz"')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.jwt.generate($p))',
+                                     opts={'vars': {'p': {'aud': ['ok', 'bad: x']}}})
+
+            # valid StringOrURI values (a URI, and no-colon plain strings) round-trip
+            ok, iss, sub = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate(({"iss": "https://issuer.example", "sub": "urn:uuid:1234"}))
+                $t.payload.aud = ("https://a.example", "b")
+                $j = $t.sign($secret, "HS256")
+                ($ok, $valu) = $lib.crypto.jwt.verify($j, $secret, ("HS256",))
+                return(($ok, $valu.payload.iss, $valu.payload.sub))
+            ''', opts={'vars': {'secret': SECRET}})
+            self.true(ok)
+            self.eq(iss, 'https://issuer.example')
+            self.eq(sub, 'urn:uuid:1234')
+
+            # empty strings are valid StringOrURI (no ':') and must stay accepted, including an
+            # empty element inside an aud array
+            ok, iss = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate(({"iss": "", "sub": ""}))
+                $t.payload.aud = ("", "x")
+                $j = $t.sign($secret, "HS256")
+                ($ok, $valu) = $lib.crypto.jwt.verify($j, $secret, ("HS256",), issuer="")
+                return(($ok, $valu.payload.iss))
+            ''', opts={'vars': {'secret': SECRET}})
+            self.true(ok)
+            self.eq(iss, '')
+
+            # verify stays lenient: a third-party token whose iss is not a valid StringOrURI
+            # (built outside our construction path) still verifies, matching PyJWT's leniency
+            badtok = forgeHmac({'alg': 'HS256', 'typ': 'JWT'}, {'iss': 'not a uri: x', 'sub': 'u'}, SECRET)
+            ok, iss = await core.callStorm('''
+                ($ok, $valu) = $lib.crypto.jwt.verify($t, $secret, ("HS256",), issuer="not a uri: x")
+                return(($ok, $valu.payload.iss))
+            ''', opts={'vars': {'t': badtok, 'secret': SECRET}})
+            self.true(ok)
+            self.eq(iss, 'not a uri: x')
+
+    async def test_stormlib_jwt_header(self):
+
+        async with self.getTestCore() as core:
+
+            rsaprv, rsapub = await self._rsaPems(core)
+            opts = {'vars': {'prvpem': rsaprv, 'pubpem': rsapub}}
+
+            jwtstr = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.header.kid = "key-1"
+                $t.header.cty = "example"
+                $t.header.alg = "none"
+                $t.payload.sub = "hdr"
+                return($t.sign($prvpem, "RS256"))
+            ''', opts=opts)
+
+            header = json.loads(s_crypto.debase64url(jwtstr.split('.')[0]))
+            self.eq(header.get('kid'), 'key-1')
+            self.eq(header.get('cty'), 'example')
+            self.eq(header.get('alg'), 'RS256')
+            self.eq(header.get('typ'), 'JWT')
+
+            opts2 = {'vars': {'tok': jwtstr, 'pubpem': rsapub}}
+            kid = await core.callStorm('''
+                ($ok, $valu) = $lib.crypto.jwt.verify($tok, $pubpem, ("RS256",))
+                return($valu.header.kid)
+            ''', opts=opts2)
+            self.eq(kid, 'key-1')
+
+    async def test_stormlib_jwt_parse(self):
+
+        async with self.getTestCore() as core:
+
+            rsaprv, _ = await self._rsaPems(core)
+            opts = {'vars': {'prvpem': rsaprv}}
+
+            info = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.payload.sub = "p"
+                $j = $t.sign($prvpem, "RS256")
+                return($lib.crypto.jwt.parse($j))
+            ''', opts=opts)
+            self.eq(info.get('typ'), 'JWS')
+            self.eq(info.get('header').get('alg'), 'RS256')
+
+            info = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.payload.sub = "p"
+                $j = $t.sign($prvpem, "RS256", fmt="json")
+                return($lib.crypto.jwt.parse($j))
+            ''', opts=opts)
+            self.eq(info.get('typ'), 'JWS')
+            self.eq(info.get('header').get('alg'), 'RS256')
+
+            jweh = s_crypto.enbase64url(b'{"alg":"RSA-OAEP","enc":"A256GCM"}')
+            jwe = f'{jweh}.a.b.c.d'
+            info = await core.callStorm('return($lib.crypto.jwt.parse($t))', opts={'vars': {'t': jwe}})
+            self.eq(info.get('typ'), 'JWE')
+            self.eq(info.get('header').get('enc'), 'A256GCM')
+
+            jwejson = json.dumps({'protected': s_crypto.enbase64url(b'{"enc":"A256GCM"}'), 'ciphertext': 'x',
+                                  'iv': 'y', 'tag': 'z', 'encrypted_key': 'k'})
+            info = await core.callStorm('return($lib.crypto.jwt.parse($t))', opts={'vars': {'t': jwejson}})
+            self.eq(info.get('typ'), 'JWE')
+
+            gjson = json.dumps({'payload': 'e30', 'signatures': [{'protected': s_crypto.enbase64url(b'{"alg":"RS256"}'), 'signature': 'x'}]})
+            info = await core.callStorm('return($lib.crypto.jwt.parse($t))', opts={'vars': {'t': gjson}})
+            self.eq(info.get('typ'), 'JWS')
+            self.eq(info.get('header').get('alg'), 'RS256')
+
+            gjson2 = json.dumps({'payload': 'e30', 'signatures': []})
+            info = await core.callStorm('return($lib.crypto.jwt.parse($t))', opts={'vars': {'t': gjson2}})
+            self.eq(info.get('typ'), 'JWS')
+            self.eq(info.get('header'), {})
+
+            badheaderjson = f'{s_crypto.enbase64url(b"123")}.b.c'
+            for bad in ('a.b', 'not json and not dotted here', '{"unknown":1}', '[]', '{',
+                        'aaa.b.c', badheaderjson):
+                with self.raises(s_exc.BadArg):
+                    await core.callStorm('return($lib.crypto.jwt.parse($t))', opts={'vars': {'t': bad}})
+
+            big = ('A' * 70000) + '.b.c'
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.jwt.parse($t))', opts={'vars': {'t': big}})
+
+    async def test_stormlib_jwt_algorithms(self):
+
+        async with self.getTestCore() as core:
+
+            algs = await core.callStorm('return($lib.crypto.jwt.algorithms)')
+            self.eq(sorted(algs), sorted(s_jwt.jwtalgs))
+            self.isin('HS256', algs)
+            self.isin('RS512', algs)
+            self.isin('ES512', algs)
+
+            # a new list is returned on each access, so mutating it does not affect the next
+            await core.callStorm('$a = $lib.crypto.jwt.algorithms $a.append("bogus")')
+            algs2 = await core.callStorm('return($lib.crypto.jwt.algorithms)')
+            self.notin('bogus', algs2)
+
+    async def test_stormlib_jwt_jwe_rejected(self):
+
+        async with self.getTestCore() as core:
+
+            jwe = 'aaaa.bbbb.cccc.dddd.eeee'
+            retn = await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",)))',
+                opts={'vars': {'t': jwe, 'k': SECRET}})
+            self.false(retn[0])
+            self.isin('JWE', retn[1][1].get('mesg'))
+
+            jwejson = json.dumps({'protected': 'e30', 'ciphertext': 'x', 'iv': 'y', 'tag': 'z', 'encrypted_key': 'k'})
+            retn = await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",)))',
+                opts={'vars': {'t': jwejson, 'k': SECRET}})
+            self.false(retn[0])
+            self.isin('JWE', retn[1][1].get('mesg'))
+
+            gjson = json.dumps({'payload': 'e30', 'signatures': [{'protected': 'e30', 'signature': 'x'}]})
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",)))',
+                opts={'vars': {'t': gjson, 'k': SECRET}}))[0])
+
+            for bad in (json.dumps({'foo': 1}), '{bad', '[1,2]'):
+                self.false((await core.callStorm(
+                    'return($lib.crypto.jwt.verify($t, $k, ("RS256",)))',
+                    opts={'vars': {'t': bad, 'k': SECRET}}))[0])
+
+    async def test_stormlib_jwt_key_objects(self):
+
+        async with self.getTestCore() as core:
+
+            for gen, alg in (('$lib.crypto.rsa.generate()', 'RS256'),
+                             ('$lib.crypto.rsa.generate()', 'PS256'),
+                             ('$lib.crypto.ecc.generate(curve="P-256")', 'ES256')):
+                ok, sub = await core.callStorm(f'''
+                    $key = {gen}
+                    $token = $lib.crypto.jwt.generate()
+                    $token.payload.sub = "obj"
+                    $jwtstr = $token.sign($key, "{alg}")
+                    ($ok, $valu) = $lib.crypto.jwt.verify($jwtstr, $key.pubkey(), ("{alg}",))
+                    return(($ok, $valu.payload.sub))
+                ''')
+                self.true(ok)
+                self.eq(sub, 'obj')
+
+    async def test_stormlib_jwt_rsa_interop(self):
+
+        async with self.getTestCore() as core:
+
+            rsaprv, rsapub = await self._rsaPems(core)
+
+            jwtstr = await core.callStorm('''
+                $key = $lib.crypto.rsa.load($prvpem)
+                $token = $lib.crypto.jwt.generate()
+                $token.payload.sub = "interop"
+                return($token.sign($key, "RS256"))
+            ''', opts={'vars': {'prvpem': rsaprv}})
+
+            h, p, s = jwtstr.split('.')
+            sig = s_crypto.debase64url(s)
+            signin = f'{h}.{p}'
+            opts = {'vars': {'pubpem': rsapub, 'signin': signin, 'sig': sig}}
+            self.true(await core.callStorm(
+                'return($lib.crypto.rsa.load($pubpem).verify($signin.encode(), $sig, padding="pkcs1v15"))', opts=opts))
+
+    async def test_stormlib_jwt_initial_payload(self):
+
+        async with self.getTestCore() as core:
+
+            ok, iss, sub = await core.callStorm('''
+                $token = $lib.crypto.jwt.generate(({"iss": "vertex", "sub": "abc"}))
+                $jwtstr = $token.sign($secret, "HS256")
+                ($ok, $valu) = $lib.crypto.jwt.verify($jwtstr, $secret, ("HS256",))
+                return(($ok, $valu.payload.iss, $valu.payload.sub))
+            ''', opts={'vars': {'secret': SECRET}})
+            self.true(ok)
+            self.eq(iss, 'vertex')
+            self.eq(sub, 'abc')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.jwt.generate("notadict"))')
+
+    async def test_stormlib_jwt_str_keys(self):
+
+        async with self.getTestCore() as core:
+
+            rsaprv, rsapub = await self._rsaPems(core)
+            self.isinstance(rsaprv, str)
+            self.isinstance(rsapub, str)
+
+            opts = {'vars': {'prvpem': rsaprv, 'pubpem': rsapub}}
+            ok, sub = await core.callStorm('''
+                $token = $lib.crypto.jwt.generate()
+                $token.payload.sub = "strkey"
+                $jwtstr = $token.sign($prvpem, "RS256")
+                ($ok, $valu) = $lib.crypto.jwt.verify($jwtstr, $pubpem, ("RS256",))
+                return(($ok, $valu.payload.sub))
+            ''', opts=opts)
+            self.true(ok)
+            self.eq(sub, 'strkey')
+
+            for secret in (SECRET_STR, SECRET):
+                opts = {'vars': {'secret': secret}}
+                ok = await core.callStorm('''
+                    $token = $lib.crypto.jwt.generate()
+                    $token.payload.sub = "hs"
+                    $jwtstr = $token.sign($secret, "HS256")
+                    ($ok, $valu) = $lib.crypto.jwt.verify($jwtstr, $secret, ("HS256",))
+                    return($ok)
+                ''', opts=opts)
+                self.true(ok)
+
+            # a str secret and the equivalent bytes secret interoperate
+            signed = await core.callStorm(
+                '$token = $lib.crypto.jwt.generate() $token.payload.sub = "hs" return($token.sign($secret, "HS256"))',
+                opts={'vars': {'secret': SECRET_STR}})
+            ok = await core.callStorm(
+                '($ok, $valu) = $lib.crypto.jwt.verify($tok, $secret, ("HS256",)) return($ok)',
+                opts={'vars': {'tok': signed, 'secret': SECRET}})
+            self.true(ok)
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign((1234), "HS256")')
+
+    async def test_stormlib_jwt_claims(self):
+
+        async with self.getTestCore() as core:
+
+            now = int(time.time())
+
+            # exp: a future exp verifies, a past one is expired
+            self.true((await self._verifyHs(core, await self._signHs(core, {'exp': now + 3600})))[0])
+            self.false((await self._verifyHs(core, await self._signHs(core, {'exp': now - 3600})))[0])
+
+            # leeway lets a just-expired token through
+            tok = await self._signHs(core, {'exp': now - 10})
+            self.false((await self._verifyHs(core, tok))[0])
+            self.true((await self._verifyHs(core, tok, leeway=3600))[0])
+
+            # nbf: a past nbf verifies, a future one is not yet valid
+            self.true((await self._verifyHs(core, await self._signHs(core, {'nbf': now - 3600})))[0])
+            self.false((await self._verifyHs(core, await self._signHs(core, {'nbf': now + 3600})))[0])
+
+            # iat present and numeric verifies
+            self.true((await self._verifyHs(core, await self._signHs(core, {'iat': now})))[0])
+
+            # non-numeric exp/nbf/iat in an incoming token are rejected
+            for claim in ('exp', 'nbf', 'iat'):
+                forged = forgeHmac({'alg': 'HS256', 'typ': 'JWT'}, {claim: 'notanumber'}, SECRET)
+                self.false((await self._verifyHs(core, forged))[0])
+
+            # audience: token aud may be a string or an array; caller audience may be a string or a list
+            self.true((await self._verifyHs(core, await self._signHs(core, {'aud': 'myapp'}), audience='myapp'))[0])
+            self.true((await self._verifyHs(core, await self._signHs(core, {'aud': ['a', 'myapp']}), audience='myapp'))[0])
+            self.true((await self._verifyHs(core, await self._signHs(core, {'aud': 'myapp'}), audience=['x', 'myapp']))[0])
+            self.false((await self._verifyHs(core, await self._signHs(core, {'aud': 'other'}), audience='myapp'))[0])
+            # audience requested but the token has no aud claim
+            self.false((await self._verifyHs(core, await self._signHs(core, {'sub': 'x'}), audience='myapp'))[0])
+            # RFC 7519 4.1.3: an empty aud carries no value to match, so it is rejected (as PyJWT
+            # does), even against an empty expected audience; an empty element inside a non-empty
+            # aud array still matches.
+            self.false((await self._verifyHs(core, await self._signHs(core, {'aud': ''}), audience=''))[0])
+            self.false((await self._verifyHs(core, await self._signHs(core, {'aud': ''}), audience='x'))[0])
+            self.true((await self._verifyHs(core, await self._signHs(core, {'aud': ['', 'x']}), audience=''))[0])
+
+            # issuer: exact string match, list membership, and NO substring matching
+            self.true((await self._verifyHs(core, await self._signHs(core, {'iss': 'vertex'}), issuer='vertex'))[0])
+            self.false((await self._verifyHs(core, await self._signHs(core, {'iss': 'vertex'}), issuer='ver'))[0])
+            self.true((await self._verifyHs(core, await self._signHs(core, {'iss': 'vertex'}), issuer=['a', 'vertex']))[0])
+            self.false((await self._verifyHs(core, await self._signHs(core, {'iss': 'vertex'}), issuer=['a', 'b']))[0])
+
+            # subject exact match
+            self.true((await self._verifyHs(core, await self._signHs(core, {'sub': 'u1'}), subject='u1'))[0])
+            self.false((await self._verifyHs(core, await self._signHs(core, {'sub': 'u1'}), subject='u2'))[0])
+
+            # required claims (presence only); a str is treated as a single name
+            tok = await self._signHs(core, {'sub': 'x'})
+            self.true((await self._verifyHs(core, tok, requiredclaims=('sub',)))[0])
+            self.true((await self._verifyHs(core, tok, requiredclaims='sub'))[0])
+            self.false((await self._verifyHs(core, tok, requiredclaims=('missing',)))[0])
+
+            # typ check against the header
+            tok = await self._signHs(core, {'sub': 'x'})
+            self.true((await self._verifyHs(core, tok, typ='JWT'))[0])
+            self.false((await self._verifyHs(core, tok, typ='at+jwt'))[0])
+
+    async def test_stormlib_jwt_claim_options(self):
+
+        async with self.getTestCore() as core:
+
+            now = int(time.time())
+            expired = await self._signHs(core, {'exp': now - 3600, 'sub': 'x'})
+
+            # disabling verify_exp lets an expired token through
+            self.true((await self._verifyHs(core, expired, options={'verify_exp': False}))[0])
+            # by default it is rejected
+            self.false((await self._verifyHs(core, expired))[0])
+
+            # options must be a dict; leeway must be non-negative
+            self.false((await self._verifyHs(core, expired, options='notadict'))[0])
+            self.false((await self._verifyHs(core, expired, leeway=-1))[0])
+
+            # an explicit null requiredclaims is treated as empty
+            good = await self._signHs(core, {'sub': 'x'})
+            self.true((await self._verifyHs(core, good, requiredclaims=None))[0])
+
+    async def test_stormlib_jwt_schema(self):
+
+        async with self.getTestCore() as core:
+
+            # setting a registered claim to the wrong type is rejected at set time
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$t = $lib.crypto.jwt.generate() $t.payload.exp = "notanumber"')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$t = $lib.crypto.jwt.generate() $t.payload.aud = (5)')
+
+            # aud may be set to an array of strings
+            ok = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.payload.aud = ("a", "b")
+                $t.payload.exp = (99999999999)
+                $j = $t.sign($secret, "HS256")
+                ($ok, $valu) = $lib.crypto.jwt.verify($j, $secret, ("HS256",), audience="b")
+                return($ok)
+            ''', opts={'vars': {'secret': SECRET}})
+            self.true(ok)
+
+            # a custom (non-registered) claim of any JSON type is allowed
+            ok = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.payload.custom = (42)
+                $j = $t.sign($secret, "HS256")
+                ($ok, $valu) = $lib.crypto.jwt.verify($j, $secret, ("HS256",))
+                return($ok)
+            ''', opts={'vars': {'secret': SECRET}})
+            self.true(ok)
+
+            # claim / header names must be strings
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$t = $lib.crypto.jwt.generate() $k = (1234) $t.payload.$k = "x"')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$t = $lib.crypto.jwt.generate() $k = (1234) $t.header.$k = "x"')
+
+            # generate() validates an initial payload up front: bad registered-claim types and
+            # non-string keys are rejected before a Jwt is created
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate(({"exp": "notanumber"}))')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate(({"aud": (5)}))')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.jwt.generate($p))',
+                                     opts={'vars': {'p': {1234: 'x'}}})
+
+            # a custom (non-registered) claim in an initial payload is allowed
+            ok, custom = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate(({"sub": "x", "custom": "y"}))
+                $j = $t.sign($secret, "HS256")
+                ($ok, $valu) = $lib.crypto.jwt.verify($j, $secret, ("HS256",))
+                return(($ok, $valu.payload.custom))
+            ''', opts={'vars': {'secret': SECRET}})
+            self.true(ok)
+            self.eq(custom, 'y')
+
+            # a registered claim mutated in place after generate() bypasses generate/setitem
+            # validation, so the sign-time gate still catches it
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('''
+                    $t = $lib.crypto.jwt.generate()
+                    $t.payload.aud = ("a",)
+                    $t.payload.aud.append((5))
+                    $t.sign($secret, "HS256")
+                ''', opts={'vars': {'secret': SECRET}})
+
+    async def test_stormlib_jwt_hardening(self):
+
+        async with self.getTestCore() as core:
+
+            rsaprv, _ = await self._rsaPems(core)
+
+            # an asymmetric key (PEM) may not be used as an HMAC secret
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign($k, "HS256")', opts={'vars': {'k': rsaprv}})
+
+            # an HMAC secret shorter than the hash output is rejected
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign($k, "HS256")', opts={'vars': {'k': b'short'}})
+
+            # an RSA key smaller than 2048 bits is rejected on sign
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('''
+                    $k = $lib.crypto.rsa.generate(bits=(1024))
+                    $lib.crypto.jwt.generate().sign($k, "RS256")
+                ''')
+
+            # ... and on verify: a token signed by a 1024-bit key is rejected
+            prikey = s_rsa.PriKey.generate(bits=1024)
+            pubpem = prikey.public().dump(fmt='pem').decode()
+            h = s_crypto.enbase64url(json.dumps({'alg': 'RS256', 'typ': 'JWT'}, separators=(',', ':')).encode())
+            p = s_crypto.enbase64url(json.dumps({'sub': 'x'}, separators=(',', ':')).encode())
+            sig = prikey.sign(f'{h}.{p}'.encode('ascii'), padding='pkcs1v15', hashalgo='sha256')
+            smalltok = f'{h}.{p}.{s_crypto.enbase64url(sig)}'
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",)))',
+                opts={'vars': {'t': smalltok, 'k': pubpem}}))[0])
+
+            # a token carrying a crit header is rejected on verify
+            crittok = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.header.crit = ("exp",)
+                $t.payload.sub = "x"
+                return($t.sign($secret, "HS256"))
+            ''', opts={'vars': {'secret': SECRET}})
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $secret, ("HS256",)))',
+                opts={'vars': {'t': crittok, 'secret': SECRET}}))[0])
+
+    async def test_stormlib_jwt_immutable(self):
+
+        async with self.getTestCore() as core:
+
+            with self.raises(s_exc.IsReadOnly):
+                await core.callStorm('''
+                    $token = $lib.crypto.jwt.generate()
+                    $token.payload.a = "1"
+                    $token.sign($secret, "HS256")
+                    $token.payload.b = "2"
+                ''', opts={'vars': {'secret': SECRET}})
+
+            with self.raises(s_exc.IsReadOnly):
+                await core.callStorm('''
+                    $token = $lib.crypto.jwt.generate()
+                    $token.sign($secret, "HS256")
+                    $token.header.kid = "late"
+                ''', opts={'vars': {'secret': SECRET}})
+
+            with self.raises(s_exc.IsReadOnly):
+                await core.callStorm('''
+                    $token = $lib.crypto.jwt.generate()
+                    $token.payload.a = "1"
+                    $jwtstr = $token.sign($secret, "HS256")
+                    ($ok, $loaded) = $lib.crypto.jwt.verify($jwtstr, $secret, ("HS256",))
+                    $loaded.payload.b = "2"
+                ''', opts={'vars': {'secret': SECRET}})
+
+            with self.raises(s_exc.IsReadOnly):
+                await core.callStorm('''
+                    $token = $lib.crypto.jwt.generate()
+                    $jwtstr = $token.sign($secret, "HS256")
+                    ($ok, $loaded) = $lib.crypto.jwt.verify($jwtstr, $secret, ("HS256",))
+                    $loaded.header.kid = "x"
+                ''', opts={'vars': {'secret': SECRET}})
+
+    async def test_stormlib_jwt_errors(self):
+
+        async with self.getTestCore() as core:
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign($secret, "HS999")',
+                                     opts={'vars': {'secret': SECRET}})
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign((1234), "HS256")')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign($lib.base64.decode(""), "HS256")')
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('''
+                    $token = $lib.crypto.jwt.generate()
+                    $token.sign($secret, "HS256")
+                    $token.sign($secret, "HS256")
+                ''', opts={'vars': {'secret': SECRET}})
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign($k, "RS256")', opts={'vars': {'k': b'not a pem'}})
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign($k, "PS256")', opts={'vars': {'k': b'not a pem'}})
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('$lib.crypto.jwt.generate().sign($k, "ES256")', opts={'vars': {'k': b'not a pem'}})
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('''
+                    $token = $lib.crypto.jwt.generate()
+                    $token.payload.custom = $lib.base64.decode("aGk=")
+                    $token.sign($secret, "HS256")
+                ''', opts={'vars': {'secret': SECRET}})
+
+    async def test_stormlib_jwt_malformed(self):
+
+        async with self.getTestCore() as core:
+
+            jwtstr = await core.callStorm('''
+                $token = $lib.crypto.jwt.generate()
+                $token.payload.sub = "x"
+                return($token.sign($secret, "HS256"))
+            ''', opts={'vars': {'secret': SECRET}})
+            opts = {'vars': {'tok': jwtstr, 'secret': SECRET}}
+
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $secret, "HS256"))', opts=opts))[0])
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $secret, ((1234),)))', opts=opts))[0])
+
+            def verify(tok, key=SECRET, algs=('HS256',)):
+                o = {'vars': {'tok': tok, 'key': key, 'algs': list(algs)}}
+                return core.callStorm('return($lib.crypto.jwt.verify($tok, $key, $algs))', opts=o)
+
+            emptyobj = s_crypto.enbase64url(b'{}')
+            badnum = s_crypto.enbase64url(b'123')
+            hdr_hs = s_crypto.enbase64url(b'{"alg":"HS256","typ":"JWT"}')
+            hdr_notyp = s_crypto.enbase64url(b'{"typ":"JWT"}')
+            openbrace = s_crypto.enbase64url(b'{')
+
+            self.false((await verify(jwtstr, algs=()))[0])
+            self.false((await verify('a.b'))[0])
+            self.false((await verify('a.a.a'))[0])
+            self.false((await verify(f'{openbrace}.{emptyobj}.AA'))[0])
+            self.false((await verify(f'{badnum}.{emptyobj}.AA'))[0])
+            self.false((await verify(f'{hdr_hs}.{badnum}.AA'))[0])
+            self.false((await verify(f'{hdr_notyp}.{emptyobj}.AA'))[0])
+            self.false((await verify(jwtstr, algs=('RS256',)))[0])
+            self.false((await verify(jwtstr, key=b''))[0])
+            self.false((await verify(jwtstr, key=1234))[0])
+
+            rsaprv, _ = await self._rsaPems(core)
+            rstok = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.payload.sub = "x"
+                return($t.sign($prvpem, "RS256"))
+            ''', opts={'vars': {'prvpem': rsaprv}})
+            self.false((await verify(rstok, key=b'not pem', algs=('RS256',)))[0])
+
+            ecprv, _ = await self._eccPems(core, 'P-256')
+            estok = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.payload.sub = "x"
+                return($t.sign($prvpem, "ES256"))
+            ''', opts={'vars': {'prvpem': ecprv}})
+            self.false((await verify(estok, key=b'not pem', algs=('ES256',)))[0])
+
+class StormLibJwtAttackTest(s_test.SynTest):
+
+    async def _rsaPems(self, core):
+        return await core.callStorm('$k = $lib.crypto.rsa.generate() return(($k.encode(), $k.pubkey().encode()))')
+
+    async def _eccPems(self, core, curve):
+        return await core.callStorm(
+            '$k = $lib.crypto.ecc.generate(curve=$c) return(($k.encode(), $k.pubkey().encode()))',
+            opts={'vars': {'c': curve}})
+
+    async def test_stormlib_jwt_attack_alg_none(self):
+
+        async with self.getTestCore() as core:
+
+            h = s_crypto.enbase64url(json.dumps({'alg': 'none', 'typ': 'JWT'}, separators=(',', ':')).encode())
+            p = s_crypto.enbase64url(json.dumps({'sub': 'admin'}, separators=(',', ':')).encode())
+            nonetok = f'{h}.{p}.'
+
+            opts = {'vars': {'tok': nonetok, 'key': SECRET}}
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $key, ("HS256",)))', opts=opts))[0])
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $key, ("none",)))', opts=opts))[0])
+
+    async def test_stormlib_jwt_attack_confusion(self):
+
+        async with self.getTestCore() as core:
+
+            _, pubpem = await self._rsaPems(core)
+
+            # forge an HS256 token using the RSA public key PEM as the HMAC secret
+            forged = forgeHmac({'alg': 'HS256', 'typ': 'JWT'}, {'sub': 'admin'}, pubpem.encode())
+
+            # the allowlist rejects the forged HS256 token when RS256 is required, AND the
+            # key-type binding rejects using an asymmetric key PEM as an HMAC secret even when
+            # HS256 is (mistakenly) allowed. Both mitigations hold.
+            opts = {'vars': {'tok': forged, 'pubkey': pubpem}}
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $pubkey, ("RS256",)))', opts=opts))[0])
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $pubkey, ("HS256",)))', opts=opts))[0])
+
+    async def test_stormlib_jwt_attack_allowlist(self):
+
+        async with self.getTestCore() as core:
+
+            rsaprv, rsapub = await self._rsaPems(core)
+
+            jwtstr = await core.callStorm('''
+                $token = $lib.crypto.jwt.generate()
+                $token.payload.sub = "x"
+                return($token.sign($prvpem, "RS256"))
+            ''', opts={'vars': {'prvpem': rsaprv}})
+
+            opts = {'vars': {'tok': jwtstr, 'pubkey': rsapub}}
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $pubkey, ("HS256",)))', opts=opts))[0])
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $pubkey, ()))', opts=opts))[0])
+
+    async def test_stormlib_jwt_attack_tamper(self):
+
+        async with self.getTestCore() as core:
+
+            jwtstr = await core.callStorm('''
+                $token = $lib.crypto.jwt.generate()
+                $token.payload.sub = "user"
+                return($token.sign($secret, "HS256"))
+            ''', opts={'vars': {'secret': SECRET}})
+
+            h, p, s = jwtstr.split('.')
+            badp = s_crypto.enbase64url(json.dumps({'sub': 'admin'}, separators=(',', ':')).encode())
+            badtok = f'{h}.{badp}.{s}'
+
+            opts = {'vars': {'tok': badtok, 'secret': SECRET}}
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $secret, ("HS256",)))', opts=opts))[0])
+
+    async def test_stormlib_jwt_attack_kid_ignored(self):
+
+        async with self.getTestCore() as core:
+
+            header = {'alg': 'HS256', 'typ': 'JWT', 'kid': '../../../etc/passwd'}
+            forged = forgeHmac(header, {'sub': 'x'}, SECRET)
+
+            opts = {'vars': {'tok': forged, 'secret': SECRET}}
+            ok, sub = await core.callStorm('''
+                ($ok, $valu) = $lib.crypto.jwt.verify($tok, $secret, ("HS256",))
+                return(($ok, $valu.payload.sub))
+            ''', opts=opts)
+            self.true(ok)
+            self.eq(sub, 'x')
+
+            opts = {'vars': {'tok': forged, 'secret': WRONGSECRET}}
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $secret, ("HS256",)))', opts=opts))[0])
+
+    async def test_stormlib_jwt_attack_ecc(self):
+
+        async with self.getTestCore() as core:
+
+            ec256prv, ec256pub = await self._eccPems(core, 'P-256')
+            _, ec384pub = await self._eccPems(core, 'P-384')
+
+            jwtstr = await core.callStorm('''
+                $token = $lib.crypto.jwt.generate()
+                $token.payload.sub = "ecc"
+                return($token.sign($prvpem, "ES256"))
+            ''', opts={'vars': {'prvpem': ec256prv}})
+
+            opts = {'vars': {'tok': jwtstr, 'pubkey': ec384pub}}
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $pubkey, ("ES384",)))', opts=opts))[0])
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $pubkey, ("ES256",)))', opts=opts))[0])
+
+            h, p, s = jwtstr.split('.')
+            raw = s_crypto.debase64url(s)
+            r = int.from_bytes(raw[:32], 'big')
+            sval = int.from_bytes(raw[32:], 'big')
+            der = c_utils.encode_dss_signature(r, sval)
+            badtok = f'{h}.{p}.{s_crypto.enbase64url(der)}'
+
+            opts = {'vars': {'tok': badtok, 'pubkey': ec256pub}}
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $pubkey, ("ES256",)))', opts=opts))[0])
+
+            zerotok = f'{h}.{p}.{s_crypto.enbase64url(bytes(64))}'
+            opts = {'vars': {'tok': zerotok, 'pubkey': ec256pub}}
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($tok, $pubkey, ("ES256",)))', opts=opts))[0])
+
+class StormLibJwtJwksTest(s_test.SynTest):
+
+    async def _mkkey(self, core, kid):
+        prvpem, pubpem = await core.callStorm(
+            '$k = $lib.crypto.rsa.generate() return(($k.encode(), $k.pubkey().encode()))')
+        return prvpem, rsaJwk(pubpem, kid)
+
+    async def _sign(self, core, prvpem, kid, sub='u'):
+        return await core.callStorm('''
+            $t = $lib.crypto.jwt.generate()
+            $t.header.kid = $kid
+            $t.payload.sub = $sub
+            return($t.sign($prvpem, "RS256"))
+        ''', opts={'vars': {'prvpem': prvpem, 'kid': kid, 'sub': sub}})
+
+    async def test_stormlib_jwt_jwks_dict(self):
+
+        async with self.getTestCore() as core:
+
+            prv1, jwk1 = await self._mkkey(core, 'k1')
+            _, jwk2 = await self._mkkey(core, 'k2')
+            tok = await self._sign(core, prv1, 'k1')
+            jwks = {'keys': [jwk1, jwk2]}
+
+            # select from a JWKS by kid
+            ok, sub = await core.callStorm(
+                '($ok, $v) = $lib.crypto.jwt.verify($t, $jwks, ("RS256",)) return(($ok, $v.payload.sub))',
+                opts={'vars': {'t': tok, 'jwks': jwks}})
+            self.true(ok)
+            self.eq(sub, 'u')
+
+            # a single JWK (not a set) also works
+            self.true((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwk, ("RS256",)))',
+                opts={'vars': {'t': tok, 'jwk': jwk1}}))[0])
+
+            # a kid with no match in the set fails
+            toknope = await self._sign(core, prv1, 'nope')
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwks, ("RS256",)))',
+                opts={'vars': {'t': toknope, 'jwks': jwks}}))[0])
+
+            # a JWKS with no kid selector and multiple keys fails
+            toknokid = await core.callStorm(
+                '$t = $lib.crypto.jwt.generate() $t.payload.sub = "u" return($t.sign($prvpem, "RS256"))',
+                opts={'vars': {'prvpem': prv1}})
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwks, ("RS256",)))',
+                opts={'vars': {'t': toknokid, 'jwks': jwks}}))[0])
+
+            # a single-key JWKS with no kid selector is used directly
+            self.true((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwks, ("RS256",)))',
+                opts={'vars': {'t': toknokid, 'jwks': {'keys': [jwk1]}}}))[0])
+
+            # a malformed keys member and a malformed JWK are rejected
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwks, ("RS256",)))',
+                opts={'vars': {'t': tok, 'jwks': {'keys': 'notalist'}}}))[0])
+            badjwk = dict(jwk1, n='!!!')
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwk, ("RS256",)))',
+                opts={'vars': {'t': tok, 'jwk': badjwk}}))[0])
+
+            # an EC JWK verifies an ES256 token; an EC JWK for an RS256 token is rejected
+            esprv, espub = await core.callStorm(
+                '$k = $lib.crypto.ecc.generate(curve="P-256") return(($k.encode(), $k.pubkey().encode()))')
+            ecjwk = eccJwk(espub, 'k1')
+            estok = await core.callStorm('''
+                $k = $lib.crypto.ecc.load($prvpem)
+                $t = $lib.crypto.jwt.generate()
+                $t.header.kid = "k1"
+                $t.payload.sub = "u"
+                return($t.sign($k, "ES256"))
+            ''', opts={'vars': {'prvpem': esprv}})
+            self.true((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwk, ("ES256",)))',
+                opts={'vars': {'t': estok, 'jwk': ecjwk}}))[0])
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwk, ("RS256",)))',
+                opts={'vars': {'t': tok, 'jwk': ecjwk}}))[0])
+
+            # an RSA JWK for an ES256 token (kty/alg mismatch) is rejected
+            es = await core.callStorm('''
+                $k = $lib.crypto.ecc.generate(curve="P-256")
+                $t = $lib.crypto.jwt.generate()
+                $t.header.kid = "k1"
+                $t.payload.sub = "u"
+                return($t.sign($k, "ES256"))
+            ''')
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwk, ("ES256",)))',
+                opts={'vars': {'t': es, 'jwk': jwk1}}))[0])
+
+            # an oct JWK verifies an HS256 token, and a non-oct JWK for HS256 is rejected
+            octjwk = {'kty': 'oct', 'kid': 'h1', 'k': s_crypto.enbase64url(SECRET)}
+            hstok = await core.callStorm('''
+                $t = $lib.crypto.jwt.generate()
+                $t.header.kid = "h1"
+                $t.payload.sub = "u"
+                return($t.sign($secret, "HS256"))
+            ''', opts={'vars': {'secret': SECRET}})
+            self.true((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwk, ("HS256",)))',
+                opts={'vars': {'t': hstok, 'jwk': octjwk}}))[0])
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwk, ("HS256",)))',
+                opts={'vars': {'t': hstok, 'jwk': jwk1}}))[0])
+
+            # an oct JWK whose k is not valid base64url fails closed rather than leaking a raw
+            # binascii error into the runtime
+            badoct = {'kty': 'oct', 'kid': 'h1', 'k': 'AAAAA'}
+            ok, info = await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $jwk, ("HS256",)))',
+                opts={'vars': {'t': hstok, 'jwk': badoct}})
+            self.false(ok)
+            self.isin('Invalid HMAC JWK k value', info[1].get('mesg'))
+
+    async def test_stormlib_jwt_jwks_uri(self):
+
+        async with self.getTestCore() as core:
+
+            prv1, jwk1 = await self._mkkey(core, 'k1')
+            tok = await self._sign(core, prv1, 'k1')
+
+            state = {'hits': 0, 'code': 200, 'body': s_json.dumps({'keys': [jwk1]})}
+            addr, port = await core.addHttpsPort(0)
+            core.addHttpApi('/jwks', JwksHandler, {'cell': core, 'state': state})
+            # use localhost (not the 127.0.0.1 literal) so the fetch exercises the pinned resolver
+            url = f'https://localhost:{port}/jwks'
+
+            base = {'t': tok, 'k': None, 'url': url}
+
+            # https is required
+            httpurl = f'http://localhost:{port}/jwks'
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",), jwks_uri=$url, ssl_verify=(false)))',
+                opts={'vars': dict(base, url=httpurl)}))[0])
+
+            # a jwks_uri missing a host, or with an unresolvable host, is rejected
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",), jwks_uri="https:///jwks"))',
+                opts={'vars': base}))[0])
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",), jwks_uri="https://nx.invalid./jwks"))',
+                opts={'vars': base}))[0])
+
+            # a loopback jwks_uri is blocked unless allowinternal is set
+            retn = await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",), jwks_uri=$url, ssl_verify=(false)))',
+                opts={'vars': base})
+            self.false(retn[0])
+            self.isin('non-global', retn[1][1].get('mesg'))
+            self.eq(state['hits'], 0)
+
+            # neither a key nor a jwks_uri is an error
+            self.false((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",)))', opts={'vars': base}))[0])
+
+            # happy path with allowinternal fetches and verifies
+            ok, sub = await core.callStorm('''
+                ($ok, $v) = $lib.crypto.jwt.verify($t, $k, ("RS256",),
+                    jwks_uri=$url, ssl_verify=(false), allowinternal=(true))
+                return(($ok, $v.payload.sub))
+            ''', opts={'vars': base})
+            self.true(ok)
+            self.eq(sub, 'u')
+            self.eq(state['hits'], 1)
+
+            # a second verify is served from cache without another fetch
+            self.true((await core.callStorm(
+                'return($lib.crypto.jwt.verify($t, $k, ("RS256",), jwks_uri=$url, ssl_verify=(false), allowinternal=(true)))',
+                opts={'vars': base}))[0])
+            self.eq(state['hits'], 1)
+
+    async def test_stormlib_jwt_jwks_uri_rotate(self):
+
+        async with self.getTestCore() as core:
+
+            prv1, jwk1 = await self._mkkey(core, 'k1')
+            prv2, jwk2 = await self._mkkey(core, 'k2')
+            tok1 = await self._sign(core, prv1, 'k1')
+            tok2 = await self._sign(core, prv2, 'k2')
+
+            state = {'hits': 0, 'code': 200, 'body': s_json.dumps({'keys': [jwk1]})}
+            addr, port = await core.addHttpsPort(0)
+            core.addHttpApi('/jwks', JwksHandler, {'cell': core, 'state': state})
+            url = f'https://127.0.0.1:{port}/jwks'
+
+            q = '''
+                return($lib.crypto.jwt.verify($t, $k, ("RS256",),
+                    jwks_uri=$url, ssl_verify=(false), allowinternal=(true)))
+            '''
+            self.true((await core.callStorm(q, opts={'vars': {'t': tok1, 'k': None, 'url': url}}))[0])
+            self.eq(state['hits'], 1)
+
+            # rotate: the endpoint now serves both keys. An unknown kid forces one refresh.
+            state['body'] = s_json.dumps({'keys': [jwk1, jwk2]})
+            self.true((await core.callStorm(q, opts={'vars': {'t': tok2, 'k': None, 'url': url}}))[0])
+            self.eq(state['hits'], 2)
+
+    async def test_stormlib_jwt_jwks_uri_stale(self):
+
+        async with self.getTestCore() as core:
+
+            prv1, jwk1 = await self._mkkey(core, 'k1')
+            tok = await self._sign(core, prv1, 'k1')
+
+            state = {'hits': 0, 'code': 500, 'body': b''}
+            addr, port = await core.addHttpsPort(0)
+            core.addHttpApi('/jwks', JwksHandler, {'cell': core, 'state': state})
+            url = f'https://127.0.0.1:{port}/jwks'
+
+            # pre-seed an expired cache entry; the refresh fails (HTTP 500) and the stale set is served
+            core.jwkscache[url] = (0.0, {'keys': [jwk1]})
+
+            ok = (await core.callStorm('''
+                return($lib.crypto.jwt.verify($t, $k, ("RS256",),
+                    jwks_uri=$url, ssl_verify=(false), allowinternal=(true)))
+            ''', opts={'vars': {'t': tok, 'k': None, 'url': url}}))[0]
+            self.true(ok)
+            self.eq(state['hits'], 1)
+
+    async def test_stormlib_jwt_jwks_uri_resolve_stale(self):
+
+        async with self.getTestCore() as core:
+
+            prv1, jwk1 = await self._mkkey(core, 'k1')
+            tok = await self._sign(core, prv1, 'k1')
+
+            url = 'https://rotated.example.com/jwks'
+            opts = {'vars': {'t': tok, 'k': None, 'url': url}}
+            q = 'return($lib.crypto.jwt.verify($t, $k, ("RS256",), jwks_uri=$url, allowinternal=(true)))'
+
+            async def boom(host, port):
+                raise s_exc.BadArg(mesg='the resolver is down', url=host)
+
+            with mock.patch.object(s_jwt, '_resolveJwksHost', boom):
+
+                # a transient resolution failure with no cached entry hard-fails
+                retn = await core.callStorm(q, opts=opts)
+                self.false(retn[0])
+                self.isin('the resolver is down', retn[1][1].get('mesg'))
+
+                # the same failure with a present (stale) cache entry serves it rather than breaking
+                core.jwkscache[url] = (0.0, {'keys': [jwk1]})
+                self.true((await core.callStorm(q, opts=opts))[0])
+
+    async def test_stormlib_jwt_jwks_uri_limits(self):
+
+        async with self.getTestCore() as core:
+
+            prv1, jwk1 = await self._mkkey(core, 'k1')
+            tok = await self._sign(core, prv1, 'k1')
+
+            addr, port = await core.addHttpsPort(0)
+
+            def check(path, body, code=200):
+                state = {'hits': 0, 'code': code, 'body': body}
+                core.addHttpApi(path, JwksHandler, {'cell': core, 'state': state})
+                url = f'https://127.0.0.1:{port}{path}'
+                return core.callStorm('''
+                    return($lib.crypto.jwt.verify($t, $k, ("RS256",),
+                        jwks_uri=$url, ssl_verify=(false), allowinternal=(true)))
+                ''', opts={'vars': {'t': tok, 'k': None, 'url': url}})
+
+            # a response larger than the cap, a non-JSON body, and a JSON body that is not a
+            # JWKS object are all rejected
+            self.false((await check('/big', s_json.dumps({'keys': [jwk1], 'pad': 'x' * (300 * 1024)})))[0])
+            self.false((await check('/notjson', b'not json{'))[0])
+            self.false((await check('/nokeys', s_json.dumps({'foo': 1})))[0])
+            self.false((await check('/http500', b'', code=500))[0])
+
+            # a configured proxy is used for the fetch (the bogus proxy makes the fetch fail)
+            core.conf['http:proxy'] = 'socks5://127.0.0.1:1'
+            state2 = {'hits': 0, 'code': 200, 'body': s_json.dumps({'keys': [jwk1]})}
+            core.addHttpApi('/jwks2', JwksHandler, {'cell': core, 'state': state2})
+            url2 = f'https://127.0.0.1:{port}/jwks2'
+            self.false((await core.callStorm('''
+                return($lib.crypto.jwt.verify($t, $k, ("RS256",),
+                    jwks_uri=$url, ssl_verify=(false), proxy=(true), allowinternal=(true)))
+            ''', opts={'vars': {'t': tok, 'k': None, 'url': url2}}))[0])
+            self.eq(state2['hits'], 0)
+
+    async def test_stormlib_jwt_jwks_uri_singleflight(self):
+
+        async with self.getTestCore() as core:
+
+            prv1, jwk1 = await self._mkkey(core, 'k1')
+            tok = await self._sign(core, prv1, 'k1')
+
+            state = {'hits': 0, 'code': 200, 'body': s_json.dumps({'keys': [jwk1]})}
+            addr, port = await core.addHttpsPort(0)
+            core.addHttpApi('/jwks', JwksHandler, {'cell': core, 'state': state})
+            url = f'https://127.0.0.1:{port}/jwks'
+
+            q = '''
+                return($lib.crypto.jwt.verify($t, $k, ("RS256",),
+                    jwks_uri=$url, ssl_verify=(false), allowinternal=(true)))
+            '''
+            opts = {'vars': {'t': tok, 'k': None, 'url': url}}
+
+            # two concurrent verifies race the cache; single-flight collapses them to one fetch
+            r1, r2 = await asyncio.gather(core.callStorm(q, opts=opts), core.callStorm(q, opts=opts))
+            self.true(r1[0])
+            self.true(r2[0])
+            self.eq(state['hits'], 1)
+
+    async def test_stormlib_jwt_jwks_uri_norefetch(self):
+
+        async with self.getTestCore() as core:
+
+            _, jwk1 = await self._mkkey(core, 'k1')
+            _, jwk2 = await self._mkkey(core, 'k2')
+            prv, _ = await self._mkkey(core, 'kx')
+            addr, port = await core.addHttpsPort(0)
+
+            # a no-kid token against a multi-key set: selection fails with no kid, so no refetch
+            toknokid = await core.callStorm(
+                '$t = $lib.crypto.jwt.generate() $t.payload.sub = "u" return($t.sign($prvpem, "RS256"))',
+                opts={'vars': {'prvpem': prv}})
+            stateA = {'hits': 0, 'code': 200, 'body': s_json.dumps({'keys': [jwk1, jwk2]})}
+            core.addHttpApi('/a', JwksHandler, {'cell': core, 'state': stateA})
+            urlA = f'https://localhost:{port}/a'
+            self.false((await core.callStorm('''
+                return($lib.crypto.jwt.verify($t, $k, ("RS256",), jwks_uri=$url, ssl_verify=(false), allowinternal=(true)))
+            ''', opts={'vars': {'t': toknokid, 'k': None, 'url': urlA}}))[0])
+            self.eq(stateA['hits'], 1)
+
+            # a kid that IS present but is the wrong key type for the alg: no refetch either
+            esprv, _ = await core.callStorm(
+                '$k = $lib.crypto.ecc.generate(curve="P-256") return(($k.encode(), $k.pubkey().encode()))')
+            estok = await core.callStorm('''
+                $k = $lib.crypto.ecc.load($prvpem)
+                $t = $lib.crypto.jwt.generate()
+                $t.header.kid = "k1"
+                $t.payload.sub = "u"
+                return($t.sign($k, "ES256"))
+            ''', opts={'vars': {'prvpem': esprv}})
+            stateB = {'hits': 0, 'code': 200, 'body': s_json.dumps({'keys': [jwk1]})}
+            core.addHttpApi('/b', JwksHandler, {'cell': core, 'state': stateB})
+            urlB = f'https://localhost:{port}/b'
+            self.false((await core.callStorm('''
+                return($lib.crypto.jwt.verify($t, $k, ("ES256",), jwks_uri=$url, ssl_verify=(false), allowinternal=(true)))
+            ''', opts={'vars': {'t': estok, 'k': None, 'url': urlB}}))[0])
+            self.eq(stateB['hits'], 1)
+
+    async def test_stormlib_jwt_jwks_uri_cache_bound(self):
+
+        async with self.getTestCore() as core:
+
+            prv1, jwk1 = await self._mkkey(core, 'k1')
+            tok = await self._sign(core, prv1, 'k1')
+            addr, port = await core.addHttpsPort(0)
+
+            def add(path, code=200):
+                state = {'hits': 0, 'code': code, 'body': s_json.dumps({'keys': [jwk1]})}
+                core.addHttpApi(path, JwksHandler, {'cell': core, 'state': state})
+                return f'https://localhost:{port}{path}'
+
+            failurl = add('/fail', code=500)
+            okurl1 = add('/ok1')
+            okurl2 = add('/ok2')
+
+            def verify(url):
+                return core.callStorm('''
+                    return($lib.crypto.jwt.verify($t, $k, ("RS256",),
+                        jwks_uri=$url, ssl_verify=(false), allowinternal=(true)))
+                ''', opts={'vars': {'t': tok, 'k': None, 'url': url}})
+
+            with mock.patch.object(s_jwt, 'JWKS_CACHE_MAX', 1):
+                # a failed fetch leaves an unlocked, uncached lock...
+                self.false((await verify(failurl))[0])
+                # ...which the next call prunes; and exceeding the cap evicts the oldest entry.
+                self.true((await verify(okurl1))[0])
+                self.true((await verify(okurl2))[0])
+
+            self.le(len(core.jwkscache), 1)
+
+            # a zero cap exercises the "nothing else to evict" break
+            with mock.patch.object(s_jwt, 'JWKS_CACHE_MAX', 0):
+                self.true((await verify(add('/ok3')))[0])
+
+    async def test_stormlib_jwt_pinned_resolver(self):
+
+        addrs = [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('1.2.3.4', 443))]
+        resolver = s_jwt._PinnedResolver(addrs)
+
+        res = await resolver.resolve('example.com', 443, socket.AF_INET)
+        self.eq(res[0]['host'], '1.2.3.4')
+        self.eq(res[0]['hostname'], 'example.com')
+
+        # a mismatched address family is filtered out
+        self.eq(await resolver.resolve('example.com', 443, socket.AF_INET6), [])
+
+        await resolver.close()

--- a/synapse/tests/test_lib_stormlib_rsa.py
+++ b/synapse/tests/test_lib_stormlib_rsa.py
@@ -1,0 +1,244 @@
+import base64
+
+import cryptography.hazmat.primitives.hashes as c_hashes
+import cryptography.hazmat.primitives.asymmetric.padding as c_padding
+
+import synapse.exc as s_exc
+import synapse.lib.crypto.rsa as s_rsa
+
+import synapse.tests.utils as s_test
+
+# A crypto:rsa:key primitivizes to a PEM string when it crosses a callStorm
+# boundary, so tests carry the PEM forms and reload the object with
+# $lib.crypto.rsa.load(...) inside each query.
+LOAD = '$key = $lib.crypto.rsa.load($prvpem)\n$pub = $lib.crypto.rsa.load($pubpem)\n'
+
+class StormLibRsaTest(s_test.SynTest):
+
+    async def _genKeyForms(self, core):
+        return await core.callStorm('''
+            $key = $lib.crypto.rsa.generate()
+            $pub = $key.pubkey()
+            return((
+                $key.encode(), $pub.encode(),
+                $key.encode(fmt="der"), $pub.encode(fmt="der"),
+            ))
+        ''')
+
+    async def test_stormlib_rsa_object(self):
+
+        async with self.getTestCore() as core:
+
+            prvpem, pubpem, prvder, pubder = await self._genKeyForms(core)
+
+            # generate() returns a private crypto:rsa:key; toprim yields a PEM private key
+            self.isinstance(prvpem, str)
+            self.true(prvpem.startswith('-----BEGIN PRIVATE KEY-----'))
+            self.true(await core.callStorm('return($lib.crypto.rsa.generate().isPrivate)'))
+
+            # toprim (applied at the callStorm return boundary) yields the PEM private key
+            toprimpem = await core.callStorm('return($lib.crypto.rsa.generate())')
+            self.true(toprimpem.startswith('-----BEGIN PRIVATE KEY-----'))
+
+            opts = {'vars': {'prvpem': prvpem, 'pubpem': pubpem}}
+
+            # encode() defaults to a PEM string, "pem" matches, and "der" returns bytes
+            enc, encpem, encder = await core.callStorm(
+                'return(($lib.crypto.rsa.load($prvpem).encode(), '
+                '$lib.crypto.rsa.load($prvpem).encode(fmt="pem"), '
+                '$lib.crypto.rsa.load($prvpem).encode(fmt="der")))', opts=opts)
+            self.isinstance(enc, str)
+            self.true(enc.startswith('-----BEGIN'))
+            self.eq(enc, encpem)
+            self.eq(encder, prvder)
+
+            # encode() with a bad format raises BadArg
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.rsa.load($prvpem).encode(fmt="newp"))', opts=opts)
+
+            # isPrivate reflects public vs private
+            self.true(await core.callStorm('return($lib.crypto.rsa.load($prvpem).isPrivate)', opts=opts))
+            self.false(await core.callStorm('return($lib.crypto.rsa.load($pubpem).isPrivate)', opts=opts))
+
+            # pubkey() returns a public-only key
+            self.false(await core.callStorm('return($lib.crypto.rsa.load($prvpem).pubkey().isPrivate)', opts=opts))
+            self.true(await core.callStorm(
+                'return($lib.crypto.rsa.load($prvpem).pubkey().encode().startswith("-----BEGIN PUBLIC KEY-----"))',
+                opts=opts))
+
+            # pubkey() on a public-only key raises BadArg
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.rsa.load($pubpem).pubkey())', opts=opts)
+
+            # sign() with a public-only key raises BadArg
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.rsa.load($pubpem).sign($lib.hex.decode("ab")))', opts=opts)
+
+    async def test_stormlib_rsa_signverify(self):
+
+        async with self.getTestCore() as core:
+
+            prvpem, pubpem, _, _ = await self._genKeyForms(core)
+            mesg = 'hello world'
+            base = {'prvpem': prvpem, 'pubpem': pubpem, 'mesg': mesg}
+
+            # pkcs1v15 sign/verify round-trips, is deterministic, and verifies on the pubkey too
+            opts = {'vars': dict(base, pad='pkcs1v15')}
+            sig = await core.callStorm(LOAD + 'return($key.sign($mesg.encode(), padding=$pad))', opts=opts)
+            self.isinstance(sig, bytes)
+            self.eq(sig, await core.callStorm(LOAD + 'return($key.sign($mesg.encode(), padding=$pad))', opts=opts))
+
+            opts = {'vars': dict(base, sig=sig, pad='pkcs1v15')}
+            self.true(await core.callStorm(LOAD + 'return($key.verify($mesg.encode(), $sig, padding=$pad))', opts=opts))
+            self.true(await core.callStorm(LOAD + 'return($pub.verify($mesg.encode(), $sig, padding=$pad))', opts=opts))
+
+            # a tampered message does not verify
+            opts = {'vars': dict(base, sig=sig, mesg='hello there', pad='pkcs1v15')}
+            self.false(await core.callStorm(LOAD + 'return($key.verify($mesg.encode(), $sig, padding=$pad))', opts=opts))
+
+            # pss is the default padding and is probabilistic, but both verify
+            opts = {'vars': base}
+            psig1 = await core.callStorm(LOAD + 'return($key.sign($mesg.encode()))', opts=opts)
+            psig2 = await core.callStorm(LOAD + 'return($key.sign($mesg.encode()))', opts=opts)
+            self.ne(psig1, psig2)
+
+            for sigv in (psig1, psig2):
+                opts = {'vars': dict(base, sig=sigv)}
+                self.true(await core.callStorm(LOAD + 'return($key.verify($mesg.encode(), $sig))', opts=opts))
+
+            # padding schemes do not cross-validate
+            opts = {'vars': dict(base, sig=psig1, pad='pkcs1v15')}
+            self.false(await core.callStorm(LOAD + 'return($key.verify($mesg.encode(), $sig, padding=$pad))', opts=opts))
+
+            opts = {'vars': dict(base, sig=sig)}
+            self.false(await core.callStorm(LOAD + 'return($key.verify($mesg.encode(), $sig))', opts=opts))
+
+            # each supported hash algorithm round-trips under both paddings
+            for pad in ('pkcs1v15', 'pss'):
+                for hashalgo in ('sha256', 'sha384', 'sha512'):
+                    opts = {'vars': dict(base, pad=pad, hashalgo=hashalgo)}
+                    asig = await core.callStorm(
+                        LOAD + 'return($key.sign($mesg.encode(), padding=$pad, hashalgo=$hashalgo))', opts=opts)
+                    opts = {'vars': dict(base, sig=asig, pad=pad, hashalgo=hashalgo)}
+                    self.true(await core.callStorm(
+                        LOAD + 'return($pub.verify($mesg.encode(), $sig, padding=$pad, hashalgo=$hashalgo))', opts=opts))
+
+            # a signature made with one hash does not verify under another
+            opts = {'vars': dict(base, hashalgo='sha384')}
+            sig384 = await core.callStorm(LOAD + 'return($key.sign($mesg.encode(), hashalgo=$hashalgo))', opts=opts)
+            opts = {'vars': dict(base, sig=sig384, hashalgo='sha512')}
+            self.false(await core.callStorm(
+                LOAD + 'return($key.verify($mesg.encode(), $sig, hashalgo=$hashalgo))', opts=opts))
+
+            # padding and hash names are case insensitive
+            opts = {'vars': base}
+            usig = await core.callStorm(
+                LOAD + 'return($key.sign($mesg.encode(), padding="PSS", hashalgo="SHA256"))', opts=opts)
+            opts = {'vars': dict(base, sig=usig)}
+            self.true(await core.callStorm(
+                LOAD + 'return($key.verify($mesg.encode(), $sig, padding="PSS", hashalgo="SHA256"))', opts=opts))
+
+            # cross-check both schemes against cryptography directly
+            pubobj = s_rsa.PubKey.load(pubpem.encode(), fmt='pem')
+            self.none(pubobj.publ.verify(sig, mesg.encode(), c_padding.PKCS1v15(), c_hashes.SHA256()))
+            cpad = c_padding.PSS(c_padding.MGF1(c_hashes.SHA256()), c_padding.PSS.MAX_LENGTH)
+            self.none(pubobj.publ.verify(psig1, mesg.encode(), cpad, c_hashes.SHA256()))
+
+            # BadArg on non-bytes byts / signature, bad padding, bad hashalgo
+            opts = {'vars': base}
+            with self.raises(s_exc.BadArg):
+                await core.callStorm(LOAD + 'return($key.sign((1234)))', opts=opts)
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm(LOAD + 'return($key.sign($mesg.encode(), padding="newp"))', opts=opts)
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm(LOAD + 'return($key.sign($mesg.encode(), hashalgo="newp"))', opts=opts)
+
+            opts = {'vars': dict(base, sig=sig)}
+            with self.raises(s_exc.BadArg):
+                await core.callStorm(LOAD + 'return($key.verify($mesg.encode(), (1234)))', opts=opts)
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm(LOAD + 'return($key.verify($mesg.encode(), $sig, padding="newp"))', opts=opts)
+
+    async def test_stormlib_rsa_load(self):
+
+        async with self.getTestCore() as core:
+
+            prvpem, pubpem, prvder, pubder = await self._genKeyForms(core)
+
+            # each encoding/kind auto-detects on load
+            for key, isprivate in ((prvpem, True), (pubpem, False), (prvder, True), (pubder, False)):
+                opts = {'vars': {'key': key}}
+                self.eq(isprivate, await core.callStorm('return($lib.crypto.rsa.load($key).isPrivate)', opts=opts))
+
+            # a PEM key may also be provided as bytes
+            opts = {'vars': {'key': prvpem.encode()}}
+            self.true(await core.callStorm('return($lib.crypto.rsa.load($key).isPrivate)', opts=opts))
+
+            # a blob containing multiple keys is rejected
+            opts = {'vars': {'key': prvpem + pubpem}}
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.rsa.load($key))', opts=opts)
+
+            # an ECC key is rejected by the RSA loader
+            eccpem = await core.callStorm('return($lib.crypto.ecc.generate().encode())')
+            opts = {'vars': {'key': eccpem}}
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.rsa.load($key))', opts=opts)
+
+            # garbage and unsupported key-argument types are rejected
+            opts = {'vars': {'key': b'not a real key'}}
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.rsa.load($key))', opts=opts)
+
+            with self.raises(s_exc.BadArg):
+                await core.callStorm('return($lib.crypto.rsa.load((1234)))')
+
+    async def test_stormlib_rsa_generate(self):
+
+        async with self.getTestCore() as core:
+
+            # the lower bound on bits is accepted
+            self.true(await core.callStorm('return($lib.crypto.rsa.generate(bits=(1024)).isPrivate)'))
+
+            # sizes outside 1024-8192 are rejected with BadArg
+            for bits in (8, 512, 1023, 8193, 16384):
+                with self.raises(s_exc.BadArg):
+                    await core.callStorm('return($lib.crypto.rsa.generate(bits=$bits))',
+                                         opts={'vars': {'bits': bits}})
+
+    async def test_stormlib_rsa_jwt(self):
+
+        async with self.getTestCore() as core:
+
+            prvpem, pubpem, _, _ = await self._genKeyForms(core)
+
+            # build an RS256 JWT purely from a crypto:rsa:key object
+            header = '{"alg":"RS256","typ":"JWT"}'
+            payload = '{"sub":"1234567890","name":"vtx"}'
+
+            q = '''
+            $key = $lib.crypto.rsa.load($prvpem)
+            $h64 = $lib.base64.encode($header.encode(), urlsafe=(true)).rstrip("=")
+            $p64 = $lib.base64.encode($payload.encode(), urlsafe=(true)).rstrip("=")
+            $signin = `{$h64}.{$p64}`
+            $sig = $key.sign($signin.encode(), padding="pkcs1v15")
+            $s64 = $lib.base64.encode($sig, urlsafe=(true)).rstrip("=")
+            return(`{$signin}.{$s64}`)
+            '''
+            opts = {'vars': {'prvpem': prvpem, 'header': header, 'payload': payload}}
+            token = await core.callStorm(q, opts=opts)
+
+            parts = token.split('.')
+            self.len(3, parts)
+
+            # the signing input round-trips through verify on the public key
+            signin = f'{parts[0]}.{parts[1]}'
+            s64 = parts[2]
+            sigbytes = base64.urlsafe_b64decode(s64 + '=' * (-len(s64) % 4))
+
+            opts = {'vars': {'pubpem': pubpem, 'signin': signin, 'sig': sigbytes}}
+            self.true(await core.callStorm(
+                'return($lib.crypto.rsa.load($pubpem).verify($signin.encode(), $sig, padding="pkcs1v15"))', opts=opts))


### PR DESCRIPTION
## Summary

This PR adds a cohesive family of first-class Storm cryptography libraries. `$lib.crypto.rsa`
and `$lib.crypto.ecc` generate and load asymmetric keys as first-class `crypto:rsa:key` /
`crypto:ecc:key` Storm objects that sign, verify, and encode themselves, and `$lib.crypto.jwt`
builds on them (plus HMAC) to construct, sign, and verify JSON Web Tokens. They share the same
conventions -- selectable hash algorithms, `s_exc.BadArg` on bad input -- so they read as one
coherent capability rather than three separate features. A key object serializes (`toprim()`) to
a PEM string, so it drops straight into `$lib.crypto.jwt` and anywhere else a PEM key is
accepted; JWT HS* secrets and any raw PEM key argument may be a str or bytes.

Everything is built on the existing `cryptography` dependency and stdlib `hmac`/`hashlib` (plus
the already-present `aiohttp`/`aiohttp_socks` for the JWKS fetch) -- no new dependencies. JWK /
JWKS and the JOSE header are supported; JWE decryption is out of scope (a JWE is detected and
rejected). All key generation, signing, and verification is run in the executor pool so the
ioloop is never blocked.

## The libraries

### `$lib.crypto.rsa` -- the `crypto:rsa:key` object

RSA keys, with both PKCS#1 v1.5 and PSS padding and selectable hash (sha256/384/512).

- `$lib.crypto.rsa.generate(bits=2048)` -> a `crypto:rsa:key` private key. `bits` is bounded to
  1024-8192 and rejected with `BadArg` outside that range.
- `$lib.crypto.rsa.load(key)` -> a `crypto:rsa:key`. The `key` is a single DER (bytes) or PEM
  (str or bytes) blob, public or private; the encoding and public/private are auto-detected. A
  blob containing more than one key, or a non-RSA key, is rejected with `BadArg`.

The `crypto:rsa:key` object:

- `isPrivate` -- boolean, true when a private key is held (can sign).
- `sign(byts, padding='pss', hashalgo='sha256')` -> signature bytes (raises unless `isPrivate`).
- `verify(byts, signature, padding='pss', hashalgo='sha256')` -> bool (public or private key).
- `pubkey()` -> a new public-only `crypto:rsa:key` (raises if already public-only).
- `encode(fmt='pem')` -> a PEM string, or DER bytes when `fmt='der'`.
- `toprim()` -> the key as a PEM string (private PEM for a private key), for portability/interop.

Hash algorithm names are case insensitive across both `rsa` and `ecc` (`hashalgo="SHA256"` works).
The sign/verify hash argument is named `hashalgo` (not `alg`) to leave `alg` free for
signing-algorithm APIs such as the JWT `alg`.

### `$lib.crypto.ecc` -- the `crypto:ecc:key` object

ECC keys over the NIST curves, mirroring the RSA object. ECDSA signatures are DER encoded.

- `$lib.crypto.ecc.generate(curve='P-256')` -> a `crypto:ecc:key` private key. Supports P-256, P-384, P-521.
- `$lib.crypto.ecc.load(key)` -> a `crypto:ecc:key` (same auto-detecting single-key load as RSA).

The `crypto:ecc:key` object mirrors `crypto:rsa:key` (`isPrivate`, `pubkey()`, `encode()`,
`toprim()` to PEM) with a padding-free signature API:

- `sign(byts, hashalgo='sha256')` -> DER signature bytes (raises unless `isPrivate`).
- `verify(byts, signature, hashalgo='sha256')` -> bool.

### `$lib.crypto.jwt` -- the JWT namespace and the `crypto:jwt` object

`$lib.crypto.jwt` is a namespace library that composes the RSA, ECC, and HMAC primitives into
full JWT support:

- `$lib.crypto.jwt.generate(payload=$lib.null)` -> a new unsigned `crypto:jwt`.
- `$lib.crypto.jwt.verify(token, key, algorithms, ...)` -> an `($ok, $valu)` tuple; on success
  `$valu` is a verified `crypto:jwt` object, on failure a dict of error info. Never raises.
- `$lib.crypto.jwt.parse(token)` -> a key-free `{typ, header}` structural read (JWS vs JWE).
- `$lib.crypto.jwt.algorithms` (gtor) -> a new list of the supported JWS algorithm names.

The `crypto:jwt` object:

- `payload` (gtor): a `crypto:jwt:dict` validated against the RFC 7519 registered-claim schema
  (`reqValidJwtClaims`, defined centrally in `synapse/lib/schemas.py` alongside the other project
  validators); individual claims are settable while constructing (`$token.payload.sub = "..."`)
  and become immutable once signed or verified.
- `header` (gtor): the JOSE header, settable until the token locks; `sign()` force-sets `alg`.
- `signature`: the raw signature bytes (null until signed/verified).
- `sign(key, alg, fmt='compact')` -> a JWT string. `fmt='json'` emits the flattened JWS JSON
  serialization. `key` accepts a PEM key, an HS* secret, or a `crypto:rsa:key`/`crypto:ecc:key`.

`verify()` takes the claim-validation options `audience`, `issuer`, `subject`, `leeway`, `typ`,
`requiredclaims`, and an `options` toggle dict; `exp`/`nbf`/`iat` are checked automatically when
present and `aud`/`iss`/`sub` when an expected value is supplied. Its `key` may additionally be a
JWK / JWKS dictionary (selected by the token `kid`), or null with a `jwks_uri` to fetch the key
set over HTTPS. The fetch is controlled by the same `ssl_verify` / `ssl_opts` / `proxy` arguments
presented by `$lib.inet.http`, plus an `allowinternal` toggle; results are cached with a TTL,
single-flight, and serve-stale-on-failure. The token's `jku`/`x5u`/`jwk` are never followed.

Supported algorithms span all three primitives: `HS256/384/512` (HMAC), `RS256/384/512`
(RSA PKCS#1 v1.5), `PS256/384/512` (RSA-PSS, digest-length salt per RFC 7518), and
`ES256/384/512` (ECDSA over P-256/P-384/P-521, using the JWT raw `R||S` signature encoding).

Header/payload are serialized and parsed via `synapse.lib.json` (the project's yyjson-backed
JSON library) rather than stdlib `json`. The signature is always computed over the exact emitted
bytes (sign) or the exact received segment bytes (verify), so serialization details never affect
verification.

## Backend work

The Storm libraries are backed by additions to the low-level crypto helpers:

- `synapse/lib/crypto/utils.py` (new): the shared name-lookup helpers used by both backends --
  `getHashByName`, `getEncodingByName`, `getCurveByName`, and `getPaddingByName` -- so the
  `sha*`/`der`/`pem`/curve/padding maps live in one place (all case-insensitive, `BadArg` on an
  unknown name). It also hosts the single base64url codec `enbase64url`/`debase64url` (the JOSE
  no-padding convention, str-or-bytes tolerant on decode) shared by the JWT layer and the JWK
  backend, and `loadKey(byts)`, the single-key auto-detecting loader shared by both key families:
  it counts `-----BEGIN` markers to reject multi-key PEM blobs, then tries private-then-public
  for the detected PEM/DER encoding, returning an `(isprivate, key)` tuple.
- `synapse/lib/crypto/jwk.py` (new): JWK <-> key conversion (`jwkToKey`) for RSA / EC public and
  private keys and the RFC 7638 thumbprint (`jwkThumbprint`).
- `synapse/lib/crypto/rsa.py`: additive -- a unified `sign(byts, padding='pss', hashalgo='sha256',
  saltlen=None)` and `verify(byts, sign, padding='pss', hashalgo='sha256', saltlen=None)` whose
  defaults reproduce the previous PSS/MGF1/SHA256/MAX_LENGTH behavior; `generate(bits=2048)`;
  `dump(fmt='der')` / `load(byts, fmt='der')` on both `PriKey` and `PubKey`; and a module-level
  `loadKey(byts)` that type-checks the RSA family. The existing `signitem`/`verifyitem` (used by
  the Cortex package-signature path and `certdir`) are preserved unchanged.
- `synapse/lib/crypto/ecc.py`: additive -- a selectable hash on `sign`/`verify`,
  `dump(fmt='der')` / `load(byts, fmt='der')`, and an ECC-family `loadKey(byts)` wrapper;
  `generate(curve='SECP384R1')` and `exchange`/`doECDHE` are unchanged. `fmt` accepts `"der"`
  (default, so existing callers are unaffected) or `"pem"`, and anything else raises `BadArg`.

At the Storm layer, `synapse/lib/stormlib/cryptoutils.py` holds the shared `CryptoKey(Prim)` base
for the `crypto:rsa:key` / `crypto:ecc:key` objects (it wires `isPrivate`, `pubkey()`, `encode()`,
and the `toprim()`-to-PEM behavior; the two subclasses add their `sign`/`verify`), plus the
argument-coercion and key-load glue the three crypto stormlibs share (`reqBytes`, `reqKey`,
`reqPadding`, the priv/pub-specific `loadRsaPriv`/`loadRsaPub` used by JWT, and the
auto-detecting loaders used by `load()`). This lives at the stormlib layer, not `crypto/utils.py`,
because it depends on `synapse.lib.stormtypes`.

Every Storm-reachable crypto path raises Synapse exceptions rather than raw Python errors, so a
`ValueError` (or other `cryptography`/stdlib exception) can never surface in the Storm runtime.
Input validation raises `s_exc.BadArg` (key-type mismatches, malformed JWK members, an
unsupported curve/`kty`, and so on); the key-load boundary in `cryptoutils.py` funnels every
`cryptography` load failure -- `ValueError`, `TypeError`, `UnsupportedAlgorithm`, `InvalidKey` --
into `BadArg`; and `jwkToKey` is fully fail-closed (an off-curve point or malformed member becomes
`BadArg`, never a leaked library error).

## Security

The JWT verify path is fail-closed and its behavior under known JWT attacks is pinned by a
dedicated test class (`StormLibJwtAttackTest`):

- **`alg:none`** is never supported and cannot be requested.
- **Algorithm allowlist is mandatory** -- the algorithm is chosen by the verifier's `algorithms`
  list, never trusted from the token header.
- **Key-type / alg binding** closes the residual RS256->HS256 confusion footgun: an asymmetric
  key (PEM, or a `crypto:*:key`) is structurally rejected as an HMAC secret and a raw secret is
  rejected for RS*/PS*/ES*, so the forgery fails even under an `HS256` allowlist.
- **Minimum key sizes** are enforced (HMAC secret >= hash output, RSA >= 2048 bits).
- **Signature tampering** is rejected; HMAC comparison uses `hmac.compare_digest`; an all-zero
  `R||S` ECDSA "psychic signature" fails.
- **Strict base64url**: token segments (and JWK members) are decoded strictly, so whitespace or
  any non-base64url character is rejected rather than silently discarded. This closes a
  malleability gap where whitespace in the signature segment (which is not part of the signing
  input) was ignored and the token still verified.
- **Claim validation** is fail-closed: `exp`/`nbf`/`iat` are checked when present, `aud`/`iss`/
  `sub` against caller-supplied expected values (exact/membership, never substring), and an
  unsupported `crit` header is rejected. A falsy `aud` (absent, empty string, or empty list) has
  no value to identify with, so a token is rejected when an audience is required (RFC 7519 4.1.3).
  On the construction side, `iss`/`sub`/`aud` are validated as RFC 7519 StringOrURI (a value
  containing a `:` must be a valid RFC 3986 URI); the verify path stays lenient toward third-party
  tokens.
- **`kid` is an opaque selector** into a caller-supplied JWK/JWKS only -- never a path, URL, or
  DB key. The token's `jku`/`x5u`/`jwk` are never followed; a `jwks_uri` is caller-supplied and
  fetched https-only with no redirects, a size cap, and (unless `allowinternal`) a block on
  loopback/link-local/private/metadata addresses.
- **ES curve/alg confusion** is rejected (the key curve must match the algorithm), and a
  DER-encoded ECDSA signature (rather than the JWT raw `R||S` form) fails verification.
- **JWE** is detected and rejected (no decryption surface).

## Performance / ioloop

Every key generation, signing, and verification call across all three libraries runs in the
executor pool via `s_coro.executor`, so none of them block the event loop. This matters most for
RSA key generation (~30 ms at 2048 bits, ~500 ms+ at 4096 bits) and for large JWT payloads. The
async argument coercions and Storm object state mutations remain on the loop; only the synchronous
crypto bodies are offloaded. Key `load()`/`encode()` are cheap parse/serialize operations and stay
on the loop.

## Tests

- `test_lib_stormlib_rsa.py` -- `crypto:rsa:key` object round-trips (sign/verify across both
  paddings and hashes, `pubkey()`, `encode()`, `isPrivate`, `toprim()`), the full `load()`
  auto-detect matrix (PEM/DER x public/private, multi-key and wrong-family rejection), the bits
  bounds, and an RS256 JWT built from the object; cross-checked against `cryptography` directly.
- `test_lib_stormlib_ecc.py` -- the `crypto:ecc:key` counterpart per curve and hash, same
  `load()` matrix and object surface, cross-checked against `cryptography` directly.
- `test_lib_stormlib_jwt.py` -- `StormLibJwtTest` (round-trips for the HS/RS/PS/ES families and
  both serializations, JOSE header, claim validation matrix, schema/string-key enforcement,
  hardening), `StormLibJwtAttackTest` (the attacks above), and `StormLibJwtJwksTest` (JWK/JWKS
  selection by `kid`, and a `jwks_uri` fetch against a local HTTPS server exercising the SSRF
  guard, size cap, TTL cache, single-flight, serve-stale, and key rotation).
- `test_lib_crypto_jwk.py` -- JWK<->key conversion for RSA/EC (public and private), off-curve
  rejection, and the RFC 7638 thumbprint vector.
- `test_lib_crypto_rsa.py` / `test_lib_crypto_ecc.py` -- backend `loadKey` autodetect unit tests
  (PEM/DER x public/private, multi-key and wrong-family rejection) and the selectable
  padding/hash and `fmt` round-trips.

Interoperability was additionally cross-validated against **PyJWT 2.12.1** (out-of-tree harness,
not committed) -- 49 checks, all passing, covering both our output against their loading and their
output against our loading:

- **Both directions, all twelve algorithms** (HS/RS/PS/ES 256/384/512): a token produced by
  `sign()` parses and verifies under `pyjwt.decode()` with the claims intact, and a token produced
  by `pyjwt.encode()` verifies under `crypto:jwt.verify()` -- including the full registered-claim
  set (`iss`/`sub`/`aud`/`exp`/`nbf`/`iat`/`jti`) plus a private claim.
- **Flattened-JSON output** (`fmt='json'`) for RS256/PS256/ES256: the emitted
  `{protected, payload, signature}` reconstructs to a compact token that PyJWT verifies.
- **JWK / JWKS interop** for RS256 and ES256: a PyJWT-signed token verifies under our
  `kid`-selected JWKS; a token we signed verifies under a `PyJWK` built from our JWK; and a JWK
  produced by PyJWT's own `to_jwk()` is consumed by our loader. The `jwkThumbprint` output matches
  an independent RFC 7638 computation.
- **Claim-validation parity**: an expired `exp`, a future `nbf`, a wrong `audience`, and a wrong
  `issuer` are each rejected by both libraries.
- **Whitespace parity**: a token mutated with leading/trailing/interior whitespace (in any segment)
  is rejected by both libraries.
- **StringOrURI**: a deliberate, spec-driven divergence -- PyJWT accepts a non-URI colon `iss`
  while our construction rejects it -- alongside empty-string parity, where both libraries accept
  empty `iss`/`sub`, both reject an empty `aud` during audience validation (RFC 7519 4.1.3), and
  both accept an empty element inside a non-empty `aud` array.

This confirms the tokens, JWKs, and claim semantics are standard and spec-compliant in both
production and consumption.

## Files

New:
- `synapse/lib/crypto/utils.py`
- `synapse/lib/crypto/jwk.py`
- `synapse/lib/stormlib/cryptoutils.py`
- `synapse/lib/stormlib/rsa.py`
- `synapse/lib/stormlib/ecc.py`
- `synapse/lib/stormlib/jwt.py`
- `synapse/tests/test_lib_crypto_jwk.py`
- `synapse/tests/test_lib_crypto_rsa.py`
- `synapse/tests/test_lib_stormlib_rsa.py`
- `synapse/tests/test_lib_stormlib_ecc.py`
- `synapse/tests/test_lib_stormlib_jwt.py`
- `changes/*.yaml` (three `feat` changelog fragments -- one per library)

Modified:
- `synapse/lib/crypto/rsa.py` (backend additions, incl. `loadKey`)
- `synapse/lib/crypto/ecc.py` (backend additions, incl. `loadKey`)
- `synapse/lib/schemas.py` (the RFC 7519 registered-claim schema + `reqValidJwtClaims` validator)
- `synapse/cortex.py` (register the `rsa`, `ecc`, and `jwt` stormlib imports; per-Cortex JWKS caches)
- `synapse/tests/test_lib_crypto_ecc.py`

Docs: the `$lib.crypto.*` reference is generated from `_storm_locals` metadata; no hand-edited docs.

## Notes for reviewers

- No new runtime dependency; the whole family builds on `cryptography` and stdlib.
- Backend `crypto/rsa.py` / `crypto/ecc.py` changes are additive; existing callers keep their
  behavior (the new `sign`/`verify`/`dump`/`load` defaults reproduce the prior output, and
  `signitem`/`verifyitem` are unchanged).
- `$lib.crypto.jwt.verify()` never raises -- every outcome, including invalid input (bad/empty
  algorithm allowlist, bad key type, malformed token), is returned as the `($ok, $info)` tuple so
  callers can branch on `$ok` without a Storm try/except. `sign()` still raises `BadArg` on bad
  input.
- The registered-claim JSON Schema and its `reqValidJwtClaims` validator live in the shared
  `synapse/lib/schemas.py` rather than in the stormlib, keeping all project schemas in one place.
  No explicit `$lib.crypto` namespace class is registered; the parent namespace is synthesized from
  the child `('crypto', ...)` lib paths of `rsa`/`ecc`/`jwt`, extending the existing `$lib.crypto`
  namespace (`hashes`/`hmac`).
