### PR TITLE
SYN-11501: Add url field to Storm command endpoint definitions

### DIFF
--- a/changes/603bbfef052d0c937ebaaf4bb84d2188.yaml
+++ b/changes/603bbfef052d0c937ebaaf4bb84d2188.yaml
@@ -1,0 +1,8 @@
+---
+desc: Added support for a ``url`` field on Storm command ``endpoints`` definitions
+  to declare the base URL an endpoint is served from. Command help now groups endpoints
+  by base URL.
+desc:literal: false
+prs: []
+type: feat
+...

--- a/synapse/lib/schemas.py
+++ b/synapse/lib/schemas.py
@@ -960,6 +960,7 @@ _reqValidPkgdefSchema = {
                         'type': 'object',
                         'properties': {
                             'path': {'type': 'string'},
+                            'url': {'type': 'string'},
                             'host': {'type': 'string'},
                             'desc': {'type': 'string'},
                         },

--- a/synapse/lib/storm.py
+++ b/synapse/lib/storm.py
@@ -33,6 +33,8 @@ import synapse.lib.stormtypes as s_stormtypes
 
 logger = logging.getLogger(__name__)
 
+endpoint_unconfigured_base = '(user-configured base URL)'
+
 MINMAX_SIZE_MAX = 100
 
 addtriggerdescr = '''
@@ -2251,12 +2253,12 @@ class Parser:
 
         posargs = ' '.join(posnames)
 
-        def printItemDesc(item, desc=None):
+        def printItemDesc(item, desc=None, indent=2):
             base_w = 32
             wrap_w = 120 - base_w
-            base = f'  {item}'
+            base = f'{"":<{indent}}{item}'
             if desc:
-                wrap_desc = self._wrap_text(desc, wrap_w) if desc else ['']
+                wrap_desc = self._wrap_text(desc, wrap_w)
                 self._printf(f'{base:<{base_w - 2}}: {wrap_desc[0]}')
                 for ln in wrap_desc[1:]:
                     self._printf(f'{"":<{base_w}}{ln}')
@@ -2275,11 +2277,17 @@ class Parser:
         if (endpoints := self.cdef.get('endpoints')):
             self._printf('')
             self._printf('Endpoints:')
-            self._printf('')
+
+            groups = {}
             for endpoint in endpoints:
-                path = endpoint['path']
-                desc = endpoint.get('desc')
-                printItemDesc(path, desc)
+                base = endpoint.get('url') or endpoint_unconfigured_base
+                groups.setdefault(base, []).append(endpoint)
+
+            for base in sorted(groups, key=lambda b: (b != endpoint_unconfigured_base, b)):
+                self._printf('')
+                self._printf(f'  {base}')
+                for endpoint in groups[base]:
+                    printItemDesc(endpoint['path'], endpoint.get('desc'), indent=4)
 
         self._printf('')
         self._printf(f'Usage: {self.prog} [options] {posargs}')

--- a/synapse/tests/files/stormpkg/testpkg.yaml
+++ b/synapse/tests/files/stormpkg/testpkg.yaml
@@ -162,6 +162,9 @@ commands:
           host: vertex.link
         - path: /v1/test/three
           desc: endpoint three
+        - path: /v1/test/four
+          url: https://vertex.link/api
+          desc: endpoint four
       perms:
         - [ power-ups, testpkg, user ]
         - [ power-ups, testpkg, admin ]

--- a/synapse/tests/test_lib_storm.py
+++ b/synapse/tests/test_lib_storm.py
@@ -4640,6 +4640,41 @@ class StormTest(s_t_utils.SynTest):
         self.eq('                                This is the final line with no leading spaces.', pars.mesgs[13])
         self.eq('  --taz <taz>                 : Taz option (default: True)', pars.mesgs[14])
 
+    async def test_storm_pkg_endpoint_schema(self):
+
+        async with self.getTestCore() as core:
+
+            base = {
+                'name': 'endptest',
+                'version': '0.0.1',
+            }
+
+            # a command.endpoints entry with an unknown key is rejected
+            pdef = dict(base)
+            pdef['commands'] = (
+                {'name': 'endptest.cmd', 'storm': '',
+                    'endpoints': [{'path': '/v1/x', 'newp': 1}]},
+            )
+            with self.raises(s_exc.SchemaViolation):
+                await core.addStormPkg(pdef)
+
+            # a command.endpoints entry missing the required path is rejected
+            pdef = dict(base)
+            pdef['commands'] = (
+                {'name': 'endptest.cmd', 'storm': '',
+                    'endpoints': [{'desc': 'no path'}]},
+            )
+            with self.raises(s_exc.SchemaViolation):
+                await core.addStormPkg(pdef)
+
+            # a well-formed command.endpoints entry validates
+            pdef = dict(base)
+            pdef['commands'] = (
+                {'name': 'endptest.cmd', 'storm': '',
+                    'endpoints': [{'url': 'https://x', 'path': '/v1/x', 'desc': 'ok'}]},
+            )
+            await core.addStormPkg(pdef)
+
     async def test_storm_cmd_help(self):
 
         async with self.getTestCore() as core:
@@ -4663,6 +4698,20 @@ class StormTest(s_t_utils.SynTest):
                                 'host': 'vertex.link',
                                 'desc': 'Single line endpoint description.'
                             },
+                            {
+                                'path': '/v1/test/three',
+                                'url': 'https://two.vertex.link/api',
+                                'desc': 'Endpoint on the second base URL.'
+                            },
+                            {
+                                'path': '/v1/test/four',
+                                'url': 'https://one.vertex.link/api',
+                            },
+                            {
+                                'path': '/v1/test/five',
+                                'url': 'https://one.vertex.link/api',
+                                'desc': 'Second endpoint on the first base URL.'
+                            },
                         ),
                         'perms': (
                             ['power-ups', 'testpkg', 'user'],
@@ -4677,12 +4726,23 @@ class StormTest(s_t_utils.SynTest):
 
             self.isin('Usage: woot [options]', helptext)
 
+            # Endpoints are grouped by their base URL, with the endpoints that do not
+            # declare one first, then the rest sorted by URL. The legacy host field is
+            # not used for grouping.
             exp = textwrap.dedent('''\
                 Endpoints:
 
-                  /v1/test/one                : My multi-line endpoint description which spans multiple lines and has a second line.
+                  (user-configured base URL)
+                    /v1/test/one              : My multi-line endpoint description which spans multiple lines and has a second line.
                                                 This is the second line of the description.
-                  /v1/test/two                : Single line endpoint description.
+                    /v1/test/two              : Single line endpoint description.
+
+                  https://one.vertex.link/api
+                    /v1/test/four
+                    /v1/test/five             : Second endpoint on the first base URL.
+
+                  https://two.vertex.link/api
+                    /v1/test/three            : Endpoint on the second base URL.
             ''').rstrip()
             self.isin(exp, helptext)
 

--- a/synapse/tests/test_tools_storm_pkg_gen.py
+++ b/synapse/tests/test_tools_storm_pkg_gen.py
@@ -134,6 +134,7 @@ class GenPkgTest(s_test.SynTest):
                 {'path': '/v1/test/one'},
                 {'path': '/v1/test/two', 'host': 'vertex.link'},
                 {'path': '/v1/test/three', 'desc': 'endpoint three'},
+                {'path': '/v1/test/four', 'url': 'https://vertex.link/api', 'desc': 'endpoint four'},
             ])
 
             self.eq(pdef['perms'][0]['perm'], ['power-ups', 'testpkg', 'user'])

--- a/synapse/tests/test_tools_utils_autodoc.py
+++ b/synapse/tests/test_tools_utils_autodoc.py
@@ -207,9 +207,12 @@ class TestAutoDoc(s_t_utils.SynTest):
             rsttext = rst.getRstText()
 
             self.isin('    Endpoints:', rsttext)
-            self.isin('      /v1/test/one\n', rsttext)
-            self.isin('      /v1/test/two\n', rsttext)
-            self.isin('      /v1/test/three              : endpoint three', rsttext)
+            self.isin('      (user-configured base URL)\n', rsttext)
+            self.isin('        /v1/test/one\n', rsttext)
+            self.isin('        /v1/test/two\n', rsttext)
+            self.isin('        /v1/test/three            : endpoint three', rsttext)
+            self.isin('      https://vertex.link/api\n', rsttext)
+            self.isin('        /v1/test/four             : endpoint four', rsttext)
 
             self.isin('    Inputs:\n', rsttext)
             self.isin('      test:int                    : Some integer input\n', rsttext)


### PR DESCRIPTION
## Summary

Synapse 3.x defines command endpoints as `{path, url, desc}` and renders them in command help grouped by base URL, with the URL as a header and paths indented beneath it. Synapse 2.x has `{path, host, desc}`, and `host` is never read -- the help printer emits only `path` and `desc`.

Two consequences today:

- A command that talks to more than one API base URL renders its endpoints as an undifferentiated flat list. A package cannot express which base URL an endpoint belongs to in a way anything consumes.
- A rapid power-up that declares endpoints against 2.x has to restructure those declarations to port to 3.x.

This backports `url` and the 3.x grouped rendering.

## Behavior

Endpoints are grouped by `url`. Those without one are listed first under a `(user-configured base URL)` placeholder, then the remaining groups sorted by URL, with declaration order preserved inside each group:

```
Endpoints:

  (user-configured base URL)
    /v1/test/one              : My multi-line endpoint description which spans multiple lines and has a second line.
                                This is the second line of the description.
    /v1/test/two              : Single line endpoint description.

  https://one.vertex.link/api
    /v1/test/four
    /v1/test/five             : Second endpoint on the first base URL.

  https://two.vertex.link/api
    /v1/test/three            : Endpoint on the second base URL.
```

This flows through to the generated package documentation, which embeds the command help verbatim.

`host` remains accepted for backward compatibility and is still unused. Note that the endpoint item is `additionalProperties: False`, so a package cannot declare both fields as a transition aid -- `url` is the one that renders.

## Notes

- `synapse/lib/storm.py` and `synapse/lib/schemas.py` changes are a direct copy of the 3.x implementation, including the `endpoint_unconfigured_base` constant and the `indent` parameter on `printItemDesc`, so the two lines do not drift.
- `test_storm_pkg_endpoint_schema` is backported from 3.x, covering the command portion. The 3.x module-level `modconf.endpoints` declaration and the autodoc section it drives are out of scope.

## Testing

`test_lib_storm.py`, `test_tools_storm_pkg_gen.py` and `test_tools_utils_autodoc.py` pass. `test_lib_storm.py::StormTest::test_storm_dmon_query_state` fails in my container, but it fails identically on unmodified `master` at the same commit (a multiprocessing teardown issue), so it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVv6mN8NjYCm6P29HQfW69