### PR TITLE
Fix layer dumps of a single node edit (SYN-11431)

### DIFF
--- a/changes/2d663bfc66307bd852601274d183815a.yaml
+++ b/changes/2d663bfc66307bd852601274d183815a.yaml
@@ -1,0 +1,7 @@
+---
+desc: Fixed a bug in ``synapse.tools.cortex.layer.dump`` where exporting a chunk containing
+  a single node edit recorded an incorrect ending offset.
+desc:literal: false
+prs: []
+type: bug
+...

--- a/synapse/tests/test_tools_cortex_layer.py
+++ b/synapse/tests/test_tools_cortex_layer.py
@@ -115,6 +115,199 @@ class LayerTest(s_test.SynTest):
                 state = s_common.yamlload(dirn, statefile)
                 self.eq(state, {'offset:next': eoffs + 256})
 
+    async def test_tools_layer_dump_single_edit(self):
+
+        async with self.getTestCore() as core:
+
+            url = core.getLocalUrl()
+
+            layr00 = await core.addLayer()
+            layr00iden = layr00.get('iden')
+            view00 = await core.addView({'layers': [layr00iden]})
+
+            layr01 = await core.addLayer()
+            layr01iden = layr01.get('iden')
+            view01 = await core.addView({'layers': [layr01iden]})
+
+            soffs = await core.getNexsIndx()
+
+            opts = {'view': view00.get('iden')}
+            nodes = await core.nodes('[test:int=1]', opts=opts)
+            self.len(1, nodes)
+
+            # A single node edit landed at soffs
+            self.eq(soffs, await core.getLayer(layr00iden).getEditOffs())
+
+            with self.getTestDir() as dirn:
+
+                argv = (
+                    '--url', url,
+                    layr00iden,
+                    dirn,
+                )
+
+                outp = self.getTestOutp()
+                self.eq(0, await s_t_dump.main(argv, outp=outp))
+                outp.expect(f'Successfully exported layer {layr00iden}.')
+
+                path = s_common.genpath(dirn, f'{core.iden}.{layr00iden}.{soffs}-{soffs}.nodeedits')
+                self.true(os.path.exists(path))
+
+                msgs = list(s_msgpack.iterfile(path))
+                self.len(3, msgs)
+
+                self.eq(msgs[0][0], 'init')
+                self.eq(msgs[0][1].get('offset'), soffs)
+
+                self.eq(msgs[1][0], 'edit')
+
+                self.eq(msgs[2][0], 'fini')
+                self.eq(msgs[2][1].get('offset'), soffs)
+
+                state = s_common.yamlload(dirn, f'{core.iden}.{layr00iden}.yaml')
+                self.eq(state, {'offset:next': soffs + 1})
+
+                # The single edit export is valid input for the load tool
+                argv = (
+                    '--url', url,
+                    layr01iden,
+                    path,
+                )
+
+                outp = self.getTestOutp()
+                self.eq(0, await s_t_load.main(argv, outp=outp))
+                outp.expect(f'Successfully loaded {path} with 1 edits ({soffs} - {soffs}).')
+
+                opts = {'view': view01.get('iden')}
+                nodes = await core.nodes('test:int', opts=opts)
+                self.len(1, nodes)
+
+    async def test_tools_layer_dump_incremental(self):
+
+        async with self.getTestCore() as core:
+
+            url = core.getLocalUrl()
+
+            layr00 = await core.addLayer()
+            layr00iden = layr00.get('iden')
+            view00 = await core.addView({'layers': [layr00iden]})
+
+            soffs = await core.getNexsIndx()
+
+            opts = {'view': view00.get('iden'), 'vars': {'n': 4}}
+            nodes = await core.nodes('for $i in $lib.range($n) { [test:int=$i] }', opts=opts)
+            self.len(4, nodes)
+
+            with self.getTestDir() as dirn:
+
+                argv = (
+                    '--url', url,
+                    layr00iden,
+                    dirn,
+                )
+
+                outp = self.getTestOutp()
+                self.eq(0, await s_t_dump.main(argv, outp=outp))
+                outp.expect(f'Successfully exported layer {layr00iden}.')
+
+                statefile = s_common.genpath(dirn, f'{core.iden}.{layr00iden}.yaml')
+                self.eq(s_common.yamlload(statefile), {'offset:next': soffs + 4})
+
+                # A single new edit leaves the next offset sitting on the last edit
+                nodes = await core.nodes('[test:str=newp]', opts=opts)
+                self.len(1, nodes)
+
+                self.eq(soffs + 4, await core.getLayer(layr00iden).getEditOffs())
+
+                outp = self.getTestOutp()
+                self.eq(0, await s_t_dump.main(argv, outp=outp))
+                outp.expect(f'Successfully exported layer {layr00iden}.')
+
+                path = s_common.genpath(dirn, f'{core.iden}.{layr00iden}.{soffs + 4}-{soffs + 4}.nodeedits')
+                self.true(os.path.exists(path))
+
+                self.eq(s_common.yamlload(statefile), {'offset:next': soffs + 5})
+
+    async def test_tools_layer_dump_chunks(self):
+
+        async with self.getTestCore() as core:
+
+            url = core.getLocalUrl()
+
+            chunksize = 10
+
+            # The final chunk holds a single edit
+            layr00 = await core.addLayer()
+            layr00iden = layr00.get('iden')
+            view00 = await core.addView({'layers': [layr00iden]})
+
+            soffs = await core.getNexsIndx()
+
+            opts = {'view': view00.get('iden'), 'vars': {'n': 11}}
+            nodes = await core.nodes('for $i in $lib.range($n) { [test:int=$i] }', opts=opts)
+            self.len(11, nodes)
+
+            with self.getTestDir() as dirn:
+
+                argv = (
+                    '--url', url,
+                    '--chunksize', str(chunksize),
+                    layr00iden,
+                    dirn,
+                )
+
+                outp = self.getTestOutp()
+                self.eq(0, await s_t_dump.main(argv, outp=outp))
+                outp.expect(f'Successfully exported layer {layr00iden}.')
+
+                path = s_common.genpath(dirn, f'{core.iden}.{layr00iden}.{soffs}-{soffs + 9}.nodeedits')
+                self.true(os.path.exists(path))
+
+                path = s_common.genpath(dirn, f'{core.iden}.{layr00iden}.{soffs + 10}-{soffs + 10}.nodeedits')
+                self.true(os.path.exists(path))
+
+                msgs = list(s_msgpack.iterfile(path))
+                self.len(3, msgs)
+
+                self.eq(msgs[0][1].get('offset'), soffs + 10)
+
+                self.eq(msgs[2][0], 'fini')
+                self.eq(msgs[2][1].get('offset'), soffs + 10)
+
+                state = s_common.yamlload(dirn, f'{core.iden}.{layr00iden}.yaml')
+                self.eq(state, {'offset:next': soffs + 11})
+
+            # The edit count is an exact multiple of the chunk size
+            layr01 = await core.addLayer()
+            layr01iden = layr01.get('iden')
+            view01 = await core.addView({'layers': [layr01iden]})
+
+            soffs = await core.getNexsIndx()
+
+            opts = {'view': view01.get('iden'), 'vars': {'n': 10}}
+            nodes = await core.nodes('for $i in $lib.range($n) { [test:int=$i] }', opts=opts)
+            self.len(10, nodes)
+
+            with self.getTestDir() as dirn:
+
+                argv = (
+                    '--url', url,
+                    '--chunksize', str(chunksize),
+                    layr01iden,
+                    dirn,
+                )
+
+                outp = self.getTestOutp()
+                self.eq(0, await s_t_dump.main(argv, outp=outp))
+                outp.expect(f'Successfully exported layer {layr01iden}.')
+
+                files = [k for k in os.listdir(dirn) if k.endswith('.nodeedits')]
+                self.len(1, files)
+                self.eq(files[0], f'{core.iden}.{layr01iden}.{soffs}-{soffs + 9}.nodeedits')
+
+                state = s_common.yamlload(dirn, f'{core.iden}.{layr01iden}.yaml')
+                self.eq(state, {'offset:next': soffs + 10})
+
     async def test_tools_layer_dump_errors(self):
 
         # Non-cortex cell

--- a/synapse/tools/cortex/layer/dump.py
+++ b/synapse/tools/cortex/layer/dump.py
@@ -61,8 +61,6 @@ async def exportLayer(opts, outp):
     if (soffs := opts.offset) is None:
         soffs = state.get('offset:next', 0)
 
-    eoffs = None
-
     async with await s_telepath.openurl(opts.url, name=f'*/layer/{opts.iden}') as layer:
 
         # Handle no edits to export
@@ -81,10 +79,10 @@ async def exportLayer(opts, outp):
             try:
                 # Pull the first edit so we can get the starting offset
                 first = await anext(nodeiter)
-            except StopAsyncIteration: # pragma: no cover
+            except StopAsyncIteration:
                 break
 
-            soffs = first[0]
+            soffs = eoffs = first[0]
 
             with _tmpfile(dirn=opts.outdir, prefix='layer.dump') as (fd, tmppath):
 


### PR DESCRIPTION
## Summary

`synapse.tools.cortex.layer.dump` fails on a layer holding a single node edit, reported as
`TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`.

`exportLayer` pulls each chunk's first edit separately so it can derive that chunk's starting offset,
then streams the remainder through an `async for`. The ending offset `eoffs` was initialized to `None`
once, outside the chunk loop, and only ever assigned inside that `async for` body -- which a chunk
holding exactly one edit never enters. `eoffs` therefore keeps whatever it had:

- **On the first chunk** it is still `None`. The `fini` footer is written as `{'offset': None}`, the
  file is named `...{soffs}-None.nodeedits`, and computing the next state offset raises the error
  above.
- **On a later chunk** there is no error at all, which is worse. `eoffs` silently retains the
  *previous* chunk's last offset, so the file is named backwards, its `fini` offset points into the
  previous chunk, and `offset:next` never advances past it -- every subsequent incremental run
  re-exports the same edit. The file is also not loadable: `layer.load` seeds `eoffs = soffs` and
  validates it against `fini`, so it rejects the export as `Incomplete/corrupt export`.

The loader already implements the right contract -- `fini.offset` is the offset of the last edit, and
a single-edit file means it equals the starting offset. The dumper did not mirror it.

## What changed

### `synapse/tools/cortex/layer/dump.py`

Seed `eoffs` from each chunk's first edit (`soffs = eoffs = first[0]`), so a chunk holding one edit
reports itself as ending where it started. The `eoffs = None` initializer above the loop is removed as
dead -- nothing reads `eoffs` outside the loop body, including on the early-exit path. The
`# pragma: no cover` comes off the `StopAsyncIteration` handler: it is reachable whenever the edit
count is an exact multiple of the chunk size, and is now covered.

No argparse argument, help string, or `descr` changes.

### `synapse/tests/test_tools_cortex_layer.py`

Three `LayerTest` cases, each confirmed to fail without the change:

- `test_tools_layer_dump_single_edit` -- the reported crash. Checks the filename, the
  `init`/`edit`/`fini` messages, the `fini` offset and the state file, then round-trips the export
  through `layer.load` into a second layer. The round trip is the strongest assertion available here,
  since the loader independently validates the `fini` offset and so rejects the file even setting the
  crash aside.
- `test_tools_layer_dump_incremental` -- dump a layer, add one edit, dump again from the written state
  file, which puts a single edit in its own chunk.
- `test_tools_layer_dump_chunks` -- the silent multi-chunk case (11 edits at `--chunksize 10`, so the
  final chunk holds one edit) and the exact-multiple case (10 edits) that reaches the
  `StopAsyncIteration` path.

Coverage of `synapse/tools/cortex/layer/` is 100% for both `dump.py` and `load.py`.

## Backward compatibility

No interface change. The fix only affects inputs that previously errored or produced a file the loader
rejects, so nothing that worked before behaves differently. Exports already written with a `None` or
stale `fini` offset were never loadable and are not migrated -- re-run the dump.

## Note for reviewers

The `soffs >= await layer.getEditIndx()` guard above the loop is deliberately untouched.
`Layer.getEditIndx()` returns the *next* log index rather than the last edit's offset, so `>=` is the
correct comparison here and an offset sitting on the last edit is admitted, not rejected.
