### PR TITLE
SYN-11505 add inet:http:request:response:cookies property

### DIFF
--- a/changes/68a93d1da3ce5ba7cbe98e7550e5928c.yaml
+++ b/changes/68a93d1da3ce5ba7cbe98e7550e5928c.yaml
@@ -1,0 +1,7 @@
+---
+desc: Added the ``inet:http:request:response:cookies`` property to record the cookies
+  set by the HTTP response.
+desc:literal: false
+prs: []
+type: model
+...

--- a/synapse/models/inet.py
+++ b/synapse/models/inet.py
@@ -2426,6 +2426,8 @@ class InetModule(s_module.CoreModule):
                         ('response:headers', ('array', {'type': 'inet:http:response:header'}), {
                             'doc': 'An array of HTTP headers from the response.'}),
                         ('response:body', ('file:bytes', {}), {}),
+                        ('response:cookies', ('array', {'type': 'inet:http:cookie', 'sorted': True, 'uniq': True}), {
+                            'doc': 'An array of HTTP cookie values parsed from the "Set-Cookie:" headers in the response.'}),
                         ('session', ('inet:http:session', {}), {
                             'doc': 'The HTTP session this request was part of.'}),
 

--- a/synapse/tests/test_model_inet.py
+++ b/synapse/tests/test_model_inet.py
@@ -822,6 +822,11 @@ class InetModelTest(s_t_utils.SynTest):
             self.eq(nodes[0].get('cookies'), ('baz=faz', 'foo=bar'))
 
             nodes = await core.nodes('''
+                [ inet:http:request=* :response:cookies={[ inet:http:cookie="foo=bar; baz=faz;" ]} ]
+            ''')
+            self.eq(nodes[0].get('response:cookies'), ('baz=faz', 'foo=bar'))
+
+            nodes = await core.nodes('''
                 [ inet:http:session=* :cookies={[ inet:http:cookie="foo=bar; baz=faz;" ]} ]
             ''')
             self.eq(nodes[0].get('cookies'), ('baz=faz', 'foo=bar'))
@@ -890,6 +895,7 @@ class InetModelTest(s_t_utils.SynTest):
                 :response:reason=OK
                 :response:headers=((baz, faz),)
                 :response:body=$p.body
+                :response:cookies={[ inet:http:cookie="sid=hehe; lang=en;" ]}
                 :client=1.2.3.4
                 :client:host=$p."client:host"
                 :server="5.5.5.5:443"
@@ -914,6 +920,7 @@ class InetModelTest(s_t_utils.SynTest):
             self.eq(node.get('response:reason'), 'OK')
             self.eq(node.get('response:headers'), (('baz', 'faz'),))
             self.eq(node.get('response:body'), 'sha256:' + 64 * 'b')
+            self.eq(node.get('response:cookies'), ('lang=en', 'sid=hehe'))
             self.eq(node.get('session'), sess)
             self.eq(node.get('fetch'), fetch)
             self.eq(node.get('sandbox:file'), 'sha256:' + 64 * 'c')
@@ -927,6 +934,7 @@ class InetModelTest(s_t_utils.SynTest):
 
             self.len(1, await core.nodes('inet:http:request -> inet:http:request:header'))
             self.len(1, await core.nodes('inet:http:request -> inet:http:response:header'))
+            self.len(2, await core.nodes('inet:http:request -> inet:http:cookie'))
 
             nodes = await core.nodes('inet:http:request -> inet:http:session [ :contact=* ]')
             self.len(1, nodes)


### PR DESCRIPTION
## Summary

Backports the `inet:http:response:cookies` addition from 3.x (vertexproject/synapse-enterprise#996) so the cookies a server set via its `Set-Cookie:` headers can be modeled in 2.x too.

2.x has no `inet:http:response` form -- the response is a set of `response:*` properties on `inet:http:request` (`:response:time`, `:response:code`, `:response:reason`, `:response:headers`, `:response:body`) -- so the property lands as `inet:http:request:response:cookies`, placed after `:response:body` to match where `:cookies` sits relative to `:body` on the request side.

The array options are copied from the neighboring `inet:http:request:cookies` and `inet:http:session:cookies` (`{'type': 'inet:http:cookie', 'sorted': True, 'uniq': True}`) rather than 3.x's newer `'array': {}` propinfo form, which does not exist in 2.x. Behavior is identical.

Adding a property needs no migration.

## Tests

`test_model_inet.py`:

- `test_http_cookie` -- a request node built with a two-cookie `Set-Cookie`-style `:response:cookies` value, asserting the normalized, sorted array, mirroring the request and session cases around it
- `test_http_request` -- `:response:cookies` added to the request node that test already builds, with an assertion alongside the other `response:*` ones, plus a `-> inet:http:cookie` pivot check next to the existing header pivots

Verified locally: `test_model_inet.py` and `test_datamodel.py` pass (85 tests).

## Docs

- changelog fragment `changes/68a93d1da3ce5ba7cbe98e7550e5928c.yaml` (type `model`)
- no committed doc to update on this side: `docs/synapse/autodocs/` is generated at docs-build time and is not in the tree
