### PR TITLE
Add it:app:suricata:rule and it:app:suricata:matched forms

### DIFF
--- a/changes/65d5b1092a529b30765cbf10acf0ef51.yaml
+++ b/changes/65d5b1092a529b30765cbf10acf0ef51.yaml
@@ -1,0 +1,6 @@
+---
+desc: Added ``it:app:suricata:rule`` and ``it:app:suricata:matched`` forms.
+desc:literal: false
+prs: []
+type: model
+...

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -3248,14 +3248,19 @@ class ItModule(s_module.CoreModule):
                 )),
 
                 ('it:app:suricata:matched', {}, (
+
                     ('rule', ('it:app:suricata:rule', {}), {
                         'doc': 'The suricata rule that matched the file.'}),
+
                     ('target', ('inet:flow', {}), {
                         'doc': 'The inet:flow that matched the suricata rule.'}),
+
                     ('time', ('time', {}), {
                         'doc': 'The time of the network flow that caused the hit.'}),
+
                     ('sensor', ('it:host', {}), {
                         'doc': 'The sensor host node that produced the hit.'}),
+
                     ('version', ('it:semver', {}), {
                         'doc': 'The version of the rule at the time of match.'}),
 

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -3245,32 +3245,13 @@ class ItModule(s_module.CoreModule):
 
                     ('enabled', ('bool', {}), {
                         'doc': 'The rule enabled status to be used for suricata evaluation engines.'}),
-
-                    ('family', ('it:prod:softname', {}), {
-                        'doc': 'The name of the software family the rule is designed to detect.'}),
                 )),
 
                 ('it:app:suricata:matched', {}, (
                     ('rule', ('it:app:suricata:rule', {}), {
                         'doc': 'The suricata rule that matched the file.'}),
-                    ('flow', ('inet:flow', {}), {
+                    ('target', ('inet:flow', {}), {
                         'doc': 'The inet:flow that matched the suricata rule.'}),
-                    ('src', ('inet:addr', {}), {
-                        'doc': 'The source address of flow that caused the hit.'}),
-                    ('src:ipv4', ('inet:ipv4', {}), {
-                        'doc': 'The source IPv4 address of the flow that caused the hit.'}),
-                    ('src:ipv6', ('inet:ipv6', {}), {
-                        'doc': 'The source IPv6 address of the flow that caused the hit.'}),
-                    ('src:port', ('inet:port', {}), {
-                        'doc': 'The source port of the flow that caused the hit.'}),
-                    ('dst', ('inet:addr', {}), {
-                        'doc': 'The destination address of the trigger.'}),
-                    ('dst:ipv4', ('inet:ipv4', {}), {
-                        'doc': 'The destination IPv4 address of the flow that caused the hit.'}),
-                    ('dst:ipv6', ('inet:ipv6', {}), {
-                        'doc': 'The destination IPv4 address of the flow that caused the hit.'}),
-                    ('dst:port', ('inet:port', {}), {
-                        'doc': 'The destination port of the flow that caused the hit.'}),
                     ('time', ('time', {}), {
                         'doc': 'The time of the network flow that caused the hit.'}),
                     ('sensor', ('it:host', {}), {

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -3238,7 +3238,7 @@ class ItModule(s_module.CoreModule):
                         'doc': 'Contact info for the author of the rule.'}),
 
                     ('created', ('time', {}), {
-                        'doc': 'The time the rule was initially created.'}),
+                        'doc': 'The time the rule was created.'}),
 
                     ('updated', ('time', {}), {
                         'doc': 'The time the rule was most recently modified.'}),

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -3256,7 +3256,7 @@ class ItModule(s_module.CoreModule):
                         'doc': 'The inet:flow that matched the suricata rule.'}),
 
                     ('time', ('time', {}), {
-                        'doc': 'The time of the network flow that caused the hit.'}),
+                        'doc': 'The time that the rule matched the network flow.'}),
 
                     ('sensor', ('it:host', {}), {
                         'doc': 'The sensor host node that produced the hit.'}),

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -1049,6 +1049,12 @@ class ItModule(s_module.CoreModule):
                 ('it:app:snort:hit', ('guid', {}), {
                     'doc': 'An instance of a snort rule hit.',
                 }),
+                ('it:app:suricata:rule', ('guid', {}), {
+                    'doc': 'A suricata rule.',
+                }),
+                ('it:app:suricata:matched', ('guid', {}), {
+                    'doc': 'An instance of a suricata rule hit.',
+                }),
                 ('it:reveng:function', ('guid', {}), {
                     'doc': 'A function inside an executable.',
                 }),
@@ -1119,6 +1125,8 @@ class ItModule(s_module.CoreModule):
                     'doc': 'The target node was returned as a result of running the query.'}),
                 (('it:app:snort:rule', 'detects', None), {
                     'doc': 'The snort rule is intended for use in detecting the target node.'}),
+                (('it:app:suricata:rule', 'detects', None), {
+                    'doc': 'The suricata rule is intended for use in detecting the target node.'}),
                 (('it:app:yara:rule', 'detects', None), {
                     'doc': 'The YARA rule is intended for use in detecting the target node.'}),
                 (('it:dev:repo', 'has', 'inet:url'), {
@@ -3180,6 +3188,73 @@ class ItModule(s_module.CoreModule):
                         'doc': 'The snort rule that matched the file.'}),
                     ('flow', ('inet:flow', {}), {
                         'doc': 'The inet:flow that matched the snort rule.'}),
+                    ('src', ('inet:addr', {}), {
+                        'doc': 'The source address of flow that caused the hit.'}),
+                    ('src:ipv4', ('inet:ipv4', {}), {
+                        'doc': 'The source IPv4 address of the flow that caused the hit.'}),
+                    ('src:ipv6', ('inet:ipv6', {}), {
+                        'doc': 'The source IPv6 address of the flow that caused the hit.'}),
+                    ('src:port', ('inet:port', {}), {
+                        'doc': 'The source port of the flow that caused the hit.'}),
+                    ('dst', ('inet:addr', {}), {
+                        'doc': 'The destination address of the trigger.'}),
+                    ('dst:ipv4', ('inet:ipv4', {}), {
+                        'doc': 'The destination IPv4 address of the flow that caused the hit.'}),
+                    ('dst:ipv6', ('inet:ipv6', {}), {
+                        'doc': 'The destination IPv4 address of the flow that caused the hit.'}),
+                    ('dst:port', ('inet:port', {}), {
+                        'doc': 'The destination port of the flow that caused the hit.'}),
+                    ('time', ('time', {}), {
+                        'doc': 'The time of the network flow that caused the hit.'}),
+                    ('sensor', ('it:host', {}), {
+                        'doc': 'The sensor host node that produced the hit.'}),
+                    ('version', ('it:semver', {}), {
+                        'doc': 'The version of the rule at the time of match.'}),
+
+                    ('dropped', ('bool', {}), {
+                        'doc': 'Set to true if the network traffic was dropped due to the match.'}),
+                )),
+
+                ('it:app:suricata:rule', {}, (
+
+                    ('id', ('str', {}), {
+                        'doc': 'The suricata rule id.'}),
+
+                    ('text', ('str', {}), {
+                        'disp': {'hint': 'text'},
+                        'doc': 'The suricata rule text.'}),
+
+                    ('name', ('str', {}), {
+                        'doc': 'The name of the suricata rule.'}),
+
+                    ('desc', ('str', {}), {
+                        'disp': {'hint': 'text'},
+                        'doc': 'A brief description of the suricata rule.'}),
+
+                    ('version', ('it:semver', {}), {
+                        'doc': 'The current version of the rule.'}),
+
+                    ('author', ('ps:contact', {}), {
+                        'doc': 'Contact info for the author of the rule.'}),
+
+                    ('created', ('time', {}), {
+                        'doc': 'The time the rule was initially created.'}),
+
+                    ('updated', ('time', {}), {
+                        'doc': 'The time the rule was most recently modified.'}),
+
+                    ('enabled', ('bool', {}), {
+                        'doc': 'The rule enabled status to be used for suricata evaluation engines.'}),
+
+                    ('family', ('it:prod:softname', {}), {
+                        'doc': 'The name of the software family the rule is designed to detect.'}),
+                )),
+
+                ('it:app:suricata:matched', {}, (
+                    ('rule', ('it:app:suricata:rule', {}), {
+                        'doc': 'The suricata rule that matched the file.'}),
+                    ('flow', ('inet:flow', {}), {
+                        'doc': 'The inet:flow that matched the suricata rule.'}),
                     ('src', ('inet:addr', {}), {
                         'doc': 'The source address of flow that caused the hit.'}),
                     ('src:ipv4', ('inet:ipv4', {}), {

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -1799,7 +1799,6 @@ class InfotechModelTest(s_t_utils.SynTest):
                 :created = 20120101
                 :updated = 20220101
                 :enabled=1
-                :family=redtree
                 :version=1.2.3
                 +(detects)> {[ it:prod:softname=woot ]}
             ]
@@ -1810,7 +1809,6 @@ class InfotechModelTest(s_t_utils.SynTest):
             self.eq('foo', nodes[0].get('name'))
             self.eq('gronk', nodes[0].get('text'))
             self.eq('bar', nodes[0].get('desc'))
-            self.eq('redtree', nodes[0].get('family'))
             self.eq(True, nodes[0].get('enabled'))
             self.eq(0x10000200003, nodes[0].get('version'))
             self.eq(1325376000000, nodes[0].get('created'))
@@ -1820,26 +1818,14 @@ class InfotechModelTest(s_t_utils.SynTest):
             self.len(1, await core.nodes('it:app:suricata:rule -(detects)> it:prod:softname'))
 
             nodes = await core.nodes('''[ it:app:suricata:matched=$hit
-                :rule=$rule :flow=$flow :src="tcp://[::ffff:0102:0304]:0"
-                :dst="tcp://[::ffff:0505:0505]:80" :time=2015 :sensor=$host
+                :rule=$rule :target=$flow :time=2015 :sensor=$host
                 :version=1.2.3 :dropped=true ]''', opts=opts)
             self.len(1, nodes)
             self.true(nodes[0].get('dropped'))
             self.eq(rule, nodes[0].get('rule'))
-            self.eq(flow, nodes[0].get('flow'))
+            self.eq(flow, nodes[0].get('target'))
             self.eq(host, nodes[0].get('sensor'))
             self.eq(1420070400000, nodes[0].get('time'))
-
-            self.eq('tcp://[::ffff:1.2.3.4]:0', nodes[0].get('src'))
-            self.eq(0, nodes[0].get('src:port'))
-            self.eq(0x01020304, nodes[0].get('src:ipv4'))
-            self.eq('::ffff:1.2.3.4', nodes[0].get('src:ipv6'))
-
-            self.eq('tcp://[::ffff:5.5.5.5]:80', nodes[0].get('dst'))
-            self.eq(80, nodes[0].get('dst:port'))
-            self.eq(0x05050505, nodes[0].get('dst:ipv4'))
-            self.eq('::ffff:5.5.5.5', nodes[0].get('dst:ipv6'))
-
             self.eq(0x10000200003, nodes[0].get('version'))
 
     async def test_it_reveng(self):

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -1779,6 +1779,69 @@ class InfotechModelTest(s_t_utils.SynTest):
 
             self.eq(0x10000200003, nodes[0].get('version'))
 
+    async def test_it_app_suricata(self):
+
+        async with self.getTestCore() as core:
+
+            hit = s_common.guid()
+            rule = s_common.guid()
+            flow = s_common.guid()
+            host = s_common.guid()
+            opts = {'vars': {'rule': rule, 'flow': flow, 'host': host, 'hit': hit}}
+
+            nodes = await core.nodes('''
+            [ it:app:suricata:rule=$rule
+                :id=999
+                :text=gronk
+                :name=foo
+                :desc=bar
+                :author = {[ ps:contact=* :name=visi ]}
+                :created = 20120101
+                :updated = 20220101
+                :enabled=1
+                :family=redtree
+                :version=1.2.3
+                +(detects)> {[ it:prod:softname=woot ]}
+            ]
+            ''', opts=opts)
+
+            self.len(1, nodes)
+            self.eq('999', nodes[0].get('id'))
+            self.eq('foo', nodes[0].get('name'))
+            self.eq('gronk', nodes[0].get('text'))
+            self.eq('bar', nodes[0].get('desc'))
+            self.eq('redtree', nodes[0].get('family'))
+            self.eq(True, nodes[0].get('enabled'))
+            self.eq(0x10000200003, nodes[0].get('version'))
+            self.eq(1325376000000, nodes[0].get('created'))
+            self.eq(1640995200000, nodes[0].get('updated'))
+            self.nn(nodes[0].get('author'))
+
+            self.len(1, await core.nodes('it:app:suricata:rule -(detects)> it:prod:softname'))
+
+            nodes = await core.nodes('''[ it:app:suricata:matched=$hit
+                :rule=$rule :flow=$flow :src="tcp://[::ffff:0102:0304]:0"
+                :dst="tcp://[::ffff:0505:0505]:80" :time=2015 :sensor=$host
+                :version=1.2.3 :dropped=true ]''', opts=opts)
+            self.len(1, nodes)
+            self.true(nodes[0].get('dropped'))
+            self.eq(rule, nodes[0].get('rule'))
+            self.eq(flow, nodes[0].get('flow'))
+            self.eq(host, nodes[0].get('sensor'))
+            self.eq(1420070400000, nodes[0].get('time'))
+
+            self.eq('tcp://[::ffff:1.2.3.4]:0', nodes[0].get('src'))
+            self.eq(0, nodes[0].get('src:port'))
+            self.eq(0x01020304, nodes[0].get('src:ipv4'))
+            self.eq('::ffff:1.2.3.4', nodes[0].get('src:ipv6'))
+
+            self.eq('tcp://[::ffff:5.5.5.5]:80', nodes[0].get('dst'))
+            self.eq(80, nodes[0].get('dst:port'))
+            self.eq(0x05050505, nodes[0].get('dst:ipv4'))
+            self.eq('::ffff:5.5.5.5', nodes[0].get('dst:ipv6'))
+
+            self.eq(0x10000200003, nodes[0].get('version'))
+
     async def test_it_reveng(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
## Summary

Adds `it:app:suricata:rule` and `it:app:suricata:matched` to the 2.x data model, modeled on the existing `it:app:snort:*` pair. This is a backport of the equivalent forms being added on the 3.x line.

- **`it:app:suricata:rule`** (guid) -- `:id`, `:text`, `:name`, `:desc`, `:version` (`it:semver`), `:author` (`ps:contact`), `:created`, `:updated`, `:enabled`, `:family` (`it:prod:softname`).
- **`it:app:suricata:matched`** (guid) -- `:rule`, `:flow`, `:src` / `:src:ipv4` / `:src:ipv6` / `:src:port`, `:dst` / `:dst:ipv4` / `:dst:ipv6` / `:dst:port`, `:time`, `:sensor` (`it:host`), `:version`, `:dropped`.
- A `detects` light edge from `it:app:suricata:rule` to any node, matching the snort and YARA rule forms.

## Two deliberate departures from `it:app:snort:*`

**The match form is `it:app:suricata:matched`, not `:hit`.** The snort form is `it:app:snort:hit` on this line, but that form is renamed to `it:app:snort:matched` on the 3.x line (recorded as a rename in the 3.x `v2modelmap.yaml`). Naming the new form `matched` here means it keeps the same name across the 2.x -> 3.x migration and needs no rename entry.

**No `:engine` property.** `it:app:snort:rule:engine` records which of several snort engines can parse the rule text. It was dropped from the 3.x suricata form and is omitted here for parity.

## Testing

`test_it_app_suricata` mirrors `test_it_app_snort`: builds a rule with every property, exercises the `detects` edge, then builds a match node and asserts the full src/dst address decomposition.

```
test_model_infotech.py + test_datamodel.py ... 38 passed, 1 skipped
ruff check .......................... All checks passed!
```

The single skip is pre-existing and gated on the `CIRCLECI` envar. A `model` changelog fragment is included. No checked-in docs required regeneration -- the form reference is built into `docs/synapse/autodocs/` at docs-build time.
