### PR TITLE
Add it:app:sigma:rule and it:app:sigma:matched forms (SYN-11294)

### DIFF
--- a/changes/31cef4e550f122fca864442498f55a7a.yaml
+++ b/changes/31cef4e550f122fca864442498f55a7a.yaml
@@ -1,0 +1,6 @@
+---
+desc: Added ``it:app:sigma:rule`` and ``it:app:sigma:matched`` forms.
+desc:literal: false
+prs: []
+type: model
+...

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -1043,6 +1043,12 @@ class ItModule(s_module.CoreModule):
                 ('it:app:yara:procmatch', ('guid', {}), {
                     'doc': 'An instance of a YARA rule match to a process.',
                 }),
+                ('it:app:sigma:rule', ('guid', {}), {
+                    'doc': 'A Sigma rule.',
+                }),
+                ('it:app:sigma:matched', ('guid', {}), {
+                    'doc': 'An instance of a Sigma rule hit.',
+                }),
                 ('it:app:snort:rule', ('guid', {}), {
                     'doc': 'A snort rule.',
                 }),
@@ -1123,6 +1129,8 @@ class ItModule(s_module.CoreModule):
                     'doc': 'The software uses the vulnerability.'}),
                 (('it:exec:query', 'found', None), {
                     'doc': 'The target node was returned as a result of running the query.'}),
+                (('it:app:sigma:rule', 'detects', None), {
+                    'doc': 'The Sigma rule is intended for use in detecting the target node.'}),
                 (('it:app:snort:rule', 'detects', None), {
                     'doc': 'The snort rule is intended for use in detecting the target node.'}),
                 (('it:app:suricata:rule', 'detects', None), {
@@ -3143,6 +3151,59 @@ class ItModule(s_module.CoreModule):
                     ('sandbox:file', ('file:bytes', {}), {
                         'doc': 'The initial sample given to a sandbox environment to analyze.'
                     }),
+                )),
+
+                ('it:app:sigma:rule', {}, (
+
+                    ('id', ('str', {}), {
+                        'doc': 'The Sigma rule id.'}),
+
+                    ('text', ('str', {}), {
+                        'disp': {'hint': 'text', 'syntax': 'yaml'},
+                        'doc': 'The Sigma rule text.'}),
+
+                    ('name', ('str', {}), {
+                        'doc': 'The name of the Sigma rule.'}),
+
+                    ('desc', ('str', {}), {
+                        'disp': {'hint': 'text'},
+                        'doc': 'A brief description of the Sigma rule.'}),
+
+                    ('url', ('inet:url', {}), {
+                        'doc': 'A URL which documents the Sigma rule.'}),
+
+                    ('version', ('it:semver', {}), {
+                        'doc': 'The current version of the rule.'}),
+
+                    ('author', ('ps:contact', {}), {
+                        'doc': 'Contact info for the author of the rule.'}),
+
+                    ('created', ('time', {}), {
+                        'doc': 'The time the rule was created.'}),
+
+                    ('updated', ('time', {}), {
+                        'doc': 'The time the rule was most recently modified.'}),
+
+                    ('enabled', ('bool', {}), {
+                        'doc': 'The rule enabled status to be used for Sigma evaluation engines.'}),
+                )),
+
+                ('it:app:sigma:matched', {}, (
+
+                    ('rule', ('it:app:sigma:rule', {}), {
+                        'doc': 'The Sigma rule that matched the log event.'}),
+
+                    ('target', ('it:log:event', {}), {
+                        'doc': 'The it:log:event that matched the Sigma rule.'}),
+
+                    ('sensor', ('it:host', {}), {
+                        'doc': 'The sensor host node that produced the hit.'}),
+
+                    ('time', ('time', {}), {
+                        'doc': 'The time that the match occurred.'}),
+
+                    ('version', ('it:semver', {}), {
+                        'doc': 'The version of the rule at the time of match.'}),
                 )),
 
                 ('it:app:snort:rule', {}, (

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -1720,6 +1720,61 @@ class InfotechModelTest(s_t_utils.SynTest):
             with self.raises(s_exc.BadTypeValu):
                 await core.nodes('[it:app:yara:netmatch=* :node=(it:dev:str, foo)]')
 
+    async def test_it_app_sigma(self):
+
+        async with self.getTestCore() as core:
+
+            hit = s_common.guid()
+            rule = s_common.guid()
+            log = s_common.guid()
+            host = s_common.guid()
+            opts = {'vars': {'rule': rule, 'log': log, 'host': host, 'hit': hit}}
+
+            nodes = await core.nodes('''
+            [ it:app:sigma:rule=$rule
+                :id=SIGMA-001
+                :text="title: Suspicious PowerShell"
+                :name="Suspicious PowerShell"
+                :desc="Detects suspicious PowerShell invocation."
+                :url=https://vertex.link/sigma/SIGMA-001
+                :author = {[ ps:contact=* :name=visi ]}
+                :created = 20240101
+                :updated = 20250101
+                :enabled=1
+                :version=1.2.3
+                +(detects)> {[ it:prod:softname=woot ]}
+            ]
+            ''', opts=opts)
+
+            self.len(1, nodes)
+            self.eq('SIGMA-001', nodes[0].get('id'))
+            self.eq('Suspicious PowerShell', nodes[0].get('name'))
+            self.eq('title: Suspicious PowerShell', nodes[0].get('text'))
+            self.eq('Detects suspicious PowerShell invocation.', nodes[0].get('desc'))
+            self.eq('https://vertex.link/sigma/SIGMA-001', nodes[0].get('url'))
+            self.eq(True, nodes[0].get('enabled'))
+            self.eq(0x10000200003, nodes[0].get('version'))
+            self.eq(1704067200000, nodes[0].get('created'))
+            self.eq(1735689600000, nodes[0].get('updated'))
+            self.nn(nodes[0].get('author'))
+
+            self.len(1, await core.nodes('it:app:sigma:rule -> ps:contact'))
+            self.len(1, await core.nodes('it:app:sigma:rule -(detects)> it:prod:softname'))
+
+            nodes = await core.nodes('''[ it:app:sigma:matched=$hit
+                :rule=$rule :target=$log :time=2015 :sensor=$host
+                :version=1.2.3 ]''', opts=opts)
+            self.len(1, nodes)
+            self.eq(rule, nodes[0].get('rule'))
+            self.eq(log, nodes[0].get('target'))
+            self.eq(host, nodes[0].get('sensor'))
+            self.eq(1420070400000, nodes[0].get('time'))
+            self.eq(0x10000200003, nodes[0].get('version'))
+
+            self.len(1, await core.nodes('it:app:sigma:matched -> it:app:sigma:rule'))
+            self.len(1, await core.nodes('it:app:sigma:matched :target -> it:log:event'))
+            self.len(1, await core.nodes('it:app:sigma:matched :sensor -> it:host'))
+
     async def test_it_app_snort(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
## Summary

Adds `it:app:sigma:rule` and `it:app:sigma:matched` to the 2.x data
model, modeled on the existing `it:app:suricata:*` pair. This is the 2.x
half of SYN-11294; the equivalent 3.x forms are being added on that line.

- **`it:app:sigma:rule`** (guid) -- `:id`, `:text`, `:name`, `:desc`,
`:url` (`inet:url`), `:version` (`it:semver`), `:author` (`ps:contact`),
`:created`, `:updated`, `:enabled`.
- **`it:app:sigma:matched`** (guid) -- `:rule`, `:target`
(`it:log:event`), `:sensor` (`it:host`), `:time`, `:version`
(`it:semver`).
- A `detects` light edge from `it:app:sigma:rule` to any node, matching
the snort, suricata, and YARA rule forms.

Both forms are placed before the snort block, and the edge ahead of the
snort edge, to keep sigma before snort and suricata.
`it:av:pattern:type` already carried `sigma` in its enum, so no change
was needed there.

## Notes

**The match form is `it:app:sigma:matched`, not `:match`.** The ticket
writes `:match`, and the YARA form on this line is `it:app:yara:match`,
but the 3.x form is `it:app:sigma:matched`. Naming it `matched` here
means it keeps the same name across the 2.x -> 3.x migration and needs no
rename entry in the 3.x `v2modelmap.yaml` -- the same reasoning applied
when `it:app:suricata:matched` was added.

**`:target`, not `:log`.** The ticket writes `:log`, but the property is
named `:target` to match `it:app:suricata:matched:target` on this line
and the interface-supplied `:target` on the 3.x form. Keeping the name
the same across both lines means no property rename entry is needed
either.

**`:version` is `it:semver`.** The ticket specifies `it:version` for the
2.x rule form, but that type does not exist on this line; `it:semver` is
what all four sibling rule forms use.

**`:sensor` is kept even though the log event has a host.**
`it:log:event` implements `it:host:activity` and so carries `:host`, but
the sensor which generates a match is frequently not the host the
activity occurred on -- a SIEM or log collector evaluates rules against
logs shipped from elsewhere. `:host` on the log event records where the
activity happened, `:sensor` what detected it. The 3.x form carries
`:sensor` for the same reason.

**`:version` on the match form** records the rule version in force at
match time, as `it:app:snort:hit` and `it:app:suricata:matched` both do.
The ticket omits it.

## Testing

`test_it_app_sigma` mirrors `test_it_app_suricata`: builds a rule with
every property and asserts each, exercises the `detects` edge and the
`ps:contact` pivot, then builds a matched node against that rule and
checks `:rule`, `:target`, `:sensor`, `:time`, and `:version`, plus the
pivots to `it:log:event` and `it:host`.

```
test_model_infotech.py + test_datamodel.py + test_lib_types.py
  + test_tools_utils_changelog.py ... 68 passed, 1 skipped
ruff check ....................... All checks passed!
```

The single skip is pre-existing and gated on the `CIRCLECI` envar. A
`model` changelog fragment is included. No checked-in docs required
regeneration -- the form reference is built into `docs/synapse/autodocs/`
at docs-build time, and `changes/modelrefs/` plus the
`model_updates/*.rst` pages are release-time artifacts. Confirmed with
`synapse.tools.utils.changelog model -c` against the v2.251.0 modelref
that both forms, all their properties, and the edge register as
additions.

