### PR TITLE
SYN-11547: Log Storm package load and unload

### DIFF
--- a/changes/95090861688596c7b26288c990a753a8.yaml
+++ b/changes/95090861688596c7b26288c990a753a8.yaml
@@ -1,0 +1,7 @@
+---
+desc: The Cortex now logs a message when a Storm package is loaded or unloaded, including
+  the package name and version as structured log fields.
+desc:literal: false
+prs: []
+type: feat
+...

--- a/changes/95090861688596c7b26288c990a753a8.yaml
+++ b/changes/95090861688596c7b26288c990a753a8.yaml
@@ -2,6 +2,7 @@
 desc: The Cortex now logs a message when a Storm package is loaded or unloaded, including
   the package name and version as structured log fields.
 desc:literal: false
-prs: []
+prs:
+- 5011
 type: feat
 ...

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -3174,7 +3174,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             self.pkggraphs[gdef['iden']] = gdef
 
         extra = self.getLogExtra(pkg=name, vers=pkgvers)
-        logger.info(f'Loaded Storm package: {name}@{pkgvers}.', extra=extra)
+        logger.info(f'Loaded Storm package: {name}@{pkgvers}.', extra=self.getLogExtra(pkg=name, vers=pkgvers))
 
     def _runStormPkgOnload(self, pkgdef):
         name = pkgdef.get('name')

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -3173,7 +3173,6 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             self._initEasyPerm(gdef)
             self.pkggraphs[gdef['iden']] = gdef
 
-        extra = self.getLogExtra(pkg=name, vers=pkgvers)
         logger.info(f'Loaded Storm package: {name}@{pkgvers}.', extra=self.getLogExtra(pkg=name, vers=pkgvers))
 
     def _runStormPkgOnload(self, pkgdef):
@@ -3305,8 +3304,7 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
 
         self.stormpkgs.pop(pkgname, None)
 
-        extra = self.getLogExtra(pkg=pkgname, vers=pkgvers)
-        logger.info(f'Unloaded Storm package: {pkgname}@{pkgvers}.', extra=extra)
+        logger.info(f'Unloaded Storm package: {pkgname}@{pkgvers}.', extra=self.getLogExtra(pkg=pkgname, vers=pkgvers))
 
     def getStormSvc(self, name):
 

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -3173,6 +3173,9 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             self._initEasyPerm(gdef)
             self.pkggraphs[gdef['iden']] = gdef
 
+        extra = self.getLogExtra(pkg=name, vers=pkgvers)
+        logger.info(f'Loaded Storm package: {name}@{pkgvers}.', extra=extra)
+
     def _runStormPkgOnload(self, pkgdef):
         name = pkgdef.get('name')
         inits = pkgdef.get('inits')
@@ -3295,11 +3298,15 @@ class Cortex(s_oauth.OAuthMixin, s_cell.Cell):  # type: ignore
             self._popStormCmd(name)
 
         pkgname = pkgdef.get('name')
+        pkgvers = pkgdef.get('version')
 
         for gdef in pkgdef.get('graphs', ()):
             self.pkggraphs.pop(gdef['iden'], None)
 
         self.stormpkgs.pop(pkgname, None)
+
+        extra = self.getLogExtra(pkg=pkgname, vers=pkgvers)
+        logger.info(f'Unloaded Storm package: {pkgname}@{pkgvers}.', extra=extra)
 
     def getStormSvc(self, name):
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -7265,6 +7265,75 @@ class CortexBasicTest(s_t_utils.SynTest):
                 mesg = f'Storm package {pkgname} requires Synapse {minver} but Cortex is running {s_version.version}'
                 self.eq(cm.exception.errinfo.get('mesg'), mesg)
 
+    async def test_stormpkg_logs(self):
+        '''
+        Loading and unloading a Storm package logs an operator-visible message
+        carrying the package name and version as structured log fields.
+        '''
+        def pkgmsgs(stream):
+            return [m for m in stream.jsonlines() if 'Storm package: ' in m['message']]
+
+        pkgdef = {
+            'name': 'pkglogs',
+            'version': '0.0.1',
+            'synapse_version': '>=2.8.0,<3.0.0',
+        }
+
+        with self.getTestDir() as dirn:
+            async with self.getTestCore(dirn=dirn) as core:
+
+                # loading a package logs a structured message an operator can
+                # watch for, carrying the package name and version
+                with self.getLoggerStream('synapse.cortex') as stream:
+                    await core.addStormPkg(pkgdef)
+
+                msgs = pkgmsgs(stream)
+                self.len(1, msgs)
+                self.eq('Loaded Storm package: pkglogs@0.0.1.', msgs[0]['message'])
+                self.eq({'pkg': 'pkglogs', 'vers': '0.0.1'}, msgs[0]['params'])
+
+                # re-adding an identical def bounces before load/unload and logs nothing
+                with self.getLoggerStream('synapse.cortex') as stream:
+                    await core.addStormPkg(pkgdef)
+
+                self.len(0, pkgmsgs(stream))
+
+                # adding a changed def for the same package unloads the old
+                # version and loads the new one
+                newpkgdef = copy.deepcopy(pkgdef)
+                newpkgdef['version'] = '0.0.2'
+
+                with self.getLoggerStream('synapse.cortex') as stream:
+                    await core.addStormPkg(newpkgdef)
+
+                msgs = pkgmsgs(stream)
+                self.len(2, msgs)
+                self.eq('Unloaded Storm package: pkglogs@0.0.1.', msgs[0]['message'])
+                self.eq({'pkg': 'pkglogs', 'vers': '0.0.1'}, msgs[0]['params'])
+                self.eq('Loaded Storm package: pkglogs@0.0.2.', msgs[1]['message'])
+                self.eq({'pkg': 'pkglogs', 'vers': '0.0.2'}, msgs[1]['params'])
+
+                # dropping the package logs the unload
+                with self.getLoggerStream('synapse.cortex') as stream:
+                    await core.delStormPkg('pkglogs')
+
+                msgs = pkgmsgs(stream)
+                self.len(1, msgs)
+                self.eq('Unloaded Storm package: pkglogs@0.0.2.', msgs[0]['message'])
+                self.eq({'pkg': 'pkglogs', 'vers': '0.0.2'}, msgs[0]['params'])
+
+                # a package stored from a prior run logs its load again at boot
+                await core.addStormPkg(newpkgdef)
+
+            with self.getLoggerStream('synapse.cortex') as stream:
+                async with self.getTestCore(dirn=dirn) as core:
+                    pass
+
+            msgs = pkgmsgs(stream)
+            self.len(1, msgs)
+            self.eq('Loaded Storm package: pkglogs@0.0.2.', msgs[0]['message'])
+            self.eq({'pkg': 'pkglogs', 'vers': '0.0.2'}, msgs[0]['params'])
+
     async def test_cortex_view_persistence(self):
         with self.getTestDir() as dirn:
             async with self.getTestCore(dirn=dirn) as core:


### PR DESCRIPTION
## Summary
- Backport of [`vertexproject/synapse-enterprise#1069`](https://github.com/vertexproject/synapse-enterprise/pull/1069).
- Log an operator-visible `Loaded Storm package: <name>@<vers>.` / `Unloaded Storm package: <name>@<vers>.` message from the Cortex whenever `loadStormPkg`/`_dropStormPkg` run, so package installs and Storm service package delivery are visible in logs.
- Structured log extras (`pkg`, `vers`) match the existing `_runStormPkgOnload` convention.
- [SYN-11547](https://vertexproject.atlassian.net/browse/SYN-11547)

## Divergences from the enterprise PR
This tree differs from `synapse-enterprise` in three ways that made this a manual backport rather than a cherry-pick:
- `_dropStormPkg` here had no `pkgvers` local; added one next to `pkgname`.
- `test_stormpkg_nomutate` (the enterprise test the upstream diff extended) doesn't exist in this repo, so coverage lives in a new `test_stormpkg_logs` test instead, covering load, no-op re-add, changed re-add (unload+load), delete, and load-at-boot.
- The enterprise changelog fragment carries a `timestamp` field not present in this repo's `_changelogSchema` (`additionalProperties: False`), so the fragment here was generated fresh via `synapse.tools.utils.changelog gen` rather than copied.

## Test plan
- [x] `python -m pytest synapse/tests/test_cortex.py -k stormpkg_logs -v`
- [x] `python -m pytest synapse/tests/test_cortex.py -k stormpkg -v` (no regressions)
- [x] `python -m pytest synapse/tests/test_lib_stormlib_pkg.py synapse/tests/test_lib_stormsvc.py synapse/tests/test_lib_module.py synapse/tests/test_datamodel.py synapse/tests/test_model_syn.py synapse/tests/test_lib_layer.py` (no regressions in tests asserting on the `synapse.cortex` log stream)
- [x] `python -m pytest synapse/tests/test_lib_storm.py -k pkg` (no regressions)
- [x] Coverage confirms both new log lines are exercised
- [x] `ruff check` clean

[SYN-11547]: https://vertexproject.atlassian.net/browse/SYN-11547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ