### PR TITLE
Add it:os:windows:task form (SYN-11288)

### DIFF
--- a/changes/c7b87939be04e836492da9f84e7e08b5.yaml
+++ b/changes/c7b87939be04e836492da9f84e7e08b5.yaml
@@ -1,0 +1,6 @@
+---
+desc: Added the ``it:os:windows:task`` form to model Windows Scheduled Task entries.
+desc:literal: false
+prs: []
+type: model
+...

--- a/synapse/models/infotech.py
+++ b/synapse/models/infotech.py
@@ -854,9 +854,8 @@ class ItModule(s_module.CoreModule):
                 ('it:os:windows:service', ('guid', {}), {
                     'doc': 'A Microsoft Windows service configuration on a host.'}),
 
-                # TODO
-                # ('it:os:windows:task', ('guid', {}), {
-                #     'doc': 'A Microsoft Windows scheduled task configuration.'}),
+                ('it:os:windows:task', ('guid', {}), {
+                    'doc': 'A Windows Scheduled Task entry.'}),
 
                 ('it:os:posix:cron', ('guid', {}), {
                     'doc': 'A cron job entry configured on a host.'}),
@@ -2667,6 +2666,33 @@ class ItModule(s_module.CoreModule):
 
                     ('imagepath', ('file:path', {}), {
                         'doc': 'The path to the service binary from the ImagePath registry key.'}),
+                )),
+
+                ('it:os:windows:task', {}, (
+
+                    ('host', ('it:host', {}), {
+                        'doc': 'The host on which the task was configured.'}),
+
+                    ('cmds', ('array', {'type': 'it:cmd', 'sorted': False, 'uniq': False}), {
+                        'doc': 'A set of ordered commands executed by the task.'}),
+
+                    ('account', ('it:account', {}), {
+                        'doc': 'The account which the task runs as.'}),
+
+                    ('period', ('ival', {}), {
+                        'doc': 'The period when the task entry existed.'}),
+
+                    ('desc', ('str', {}), {
+                        'doc': 'The description of the task.'}),
+
+                    ('uri', ('file:path', {}), {
+                        'doc': 'The location of the task within the Windows Task Scheduler.'}),
+
+                    ('path', ('file:path', {}), {
+                        'doc': 'The path of the task metadata file.'}),
+
+                    ('file', ('file:bytes', {}), {
+                        'doc': 'The file containing the task metadata.'}),
                 )),
 
                 ('it:os:posix:cron', {}, (

--- a/synapse/tests/test_model_infotech.py
+++ b/synapse/tests/test_model_infotech.py
@@ -2612,6 +2612,50 @@ class InfotechModelTest(s_t_utils.SynTest):
 
             self.len(1, await core.nodes('[ it:exec:proc=* :windows:service={ it:os:windows:service } ] -> it:os:windows:service'))
 
+    async def test_infotech_windows_task(self):
+
+        async with self.getTestCore() as core:
+
+            opts = {'vars': {'uri': '\\Microsoft\\Windows\\Woot\\Telemetry'}}
+
+            nodes = await core.nodes('''
+                [ it:os:windows:task=*
+                    :host=*
+                    :cmds=("cmd.exe /c woot.bat", "PowerShell.exe -Enc ZgBvAG8A", "cmd.exe /c woot.bat")
+                    :account=*
+                    :period=(2020-01-01, 2021-01-01)
+                    :desc="Daily telemetry upload"
+                    :uri=$uri
+                    :path=c:/windows/system32/tasks/woot.xml
+                    :file=*
+                ]
+            ''', opts=opts)
+
+            self.len(1, nodes)
+            self.eq(nodes[0].get('desc'), 'Daily telemetry upload')
+            self.eq(nodes[0].get('uri'), 'microsoft/windows/woot/telemetry')
+            self.eq(nodes[0].get('path'), 'c:/windows/system32/tasks/woot.xml')
+            self.eq(nodes[0].get('period'), (1577836800000, 1609459200000))
+            self.nn(nodes[0].get('host'))
+            self.nn(nodes[0].get('account'))
+            self.nn(nodes[0].get('file'))
+
+            # the commands stay in order and the repeat is preserved, so the
+            # pivot walks three entries but resolves only two distinct nodes
+            self.eq(nodes[0].get('cmds'), ('cmd.exe /c woot.bat',
+                                           'PowerShell.exe -Enc ZgBvAG8A',
+                                           'cmd.exe /c woot.bat'))
+
+            self.len(1, await core.nodes('it:os:windows:task -> it:host'))
+            self.len(3, await core.nodes('it:os:windows:task -> it:cmd'))
+            self.len(2, await core.nodes('it:cmd'))
+            self.len(1, await core.nodes('it:os:windows:task -> it:account'))
+            self.len(1, await core.nodes('it:os:windows:task -> file:bytes'))
+            self.len(2, await core.nodes('it:os:windows:task -> file:path'))
+            self.len(1, await core.nodes('it:os:windows:task:desc="Daily telemetry upload"'))
+            self.len(1, await core.nodes('it:os:windows:task:period@=2020'))
+            self.len(1, await core.nodes('it:os:windows:task:cmds*[="cmd.exe /c woot.bat"]'))
+
     async def test_infotech_posix_cron(self):
 
         async with self.getTestCore() as core:


### PR DESCRIPTION
## Summary

Adds ``it:os:windows:task`` to model a Windows Scheduled Task entry, replacing the
commented-out TODO type placeholder that sat between the Windows service and POSIX cron
types. This is the **v2 half of SYN-11288**; the v3 form is
[synapse-enterprise#1079](https://github.com/vertexproject/synapse-enterprise/pull/1079).

The form is modeled directly on ``it:os:posix:cron``, its closest analogue, with
``:host``, ``:account``, ``:period``, ``:desc``, ``:path``, and ``:file``. It declares
``:cmds`` as an array of ``it:cmd``, since a task runs an ordered list of actions which
may repeat. The form props sit between the ``it:os:windows:service`` and
``it:os:posix:cron`` forms so the ``forms`` order mirrors the ``types`` order.

## Property set

Two departures from the ticket's text:

- **The ticket spells the Task Scheduler location ``:task:uri``; this uses ``:uri``.**
  On a form already named ``it:os:windows:task`` the longer spelling reads
  ``it:os:windows:task:task:uri``. More importantly, the v3 form uses ``:uri``, and
  ``v2modelmap.yaml`` on the v3 side supports property-level renames -- so a split would
  need a permanent mapping entry. The form has not shipped on either line, so keeping the
  names identical costs nothing and avoids that entry entirely.
- **``:creator`` and ``:schedule`` are omitted**, per the ticket. A task is activated by
  one or more triggers which may be time-based or event-driven, so a single schedule
  string would misstate it.

``sorted`` and ``uniq`` are declared explicitly on ``:cmds`` even though both already
default to ``False`` for the Array type (``synapse/lib/types.py:435``). The convention in
this file is to declare array opts only when non-default -- ``it:software:image:parents``
is the ordered-array precedent and omits them -- so this is deliberate redundancy, kept so
the v2 and v3 declarations of the same property read identically. Happy to trim it.

``:account`` points at ``it:account``, as the ticket specifies; there is no
Windows-specific account form on this line (``it:account`` carries a ``windows:sid``
property instead).

The ``it:exec:proc:windows:task`` placeholder is deliberately left untouched.

## Tests

``test_infotech_windows_task`` pins every property's normed value. ``:cmds`` is set out of
order with a repeated command, so ``-> it:cmd`` walks **three** entries while a bare
``it:cmd`` lift returns only **two** distinct nodes -- that pair of assertions is what
proves the ordering and the duplicate survived.

The task URI is passed through an ``opts`` variable to avoid Storm backslash escaping.
Note that ``file:path`` on this line lowercases and strips slashes, so
``\Microsoft\Windows\Woot\Telemetry`` norms to ``microsoft/windows/woot/telemetry`` --
where the v3 line yields ``/Microsoft/Windows/Woot/Telemetry``. That difference is
inherent to the 2.x type; each test pins its own line's value.

## No docs regeneration

The form reference is built into ``docs/synapse/autodocs/`` at docs-build time, and
``changes/modelrefs/`` plus the ``model_updates/*.rst`` pages are release-time artifacts.

Confirmed with ``synapse.tools.utils.changelog model -c`` against the v2.251.0 modelref
that the form and all eight of its properties register as additions.

## Verification

| Check | Result |
|---|---|
| ``test_model_infotech.py``, ``test_datamodel.py`` | 40 passed, 1 skipped |
| ``ruff check`` | All checks passed |
| ``changelog model -c`` vs v2.251.0 modelref | Form + 8 properties register as additions |
